### PR TITLE
Multi-document values file support

### DIFF
--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/DependencyCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/DependencyCommand.java
@@ -7,6 +7,7 @@ import org.alexmond.jhelm.core.ChartLock;
 import org.alexmond.jhelm.core.Dependency;
 import org.alexmond.jhelm.core.DependencyResolver;
 import org.alexmond.jhelm.core.RepoManager;
+import org.alexmond.jhelm.core.ValuesLoader;
 import org.alexmond.jhelm.core.ChartLock.LockDependency;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
@@ -219,16 +220,13 @@ public class DependencyCommand implements Runnable {
 			return yamlMapper.readValue(chartFile, ChartMetadata.class);
 		}
 
-		@SuppressWarnings("unchecked")
 		private Map<String, Object> loadValues(File chartDir) {
 			try {
 				File valuesFile = new File(chartDir, "values.yaml");
 				if (!valuesFile.exists()) {
 					return new HashMap<>();
 				}
-
-				YAMLMapper yamlMapper = YAMLMapper.builder().build();
-				return yamlMapper.readValue(valuesFile, Map.class);
+				return ValuesLoader.load(valuesFile);
 			}
 			catch (Exception ex) {
 				log.warn("Failed to load values.yaml: {}", ex.getMessage());

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/ChartLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/ChartLoader.java
@@ -28,11 +28,11 @@ public class ChartLoader {
 		}
 		ChartMetadata metadata = yamlMapper.readValue(metadataFile, ChartMetadata.class);
 
-		// Load values.yaml
+		// Load values.yaml (supports multi-document files separated by ---)
 		File valuesFile = new File(chartDir, "values.yaml");
 		Map<String, Object> values = new HashMap<>();
 		if (valuesFile.exists()) {
-			values = yamlMapper.readValue(valuesFile, Map.class);
+			values = ValuesLoader.load(valuesFile);
 		}
 
 		// Load templates

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/ValuesLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/ValuesLoader.java
@@ -1,0 +1,58 @@
+package org.alexmond.jhelm.core;
+
+import tools.jackson.databind.MappingIterator;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility for loading Helm values YAML files, including multi-document files.
+ * <p>
+ * A multi-document YAML file contains multiple documents separated by {@code ---}.
+ * Documents are merged in order: later documents override earlier ones, with nested maps
+ * deep-merged rather than replaced.
+ */
+public final class ValuesLoader {
+
+	private ValuesLoader() {
+	}
+
+	/**
+	 * Loads a YAML values file, supporting multi-document files.
+	 * @param valuesFile the YAML file to load
+	 * @return merged values map (empty map if file has no non-null documents)
+	 * @throws IOException if the file cannot be read
+	 */
+	@SuppressWarnings("unchecked")
+	public static Map<String, Object> load(File valuesFile) throws IOException {
+		YAMLMapper mapper = YAMLMapper.builder().build();
+		Map<String, Object> merged = new HashMap<>();
+		try (MappingIterator<Object> it = mapper.readerFor(Object.class).readValues(valuesFile)) {
+			while (it.hasNext()) {
+				Object doc = it.next();
+				if (doc instanceof Map) {
+					deepMerge(merged, (Map<String, Object>) doc);
+				}
+			}
+		}
+		return merged;
+	}
+
+	@SuppressWarnings("unchecked")
+	static void deepMerge(Map<String, Object> base, Map<String, Object> override) {
+		for (Map.Entry<String, Object> entry : override.entrySet()) {
+			Object overrideVal = entry.getValue();
+			Object baseVal = base.get(entry.getKey());
+			if ((overrideVal instanceof Map) && (baseVal instanceof Map)) {
+				deepMerge((Map<String, Object>) baseVal, (Map<String, Object>) overrideVal);
+			}
+			else {
+				base.put(entry.getKey(), overrideVal);
+			}
+		}
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/ValuesLoaderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/ValuesLoaderTest.java
@@ -1,0 +1,135 @@
+package org.alexmond.jhelm.core;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ValuesLoaderTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void testSingleDocument() throws IOException {
+		File f = writeValues("""
+				replicaCount: 2
+				image:
+				  repository: nginx
+				  tag: latest
+				""");
+		Map<String, Object> result = ValuesLoader.load(f);
+		assertEquals(2, result.get("replicaCount"));
+		Map<?, ?> image = (Map<?, ?>) result.get("image");
+		assertEquals("nginx", image.get("repository"));
+		assertEquals("latest", image.get("tag"));
+	}
+
+	@Test
+	void testMultiDocumentNonOverlapping() throws IOException {
+		File f = writeValues("""
+				key1: value1
+				---
+				key2: value2
+				""");
+		Map<String, Object> result = ValuesLoader.load(f);
+		assertEquals("value1", result.get("key1"));
+		assertEquals("value2", result.get("key2"));
+	}
+
+	@Test
+	void testMultiDocumentLaterOverridesScalar() throws IOException {
+		File f = writeValues("""
+				replicas: 1
+				name: original
+				---
+				replicas: 3
+				""");
+		Map<String, Object> result = ValuesLoader.load(f);
+		assertEquals(3, result.get("replicas"));
+		assertEquals("original", result.get("name"));
+	}
+
+	@Test
+	void testMultiDocumentDeepMergeNestedMaps() throws IOException {
+		File f = writeValues("""
+				db:
+				  host: localhost
+				  port: 5432
+				---
+				db:
+				  port: 5433
+				  name: mydb
+				""");
+		Map<String, Object> result = ValuesLoader.load(f);
+		Map<?, ?> db = (Map<?, ?>) result.get("db");
+		assertEquals("localhost", db.get("host"));
+		assertEquals(5433, db.get("port"));
+		assertEquals("mydb", db.get("name"));
+	}
+
+	@Test
+	void testEmptyDocumentSkipped() throws IOException {
+		File f = writeValues("""
+				key1: value1
+				---
+				---
+				key2: value2
+				""");
+		Map<String, Object> result = ValuesLoader.load(f);
+		assertEquals("value1", result.get("key1"));
+		assertEquals("value2", result.get("key2"));
+		assertEquals(2, result.size());
+	}
+
+	@Test
+	void testAllEmptyDocuments() throws IOException {
+		File f = writeValues("---\n---\n");
+		Map<String, Object> result = ValuesLoader.load(f);
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	void testEmptyFile() throws IOException {
+		File f = writeValues("");
+		Map<String, Object> result = ValuesLoader.load(f);
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	void testDeepMergeDirectly() {
+		Map<String, Object> base = new HashMap<>();
+		Map<String, Object> nested = new HashMap<>();
+		nested.put("a", 1);
+		base.put("nested", nested);
+		base.put("scalar", "original");
+
+		Map<String, Object> override = new HashMap<>();
+		Map<String, Object> nestedOverride = new HashMap<>();
+		nestedOverride.put("b", 2);
+		override.put("nested", nestedOverride);
+		override.put("scalar", "updated");
+
+		ValuesLoader.deepMerge(base, override);
+
+		assertEquals("updated", base.get("scalar"));
+		Map<?, ?> mergedNested = (Map<?, ?>) base.get("nested");
+		assertEquals(1, mergedNested.get("a"));
+		assertEquals(2, mergedNested.get("b"));
+	}
+
+	private File writeValues(String content) throws IOException {
+		Path file = tempDir.resolve("values.yaml");
+		Files.writeString(file, content);
+		return file.toFile();
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `ValuesLoader` utility class that parses YAML values files with multiple documents (`---` separated)
- Documents are deep-merged in order — later documents override earlier ones; nested maps are merged recursively
- Empty and null documents are skipped gracefully
- Update `ChartLoader` and `DependencyCommand` to use `ValuesLoader` instead of single-document `readValue()`

## Test plan
- [x] `ValuesLoaderTest`: 8 unit tests covering single-doc, multi-doc merge, scalar override, deep merge, empty docs, empty file, all-null docs, direct `deepMerge`
- [x] All 161 jhelm-core tests pass
- [x] All 128 jhelm-app tests pass

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)