### PR TITLE
Add MethodLength(80) and FileLength(1000) Checkstyle rules

### DIFF
--- a/.claude/skills/coding-standards/SKILL.md
+++ b/.claude/skills/coding-standards/SKILL.md
@@ -33,6 +33,24 @@ user-invocable: false
 - Define dependency versions as properties in root `pom.xml` `<properties>` (unless managed by Spring Boot parent)
 - Keep `jhelm-gotemplate` free of Spring dependencies
 
+### Size Guidelines
+
+Two thresholds apply — **consider** and **enforce**:
+
+| Scope | Consider refactoring | Checkstyle enforces (build fails) |
+|---|---|---|
+| **File** | > 500 lines | > 1000 lines |
+| **Method** | > 50 lines | > 80 lines |
+
+**Consider (500 lines / 50 lines):** A warning signal. Before adding more code to a large file or method, ask whether it should be split. Extract helpers, separate concerns, or move related methods to a dedicated class.
+
+**Enforce (1000 lines / 80 lines):** Hard limit. The build fails at `validate` phase. Refactoring is required — no exceptions except the suppressions below.
+
+**Current suppressions** (`checkstyle-suppressions.xml`):
+- `Lexer.java`, `Parser.java` — state machines; long methods are inherent to the pattern
+- `HelmChartTemplates.java` — methods return static YAML text blocks, not logic
+- `*Test.java` — test files are exempt from both size limits
+
 ### Checkstyle Rules (enforced — violations fail build)
 - **Catch variable**: must be `ex`, not `e` (SpringCatch)
 - **Braces required**: `if/else/for/while` always need `{}` (NeedBraces)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,15 @@ jhelm (parent)
    ./mvnw spring-javaformat:apply && ./mvnw validate
    ```
 
+### Size limits
+
+Configured in `checkstyle.xml` (project root):
+
+| Scope | Consider refactoring | Build fails |
+|---|---|---|
+| File | > 500 lines | > 1000 lines |
+| Method | > 50 lines | > 80 lines |
+
 ### Suppressions
 
 `checkstyle-suppressions.xml` at project root. Currently suppresses:
@@ -138,3 +147,6 @@ jhelm (parent)
 - `RequireThis` — not enforced
 - `SpringMethodVisibility` for `KpsComparisonTest.java` — TrustManager interface requires public
 - `NestedIfDepth` for `RepoManager.java` — intentional deep YAML parsing
+- `MethodLength` for `Lexer.java`, `Parser.java` — state machines; pattern requires long dispatch methods
+- `MethodLength`+`FileLength` for `HelmChartTemplates.java` — static YAML text blocks, not logic
+- `MethodLength`+`FileLength` for `*Test.java` — test files exempt from size limits

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -33,4 +33,16 @@
 
     <!-- RepoManager has deeply nested YAML parsing logic that is intentional -->
     <suppress checks="NestedIfDepth" files="RepoManager\.java"/>
+
+    <!-- Lexer and Parser are state machines — long methods are an inherent property of the pattern -->
+    <suppress checks="MethodLength" files="Parser\.java"/>
+    <suppress checks="MethodLength" files="Lexer\.java"/>
+
+    <!-- HelmChartTemplates methods return static YAML text blocks, not logic — size limits don't apply -->
+    <suppress checks="MethodLength" files="HelmChartTemplates\.java"/>
+    <suppress checks="FileLength" files="HelmChartTemplates\.java"/>
+
+    <!-- Test files are exempt from size limits: test methods are short but files accumulate many of them -->
+    <suppress checks="MethodLength" files=".*Test\.java"/>
+    <suppress checks="FileLength" files=".*Test\.java"/>
 </suppressions>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+
+    <!-- Delegate all Spring-style checks to the standard Spring configuration -->
+    <module name="io.spring.javaformat.checkstyle.SpringChecks"/>
+
+    <!-- File length: source files must not exceed 1000 lines -->
+    <module name="FileLength">
+        <property name="max" value="1000"/>
+    </module>
+
+    <module name="TreeWalker">
+        <!-- Method length: methods must not exceed 80 lines -->
+        <module name="MethodLength">
+            <property name="max" value="80"/>
+        </module>
+    </module>
+
+</module>

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/Engine.java
@@ -251,45 +251,7 @@ public class Engine {
 		StringBuilder sb = new StringBuilder();
 
 		// Render current chart templates
-		for (Chart.Template t : chart.getTemplates()) {
-			if (t.getName().endsWith(".yaml")) {
-				try {
-					factory.parse(t.getName(), t.getData());
-					StringWriter writer = new StringWriter();
-
-					// Template name in context should be current template
-					Map<String, Object> templateMap = new HashMap<>((Map<String, Object>) context.get("Template"));
-					templateMap.put("Name", chart.getMetadata().getName() + "/templates/" + t.getName());
-					Map<String, Object> currentContext = new HashMap<>(context);
-					currentContext.put("Template", templateMap);
-
-					factory.execute(t.getName(), currentContext, writer);
-					String rendered = writer.toString();
-					if (rendered != null && !rendered.trim().isEmpty()) {
-						// If template already ends with document separator, don't add
-						// another
-						if (!rendered.trim().endsWith("---")) {
-							sb.append(rendered);
-							if (!rendered.endsWith("\n")) {
-								sb.append("\n");
-							}
-							sb.append("---\n");
-						}
-						else {
-							sb.append(rendered);
-						}
-					}
-				}
-				catch (StackOverflowError ex) {
-					log.error("StackOverflowError rendering template {}: {}", t.getName(), ex.getMessage());
-					// Skip this template but don't fail the whole chart if possible
-				}
-				catch (Exception ex) {
-					log.error("Failed to render template {}: {}", t.getName(), ex.getMessage());
-					throw new RuntimeException("Failed to render template " + t.getName(), ex);
-				}
-			}
-		}
+		renderChartTemplates(chart, context, sb);
 
 		// Render subcharts
 		for (Chart subchart : chart.getDependencies()) {
@@ -318,6 +280,45 @@ public class Engine {
 		}
 
 		return sb.toString();
+	}
+
+	private void renderChartTemplates(Chart chart, Map<String, Object> context, StringBuilder sb) {
+		for (Chart.Template t : chart.getTemplates()) {
+			if (!t.getName().endsWith(".yaml")) {
+				continue;
+			}
+			try {
+				factory.parse(t.getName(), t.getData());
+				StringWriter writer = new StringWriter();
+
+				Map<String, Object> templateMap = new HashMap<>((Map<String, Object>) context.get("Template"));
+				templateMap.put("Name", chart.getMetadata().getName() + "/templates/" + t.getName());
+				Map<String, Object> currentContext = new HashMap<>(context);
+				currentContext.put("Template", templateMap);
+
+				factory.execute(t.getName(), currentContext, writer);
+				String rendered = writer.toString();
+				if (rendered != null && !rendered.trim().isEmpty()) {
+					if (!rendered.trim().endsWith("---")) {
+						sb.append(rendered);
+						if (!rendered.endsWith("\n")) {
+							sb.append("\n");
+						}
+						sb.append("---\n");
+					}
+					else {
+						sb.append(rendered);
+					}
+				}
+			}
+			catch (StackOverflowError ex) {
+				log.error("StackOverflowError rendering template {}: {}", t.getName(), ex.getMessage());
+			}
+			catch (Exception ex) {
+				log.error("Failed to render template {}: {}", t.getName(), ex.getMessage());
+				throw new RuntimeException("Failed to render template " + t.getName(), ex);
+			}
+		}
 	}
 
 	private Map<String, Object> mergeValues(Map<String, Object> defaults, Map<String, Object> overrides) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/RepoManager.java
@@ -385,45 +385,10 @@ public class RepoManager {
 			.findFirst()
 			.orElseThrow(() -> new IOException("Repository not found: " + searchRepoName));
 
-		// Try to find the actual URL from the index.yaml if available
-		String chartUrl = null;
-		String chartDigest = null;
-		File indexFile = getIndexCacheFile(finalRepoName);
-		if (indexFile.exists()) {
-			try (InputStream in = new FileInputStream(indexFile)) {
-				java.util.Map<?, ?> root = yamlMapper.readValue(in, java.util.Map.class);
-				java.util.Map<?, ?> entries = (java.util.Map<?, ?>) root.get("entries");
-				if (entries != null) {
-					java.util.List<?> versions = (java.util.List<?>) entries.get(finalChartName);
-					if (versions != null) {
-						for (Object o : versions) {
-							java.util.Map<?, ?> m = (java.util.Map<?, ?>) o;
-							if (version.equals(asString(m.get("version")))) {
-								java.util.List<?> urls = (java.util.List<?>) m.get("urls");
-								if (urls != null && !urls.isEmpty()) {
-									chartUrl = asString(urls.get(0));
-									chartDigest = asString(m.get("digest"));
-									break;
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
-		if (chartUrl == null) {
-			// Fallback to convention
-			chartUrl = repo.getUrl() + "/" + finalChartName + "-" + version + ".tgz";
-		}
-		else if (!chartUrl.contains("://")) {
-			// Handle relative URLs
-			String base = repo.getUrl();
-			if (!base.endsWith("/")) {
-				base += "/";
-			}
-			chartUrl = base + chartUrl;
-		}
+		String[] indexEntry = lookupChartInIndex(getIndexCacheFile(finalRepoName), finalChartName, version);
+		String chartUrl = resolveChartUrl((indexEntry != null) ? indexEntry[0] : null, repo.getUrl(), finalChartName,
+				version);
+		String chartDigest = (indexEntry != null) ? indexEntry[1] : null;
 
 		if (chartDigest != null) {
 			File cached = getChartCacheFile(chartDigest);
@@ -448,6 +413,44 @@ public class RepoManager {
 				Files.copy(downloaded.toPath(), cacheTarget.toPath());
 			}
 		}
+	}
+
+	private String[] lookupChartInIndex(File indexFile, String chartName, String version) throws IOException {
+		if (!indexFile.exists()) {
+			return null;
+		}
+		try (InputStream in = new FileInputStream(indexFile)) {
+			java.util.Map<?, ?> root = yamlMapper.readValue(in, java.util.Map.class);
+			java.util.Map<?, ?> entries = (java.util.Map<?, ?>) root.get("entries");
+			if (entries == null) {
+				return null;
+			}
+			java.util.List<?> versions = (java.util.List<?>) entries.get(chartName);
+			if (versions == null) {
+				return null;
+			}
+			for (Object o : versions) {
+				java.util.Map<?, ?> m = (java.util.Map<?, ?>) o;
+				if (version.equals(asString(m.get("version")))) {
+					java.util.List<?> urls = (java.util.List<?>) m.get("urls");
+					if (urls != null && !urls.isEmpty()) {
+						return new String[] { asString(urls.get(0)), asString(m.get("digest")) };
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	private String resolveChartUrl(String indexUrl, String repoUrl, String chartName, String version) {
+		if (indexUrl == null) {
+			return repoUrl + "/" + chartName + "-" + version + ".tgz";
+		}
+		if (!indexUrl.contains("://")) {
+			String base = repoUrl.endsWith("/") ? repoUrl : repoUrl + "/";
+			return base + indexUrl;
+		}
+		return indexUrl;
 	}
 
 	public void pullFromUrl(String chartUrl, String destDir, String fileName) throws IOException {
@@ -484,29 +487,14 @@ public class RepoManager {
 
 	public void pullOci(String ociUrl, String destDir, String fileName) throws IOException {
 		log.info("Pulling OCI chart from {} to {}", ociUrl, destDir);
-		// oci://registry/repo/chart:version or oci://registry/repo/chart (tag defaults to
-		// latest)
-		String raw = ociUrl.substring(6);
-		int firstSlash = raw.indexOf('/');
-		if (firstSlash == -1) {
-			throw new IOException("Invalid OCI URL: " + ociUrl);
-		}
-		String registry = raw.substring(0, firstSlash);
-		String path = raw.substring(firstSlash + 1);
-		String tag = "latest";
-		if (path.contains(":")) {
-			int colon = path.lastIndexOf(':');
-			tag = path.substring(colon + 1);
-			path = path.substring(0, colon);
-		}
+		String[] ociParts = parseOciUrl(ociUrl);
+		String registry = ociParts[0];
+		String path = ociParts[1];
+		String tag = ociParts[2];
 
 		// 1. Get Token
-		String token = null;
-		String auth = null;
-		if (registryManager != null) {
-			auth = registryManager.getAuth(registry);
-		}
-		token = fetchOciToken(registry, path, auth);
+		String auth = (registryManager != null) ? registryManager.getAuth(registry) : null;
+		String token = fetchOciToken(registry, path, auth);
 
 		// 2. Get Manifest
 		String manifestUrl = "https://" + registry + "/v2/" + path + "/manifests/" + tag;
@@ -562,6 +550,23 @@ public class RepoManager {
 		// 5. Untar it automatically to match helm behavior
 		File tgzFile = new File(destDir, fileName);
 		untar(tgzFile, new File(destDir));
+	}
+
+	private String[] parseOciUrl(String ociUrl) throws IOException {
+		String raw = ociUrl.substring(6);
+		int firstSlash = raw.indexOf('/');
+		if (firstSlash == -1) {
+			throw new IOException("Invalid OCI URL: " + ociUrl);
+		}
+		String registry = raw.substring(0, firstSlash);
+		String path = raw.substring(firstSlash + 1);
+		String tag = "latest";
+		if (path.contains(":")) {
+			int colon = path.lastIndexOf(':');
+			tag = path.substring(colon + 1);
+			path = path.substring(0, colon);
+		}
+		return new String[] { registry, path, tag };
 	}
 
 	private String fetchOciToken(String registry, String path, String auth) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
                             <goal>check</goal>
                         </goals>
                         <configuration>
-                            <configLocation>io/spring/javaformat/checkstyle/checkstyle.xml</configLocation>
+                            <configLocation>checkstyle.xml</configLocation>
                             <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
                             <includeTestSourceDirectory>true</includeTestSourceDirectory>
                         </configuration>


### PR DESCRIPTION
## Summary
- Add project-level `checkstyle.xml` wrapping `SpringChecks` with `FileLength` (max=1000) and `MethodLength` (max=80) size limits
- Document a two-tier size guideline: consider-refactoring (500 lines / 50 lines) and enforce/build-fails (1000 lines / 80 lines)
- Suppress size limits for Lexer/Parser (state machines), HelmChartTemplates (static YAML text blocks), and `*Test.java` files
- Refactor `Engine.renderWithSubcharts()`, `RepoManager.pull()`, and `RepoManager.pullOci()` to comply with new limits
- Update `coding-standards` skill and `CLAUDE.md` with the size guideline thresholds

## Test plan
- [ ] Run `./mvnw validate` — all modules pass with 0 Checkstyle violations
- [ ] Run `./mvnw test` — all 986 tests pass
- [ ] Verify `checkstyle.xml` configures `FileLength(1000)` and `MethodLength(80)`
- [ ] Verify `checkstyle-suppressions.xml` has correct suppressions for Lexer, Parser, HelmChartTemplates, *Test

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)