### PR TITLE
Add allowed tools to Claude GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,3 +47,5 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
+          claude_args: |
+            --allowedTools "Bash(./mvnw *)" "Bash(mvn *)" "Bash(git *)" "Bash(gh *)" "Bash(helm *)" "Bash(kubectl *)" "Bash(java *)" "Bash(ls *)" "Bash(mkdir *)" "Bash(cp *)" "Bash(mv *)"


### PR DESCRIPTION
## Summary
- Add `--allowedTools` via `claude_args` to permit Claude to run build and test commands
- Without this, Claude reports "unable to run build/tests due to command restrictions"

## Allowed tools
- `./mvnw *`, `mvn *` — Maven builds and tests
- `git *` — Git operations (branch, commit, push)
- `gh *` — GitHub CLI (PRs, issues)
- `helm *` — Helm CLI
- `kubectl *` — Kubernetes CLI
- `java *` — Java commands
- `ls *`, `mkdir *`, `cp *`, `mv *` — Basic file system operations

## Test plan
- [ ] Trigger `@claude` on an issue and ask it to run `./mvnw test`
- [ ] Verify Claude no longer reports command restrictions

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)