### PR TITLE
Fix Claude GitHub Action with Java 21, Helm, and write permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,32 +19,31 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
## Summary
- Add **Java 21** setup (`actions/setup-java@v4` with temurin + Maven cache) so Claude can run `./mvnw test` and `./mvnw clean install`
- Add **Helm CLI** setup (`azure/setup-helm@v4`) so Claude can run integration tests that compare against native Helm
- Upgrade permissions from `read` to `write` for `contents`, `pull-requests`, and `issues` so Claude can push branches and create PRs when asked

## Test plan
- [ ] Trigger `@claude` on an issue and ask it to build the project (`./mvnw clean install`)
- [ ] Trigger `@claude` on a PR and ask it to run tests (`./mvnw test`)
- [ ] Verify Claude can create branches and PRs when asked

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)