### PR TITLE
Fix claude_args format for allowedTools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,5 +47,4 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
-          claude_args: |
-            --allowedTools "Bash(./mvnw *)" "Bash(mvn *)" "Bash(git *)" "Bash(gh *)" "Bash(helm *)" "Bash(kubectl *)" "Bash(java *)" "Bash(ls *)" "Bash(mkdir *)" "Bash(cp *)" "Bash(mv *)"
+          claude_args: '--allowedTools "Bash(./mvnw *),Bash(mvn *),Bash(git *),Bash(gh *),Bash(helm *),Bash(kubectl *),Bash(java *),Bash(ls *),Bash(mkdir *),Bash(cp *),Bash(mv *)"'


### PR DESCRIPTION
## Summary
- Fix `--allowedTools` format from space-separated quoted values to a single comma-separated string
- The previous format caused `Claude Code process exited with code 1`

## Before (broken)
```yaml
claude_args: |
  --allowedTools "Bash(./mvnw *)" "Bash(git *)" ...
```

## After (fixed)
```yaml
claude_args: '--allowedTools "Bash(./mvnw *),Bash(git *),..."'
```

## Test plan
- [ ] Trigger `@claude` on an issue and verify it no longer crashes with exit code 1
- [ ] Verify Claude can run `./mvnw test` and `git` commands

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)