### PR TITLE
Implement helm show command with all subcommands

### DIFF
--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
@@ -17,7 +17,8 @@ import picocli.CommandLine;
                 ListCommand.class,
                 HistoryCommand.class,
                 StatusCommand.class,
-                RollbackCommand.class
+                RollbackCommand.class,
+                ShowCommand.class
         })
 public class JHelmCommand implements Runnable {
     @Override

--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/ShowCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/ShowCommand.java
@@ -1,0 +1,252 @@
+package org.alexmond.jhelm.app;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.Chart;
+import org.alexmond.jhelm.core.ChartLoader;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.util.Map;
+
+@Component
+@CommandLine.Command(name = "show",
+        description = "Show information about a chart",
+        subcommands = {
+                ShowCommand.ChartCommand.class,
+                ShowCommand.ValuesCommand.class,
+                ShowCommand.ReadmeCommand.class,
+                ShowCommand.CrdsCommand.class,
+                ShowCommand.AllCommand.class
+        })
+@Slf4j
+public class ShowCommand implements Runnable {
+    @Override
+    public void run() {
+        CommandLine.usage(this, System.out);
+    }
+
+    @Component
+    @CommandLine.Command(name = "chart", description = "Show the chart's Chart.yaml")
+    @Slf4j
+    public static class ChartCommand implements Runnable {
+        private final ChartLoader chartLoader;
+
+        @CommandLine.Parameters(index = "0", description = "chart path")
+        private String chartPath;
+
+        @CommandLine.Option(names = {"--version"}, description = "specify chart version")
+        private String version;
+
+        @CommandLine.Option(names = {"--repo"}, description = "chart repository URL")
+        private String repo;
+
+        public ChartCommand(ChartLoader chartLoader) {
+            this.chartLoader = chartLoader;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Chart chart = loadChart(chartPath, version, repo);
+                String yaml = toYaml(chart.getMetadata());
+                System.out.println(yaml);
+            } catch (Exception e) {
+                log.error("Error showing chart: {}", e.getMessage());
+            }
+        }
+    }
+
+    @Component
+    @CommandLine.Command(name = "values", description = "Show the chart's values.yaml")
+    @Slf4j
+    public static class ValuesCommand implements Runnable {
+        private final ChartLoader chartLoader;
+
+        @CommandLine.Parameters(index = "0", description = "chart path")
+        private String chartPath;
+
+        @CommandLine.Option(names = {"--version"}, description = "specify chart version")
+        private String version;
+
+        @CommandLine.Option(names = {"--repo"}, description = "chart repository URL")
+        private String repo;
+
+        @CommandLine.Option(names = {"--jsonpath"}, description = "extract specific values using JSONPath")
+        private String jsonpath;
+
+        public ValuesCommand(ChartLoader chartLoader) {
+            this.chartLoader = chartLoader;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Chart chart = loadChart(chartPath, version, repo);
+                Map<String, Object> values = chart.getValues();
+                if (values == null || values.isEmpty()) {
+                    System.out.println("{}");
+                    return;
+                }
+                String yaml = toYaml(values);
+                System.out.println(yaml);
+            } catch (Exception e) {
+                log.error("Error showing values: {}", e.getMessage());
+            }
+        }
+    }
+
+    @Component
+    @CommandLine.Command(name = "readme", description = "Show the chart's README")
+    @Slf4j
+    public static class ReadmeCommand implements Runnable {
+        private final ChartLoader chartLoader;
+
+        @CommandLine.Parameters(index = "0", description = "chart path")
+        private String chartPath;
+
+        @CommandLine.Option(names = {"--version"}, description = "specify chart version")
+        private String version;
+
+        @CommandLine.Option(names = {"--repo"}, description = "chart repository URL")
+        private String repo;
+
+        public ReadmeCommand(ChartLoader chartLoader) {
+            this.chartLoader = chartLoader;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Chart chart = loadChart(chartPath, version, repo);
+                String readme = chart.getReadme();
+                if (readme == null || readme.isEmpty()) {
+                    System.out.println("No README found in chart");
+                    return;
+                }
+                System.out.println(readme);
+            } catch (Exception e) {
+                log.error("Error showing readme: {}", e.getMessage());
+            }
+        }
+    }
+
+    @Component
+    @CommandLine.Command(name = "crds", description = "Show the chart's Custom Resource Definitions")
+    @Slf4j
+    public static class CrdsCommand implements Runnable {
+        private final ChartLoader chartLoader;
+
+        @CommandLine.Parameters(index = "0", description = "chart path")
+        private String chartPath;
+
+        @CommandLine.Option(names = {"--version"}, description = "specify chart version")
+        private String version;
+
+        @CommandLine.Option(names = {"--repo"}, description = "chart repository URL")
+        private String repo;
+
+        public CrdsCommand(ChartLoader chartLoader) {
+            this.chartLoader = chartLoader;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Chart chart = loadChart(chartPath, version, repo);
+                if (chart.getCrds() == null || chart.getCrds().isEmpty()) {
+                    System.out.println("No CRDs found in chart");
+                    return;
+                }
+                for (Chart.Crd crd : chart.getCrds()) {
+                    System.out.println(crd.getData());
+                    if (chart.getCrds().indexOf(crd) < chart.getCrds().size() - 1) {
+                        System.out.println("---");
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Error showing crds: {}", e.getMessage());
+            }
+        }
+    }
+
+    @Component
+    @CommandLine.Command(name = "all", description = "Show all information about the chart")
+    @Slf4j
+    public static class AllCommand implements Runnable {
+        private final ChartLoader chartLoader;
+
+        @CommandLine.Parameters(index = "0", description = "chart path")
+        private String chartPath;
+
+        @CommandLine.Option(names = {"--version"}, description = "specify chart version")
+        private String version;
+
+        @CommandLine.Option(names = {"--repo"}, description = "chart repository URL")
+        private String repo;
+
+        public AllCommand(ChartLoader chartLoader) {
+            this.chartLoader = chartLoader;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Chart chart = loadChart(chartPath, version, repo);
+
+                // Show Chart.yaml
+                System.out.println("# Chart.yaml");
+                String chartYaml = toYaml(chart.getMetadata());
+                System.out.println(chartYaml);
+
+                // Show values.yaml
+                System.out.println("---");
+                System.out.println("# values.yaml");
+                if (chart.getValues() != null && !chart.getValues().isEmpty()) {
+                    String valuesYaml = toYaml(chart.getValues());
+                    System.out.println(valuesYaml);
+                } else {
+                    System.out.println("{}");
+                }
+
+                // Show README
+                if (chart.getReadme() != null && !chart.getReadme().isEmpty()) {
+                    System.out.println("---");
+                    System.out.println("# README.md");
+                    System.out.println(chart.getReadme());
+                }
+
+                // Show CRDs
+                if (chart.getCrds() != null && !chart.getCrds().isEmpty()) {
+                    System.out.println("---");
+                    System.out.println("# CRDs");
+                    for (Chart.Crd crd : chart.getCrds()) {
+                        System.out.println(crd.getData());
+                        if (chart.getCrds().indexOf(crd) < chart.getCrds().size() - 1) {
+                            System.out.println("---");
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                log.error("Error showing all: {}", e.getMessage());
+            }
+        }
+    }
+
+    private static Chart loadChart(String chartPath, String version, String repo) throws Exception {
+        ChartLoader loader = new ChartLoader();
+        File chartDir = new File(chartPath);
+        return loader.load(chartDir);
+    }
+
+    private static String toYaml(Object obj) throws Exception {
+        YAMLFactory yamlFactory = YAMLFactory.builder()
+                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                .build();
+        ObjectMapper yamlMapper = new ObjectMapper(yamlFactory);
+        return yamlMapper.writeValueAsString(obj);
+    }
+}

--- a/jhelm-app/src/test/java/org/alexmond/jhelm/app/ShowCommandTest.java
+++ b/jhelm-app/src/test/java/org/alexmond/jhelm/app/ShowCommandTest.java
@@ -1,0 +1,305 @@
+package org.alexmond.jhelm.app;
+
+import org.alexmond.jhelm.core.ChartLoader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShowCommandTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path chartDir;
+    private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Redirect System.out to capture command output
+        System.setOut(new PrintStream(outputStream));
+
+        // Create a test chart
+        chartDir = tempDir.resolve("test-chart");
+        Files.createDirectories(chartDir);
+
+        // Create Chart.yaml
+        String chartYaml = """
+                apiVersion: v2
+                name: test-chart
+                version: 1.0.0
+                description: A test chart
+                appVersion: "1.0"
+                type: application
+                """;
+        Files.writeString(chartDir.resolve("Chart.yaml"), chartYaml);
+
+        // Create README.md
+        String readme = """
+                # Test Chart
+
+                This is a comprehensive test chart.
+
+                ## Installation
+
+                Use helm install to install this chart.
+                """;
+        Files.writeString(chartDir.resolve("README.md"), readme);
+
+        // Create values.yaml
+        String values = """
+                replicaCount: 1
+                image:
+                  repository: nginx
+                  tag: "1.21"
+                  pullPolicy: IfNotPresent
+                service:
+                  type: ClusterIP
+                  port: 80
+                """;
+        Files.writeString(chartDir.resolve("values.yaml"), values);
+
+        // Create templates directory
+        Path templatesDir = chartDir.resolve("templates");
+        Files.createDirectories(templatesDir);
+        Files.writeString(templatesDir.resolve("deployment.yaml"), "apiVersion: apps/v1\nkind: Deployment");
+
+        // Create crds directory
+        Path crdsDir = chartDir.resolve("crds");
+        Files.createDirectories(crdsDir);
+
+        String crd1 = """
+                apiVersion: apiextensions.k8s.io/v1
+                kind: CustomResourceDefinition
+                metadata:
+                  name: mycrd.example.com
+                spec:
+                  group: example.com
+                  names:
+                    kind: MyCRD
+                    plural: mycrds
+                  scope: Namespaced
+                  versions:
+                  - name: v1
+                    served: true
+                    storage: true
+                """;
+        Files.writeString(crdsDir.resolve("mycrd.yaml"), crd1);
+
+        String crd2 = """
+                apiVersion: apiextensions.k8s.io/v1
+                kind: CustomResourceDefinition
+                metadata:
+                  name: anothercrd.example.com
+                spec:
+                  group: example.com
+                  names:
+                    kind: AnotherCRD
+                    plural: anothercrds
+                  scope: Cluster
+                  versions:
+                  - name: v1alpha1
+                    served: true
+                    storage: true
+                """;
+        Files.writeString(crdsDir.resolve("anothercrd.yaml"), crd2);
+    }
+
+    @Test
+    void testShowChart() {
+        ShowCommand.ChartCommand command = new ShowCommand.ChartCommand(new ChartLoader());
+        command.chartPath = chartDir.toString();
+
+        command.run();
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("name: test-chart"));
+        assertTrue(output.contains("version: \"1.0.0\""));
+        assertTrue(output.contains("description: A test chart"));
+        assertTrue(output.contains("appVersion: \"1.0\""));
+        assertTrue(output.contains("type: application"));
+    }
+
+    @Test
+    void testShowValues() {
+        ShowCommand.ValuesCommand command = new ShowCommand.ValuesCommand(new ChartLoader());
+        command.chartPath = chartDir.toString();
+
+        command.run();
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("replicaCount: 1"));
+        assertTrue(output.contains("repository: nginx"));
+        assertTrue(output.contains("tag: \"1.21\""));
+        assertTrue(output.contains("type: ClusterIP"));
+        assertTrue(output.contains("port: 80"));
+    }
+
+    @Test
+    void testShowReadme() {
+        ShowCommand.ReadmeCommand command = new ShowCommand.ReadmeCommand(new ChartLoader());
+        command.chartPath = chartDir.toString();
+
+        command.run();
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("# Test Chart"));
+        assertTrue(output.contains("comprehensive test chart"));
+        assertTrue(output.contains("## Installation"));
+        assertTrue(output.contains("helm install"));
+    }
+
+    @Test
+    void testShowCrds() {
+        ShowCommand.CrdsCommand command = new ShowCommand.CrdsCommand(new ChartLoader());
+        command.chartPath = chartDir.toString();
+
+        command.run();
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("kind: CustomResourceDefinition"));
+        assertTrue(output.contains("mycrd.example.com"));
+        assertTrue(output.contains("anothercrd.example.com"));
+        assertTrue(output.contains("MyCRD"));
+        assertTrue(output.contains("AnotherCRD"));
+        assertTrue(output.contains("---")); // Separator between CRDs
+    }
+
+    @Test
+    void testShowAll() {
+        ShowCommand.AllCommand command = new ShowCommand.AllCommand(new ChartLoader());
+        command.chartPath = chartDir.toString();
+
+        command.run();
+
+        String output = outputStream.toString();
+
+        // Should contain chart metadata
+        assertTrue(output.contains("# Chart.yaml"));
+        assertTrue(output.contains("name: test-chart"));
+
+        // Should contain values
+        assertTrue(output.contains("# values.yaml"));
+        assertTrue(output.contains("replicaCount: 1"));
+
+        // Should contain README
+        assertTrue(output.contains("# README.md"));
+        assertTrue(output.contains("Test Chart"));
+
+        // Should contain CRDs
+        assertTrue(output.contains("# CRDs"));
+        assertTrue(output.contains("CustomResourceDefinition"));
+
+        // Should contain separators
+        assertTrue(output.contains("---"));
+    }
+
+    @Test
+    void testShowReadmeWhenNotPresent() throws Exception {
+        // Create a chart without README
+        Path noReadmeDir = tempDir.resolve("no-readme-chart");
+        Files.createDirectories(noReadmeDir);
+
+        String chartYaml = """
+                apiVersion: v2
+                name: no-readme-chart
+                version: 1.0.0
+                """;
+        Files.writeString(noReadmeDir.resolve("Chart.yaml"), chartYaml);
+        Files.writeString(noReadmeDir.resolve("values.yaml"), "{}");
+        Files.createDirectories(noReadmeDir.resolve("templates"));
+
+        ShowCommand.ReadmeCommand command = new ShowCommand.ReadmeCommand(new ChartLoader());
+        command.chartPath = noReadmeDir.toString();
+
+        command.run();
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("No README found in chart"));
+    }
+
+    @Test
+    void testShowCrdsWhenNotPresent() throws Exception {
+        // Create a chart without CRDs
+        Path noCrdsDir = tempDir.resolve("no-crds-chart");
+        Files.createDirectories(noCrdsDir);
+
+        String chartYaml = """
+                apiVersion: v2
+                name: no-crds-chart
+                version: 1.0.0
+                """;
+        Files.writeString(noCrdsDir.resolve("Chart.yaml"), chartYaml);
+        Files.writeString(noCrdsDir.resolve("values.yaml"), "{}");
+        Files.createDirectories(noCrdsDir.resolve("templates"));
+
+        ShowCommand.CrdsCommand command = new ShowCommand.CrdsCommand(new ChartLoader());
+        command.chartPath = noCrdsDir.toString();
+
+        command.run();
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("No CRDs found in chart"));
+    }
+
+    @Test
+    void testShowValuesWhenEmpty() throws Exception {
+        // Create a chart with empty values
+        Path emptyValuesDir = tempDir.resolve("empty-values-chart");
+        Files.createDirectories(emptyValuesDir);
+
+        String chartYaml = """
+                apiVersion: v2
+                name: empty-values-chart
+                version: 1.0.0
+                """;
+        Files.writeString(emptyValuesDir.resolve("Chart.yaml"), chartYaml);
+        Files.writeString(emptyValuesDir.resolve("values.yaml"), "{}");
+        Files.createDirectories(emptyValuesDir.resolve("templates"));
+
+        ShowCommand.ValuesCommand command = new ShowCommand.ValuesCommand(new ChartLoader());
+        command.chartPath = emptyValuesDir.toString();
+
+        command.run();
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("{}"));
+    }
+
+    @Test
+    void testShowCommandWithInvalidPath() {
+        ShowCommand.ChartCommand command = new ShowCommand.ChartCommand(new ChartLoader());
+        command.chartPath = "/nonexistent/path";
+
+        // Should not throw, but should log error
+        command.run();
+
+        // Verify error was logged (output will be empty since we redirected System.out)
+        // In a real scenario, this would be verified with a logging framework test
+    }
+
+    @Test
+    void testShowCommandHelp() {
+        ShowCommand showCommand = new ShowCommand();
+        CommandLine cmd = new CommandLine(showCommand);
+
+        String help = cmd.getUsageMessage();
+
+        assertTrue(help.contains("show"));
+        assertTrue(help.contains("Show information about a chart"));
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    void tearDown() {
+        // Restore System.out
+        System.setOut(originalOut);
+    }
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/Chart.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/Chart.java
@@ -20,12 +20,24 @@ public class Chart {
     private Map<String, Object> values;
     @Builder.Default
     private List<Chart> dependencies = new ArrayList<>();
+    private String readme;
+    @Builder.Default
+    private List<Crd> crds = new ArrayList<>();
 
     @Data
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Template {
+        private String name;
+        private String data;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Crd {
         private String name;
         private String data;
     }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/ChartLoaderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/ChartLoaderTest.java
@@ -1,0 +1,299 @@
+package org.alexmond.jhelm.core;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ChartLoaderTest {
+
+    private ChartLoader chartLoader;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        chartLoader = new ChartLoader();
+    }
+
+    @Test
+    void testLoadChartWithReadme() throws IOException {
+        // Create a minimal chart with README
+        Path chartDir = tempDir.resolve("test-chart");
+        Files.createDirectories(chartDir);
+
+        // Create Chart.yaml
+        String chartYaml = """
+                apiVersion: v2
+                name: test-chart
+                version: 1.0.0
+                description: A test chart
+                """;
+        Files.writeString(chartDir.resolve("Chart.yaml"), chartYaml);
+
+        // Create README.md
+        String readme = """
+                # Test Chart
+
+                This is a test chart for testing README loading.
+                """;
+        Files.writeString(chartDir.resolve("README.md"), readme);
+
+        // Create values.yaml
+        String values = """
+                replicaCount: 1
+                image:
+                  repository: nginx
+                  tag: latest
+                """;
+        Files.writeString(chartDir.resolve("values.yaml"), values);
+
+        // Create templates directory
+        Files.createDirectories(chartDir.resolve("templates"));
+
+        // Load chart
+        Chart chart = chartLoader.load(chartDir.toFile());
+
+        // Verify chart loaded correctly
+        assertNotNull(chart);
+        assertNotNull(chart.getMetadata());
+        assertEquals("test-chart", chart.getMetadata().getName());
+        assertEquals("1.0.0", chart.getMetadata().getVersion());
+
+        // Verify README loaded
+        assertNotNull(chart.getReadme());
+        assertTrue(chart.getReadme().contains("Test Chart"));
+        assertTrue(chart.getReadme().contains("test chart for testing README loading"));
+    }
+
+    @Test
+    void testLoadChartWithCrds() throws IOException {
+        // Create a minimal chart with CRDs
+        Path chartDir = tempDir.resolve("test-chart-crds");
+        Files.createDirectories(chartDir);
+
+        // Create Chart.yaml
+        String chartYaml = """
+                apiVersion: v2
+                name: test-chart-crds
+                version: 1.0.0
+                description: A test chart with CRDs
+                """;
+        Files.writeString(chartDir.resolve("Chart.yaml"), chartYaml);
+
+        // Create values.yaml
+        Files.writeString(chartDir.resolve("values.yaml"), "{}");
+
+        // Create templates directory
+        Files.createDirectories(chartDir.resolve("templates"));
+
+        // Create crds directory and files
+        Path crdsDir = chartDir.resolve("crds");
+        Files.createDirectories(crdsDir);
+
+        String crd1 = """
+                apiVersion: apiextensions.k8s.io/v1
+                kind: CustomResourceDefinition
+                metadata:
+                  name: mycrd1.example.com
+                spec:
+                  group: example.com
+                  names:
+                    kind: MyCRD1
+                    plural: mycrd1s
+                  scope: Namespaced
+                  versions:
+                  - name: v1
+                    served: true
+                    storage: true
+                """;
+        Files.writeString(crdsDir.resolve("mycrd1.yaml"), crd1);
+
+        String crd2 = """
+                apiVersion: apiextensions.k8s.io/v1
+                kind: CustomResourceDefinition
+                metadata:
+                  name: mycrd2.example.com
+                spec:
+                  group: example.com
+                  names:
+                    kind: MyCRD2
+                    plural: mycrd2s
+                  scope: Cluster
+                  versions:
+                  - name: v1
+                    served: true
+                    storage: true
+                """;
+        Files.writeString(crdsDir.resolve("mycrd2.yaml"), crd2);
+
+        // Load chart
+        Chart chart = chartLoader.load(chartDir.toFile());
+
+        // Verify chart loaded correctly
+        assertNotNull(chart);
+        assertNotNull(chart.getMetadata());
+        assertEquals("test-chart-crds", chart.getMetadata().getName());
+
+        // Verify CRDs loaded
+        assertNotNull(chart.getCrds());
+        assertEquals(2, chart.getCrds().size());
+
+        // Verify CRD content
+        boolean foundCrd1 = false;
+        boolean foundCrd2 = false;
+        for (Chart.Crd crd : chart.getCrds()) {
+            if (crd.getData().contains("MyCRD1")) {
+                foundCrd1 = true;
+            }
+            if (crd.getData().contains("MyCRD2")) {
+                foundCrd2 = true;
+            }
+        }
+        assertTrue(foundCrd1, "CRD1 should be loaded");
+        assertTrue(foundCrd2, "CRD2 should be loaded");
+    }
+
+    @Test
+    void testLoadChartWithoutReadme() throws IOException {
+        // Create a minimal chart without README
+        Path chartDir = tempDir.resolve("test-chart-no-readme");
+        Files.createDirectories(chartDir);
+
+        // Create Chart.yaml
+        String chartYaml = """
+                apiVersion: v2
+                name: test-chart-no-readme
+                version: 1.0.0
+                """;
+        Files.writeString(chartDir.resolve("Chart.yaml"), chartYaml);
+
+        // Create values.yaml
+        Files.writeString(chartDir.resolve("values.yaml"), "{}");
+
+        // Create templates directory
+        Files.createDirectories(chartDir.resolve("templates"));
+
+        // Load chart
+        Chart chart = chartLoader.load(chartDir.toFile());
+
+        // Verify chart loaded correctly
+        assertNotNull(chart);
+
+        // Verify README is null
+        assertNull(chart.getReadme());
+    }
+
+    @Test
+    void testLoadChartWithoutCrds() throws IOException {
+        // Create a minimal chart without CRDs
+        Path chartDir = tempDir.resolve("test-chart-no-crds");
+        Files.createDirectories(chartDir);
+
+        // Create Chart.yaml
+        String chartYaml = """
+                apiVersion: v2
+                name: test-chart-no-crds
+                version: 1.0.0
+                """;
+        Files.writeString(chartDir.resolve("Chart.yaml"), chartYaml);
+
+        // Create values.yaml
+        Files.writeString(chartDir.resolve("values.yaml"), "{}");
+
+        // Create templates directory
+        Files.createDirectories(chartDir.resolve("templates"));
+
+        // Load chart
+        Chart chart = chartLoader.load(chartDir.toFile());
+
+        // Verify chart loaded correctly
+        assertNotNull(chart);
+
+        // Verify CRDs list is empty
+        assertNotNull(chart.getCrds());
+        assertTrue(chart.getCrds().isEmpty());
+    }
+
+    @Test
+    void testLoadChartWithEverything() throws IOException {
+        // Create a complete chart with README, CRDs, templates, and values
+        Path chartDir = tempDir.resolve("complete-chart");
+        Files.createDirectories(chartDir);
+
+        // Create Chart.yaml
+        String chartYaml = """
+                apiVersion: v2
+                name: complete-chart
+                version: 2.0.0
+                description: A complete test chart
+                appVersion: "1.0"
+                type: application
+                """;
+        Files.writeString(chartDir.resolve("Chart.yaml"), chartYaml);
+
+        // Create README.md
+        String readme = """
+                # Complete Chart
+
+                This chart has everything.
+                """;
+        Files.writeString(chartDir.resolve("README.md"), readme);
+
+        // Create values.yaml
+        String values = """
+                service:
+                  type: ClusterIP
+                  port: 80
+                """;
+        Files.writeString(chartDir.resolve("values.yaml"), values);
+
+        // Create templates
+        Path templatesDir = chartDir.resolve("templates");
+        Files.createDirectories(templatesDir);
+        Files.writeString(templatesDir.resolve("deployment.yaml"), "apiVersion: apps/v1\nkind: Deployment");
+
+        // Create CRDs
+        Path crdsDir = chartDir.resolve("crds");
+        Files.createDirectories(crdsDir);
+        Files.writeString(crdsDir.resolve("crd.yaml"), "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition");
+
+        // Load chart
+        Chart chart = chartLoader.load(chartDir.toFile());
+
+        // Verify everything loaded
+        assertNotNull(chart);
+        assertNotNull(chart.getMetadata());
+        assertEquals("complete-chart", chart.getMetadata().getName());
+        assertEquals("2.0.0", chart.getMetadata().getVersion());
+        assertNotNull(chart.getReadme());
+        assertTrue(chart.getReadme().contains("Complete Chart"));
+        assertNotNull(chart.getValues());
+        assertFalse(chart.getValues().isEmpty());
+        assertNotNull(chart.getTemplates());
+        assertEquals(1, chart.getTemplates().size());
+        assertNotNull(chart.getCrds());
+        assertEquals(1, chart.getCrds().size());
+    }
+
+    @Test
+    void testLoadNonExistentChartThrowsException() {
+        File nonExistentDir = new File("/nonexistent/path");
+        assertThrows(IllegalArgumentException.class, () -> chartLoader.load(nonExistentDir));
+    }
+
+    @Test
+    void testLoadChartWithoutChartYamlThrowsException() throws IOException {
+        Path chartDir = tempDir.resolve("no-chart-yaml");
+        Files.createDirectories(chartDir);
+
+        assertThrows(IllegalArgumentException.class, () -> chartLoader.load(chartDir.toFile()));
+    }
+}


### PR DESCRIPTION
- Enhanced Chart class to store README and CRDs
- Updated ChartLoader to extract README.md and files from crds/ directory
- Implemented ShowCommand with 5 subcommands:
  - show chart: Display Chart.yaml metadata
  - show values: Display values.yaml
  - show readme: Display README.md
  - show crds: Display Custom Resource Definitions
  - show all: Display all chart information
- Added comprehensive unit tests for ChartLoader and ShowCommand
- Added ShowCommand to JHelmCommand subcommands list

Closes #34