### PR TITLE
Replace GET+replace apply strategy with Server-Side Apply (#4)

### DIFF
--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/HelmKubeService.java
@@ -4,13 +4,14 @@ import tools.jackson.databind.json.JsonMapper;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapList;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1PodList;
-import io.kubernetes.client.openapi.models.V1Secret;
+import io.kubernetes.client.util.PatchUtils;
 import io.kubernetes.client.util.Yaml;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -207,118 +208,21 @@ public class HelmKubeService implements KubeService {
 
 		log.info("Applying {} ({}/{}) {} in namespace {}", kind, group, version, name, namespace);
 
-		if (group.isEmpty() && version.equals("v1")) {
-			applyCoreResource(namespace, kind, name, obj);
-			return;
-		}
-
-		// We use CustomObjectsApi for generic resource handling
+		V1Patch patch = new V1Patch(Yaml.dump(obj));
 		CustomObjectsApi api = new CustomObjectsApi(apiClient);
 
-		try {
+		PatchUtils.patch(Object.class, () -> {
 			if (namespace != null && !namespace.isEmpty()) {
-				api.getNamespacedCustomObject(group, version, namespace, plural, name);
-				api.replaceNamespacedCustomObject(group, version, namespace, plural, name, obj);
+				return api.patchNamespacedCustomObject(group, version, namespace, plural, name, patch)
+					.fieldManager("helm")
+					.force(true)
+					.buildCall(null);
 			}
-			else {
-				api.getClusterCustomObject(group, version, plural, name).execute();
-				api.replaceClusterCustomObject(group, version, plural, name, obj).execute();
-			}
-		}
-		catch (Exception ex) {
-			if (ex instanceof ApiException ae && ae.getCode() == 404) {
-				try {
-					if (namespace != null && !namespace.isEmpty()) {
-						api.createNamespacedCustomObject(group, version, namespace, plural, obj);
-					}
-					else {
-						api.createClusterCustomObject(group, version, plural, obj).execute();
-					}
-				}
-				catch (Exception ce) {
-					log.error("Create failed for {}: {}", kind,
-							(ce instanceof ApiException cae) ? cae.getResponseBody() : ce.getMessage());
-					throw ce;
-				}
-			}
-			else {
-				log.error("Apply failed for {}: {}", kind,
-						(ex instanceof ApiException ae2) ? ae2.getResponseBody() : ex.getMessage());
-				throw ex;
-			}
-		}
-	}
-
-	private void applyCoreResource(String namespace, String kind, String name, KubernetesObject obj)
-			throws ApiException {
-		CoreV1Api api = new CoreV1Api(apiClient);
-		String yaml = Yaml.dump(obj);
-
-		switch (kind) {
-			case "ConfigMap" -> {
-				V1ConfigMap cm = Yaml.loadAs(yaml, V1ConfigMap.class);
-				try {
-					api.readNamespacedConfigMap(name, namespace).execute();
-					api.replaceNamespacedConfigMap(name, namespace, cm).execute();
-				}
-				catch (Exception ex) {
-					if (ex instanceof ApiException ae && ae.getCode() == 404) {
-						api.createNamespacedConfigMap(namespace, cm).execute();
-					}
-					else {
-						throw ex;
-					}
-				}
-			}
-			case "Service" -> {
-				io.kubernetes.client.openapi.models.V1Service svc = Yaml.loadAs(yaml,
-						io.kubernetes.client.openapi.models.V1Service.class);
-				try {
-					api.readNamespacedService(name, namespace).execute();
-					api.replaceNamespacedService(name, namespace, svc).execute();
-				}
-				catch (Exception ex) {
-					if (ex instanceof ApiException ae && ae.getCode() == 404) {
-						api.createNamespacedService(namespace, svc).execute();
-					}
-					else {
-						throw ex;
-					}
-				}
-			}
-			case "Secret" -> {
-				V1Secret secret = Yaml.loadAs(yaml, V1Secret.class);
-				try {
-					api.readNamespacedSecret(name, namespace).execute();
-					api.replaceNamespacedSecret(name, namespace, secret).execute();
-				}
-				catch (Exception ex) {
-					if (ex instanceof ApiException ae && ae.getCode() == 404) {
-						api.createNamespacedSecret(namespace, secret).execute();
-					}
-					else {
-						throw ex;
-					}
-				}
-			}
-			default -> {
-				// Fallback to CustomObjectsApi if not explicitly handled
-				CustomObjectsApi coa = new CustomObjectsApi(apiClient);
-				String plural = inferPlural(kind);
-				try {
-					coa.getNamespacedCustomObject("", "v1", namespace, plural, name).execute();
-					coa.replaceNamespacedCustomObject("", "v1", namespace, plural, name, obj).execute();
-				}
-				catch (Exception ex) {
-					if (ex instanceof ApiException ae && ae.getCode() == 404) {
-						coa.createNamespacedCustomObject("", "v1", namespace, plural, obj).execute();
-					}
-					else {
-						throw ex;
-					}
-				}
-			}
-		}
+			return api.patchClusterCustomObject(group, version, plural, name, patch)
+				.fieldManager("helm")
+				.force(true)
+				.buildCall(null);
+		}, V1Patch.PATCH_FORMAT_APPLY_YAML, apiClient);
 	}
 
 	/**

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/HelmKubeServiceTest.java
@@ -1,6 +1,7 @@
 package org.alexmond.jhelm.kube;
 
 import tools.jackson.databind.json.JsonMapper;
+import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiClient;
 import java.util.Base64;
 import io.kubernetes.client.openapi.ApiException;
@@ -11,8 +12,7 @@ import io.kubernetes.client.openapi.models.V1ConfigMapList;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
-import io.kubernetes.client.openapi.models.V1Secret;
-import io.kubernetes.client.openapi.models.V1Service;
+import io.kubernetes.client.util.PatchUtils;
 import org.alexmond.jhelm.core.Release;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
 import java.time.OffsetDateTime;
@@ -39,9 +40,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.mockConstruction;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mockStatic;
 
 class HelmKubeServiceTest {
 
@@ -56,9 +55,15 @@ class HelmKubeServiceTest {
 
 	private MockedConstruction<CustomObjectsApi> customObjectsApiConstruction;
 
+	private MockedStatic<PatchUtils> patchUtilsMock;
+
 	private CoreV1Api mockCoreV1Api;
 
 	private CustomObjectsApi mockCustomObjectsApi;
+
+	private CustomObjectsApi.APIpatchNamespacedCustomObjectRequest mockPatchRequest;
+
+	private CustomObjectsApi.APIpatchClusterCustomObjectRequest mockClusterPatchRequest;
 
 	@BeforeEach
 	void setUp() {
@@ -73,6 +78,9 @@ class HelmKubeServiceTest {
 		}
 		if (customObjectsApiConstruction != null) {
 			customObjectsApiConstruction.close();
+		}
+		if (patchUtilsMock != null) {
+			patchUtilsMock.close();
 		}
 	}
 
@@ -109,6 +117,32 @@ class HelmKubeServiceTest {
 		when(listReq.labelSelector(anyString())).thenReturn(listReq);
 		when(listReq.execute()).thenReturn(list);
 		when(mock.listNamespacedConfigMap(anyString())).thenReturn(listReq);
+	}
+
+	private void setupSsaMock() {
+		customObjectsApiConstruction = mockConstruction(CustomObjectsApi.class, (mock, ctx) -> {
+			mockCustomObjectsApi = mock;
+
+			mockPatchRequest = mock(CustomObjectsApi.APIpatchNamespacedCustomObjectRequest.class);
+			when(mockPatchRequest.fieldManager(anyString())).thenReturn(mockPatchRequest);
+			when(mockPatchRequest.force(any(Boolean.class))).thenReturn(mockPatchRequest);
+			when(mockPatchRequest.buildCall(any())).thenReturn(null);
+			when(mock.patchNamespacedCustomObject(any(), any(), any(), any(), any(), any()))
+				.thenReturn(mockPatchRequest);
+
+			mockClusterPatchRequest = mock(CustomObjectsApi.APIpatchClusterCustomObjectRequest.class);
+			when(mockClusterPatchRequest.fieldManager(anyString())).thenReturn(mockClusterPatchRequest);
+			when(mockClusterPatchRequest.force(any(Boolean.class))).thenReturn(mockClusterPatchRequest);
+			when(mockClusterPatchRequest.buildCall(any())).thenReturn(null);
+			when(mock.patchClusterCustomObject(any(), any(), any(), any(), any())).thenReturn(mockClusterPatchRequest);
+		});
+
+		patchUtilsMock = mockStatic(PatchUtils.class);
+		patchUtilsMock.when(() -> PatchUtils.patch(any(), any(), anyString(), any())).thenAnswer((invocation) -> {
+			PatchUtils.PatchCallFunc func = invocation.getArgument(1);
+			func.getCall();
+			return null;
+		});
 	}
 
 	// --- storeRelease ---
@@ -321,10 +355,31 @@ class HelmKubeServiceTest {
 		assertEquals(List.of("pod-1", "pod-2"), kubeService.listPods("default"));
 	}
 
-	// --- apply ---
+	// --- apply (Server-Side Apply) ---
 
 	@Test
-	void testApplyConfigMapCreatesNew() throws Exception {
+	void testApplyNamespacedResourceUsesSSA() throws Exception {
+		String yaml = """
+				apiVersion: apps/v1
+				kind: Deployment
+				metadata:
+				  name: my-deploy
+				  namespace: default
+				spec:
+				  replicas: 1
+				""";
+
+		setupSsaMock();
+		kubeService.apply("default", yaml);
+
+		verify(mockCustomObjectsApi).patchNamespacedCustomObject(eq("apps"), eq("v1"), eq("default"), eq("deployments"),
+				eq("my-deploy"), any(V1Patch.class));
+		verify(mockPatchRequest).fieldManager("helm");
+		verify(mockPatchRequest).force(true);
+	}
+
+	@Test
+	void testApplyCoreV1ResourceUsesSSA() throws Exception {
 		String yaml = """
 				apiVersion: v1
 				kind: ConfigMap
@@ -335,254 +390,59 @@ class HelmKubeServiceTest {
 				  key: value
 				""";
 
-		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
-			mockCoreV1Api = mock;
-			// readNamespacedConfigMap throws 404 -> create
-			var readReq = mock(CoreV1Api.APIreadNamespacedConfigMapRequest.class);
-			when(readReq.execute()).thenThrow(new ApiException(404, "Not found"));
-			when(mock.readNamespacedConfigMap(eq("my-config"), eq("default"))).thenReturn(readReq);
-
-			var createReq = mock(CoreV1Api.APIcreateNamespacedConfigMapRequest.class);
-			when(createReq.execute()).thenReturn(new V1ConfigMap());
-			when(mock.createNamespacedConfigMap(eq("default"), any(V1ConfigMap.class))).thenReturn(createReq);
-		});
-
+		setupSsaMock();
 		kubeService.apply("default", yaml);
-		verify(mockCoreV1Api).createNamespacedConfigMap(eq("default"), any(V1ConfigMap.class));
+
+		verify(mockCustomObjectsApi).patchNamespacedCustomObject(eq(""), eq("v1"), eq("default"), eq("configmaps"),
+				eq("my-config"), any(V1Patch.class));
+		verify(mockPatchRequest).fieldManager("helm");
+		verify(mockPatchRequest).force(true);
 	}
 
 	@Test
-	void testApplyConfigMapReplacesExisting() throws Exception {
+	void testApplyClusterScopedResourceUsesSSA() throws Exception {
 		String yaml = """
 				apiVersion: v1
-				kind: ConfigMap
+				kind: Namespace
 				metadata:
-				  name: my-config
-				  namespace: default
-				data:
-				  key: value
+				  name: my-ns
 				""";
 
-		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
-			mockCoreV1Api = mock;
-			var readReq = mock(CoreV1Api.APIreadNamespacedConfigMapRequest.class);
-			when(readReq.execute()).thenReturn(new V1ConfigMap());
-			when(mock.readNamespacedConfigMap(eq("my-config"), eq("default"))).thenReturn(readReq);
+		setupSsaMock();
+		kubeService.apply("", yaml);
 
-			var replaceReq = mock(CoreV1Api.APIreplaceNamespacedConfigMapRequest.class);
-			when(replaceReq.execute()).thenReturn(new V1ConfigMap());
-			when(mock.replaceNamespacedConfigMap(eq("my-config"), eq("default"), any(V1ConfigMap.class)))
-				.thenReturn(replaceReq);
-		});
-
-		kubeService.apply("default", yaml);
-		verify(mockCoreV1Api).replaceNamespacedConfigMap(eq("my-config"), eq("default"), any(V1ConfigMap.class));
+		verify(mockCustomObjectsApi).patchClusterCustomObject(eq(""), eq("v1"), eq("namespaces"), eq("my-ns"),
+				any(V1Patch.class));
+		verify(mockClusterPatchRequest).fieldManager("helm");
+		verify(mockClusterPatchRequest).force(true);
 	}
 
 	@Test
-	void testApplyServiceCreatesNew() throws Exception {
+	void testApplyThrowsOnApiException() {
 		String yaml = """
-				apiVersion: v1
-				kind: Service
+				apiVersion: apps/v1
+				kind: Deployment
 				metadata:
-				  name: my-svc
-				  namespace: default
-				spec:
-				  ports:
-				  - port: 80
-				""";
-
-		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
-			mockCoreV1Api = mock;
-			var readReq = mock(CoreV1Api.APIreadNamespacedServiceRequest.class);
-			when(readReq.execute()).thenThrow(new ApiException(404, "Not found"));
-			when(mock.readNamespacedService(eq("my-svc"), eq("default"))).thenReturn(readReq);
-
-			var createReq = mock(CoreV1Api.APIcreateNamespacedServiceRequest.class);
-			when(createReq.execute()).thenReturn(new V1Service());
-			when(mock.createNamespacedService(eq("default"), any(V1Service.class))).thenReturn(createReq);
-		});
-
-		kubeService.apply("default", yaml);
-		verify(mockCoreV1Api).createNamespacedService(eq("default"), any(V1Service.class));
-	}
-
-	@Test
-	void testApplySecretCreatesNew() throws Exception {
-		String yaml = """
-				apiVersion: v1
-				kind: Secret
-				metadata:
-				  name: my-secret
-				  namespace: default
-				type: Opaque
-				data:
-				  password: cGFzc3dvcmQ=
-				""";
-
-		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
-			mockCoreV1Api = mock;
-			var readReq = mock(CoreV1Api.APIreadNamespacedSecretRequest.class);
-			when(readReq.execute()).thenThrow(new ApiException(404, "Not found"));
-			when(mock.readNamespacedSecret(eq("my-secret"), eq("default"))).thenReturn(readReq);
-
-			var createReq = mock(CoreV1Api.APIcreateNamespacedSecretRequest.class);
-			when(createReq.execute()).thenReturn(new V1Secret());
-			when(mock.createNamespacedSecret(eq("default"), any(V1Secret.class))).thenReturn(createReq);
-		});
-
-		kubeService.apply("default", yaml);
-		verify(mockCoreV1Api).createNamespacedSecret(eq("default"), any(V1Secret.class));
-	}
-
-	@Test
-	void testApplyServiceReplacesExisting() throws Exception {
-		String yaml = """
-				apiVersion: v1
-				kind: Service
-				metadata:
-				  name: my-svc
-				  namespace: default
-				spec:
-				  ports:
-				  - port: 80
-				""";
-
-		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
-			mockCoreV1Api = mock;
-			var readReq = mock(CoreV1Api.APIreadNamespacedServiceRequest.class);
-			when(readReq.execute()).thenReturn(new V1Service());
-			when(mock.readNamespacedService(eq("my-svc"), eq("default"))).thenReturn(readReq);
-
-			var replaceReq = mock(CoreV1Api.APIreplaceNamespacedServiceRequest.class);
-			when(replaceReq.execute()).thenReturn(new V1Service());
-			when(mock.replaceNamespacedService(eq("my-svc"), eq("default"), any(V1Service.class)))
-				.thenReturn(replaceReq);
-		});
-
-		kubeService.apply("default", yaml);
-		verify(mockCoreV1Api).replaceNamespacedService(eq("my-svc"), eq("default"), any(V1Service.class));
-	}
-
-	@Test
-	void testApplySecretReplacesExisting() throws Exception {
-		String yaml = """
-				apiVersion: v1
-				kind: Secret
-				metadata:
-				  name: my-secret
-				  namespace: default
-				type: Opaque
-				data:
-				  password: cGFzc3dvcmQ=
-				""";
-
-		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
-			mockCoreV1Api = mock;
-			var readReq = mock(CoreV1Api.APIreadNamespacedSecretRequest.class);
-			when(readReq.execute()).thenReturn(new V1Secret());
-			when(mock.readNamespacedSecret(eq("my-secret"), eq("default"))).thenReturn(readReq);
-
-			var replaceReq = mock(CoreV1Api.APIreplaceNamespacedSecretRequest.class);
-			when(replaceReq.execute()).thenReturn(new V1Secret());
-			when(mock.replaceNamespacedSecret(eq("my-secret"), eq("default"), any(V1Secret.class)))
-				.thenReturn(replaceReq);
-		});
-
-		kubeService.apply("default", yaml);
-		verify(mockCoreV1Api).replaceNamespacedSecret(eq("my-secret"), eq("default"), any(V1Secret.class));
-	}
-
-	@Test
-	void testApplyServiceThrowsOnNon404Error() {
-		String yaml = """
-				apiVersion: v1
-				kind: Service
-				metadata:
-				  name: my-svc
-				  namespace: default
-				spec:
-				  ports:
-				  - port: 80
-				""";
-
-		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
-			var readReq = mock(CoreV1Api.APIreadNamespacedServiceRequest.class);
-			when(readReq.execute()).thenThrow(new ApiException(500, "Server error"));
-			when(mock.readNamespacedService(eq("my-svc"), eq("default"))).thenReturn(readReq);
-		});
-
-		assertThrows(Exception.class, () -> kubeService.apply("default", yaml));
-	}
-
-	@Test
-	void testApplySecretThrowsOnNon404Error() {
-		String yaml = """
-				apiVersion: v1
-				kind: Secret
-				metadata:
-				  name: my-secret
-				  namespace: default
-				type: Opaque
-				data:
-				  password: cGFzc3dvcmQ=
-				""";
-
-		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
-			var readReq = mock(CoreV1Api.APIreadNamespacedSecretRequest.class);
-			when(readReq.execute()).thenThrow(new ApiException(500, "Server error"));
-			when(mock.readNamespacedSecret(eq("my-secret"), eq("default"))).thenReturn(readReq);
-		});
-
-		assertThrows(Exception.class, () -> kubeService.apply("default", yaml));
-	}
-
-	@Test
-	void testApplyConfigMapThrowsOnNon404Error() {
-		String yaml = """
-				apiVersion: v1
-				kind: ConfigMap
-				metadata:
-				  name: my-config
-				  namespace: default
-				data:
-				  key: value
-				""";
-
-		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
-			var readReq = mock(CoreV1Api.APIreadNamespacedConfigMapRequest.class);
-			when(readReq.execute()).thenThrow(new ApiException(500, "Server error"));
-			when(mock.readNamespacedConfigMap(eq("my-config"), eq("default"))).thenReturn(readReq);
-		});
-
-		assertThrows(Exception.class, () -> kubeService.apply("default", yaml));
-	}
-
-	@Test
-	void testApplyUnknownCoreResourceFallsBackToCustomObjects() throws Exception {
-		String yaml = """
-				apiVersion: v1
-				kind: Endpoints
-				metadata:
-				  name: my-endpoints
+				  name: my-deploy
 				  namespace: default
 				""";
 
-		coreV1ApiConstruction = mockConstruction(CoreV1Api.class);
 		customObjectsApiConstruction = mockConstruction(CustomObjectsApi.class, (mock, ctx) -> {
-			mockCustomObjectsApi = mock;
-			var getReq = mock(CustomObjectsApi.APIgetNamespacedCustomObjectRequest.class);
-			when(getReq.execute()).thenThrow(new ApiException(404, "Not found"));
-			when(mock.getNamespacedCustomObject(eq(""), eq("v1"), eq("default"), eq("endpointss"), eq("my-endpoints")))
-				.thenReturn(getReq);
-
-			var createReq = mock(CustomObjectsApi.APIcreateNamespacedCustomObjectRequest.class);
-			when(createReq.execute()).thenReturn(new Object());
-			when(mock.createNamespacedCustomObject(eq(""), eq("v1"), eq("default"), eq("endpointss"), any()))
-				.thenReturn(createReq);
+			var patchReq = mock(CustomObjectsApi.APIpatchNamespacedCustomObjectRequest.class);
+			when(patchReq.fieldManager(anyString())).thenReturn(patchReq);
+			when(patchReq.force(any(Boolean.class))).thenReturn(patchReq);
+			when(patchReq.buildCall(any())).thenThrow(new ApiException(500, "Server error"));
+			when(mock.patchNamespacedCustomObject(any(), any(), any(), any(), any(), any())).thenReturn(patchReq);
 		});
 
-		kubeService.apply("default", yaml);
+		patchUtilsMock = mockStatic(PatchUtils.class);
+		patchUtilsMock.when(() -> PatchUtils.patch(any(), any(), anyString(), any())).thenAnswer((invocation) -> {
+			PatchUtils.PatchCallFunc func = invocation.getArgument(1);
+			func.getCall();
+			return null;
+		});
+
+		assertThrows(Exception.class, () -> kubeService.apply("default", yaml));
 	}
 
 	// --- delete ---


### PR DESCRIPTION
## Summary

- Replaces the fragile read-then-replace pattern in `HelmKubeService.applyResource()` with Kubernetes **Server-Side Apply (SSA)** via `PatchUtils.patch()` and `CustomObjectsApi`
- Deletes `applyCoreResource()` entirely — the 70-line type-specific switch (ConfigMap / Service / Secret / fallback) is gone
- All resource types (core `v1` with `group=""` and non-core like `apps/v1`) now flow through a single SSA call with `fieldManager("helm")` and `force(true)`, matching Helm 4 behaviour

## Test plan

- [x] Replaced 10 old apply tests (GET→replace-or-404-create flow) with 4 focused SSA tests
- [x] `testApplyNamespacedResourceUsesSSA` — verifies `patchNamespacedCustomObject` called with correct group/version/namespace/plural/name
- [x] `testApplyCoreV1ResourceUsesSSA` — verifies core resources (`group=""`) use the same path
- [x] `testApplyClusterScopedResourceUsesSSA` — verifies empty namespace routes to `patchClusterCustomObject`
- [x] `testApplyThrowsOnApiException` — verifies exceptions propagate correctly
- [x] All 82 `jhelm-kube` tests pass, 0 Checkstyle violations, full build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)