### PR TITLE
Implement helm get command with 6 subcommands

### DIFF
--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/GetCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/GetCommand.java
@@ -1,0 +1,275 @@
+package org.alexmond.jhelm.app;
+
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.GetAction;
+import org.alexmond.jhelm.core.Release;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+@CommandLine.Command(name = "get",
+        description = "Download extended information of a named release",
+        subcommands = {
+                GetCommand.ValuesCommand.class,
+                GetCommand.ManifestCommand.class,
+                GetCommand.NotesCommand.class,
+                GetCommand.HooksCommand.class,
+                GetCommand.MetadataCommand.class,
+                GetCommand.AllCommand.class
+        })
+@Slf4j
+public class GetCommand implements Runnable {
+    @Override
+    public void run() {
+        CommandLine.usage(this, System.out);
+    }
+
+    private static Optional<Release> resolveRelease(GetAction getAction, String name, String namespace, int revision) throws Exception {
+        if (revision > 0) {
+            return getAction.getReleaseByRevision(name, namespace, revision);
+        }
+        return getAction.getRelease(name, namespace);
+    }
+
+    @Component
+    @CommandLine.Command(name = "values", description = "Download the values file for a named release")
+    @Slf4j
+    public static class ValuesCommand implements Runnable {
+        private final GetAction getAction;
+
+        @CommandLine.Parameters(index = "0", description = "release name")
+        String releaseName;
+
+        @CommandLine.Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "namespace")
+        String namespace;
+
+        @CommandLine.Option(names = {"--revision"}, defaultValue = "-1", description = "get the named release with revision")
+        int revision;
+
+        @CommandLine.Option(names = {"-a", "--all"}, description = "dump all (computed) values")
+        boolean allValues;
+
+        @CommandLine.Option(names = {"-o", "--output"}, defaultValue = "yaml", description = "output format (yaml or json)")
+        String output;
+
+        public ValuesCommand(GetAction getAction) {
+            this.getAction = getAction;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Optional<Release> releaseOpt = resolveRelease(getAction, releaseName, namespace, revision);
+                if (releaseOpt.isEmpty()) {
+                    log.error("Error: release not found: {}", releaseName);
+                    return;
+                }
+                Release release = releaseOpt.get();
+                if ("json".equalsIgnoreCase(output)) {
+                    Map<String, Object> values;
+                    if (release.getConfig() != null && release.getConfig().getValues() != null) {
+                        values = release.getConfig().getValues();
+                    } else {
+                        values = Map.of();
+                    }
+                    System.out.println(getAction.toJson(values));
+                } else {
+                    System.out.println(getAction.getValues(release, allValues));
+                }
+            } catch (Exception e) {
+                log.error("Error getting values: {}", e.getMessage());
+            }
+        }
+    }
+
+    @Component
+    @CommandLine.Command(name = "manifest", description = "Download the manifest for a named release")
+    @Slf4j
+    public static class ManifestCommand implements Runnable {
+        private final GetAction getAction;
+
+        @CommandLine.Parameters(index = "0", description = "release name")
+        String releaseName;
+
+        @CommandLine.Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "namespace")
+        String namespace;
+
+        @CommandLine.Option(names = {"--revision"}, defaultValue = "-1", description = "get the named release with revision")
+        int revision;
+
+        public ManifestCommand(GetAction getAction) {
+            this.getAction = getAction;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Optional<Release> releaseOpt = resolveRelease(getAction, releaseName, namespace, revision);
+                if (releaseOpt.isEmpty()) {
+                    log.error("Error: release not found: {}", releaseName);
+                    return;
+                }
+                System.out.println(getAction.getManifest(releaseOpt.get()));
+            } catch (Exception e) {
+                log.error("Error getting manifest: {}", e.getMessage());
+            }
+        }
+    }
+
+    @Component
+    @CommandLine.Command(name = "notes", description = "Download the notes for a named release")
+    @Slf4j
+    public static class NotesCommand implements Runnable {
+        private final GetAction getAction;
+
+        @CommandLine.Parameters(index = "0", description = "release name")
+        String releaseName;
+
+        @CommandLine.Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "namespace")
+        String namespace;
+
+        @CommandLine.Option(names = {"--revision"}, defaultValue = "-1", description = "get the named release with revision")
+        int revision;
+
+        public NotesCommand(GetAction getAction) {
+            this.getAction = getAction;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Optional<Release> releaseOpt = resolveRelease(getAction, releaseName, namespace, revision);
+                if (releaseOpt.isEmpty()) {
+                    log.error("Error: release not found: {}", releaseName);
+                    return;
+                }
+                String notes = getAction.getNotes(releaseOpt.get());
+                if (notes.isEmpty()) {
+                    System.out.println("No notes found for release");
+                } else {
+                    System.out.println(notes);
+                }
+            } catch (Exception e) {
+                log.error("Error getting notes: {}", e.getMessage());
+            }
+        }
+    }
+
+    @Component
+    @CommandLine.Command(name = "hooks", description = "Download all hooks for a named release")
+    @Slf4j
+    public static class HooksCommand implements Runnable {
+        private final GetAction getAction;
+
+        @CommandLine.Parameters(index = "0", description = "release name")
+        String releaseName;
+
+        @CommandLine.Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "namespace")
+        String namespace;
+
+        @CommandLine.Option(names = {"--revision"}, defaultValue = "-1", description = "get the named release with revision")
+        int revision;
+
+        public HooksCommand(GetAction getAction) {
+            this.getAction = getAction;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Optional<Release> releaseOpt = resolveRelease(getAction, releaseName, namespace, revision);
+                if (releaseOpt.isEmpty()) {
+                    log.error("Error: release not found: {}", releaseName);
+                    return;
+                }
+                String hooks = getAction.getHooks(releaseOpt.get());
+                if (hooks.isEmpty()) {
+                    System.out.println("No hooks found for release");
+                } else {
+                    System.out.println(hooks);
+                }
+            } catch (Exception e) {
+                log.error("Error getting hooks: {}", e.getMessage());
+            }
+        }
+    }
+
+    @Component
+    @CommandLine.Command(name = "metadata", description = "Download the metadata for a named release")
+    @Slf4j
+    public static class MetadataCommand implements Runnable {
+        private final GetAction getAction;
+
+        @CommandLine.Parameters(index = "0", description = "release name")
+        String releaseName;
+
+        @CommandLine.Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "namespace")
+        String namespace;
+
+        @CommandLine.Option(names = {"--revision"}, defaultValue = "-1", description = "get the named release with revision")
+        int revision;
+
+        @CommandLine.Option(names = {"-o", "--output"}, defaultValue = "yaml", description = "output format (yaml or json)")
+        String output;
+
+        public MetadataCommand(GetAction getAction) {
+            this.getAction = getAction;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Optional<Release> releaseOpt = resolveRelease(getAction, releaseName, namespace, revision);
+                if (releaseOpt.isEmpty()) {
+                    log.error("Error: release not found: {}", releaseName);
+                    return;
+                }
+                Map<String, Object> metadata = getAction.getMetadata(releaseOpt.get());
+                if ("json".equalsIgnoreCase(output)) {
+                    System.out.println(getAction.toJson(metadata));
+                } else {
+                    System.out.println(getAction.toYaml(metadata));
+                }
+            } catch (Exception e) {
+                log.error("Error getting metadata: {}", e.getMessage());
+            }
+        }
+    }
+
+    @Component
+    @CommandLine.Command(name = "all", description = "Download all information for a named release")
+    @Slf4j
+    public static class AllCommand implements Runnable {
+        private final GetAction getAction;
+
+        @CommandLine.Parameters(index = "0", description = "release name")
+        String releaseName;
+
+        @CommandLine.Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "namespace")
+        String namespace;
+
+        @CommandLine.Option(names = {"--revision"}, defaultValue = "-1", description = "get the named release with revision")
+        int revision;
+
+        public AllCommand(GetAction getAction) {
+            this.getAction = getAction;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Optional<Release> releaseOpt = resolveRelease(getAction, releaseName, namespace, revision);
+                if (releaseOpt.isEmpty()) {
+                    log.error("Error: release not found: {}", releaseName);
+                    return;
+                }
+                System.out.println(getAction.getAll(releaseOpt.get(), false));
+            } catch (Exception e) {
+                log.error("Error getting release info: {}", e.getMessage());
+            }
+        }
+    }
+}

