### PR TITLE
Add content-based chart caching (Issue #6)

### DIFF
--- a/.claude/skills/push/skill.md
+++ b/.claude/skills/push/skill.md
@@ -1,0 +1,126 @@
+---
+name: push
+description: Create/update GitHub issue, branch, commit, PR, then continue implementing
+argument-hint: [issue-number or description]
+allowed-tools: Bash(gh *), Bash(git *)
+---
+
+## Push Workflow: Issue → Branch → PR → Continue
+
+Argument `$ARGUMENTS` is either:
+- An **existing issue number** (e.g. `42`) — update it and wire up the branch/PR
+- A **short description** (e.g. `add retry logic for HTTP calls`) — create a new issue first
+
+---
+
+### Step 1: Resolve or create the GitHub issue
+
+**If `$ARGUMENTS` is a number** — view the existing issue:
+```bash
+gh issue view $ARGUMENTS
+```
+
+**If `$ARGUMENTS` is a description** — create a new issue:
+```bash
+gh issue create \
+  --title "$ARGUMENTS" \
+  --body "## Context
+<fill in context from current conversation / recent commits>
+
+## Acceptance criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>"
+```
+Capture the new issue number from the output (e.g. `#59`).
+
+---
+
+### Step 2: Ensure we're on main and up to date
+```bash
+git checkout main && git pull
+```
+
+---
+
+### Step 3: Create a feature branch named after the issue
+```bash
+git checkout -b feature/<issue-number>-<short-slug>
+```
+Where `<short-slug>` is 2–4 words from the issue title, kebab-cased (e.g. `feature/59-retry-http-calls`).
+
+If a matching branch already exists, check it out instead:
+```bash
+git checkout feature/<issue-number>-<short-slug>
+```
+
+---
+
+### Step 4: Stage and commit any local changes (if present)
+
+Check for uncommitted work first:
+```bash
+git status
+git diff --stat
+```
+
+If there are changes to commit:
+```bash
+git add <changed-files>
+git commit -m "$(cat <<'EOF'
+<imperative summary under 72 chars>
+
+Closes #<issue-number>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+If there are **no** changes yet, skip this step — implementation comes after the PR is open.
+
+---
+
+### Step 5: Push the branch
+```bash
+git push -u origin HEAD
+```
+
+---
+
+### Step 6: Create the pull request (draft if no code yet)
+```bash
+gh pr create \
+  --title "<concise title matching issue>" \
+  --body "$(cat <<'EOF'
+## Summary
+- <bullet 1>
+- <bullet 2>
+
+## Test plan
+- [ ] Run `./mvnw test -pl <module>`
+- [ ] Verify <key behavior>
+
+Closes #<issue-number>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" \
+  --draft
+```
+
+Remove `--draft` if there are already commits with real code on the branch.
+
+Report the PR URL to the user.
+
+---
+
+### Step 7: Continue implementing
+
+Now implement the work described in the issue:
+- Read the issue body for full requirements
+- Follow project coding standards (Java 21, Lombok, tabs, spring-javaformat)
+- Run `./mvnw test -pl <module>` after each meaningful change
+- When done, mark the PR ready for review:
+  ```bash
+  gh pr ready
+  ```

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/RepoManager.java
@@ -26,6 +26,9 @@ import java.io.BufferedInputStream;
 import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 
@@ -169,6 +172,43 @@ public class RepoManager {
 
 	private File getIndexCacheFile(String repoName) {
 		return new File(getCacheDir(), repoName + "-index.yaml");
+	}
+
+	File getChartCacheDir() {
+		File dir = new File(getCacheDir(), "charts");
+		dir.mkdirs();
+		return dir;
+	}
+
+	File getChartCacheFile(String digest) {
+		String hex = digest.startsWith("sha256:") ? digest.substring(7) : digest;
+		return new File(getChartCacheDir(), hex + ".tgz");
+	}
+
+	String computeFileSha256(File file) throws IOException {
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+			try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
+				byte[] buf = new byte[8192];
+				int n;
+				while ((n = in.read(buf)) != -1) {
+					md.update(buf, 0, n);
+				}
+			}
+			byte[] hash = md.digest();
+			StringBuilder sb = new StringBuilder();
+			for (byte b : hash) {
+				String hex = Integer.toHexString(0xff & b);
+				if (hex.length() == 1) {
+					sb.append('0');
+				}
+				sb.append(hex);
+			}
+			return sb.toString();
+		}
+		catch (NoSuchAlgorithmException ex) {
+			throw new IOException("SHA-256 not available", ex);
+		}
 	}
 
 	public void updateRepo(String name) throws IOException {
@@ -347,6 +387,7 @@ public class RepoManager {
 
 		// Try to find the actual URL from the index.yaml if available
 		String chartUrl = null;
+		String chartDigest = null;
 		File indexFile = getIndexCacheFile(finalRepoName);
 		if (indexFile.exists()) {
 			try (InputStream in = new FileInputStream(indexFile)) {
@@ -361,6 +402,7 @@ public class RepoManager {
 								java.util.List<?> urls = (java.util.List<?>) m.get("urls");
 								if (urls != null && !urls.isEmpty()) {
 									chartUrl = asString(urls.get(0));
+									chartDigest = asString(m.get("digest"));
 									break;
 								}
 							}
@@ -383,7 +425,29 @@ public class RepoManager {
 			chartUrl = base + chartUrl;
 		}
 
-		pullFromUrl(chartUrl, destDir, finalChartName + "-" + version + ".tgz");
+		if (chartDigest != null) {
+			File cached = getChartCacheFile(chartDigest);
+			if (cached.exists()) {
+				log.info("Using cached chart (digest: {})", chartDigest);
+				File destFile = new File(destDir, finalChartName + "-" + version + ".tgz");
+				Files.copy(cached.toPath(), destFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+				untar(destFile, new File(destDir));
+				return;
+			}
+		}
+
+		String tgzFileName = finalChartName + "-" + version + ".tgz";
+		pullFromUrl(chartUrl, destDir, tgzFileName);
+
+		// Store in content cache after download
+		File downloaded = new File(destDir, tgzFileName);
+		if (downloaded.exists()) {
+			String actualDigest = computeFileSha256(downloaded);
+			File cacheTarget = getChartCacheFile(actualDigest);
+			if (!cacheTarget.exists()) {
+				Files.copy(downloaded.toPath(), cacheTarget.toPath());
+			}
+		}
 	}
 
 	public void pullFromUrl(String chartUrl, String destDir, String fileName) throws IOException {
@@ -473,9 +537,27 @@ public class RepoManager {
 			throw new IOException("No chart layer found in OCI manifest for " + ociUrl);
 		}
 
-		// 4. Download Layer (blob)
+		// 4. Download Layer (blob) — check content cache first
+		File cached = getChartCacheFile(digest);
+		if (cached.exists()) {
+			log.info("Using cached OCI chart (digest: {})", digest);
+			File destFile = new File(destDir, fileName);
+			Files.copy(cached.toPath(), destFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+			untar(destFile, new File(destDir));
+			return;
+		}
+
 		String blobUrl = "https://" + registry + "/v2/" + path + "/blobs/" + digest;
 		downloadBlob(blobUrl, token, destDir, fileName);
+
+		// Store in content cache after download
+		File downloaded = new File(destDir, fileName);
+		if (downloaded.exists()) {
+			File cacheTarget = getChartCacheFile(digest);
+			if (!cacheTarget.exists()) {
+				Files.copy(downloaded.toPath(), cacheTarget.toPath());
+			}
+		}
 
 		// 5. Untar it automatically to match helm behavior
 		File tgzFile = new File(destDir, fileName);

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/RepoManagerTest.java
@@ -3,13 +3,17 @@ package org.alexmond.jhelm.core;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RepoManagerTest {
 
@@ -46,6 +50,49 @@ class RepoManagerTest {
 	void testRepoNotFound() {
 		RepoManager repoManager = new RepoManager();
 		assertThrows(IOException.class, () -> repoManager.getChartVersions("non-existent", "nginx"));
+	}
+
+	@Test
+	void testComputeFileSha256() throws IOException {
+		RepoManager repoManager = new RepoManager();
+		File file = tempDir.resolve("test.bin").toFile();
+		byte[] content = "hello world".getBytes(StandardCharsets.UTF_8);
+		try (FileOutputStream fos = new FileOutputStream(file)) {
+			fos.write(content);
+		}
+		String actual = repoManager.computeFileSha256(file);
+		assertNotNull(actual);
+		assertEquals(64, actual.length());
+		assertTrue(actual.matches("[0-9a-f]{64}"));
+	}
+
+	@Test
+	void testComputeFileSha256KnownValue() throws IOException {
+		RepoManager repoManager = new RepoManager();
+		File file = tempDir.resolve("known.bin").toFile();
+		// Empty file has a known SHA-256
+		file.createNewFile();
+		String actual = repoManager.computeFileSha256(file);
+		// SHA-256 of empty input
+		assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", actual);
+	}
+
+	@Test
+	void testGetChartCacheFileStripsPrefix() throws IOException {
+		RepoManager repoManager = new RepoManager();
+		File withPrefix = repoManager.getChartCacheFile("sha256:abcdef1234");
+		File withoutPrefix = repoManager.getChartCacheFile("abcdef1234");
+		assertEquals(withPrefix.getName(), withoutPrefix.getName());
+		assertEquals("abcdef1234.tgz", withPrefix.getName());
+	}
+
+	@Test
+	void testGetChartCacheDirIsSubdirOfCacheDir() {
+		RepoManager repoManager = new RepoManager();
+		File chartCacheDir = repoManager.getChartCacheDir();
+		assertNotNull(chartCacheDir);
+		assertEquals("charts", chartCacheDir.getName());
+		assertTrue(chartCacheDir.exists());
 	}
 
 }


### PR DESCRIPTION
## Summary
- Charts pulled from Helm repos are now cached by SHA-256 digest in `~/.cache/jhelm/repository/charts/{sha256}.tgz`
- On subsequent `pull()` calls with a matching digest from `index.yaml`, the cached file is used — no network request made
- OCI blobs use their manifest digest as the cache key in `pullOci()`
- After any fresh download the chart is automatically stored in the cache for future hits

## New helpers (package-private)
- `getChartCacheDir()` — returns `{cacheDir}/charts/`, creates on demand
- `getChartCacheFile(digest)` — strips `sha256:` prefix, returns the `.tgz` path
- `computeFileSha256(file)` — streams file through `MessageDigest`, returns 64-char hex string

## Test plan
- [x] `./mvnw test -pl jhelm-core -Dtest=RepoManagerTest` — 6 tests pass
- [x] `./mvnw validate -pl jhelm-core` — 0 Checkstyle violations
- [x] `testComputeFileSha256KnownValue` verifies empty-file SHA-256 against canonical value
- [x] `testGetChartCacheFileStripsPrefix` verifies `sha256:` stripping

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)