--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
@@ -19,6 +19,7 @@ import picocli.CommandLine;
                 StatusCommand.class,
                 RollbackCommand.class,
                 ShowCommand.class,
+                GetCommand.class,
                 DependencyCommand.class
         })
 public class JHelmCommand implements Runnable {

--- a/jhelm-app/src/test/java/org/alexmond/jhelm/app/GetCommandTest.java
+++ b/jhelm-app/src/test/java/org/alexmond/jhelm/app/GetCommandTest.java
@@ -1,0 +1,344 @@
+package org.alexmond.jhelm.app;
+
+import org.alexmond.jhelm.core.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+class GetCommandTest {
+
+    @Mock
+    private GetAction getAction;
+
+    private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        System.setOut(new PrintStream(outputStream));
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(originalOut);
+    }
+
+    @Test
+    void testGetCommandShowsUsage() {
+        GetCommand getCommand = new GetCommand();
+        getCommand.run();
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("get") || output.contains("Usage"));
+    }
+
+    @Test
+    void testValuesCommand() throws Exception {
+        Release release = createRelease();
+        when(getAction.getRelease("my-release", "default")).thenReturn(Optional.of(release));
+        when(getAction.getValues(release, false)).thenReturn("key: value\n");
+
+        GetCommand.ValuesCommand cmd = new GetCommand.ValuesCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+
+        assertTrue(outputStream.toString().contains("key: value"));
+    }
+
+    @Test
+    void testValuesCommandWithAllFlag() throws Exception {
+        Release release = createRelease();
+        when(getAction.getRelease("my-release", "default")).thenReturn(Optional.of(release));
+        when(getAction.getValues(release, true)).thenReturn("merged: values\n");
+
+        GetCommand.ValuesCommand cmd = new GetCommand.ValuesCommand(getAction);
+        new CommandLine(cmd).execute("my-release", "--all");
+
+        assertTrue(outputStream.toString().contains("merged: values"));
+    }
+
+    @Test
+    void testValuesCommandJsonOutput() throws Exception {
+        Release release = createReleaseWithConfig();
+        when(getAction.getRelease("my-release", "default")).thenReturn(Optional.of(release));
+        when(getAction.toJson(any())).thenReturn("{\"key\": \"value\"}");
+
+        GetCommand.ValuesCommand cmd = new GetCommand.ValuesCommand(getAction);
+        new CommandLine(cmd).execute("my-release", "-o", "json");
+
+        assertTrue(outputStream.toString().contains("{\"key\": \"value\"}"));
+    }
+
+    @Test
+    void testValuesCommandNotFound() throws Exception {
+        when(getAction.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
+
+        GetCommand.ValuesCommand cmd = new GetCommand.ValuesCommand(getAction);
+        new CommandLine(cmd).execute("missing");
+
+        // error logged, no output
+    }
+
+    @Test
+    void testValuesCommandWithError() throws Exception {
+        when(getAction.getRelease(anyString(), anyString())).thenThrow(new RuntimeException("fail"));
+
+        GetCommand.ValuesCommand cmd = new GetCommand.ValuesCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+    }
+
+    @Test
+    void testManifestCommand() throws Exception {
+        Release release = createRelease();
+        when(getAction.getRelease("my-release", "default")).thenReturn(Optional.of(release));
+        when(getAction.getManifest(release)).thenReturn("---\nkind: Service\n");
+
+        GetCommand.ManifestCommand cmd = new GetCommand.ManifestCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+
+        assertTrue(outputStream.toString().contains("kind: Service"));
+    }
+
+    @Test
+    void testManifestCommandNotFound() throws Exception {
+        when(getAction.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
+
+        GetCommand.ManifestCommand cmd = new GetCommand.ManifestCommand(getAction);
+        new CommandLine(cmd).execute("missing");
+    }
+
+    @Test
+    void testManifestCommandWithError() throws Exception {
+        when(getAction.getRelease(anyString(), anyString())).thenThrow(new RuntimeException("fail"));
+
+        GetCommand.ManifestCommand cmd = new GetCommand.ManifestCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+    }
+
+    @Test
+    void testNotesCommand() throws Exception {
+        Release release = createRelease();
+        when(getAction.getRelease("my-release", "default")).thenReturn(Optional.of(release));
+        when(getAction.getNotes(release)).thenReturn("Thank you for installing.");
+
+        GetCommand.NotesCommand cmd = new GetCommand.NotesCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+
+        assertTrue(outputStream.toString().contains("Thank you for installing."));
+    }
+
+    @Test
+    void testNotesCommandEmpty() throws Exception {
+        Release release = createRelease();
+        when(getAction.getRelease("my-release", "default")).thenReturn(Optional.of(release));
+        when(getAction.getNotes(release)).thenReturn("");
+
+        GetCommand.NotesCommand cmd = new GetCommand.NotesCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+
+        assertTrue(outputStream.toString().contains("No notes found"));
+    }
+
+    @Test
+    void testNotesCommandNotFound() throws Exception {
+        when(getAction.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
+
+        GetCommand.NotesCommand cmd = new GetCommand.NotesCommand(getAction);
+        new CommandLine(cmd).execute("missing");
+    }
+
+    @Test
+    void testNotesCommandWithError() throws Exception {
+        when(getAction.getRelease(anyString(), anyString())).thenThrow(new RuntimeException("fail"));
+
+        GetCommand.NotesCommand cmd = new GetCommand.NotesCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+    }
+
+    @Test
+    void testHooksCommand() throws Exception {
+        Release release = createRelease();
+        when(getAction.getRelease("my-release", "default")).thenReturn(Optional.of(release));
+        when(getAction.getHooks(release)).thenReturn("kind: Job\nannotations:\n  helm.sh/hook: pre-install\n");
+
+        GetCommand.HooksCommand cmd = new GetCommand.HooksCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+
+        assertTrue(outputStream.toString().contains("helm.sh/hook"));
+    }
+
+    @Test
+    void testHooksCommandEmpty() throws Exception {
+        Release release = createRelease();
+        when(getAction.getRelease("my-release", "default")).thenReturn(Optional.of(release));
+        when(getAction.getHooks(release)).thenReturn("");
+
+        GetCommand.HooksCommand cmd = new GetCommand.HooksCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+
+        assertTrue(outputStream.toString().contains("No hooks found"));
+    }
+
+    @Test
+    void testHooksCommandNotFound() throws Exception {
+        when(getAction.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
+
+        GetCommand.HooksCommand cmd = new GetCommand.HooksCommand(getAction);
+        new CommandLine(cmd).execute("missing");
+    }
+
+    @Test
+    void testHooksCommandWithError() throws Exception {
+        when(getAction.getRelease(anyString(), anyString())).thenThrow(new RuntimeException("fail"));
+
+        GetCommand.HooksCommand cmd = new GetCommand.HooksCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+    }
+
+    @Test
+    void testMetadataCommand() throws Exception {
+        Release release = createRelease();
+        when(getAction.getRelease("my-release", "default")).thenReturn(Optional.of(release));
+        when(getAction.getMetadata(release)).thenReturn(Map.of("name", "my-release", "status", "deployed"));
+        when(getAction.toYaml(any())).thenReturn("name: my-release\nstatus: deployed\n");
+
+        GetCommand.MetadataCommand cmd = new GetCommand.MetadataCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+
+        assertTrue(outputStream.toString().contains("name: my-release"));
+    }
+
+    @Test
+    void testMetadataCommandJsonOutput() throws Exception {
+        Release release = createRelease();
+        when(getAction.getRelease("my-release", "default")).thenReturn(Optional.of(release));
+        when(getAction.getMetadata(release)).thenReturn(Map.of("name", "my-release"));
+        when(getAction.toJson(any())).thenReturn("{\"name\":\"my-release\"}");
+
+        GetCommand.MetadataCommand cmd = new GetCommand.MetadataCommand(getAction);
+        new CommandLine(cmd).execute("my-release", "-o", "json");
+
+        assertTrue(outputStream.toString().contains("{\"name\":\"my-release\"}"));
+    }
+
+    @Test
+    void testMetadataCommandNotFound() throws Exception {
+        when(getAction.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
+
+        GetCommand.MetadataCommand cmd = new GetCommand.MetadataCommand(getAction);
+        new CommandLine(cmd).execute("missing");
+    }
+
+    @Test
+    void testMetadataCommandWithError() throws Exception {
+        when(getAction.getRelease(anyString(), anyString())).thenThrow(new RuntimeException("fail"));
+
+        GetCommand.MetadataCommand cmd = new GetCommand.MetadataCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+    }
+
+    @Test
+    void testAllCommand() throws Exception {
+        Release release = createRelease();
+        when(getAction.getRelease("my-release", "default")).thenReturn(Optional.of(release));
+        when(getAction.getAll(release, false)).thenReturn("MANIFEST:\n---\nVALUES:\n{}");
+
+        GetCommand.AllCommand cmd = new GetCommand.AllCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("MANIFEST:"));
+        assertTrue(output.contains("VALUES:"));
+    }
+
+    @Test
+    void testAllCommandNotFound() throws Exception {
+        when(getAction.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
+
+        GetCommand.AllCommand cmd = new GetCommand.AllCommand(getAction);
+        new CommandLine(cmd).execute("missing");
+    }
+
+    @Test
+    void testAllCommandWithError() throws Exception {
+        when(getAction.getRelease(anyString(), anyString())).thenThrow(new RuntimeException("fail"));
+
+        GetCommand.AllCommand cmd = new GetCommand.AllCommand(getAction);
+        new CommandLine(cmd).execute("my-release");
+    }
+
+    @Test
+    void testSubcommandWithRevision() throws Exception {
+        Release release = createRelease();
+        when(getAction.getReleaseByRevision("my-release", "default", 2)).thenReturn(Optional.of(release));
+        when(getAction.getManifest(release)).thenReturn("---\nkind: Deployment\n");
+
+        GetCommand.ManifestCommand cmd = new GetCommand.ManifestCommand(getAction);
+        new CommandLine(cmd).execute("my-release", "--revision", "2");
+
+        assertTrue(outputStream.toString().contains("kind: Deployment"));
+    }
+
+    @Test
+    void testSubcommandWithNamespace() throws Exception {
+        Release release = createRelease();
+        when(getAction.getRelease("my-release", "prod")).thenReturn(Optional.of(release));
+        when(getAction.getManifest(release)).thenReturn("---\nkind: Service\n");
+
+        GetCommand.ManifestCommand cmd = new GetCommand.ManifestCommand(getAction);
+        new CommandLine(cmd).execute("my-release", "-n", "prod");
+
+        assertTrue(outputStream.toString().contains("kind: Service"));
+    }
+
+    private Release createRelease() {
+        ChartMetadata metadata = ChartMetadata.builder()
+                .name("test-chart")
+                .version("1.0.0")
+                .build();
+
+        Chart chart = Chart.builder()
+                .metadata(metadata)
+                .build();
+
+        Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+                .status("deployed")
+                .lastDeployed(OffsetDateTime.now())
+                .build();
+
+        return Release.builder()
+                .name("my-release")
+                .namespace("default")
+                .version(1)
+                .chart(chart)
+                .info(info)
+                .manifest("---\nkind: Service\n")
+                .build();
+    }
+
+    private Release createReleaseWithConfig() {
+        Release release = createRelease();
+        release.setConfig(Release.MapConfig.builder()
+                .values(Map.of("key", "value"))
+                .build());
+        return release;
+    }
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/CoreConfig.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/CoreConfig.java
@@ -67,6 +67,11 @@ public class CoreConfig {
     }
 
     @Bean
+    public GetAction getAction(KubeService kubeService) {
+        return new GetAction(kubeService);
+    }
+
+    @Bean
     public ShowAction showAction(ChartLoader chartLoader) {
         return new ShowAction(chartLoader);
     }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/GetAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/GetAction.java
@@ -1,0 +1,134 @@
+package org.alexmond.jhelm.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import lombok.RequiredArgsConstructor;
+
+import java.util.*;
+
+@RequiredArgsConstructor
+public class GetAction {
+
+    private final KubeService kubeService;
+
+    public Optional<Release> getRelease(String name, String namespace) throws Exception {
+        return kubeService.getRelease(name, namespace);
+    }
+
+    public Optional<Release> getReleaseByRevision(String name, String namespace, int revision) throws Exception {
+        List<Release> history = kubeService.getReleaseHistory(name, namespace);
+        return history.stream()
+                .filter(r -> r.getVersion() == revision)
+                .findFirst();
+    }
+
+    public String getValues(Release release, boolean all) throws Exception {
+        if (all && release.getChart() != null && release.getChart().getValues() != null) {
+            Map<String, Object> merged = new LinkedHashMap<>(release.getChart().getValues());
+            if (release.getConfig() != null && release.getConfig().getValues() != null) {
+                merged.putAll(release.getConfig().getValues());
+            }
+            return toYaml(merged);
+        }
+        if (release.getConfig() == null || release.getConfig().getValues() == null
+                || release.getConfig().getValues().isEmpty()) {
+            return "{}";
+        }
+        return toYaml(release.getConfig().getValues());
+    }
+
+    public String getManifest(Release release) {
+        return release.getManifest() != null ? release.getManifest() : "";
+    }
+
+    public String getNotes(Release release) {
+        if (release.getInfo() != null && release.getInfo().getNotes() != null) {
+            return release.getInfo().getNotes();
+        }
+        return "";
+    }
+
+    public String getHooks(Release release) {
+        if (release.getManifest() == null || release.getManifest().isEmpty()) {
+            return "";
+        }
+        String[] docs = release.getManifest().split("---");
+        StringBuilder hooks = new StringBuilder();
+        for (String doc : docs) {
+            if (doc.trim().isEmpty()) {
+                continue;
+            }
+            if (doc.contains("helm.sh/hook")) {
+                if (!hooks.isEmpty()) {
+                    hooks.append("---\n");
+                }
+                hooks.append(doc.trim()).append("\n");
+            }
+        }
+        return hooks.toString();
+    }
+
+    public Map<String, Object> getMetadata(Release release) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("name", release.getName());
+        metadata.put("namespace", release.getNamespace());
+        metadata.put("revision", release.getVersion());
+        if (release.getChart() != null && release.getChart().getMetadata() != null) {
+            ChartMetadata cm = release.getChart().getMetadata();
+            metadata.put("chart", cm.getName() + "-" + cm.getVersion());
+            metadata.put("appVersion", cm.getAppVersion());
+        }
+        if (release.getInfo() != null) {
+            metadata.put("status", release.getInfo().getStatus());
+            metadata.put("deployedAt", release.getInfo().getLastDeployed());
+        }
+        return metadata;
+    }
+
+    public String getAll(Release release, boolean allValues) throws Exception {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("MANIFEST:\n");
+        sb.append(getManifest(release));
+        if (!getManifest(release).endsWith("\n")) {
+            sb.append("\n");
+        }
+
+        String hooks = getHooks(release);
+        if (!hooks.isEmpty()) {
+            sb.append("\nHOOKS:\n");
+            sb.append(hooks);
+        }
+
+        String notes = getNotes(release);
+        if (!notes.isEmpty()) {
+            sb.append("\nNOTES:\n");
+            sb.append(notes);
+            if (!notes.endsWith("\n")) {
+                sb.append("\n");
+            }
+        }
+
+        sb.append("\nVALUES:\n");
+        sb.append(getValues(release, allValues));
+
+        return sb.toString();
+    }
+
+    public String toYaml(Object obj) throws Exception {
+        YAMLFactory yamlFactory = YAMLFactory.builder()
+                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+                .build();
+        ObjectMapper yamlMapper = new ObjectMapper(yamlFactory);
+        return yamlMapper.writeValueAsString(obj);
+    }
+
+    public String toJson(Object obj) throws Exception {
+        ObjectMapper jsonMapper = new ObjectMapper();
+        jsonMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        return jsonMapper.writeValueAsString(obj);
+    }
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/Release.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/Release.java
@@ -30,6 +30,7 @@ public class Release {
         private OffsetDateTime deleted;
         private String description;
         private String status; // e.g., "deployed", "uninstalled"
+        private String notes;
     }
 
     @Data

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/GetActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/GetActionTest.java
@@ -1,0 +1,359 @@
+package org.alexmond.jhelm.core;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+class GetActionTest {
+
+    @Mock
+    private KubeService kubeService;
+
+    private GetAction getAction;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        getAction = new GetAction(kubeService);
+    }
+
+    @Test
+    void testGetRelease() throws Exception {
+        Release release = createRelease();
+        when(kubeService.getRelease("my-release", "default")).thenReturn(Optional.of(release));
+
+        Optional<Release> result = getAction.getRelease("my-release", "default");
+
+        assertTrue(result.isPresent());
+        assertEquals("my-release", result.get().getName());
+    }
+
+    @Test
+    void testGetReleaseNotFound() throws Exception {
+        when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
+
+        Optional<Release> result = getAction.getRelease("missing", "default");
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void testGetReleaseByRevision() throws Exception {
+        Release v1 = createReleaseWithVersion(1);
+        Release v2 = createReleaseWithVersion(2);
+        when(kubeService.getReleaseHistory("my-release", "default")).thenReturn(List.of(v1, v2));
+
+        Optional<Release> result = getAction.getReleaseByRevision("my-release", "default", 2);
+
+        assertTrue(result.isPresent());
+        assertEquals(2, result.get().getVersion());
+    }
+
+    @Test
+    void testGetReleaseByRevisionNotFound() throws Exception {
+        Release v1 = createReleaseWithVersion(1);
+        when(kubeService.getReleaseHistory("my-release", "default")).thenReturn(List.of(v1));
+
+        Optional<Release> result = getAction.getReleaseByRevision("my-release", "default", 99);
+
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void testGetValuesUserOnly() throws Exception {
+        Release release = createReleaseWithValues();
+
+        String values = getAction.getValues(release, false);
+
+        assertTrue(values.contains("key1: userVal1"));
+    }
+
+    @Test
+    void testGetValuesAllMerged() throws Exception {
+        Release release = createReleaseWithValues();
+
+        String values = getAction.getValues(release, true);
+
+        assertTrue(values.contains("key1: userVal1"));
+        assertTrue(values.contains("chartDefault: defaultVal"));
+    }
+
+    @Test
+    void testGetValuesEmptyConfig() throws Exception {
+        Release release = createRelease();
+
+        String values = getAction.getValues(release, false);
+
+        assertEquals("{}", values);
+    }
+
+    @Test
+    void testGetValuesAllWithNullConfig() throws Exception {
+        Release release = Release.builder()
+                .name("my-release")
+                .chart(Chart.builder()
+                        .metadata(ChartMetadata.builder().name("test").version("1.0.0").build())
+                        .values(Map.of("chartKey", "chartVal"))
+                        .build())
+                .build();
+
+        String values = getAction.getValues(release, true);
+
+        assertTrue(values.contains("chartKey: chartVal"));
+    }
+
+    @Test
+    void testGetManifest() {
+        Release release = createRelease();
+
+        String manifest = getAction.getManifest(release);
+
+        assertEquals("---\nkind: Service\nmetadata:\n  name: my-svc\n", manifest);
+    }
+
+    @Test
+    void testGetManifestNull() {
+        Release release = Release.builder().name("empty").build();
+
+        String manifest = getAction.getManifest(release);
+
+        assertEquals("", manifest);
+    }
+
+    @Test
+    void testGetNotes() {
+        Release release = createReleaseWithNotes();
+
+        String notes = getAction.getNotes(release);
+
+        assertEquals("Thank you for installing test-chart.", notes);
+    }
+
+    @Test
+    void testGetNotesEmpty() {
+        Release release = createRelease();
+
+        String notes = getAction.getNotes(release);
+
+        assertEquals("", notes);
+    }
+
+    @Test
+    void testGetNotesNullInfo() {
+        Release release = Release.builder().name("no-info").build();
+
+        String notes = getAction.getNotes(release);
+
+        assertEquals("", notes);
+    }
+
+    @Test
+    void testGetHooks() {
+        String manifest = """
+                ---
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: my-config
+                ---
+                apiVersion: batch/v1
+                kind: Job
+                metadata:
+                  name: my-hook
+                  annotations:
+                    helm.sh/hook: pre-install
+                ---
+                apiVersion: v1
+                kind: Service
+                metadata:
+                  name: my-svc
+                """;
+        Release release = Release.builder().name("test").manifest(manifest).build();
+
+        String hooks = getAction.getHooks(release);
+
+        assertTrue(hooks.contains("helm.sh/hook: pre-install"));
+        assertTrue(hooks.contains("kind: Job"));
+        assertFalse(hooks.contains("kind: ConfigMap"));
+        assertFalse(hooks.contains("kind: Service"));
+    }
+
+    @Test
+    void testGetHooksNone() {
+        Release release = Release.builder()
+                .name("test")
+                .manifest("---\nkind: Service\n")
+                .build();
+
+        String hooks = getAction.getHooks(release);
+
+        assertEquals("", hooks);
+    }
+
+    @Test
+    void testGetHooksEmptyManifest() {
+        Release release = Release.builder().name("test").manifest("").build();
+
+        assertEquals("", getAction.getHooks(release));
+    }
+
+    @Test
+    void testGetHooksNullManifest() {
+        Release release = Release.builder().name("test").build();
+
+        assertEquals("", getAction.getHooks(release));
+    }
+
+    @Test
+    void testGetMetadata() {
+        Release release = createRelease();
+
+        Map<String, Object> metadata = getAction.getMetadata(release);
+
+        assertEquals("my-release", metadata.get("name"));
+        assertEquals("default", metadata.get("namespace"));
+        assertEquals(1, metadata.get("revision"));
+        assertEquals("test-chart-1.0.0", metadata.get("chart"));
+        assertEquals("deployed", metadata.get("status"));
+    }
+
+    @Test
+    void testGetMetadataMinimal() {
+        Release release = Release.builder()
+                .name("minimal")
+                .namespace("ns")
+                .version(3)
+                .build();
+
+        Map<String, Object> metadata = getAction.getMetadata(release);
+
+        assertEquals("minimal", metadata.get("name"));
+        assertEquals("ns", metadata.get("namespace"));
+        assertEquals(3, metadata.get("revision"));
+        assertFalse(metadata.containsKey("chart"));
+        assertFalse(metadata.containsKey("status"));
+    }
+
+    @Test
+    void testGetAll() throws Exception {
+        Release release = createReleaseWithNotes();
+
+        String all = getAction.getAll(release, false);
+
+        assertTrue(all.contains("MANIFEST:"));
+        assertTrue(all.contains("NOTES:"));
+        assertTrue(all.contains("VALUES:"));
+    }
+
+    @Test
+    void testGetAllWithHooks() throws Exception {
+        String manifest = """
+                ---
+                apiVersion: v1
+                kind: Service
+                metadata:
+                  name: my-svc
+                ---
+                apiVersion: batch/v1
+                kind: Job
+                metadata:
+                  annotations:
+                    helm.sh/hook: pre-install
+                """;
+        Release release = Release.builder()
+                .name("test")
+                .manifest(manifest)
+                .info(Release.ReleaseInfo.builder().status("deployed").build())
+                .build();
+
+        String all = getAction.getAll(release, false);
+
+        assertTrue(all.contains("MANIFEST:"));
+        assertTrue(all.contains("HOOKS:"));
+        assertTrue(all.contains("VALUES:"));
+    }
+
+    @Test
+    void testToYaml() throws Exception {
+        String yaml = getAction.toYaml(Map.of("key", "value"));
+        assertTrue(yaml.contains("key: value"));
+    }
+
+    @Test
+    void testToJson() throws Exception {
+        String json = getAction.toJson(Map.of("key", "value"));
+        assertTrue(json.contains("\"key\""));
+        assertTrue(json.contains("\"value\""));
+    }
+
+    private Release createRelease() {
+        return Release.builder()
+                .name("my-release")
+                .namespace("default")
+                .version(1)
+                .chart(Chart.builder()
+                        .metadata(ChartMetadata.builder()
+                                .name("test-chart")
+                                .version("1.0.0")
+                                .appVersion("1.0")
+                                .build())
+                        .build())
+                .info(Release.ReleaseInfo.builder()
+                        .status("deployed")
+                        .lastDeployed(OffsetDateTime.now())
+                        .build())
+                .manifest("---\nkind: Service\nmetadata:\n  name: my-svc\n")
+                .build();
+    }
+
+    private Release createReleaseWithVersion(int version) {
+        return Release.builder()
+                .name("my-release")
+                .namespace("default")
+                .version(version)
+                .info(Release.ReleaseInfo.builder().status("deployed").build())
+                .build();
+    }
+
+    private Release createReleaseWithValues() {
+        return Release.builder()
+                .name("my-release")
+                .namespace("default")
+                .version(1)
+                .chart(Chart.builder()
+                        .metadata(ChartMetadata.builder().name("test").version("1.0.0").build())
+                        .values(Map.of("chartDefault", "defaultVal", "key1", "chartVal1"))
+                        .build())
+                .config(Release.MapConfig.builder()
+                        .values(Map.of("key1", "userVal1"))
+                        .build())
+                .info(Release.ReleaseInfo.builder().status("deployed").build())
+                .build();
+    }
+
+    private Release createReleaseWithNotes() {
+        return Release.builder()
+                .name("my-release")
+                .namespace("default")
+                .version(1)
+                .chart(Chart.builder()
+                        .metadata(ChartMetadata.builder().name("test-chart").version("1.0.0").build())
+                        .build())
+                .info(Release.ReleaseInfo.builder()
+                        .status("deployed")
+                        .notes("Thank you for installing test-chart.")
+                        .build())
+                .manifest("---\nkind: Service\n")
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #33

- Add `GetAction` in `jhelm-core` with methods to retrieve release values, manifest, notes, hooks, metadata, and combined output
- Add `GetCommand` in `jhelm-app` with 6 subcommands: `values`, `manifest`, `notes`, `hooks`, `metadata`, `all`
- Add `notes` field to `Release.ReleaseInfo` for storing rendered NOTES.txt content
- Wire `GetAction` bean in `CoreConfig` and register `GetCommand` in `JHelmCommand`

### Subcommands

| Subcommand | Description | Extra Options |
|---|---|---|
| `get values` | User-supplied values (or merged with `--all`) | `--all`, `-o yaml/json` |
| `get manifest` | Rendered Kubernetes manifests | — |
| `get notes` | Release notes (NOTES.txt) | — |
| `get hooks` | Manifests with `helm.sh/hook` annotations | — |
| `get metadata` | Release name, chart, version, status, timestamps | `-o yaml/json` |
| `get all` | Combined output of all sections | — |

All subcommands support `--namespace` and `--revision` options.

### Files Changed

**New files:**
- `jhelm-core/src/main/java/.../GetAction.java` — Action class with release retrieval and formatting logic
- `jhelm-app/src/main/java/.../GetCommand.java` — Parent command with 6 static inner class subcommands
- `jhelm-core/src/test/java/.../GetActionTest.java` — 23 unit tests
- `jhelm-app/src/test/java/.../GetCommandTest.java` — 26 unit tests

**Modified files:**
- `Release.java` — Added `notes` field to `ReleaseInfo`
- `CoreConfig.java` — Added `GetAction` bean
- `JHelmCommand.java` — Registered `GetCommand` subcommand

## Test plan

- [x] `GetActionTest` — 23 tests covering all action methods (values merge, hooks extraction, metadata, revision lookup, edge cases)
- [x] `GetCommandTest` — 26 tests covering all 6 subcommands (success, not-found, error, revision, namespace, output formats)
- [x] Full build passes: `./mvnw clean test` — 121 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)