### PR TITLE
Add -f/--values and --set flag support to commands

### DIFF
--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/InstallCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/InstallCommand.java
@@ -8,8 +8,13 @@ import org.alexmond.jhelm.core.Release;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+import org.alexmond.jhelm.core.ValuesOverrides;
+import picocli.CommandLine.Option;
+
 import java.io.File;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 @Component
 @CommandLine.Command(name = "install", description = "install a chart")
@@ -30,6 +35,12 @@ public class InstallCommand implements Runnable {
 	@CommandLine.Option(names = { "--dry-run" }, description = "simulate an install")
 	private boolean dryRun;
 
+	@Option(names = { "-f", "--values" }, description = "specify values YAML files")
+	private List<String> valuesFiles = new ArrayList<>();
+
+	@Option(names = { "--set" }, description = "set values on the command line (key=value, dot notation supported)")
+	private List<String> setValues = new ArrayList<>();
+
 	public InstallCommand(InstallAction installAction) {
 		this.installAction = installAction;
 	}
@@ -39,8 +50,9 @@ public class InstallCommand implements Runnable {
 		try {
 			ChartLoader loader = new ChartLoader();
 			Chart chart = loader.load(new File(chartPath));
+			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues);
 
-			Release release = installAction.install(chart, name, namespace, new HashMap<>(), 1, dryRun);
+			Release release = installAction.install(chart, name, namespace, overrides, 1, dryRun);
 
 			if (dryRun) {
 				log.info("NAME: {}", release.getName());

--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/TemplateCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/TemplateCommand.java
@@ -2,8 +2,14 @@ package org.alexmond.jhelm.app;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.TemplateAction;
+import org.alexmond.jhelm.core.ValuesOverrides;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
+import picocli.CommandLine.Option;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 @Component
 @CommandLine.Command(name = "template", description = "locally render templates")
@@ -18,6 +24,15 @@ public class TemplateCommand implements Runnable {
 	@CommandLine.Parameters(index = "1", description = "chart path")
 	private String chartPath;
 
+	@Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
+	private String namespace;
+
+	@Option(names = { "-f", "--values" }, description = "specify values YAML files")
+	private List<String> valuesFiles = new ArrayList<>();
+
+	@Option(names = { "--set" }, description = "set values on the command line (key=value, dot notation supported)")
+	private List<String> setValues = new ArrayList<>();
+
 	public TemplateCommand(TemplateAction templateAction) {
 		this.templateAction = templateAction;
 	}
@@ -25,7 +40,8 @@ public class TemplateCommand implements Runnable {
 	@Override
 	public void run() {
 		try {
-			String manifest = templateAction.render(chartPath, name, "default");
+			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues);
+			String manifest = templateAction.render(chartPath, name, namespace, overrides);
 			log.info("\n{}", manifest);
 		}
 		catch (Exception ex) {

--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/UpgradeCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/UpgradeCommand.java
@@ -10,8 +10,13 @@ import org.alexmond.jhelm.core.UpgradeAction;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+import org.alexmond.jhelm.core.ValuesOverrides;
+import picocli.CommandLine.Option;
+
 import java.io.File;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Component
@@ -40,6 +45,12 @@ public class UpgradeCommand implements Runnable {
 	@CommandLine.Option(names = { "--dry-run" }, description = "simulate an upgrade")
 	private boolean dryRun;
 
+	@Option(names = { "-f", "--values" }, description = "specify values YAML files")
+	private List<String> valuesFiles = new ArrayList<>();
+
+	@Option(names = { "--set" }, description = "set values on the command line (key=value, dot notation supported)")
+	private List<String> setValues = new ArrayList<>();
+
 	public UpgradeCommand(KubeService kubeService, InstallAction installAction, UpgradeAction upgradeAction) {
 		this.kubeService = kubeService;
 		this.installAction = installAction;
@@ -52,10 +63,11 @@ public class UpgradeCommand implements Runnable {
 			Optional<Release> currentReleaseOpt = kubeService.getRelease(name, namespace);
 			ChartLoader loader = new ChartLoader();
 			Chart chart = loader.load(new File(chartPath));
+			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues);
 
 			if (currentReleaseOpt.isEmpty()) {
 				if (install) {
-					Release release = installAction.install(chart, name, namespace, new HashMap<>(), 1, dryRun);
+					Release release = installAction.install(chart, name, namespace, overrides, 1, dryRun);
 					if (dryRun) {
 						printRelease(release);
 					}
@@ -69,7 +81,7 @@ public class UpgradeCommand implements Runnable {
 				return;
 			}
 
-			Release upgradedRelease = upgradeAction.upgrade(currentReleaseOpt.get(), chart, new HashMap<>(), dryRun);
+			Release upgradedRelease = upgradeAction.upgrade(currentReleaseOpt.get(), chart, overrides, dryRun);
 
 			if (dryRun) {
 				printRelease(upgradedRelease);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/TemplateAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/TemplateAction.java
@@ -11,8 +11,16 @@ public class TemplateAction {
 	private final Engine engine;
 
 	public String render(String chartPath, String releaseName, String namespace) throws Exception {
+		return render(chartPath, releaseName, namespace, new HashMap<>());
+	}
+
+	public String render(String chartPath, String releaseName, String namespace, Map<String, Object> overrides)
+			throws Exception {
 		ChartLoader loader = new ChartLoader();
 		Chart chart = loader.load(new File(chartPath));
+
+		Map<String, Object> values = new HashMap<>(chart.getValues());
+		ValuesLoader.deepMerge(values, overrides);
 
 		Map<String, Object> releaseData = new HashMap<>();
 		releaseData.put("Name", releaseName);
@@ -22,7 +30,7 @@ public class TemplateAction {
 		releaseData.put("IsUpgrade", false);
 		releaseData.put("Revision", 1);
 
-		return engine.render(chart, chart.getValues(), releaseData);
+		return engine.render(chart, values, releaseData);
 	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/ValuesOverrides.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/ValuesOverrides.java
@@ -1,0 +1,76 @@
+package org.alexmond.jhelm.core;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility for building value override maps from {@code -f}/ {@code --values} files and
+ * {@code --set key=value} arguments.
+ * <p>
+ * Files are loaded in order using {@link ValuesLoader} (which supports multi-document
+ * YAML). {@code --set} arguments are parsed last so they take precedence over file
+ * values. Dot-separated keys create nested maps (e.g. {@code outer.inner=v} produces
+ * {@code {outer: {inner: "v"}}}).
+ */
+public final class ValuesOverrides {
+
+	private ValuesOverrides() {
+	}
+
+	/**
+	 * Build a merged override map from values files and {@code --set} arguments.
+	 * @param files paths to YAML values files; {@code null} or empty means none
+	 * @param setArgs {@code key=value} strings; {@code null} or empty means none
+	 * @return merged override map
+	 * @throws Exception if any values file cannot be read
+	 */
+	public static Map<String, Object> parse(List<String> files, List<String> setArgs) throws Exception {
+		Map<String, Object> merged = new HashMap<>();
+		if (files != null) {
+			for (String path : files) {
+				Map<String, Object> fileValues = ValuesLoader.load(new File(path));
+				ValuesLoader.deepMerge(merged, fileValues);
+			}
+		}
+		if (setArgs != null) {
+			for (String arg : setArgs) {
+				applySet(merged, arg);
+			}
+		}
+		return merged;
+	}
+
+	/**
+	 * Parse a single {@code key=value} set argument and apply it to {@code target}.
+	 * <p>
+	 * Keys may use dot notation to set nested values (e.g. {@code a.b=v}).
+	 * @param target the map to merge into
+	 * @param arg the {@code key=value} string
+	 */
+	@SuppressWarnings("unchecked")
+	static void applySet(Map<String, Object> target, String arg) {
+		int eq = arg.indexOf('=');
+		if (eq < 0) {
+			return;
+		}
+		String keyPath = arg.substring(0, eq);
+		String value = arg.substring(eq + 1);
+		String[] parts = keyPath.split("\\.", -1);
+		Map<String, Object> current = target;
+		for (int i = 0; i < parts.length - 1; i++) {
+			Object existing = current.get(parts[i]);
+			if (existing instanceof Map) {
+				current = (Map<String, Object>) existing;
+			}
+			else {
+				Map<String, Object> nested = new HashMap<>();
+				current.put(parts[i], nested);
+				current = nested;
+			}
+		}
+		current.put(parts[parts.length - 1], value);
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/ValuesOverridesTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/ValuesOverridesTest.java
@@ -1,0 +1,150 @@
+package org.alexmond.jhelm.core;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ValuesOverridesTest {
+
+	@TempDir
+	Path tempDir;
+
+	// --- applySet ---
+
+	@Test
+	void testApplySetSimpleKey() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "key=value");
+		assertEquals("value", target.get("key"));
+	}
+
+	@Test
+	void testApplySetDotNotation() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "outer.inner=v");
+		Map<?, ?> outer = (Map<?, ?>) target.get("outer");
+		assertEquals("v", outer.get("inner"));
+	}
+
+	@Test
+	void testApplySetDeepNesting() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "a.b.c=deep");
+		Map<?, ?> a = (Map<?, ?>) target.get("a");
+		Map<?, ?> b = (Map<?, ?>) a.get("b");
+		assertEquals("deep", b.get("c"));
+	}
+
+	@Test
+	void testApplySetMergesIntoExistingMap() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "db.host=localhost");
+		ValuesOverrides.applySet(target, "db.port=5432");
+		Map<?, ?> db = (Map<?, ?>) target.get("db");
+		assertEquals("localhost", db.get("host"));
+		assertEquals("5432", db.get("port"));
+	}
+
+	@Test
+	void testApplySetOverwritesExistingScalar() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "key=old");
+		ValuesOverrides.applySet(target, "key=new");
+		assertEquals("new", target.get("key"));
+	}
+
+	@Test
+	void testApplySetIgnoresMissingEquals() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "noequals");
+		assertTrue(target.isEmpty());
+	}
+
+	@Test
+	void testApplySetValueWithEquals() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "key=a=b");
+		assertEquals("a=b", target.get("key"));
+	}
+
+	// --- parse from files ---
+
+	@Test
+	void testParseFromSingleFile() throws Exception {
+		Path f = writeValues("replicas: 3\nimage: nginx\n");
+		Map<String, Object> result = ValuesOverrides.parse(List.of(f.toString()), null);
+		assertEquals(3, result.get("replicas"));
+		assertEquals("nginx", result.get("image"));
+	}
+
+	@Test
+	void testParseFromMultipleFiles() throws Exception {
+		Path f1 = writeFile("f1.yaml", "key1: v1\n");
+		Path f2 = writeFile("f2.yaml", "key2: v2\n");
+		Map<String, Object> result = ValuesOverrides.parse(List.of(f1.toString(), f2.toString()), null);
+		assertEquals("v1", result.get("key1"));
+		assertEquals("v2", result.get("key2"));
+	}
+
+	@Test
+	void testParseFilesLaterOverridesEarlier() throws Exception {
+		Path f1 = writeFile("base.yaml", "replicas: 1\nimage: nginx\n");
+		Path f2 = writeFile("override.yaml", "replicas: 5\n");
+		Map<String, Object> result = ValuesOverrides.parse(List.of(f1.toString(), f2.toString()), null);
+		assertEquals(5, result.get("replicas"));
+		assertEquals("nginx", result.get("image"));
+	}
+
+	// --- parse from --set ---
+
+	@Test
+	void testParseFromSetArgs() throws Exception {
+		Map<String, Object> result = ValuesOverrides.parse(null, List.of("key=value", "other=123"));
+		assertEquals("value", result.get("key"));
+		assertEquals("123", result.get("other"));
+	}
+
+	// --- combined ---
+
+	@Test
+	void testSetOverridesFile() throws Exception {
+		Path f = writeValues("replicas: 1\nimage: nginx\n");
+		Map<String, Object> result = ValuesOverrides.parse(List.of(f.toString()), List.of("replicas=3"));
+		assertEquals("3", result.get("replicas"));
+		assertEquals("nginx", result.get("image"));
+	}
+
+	@Test
+	void testEmptyInputs() throws Exception {
+		Map<String, Object> result = ValuesOverrides.parse(List.of(), List.of());
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	void testNullInputs() throws Exception {
+		Map<String, Object> result = ValuesOverrides.parse(null, null);
+		assertTrue(result.isEmpty());
+	}
+
+	// --- helpers ---
+
+	private Path writeValues(String content) throws IOException {
+		return writeFile("values.yaml", content);
+	}
+
+	private Path writeFile(String name, String content) throws IOException {
+		Path file = tempDir.resolve(name);
+		Files.writeString(file, content);
+		return file;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add \`ValuesOverrides\` utility in \`jhelm-core\` for parsing \`-f\` values files and \`--set key=value\` arguments (dot notation for nested keys, e.g. \`db.port=5432\`)
- Wire \`-f\`/\`--values\` and \`--set\` options into \`install\`, \`upgrade\`, and \`template\` commands
- Add \`--namespace\`/\`-n\` option to \`template\` (was missing)
- Add override-accepting overload to \`TemplateAction.render()\`
- \`--set\` args take precedence over \`-f\` files, which take precedence over chart defaults

## Test plan
- [x] 14 unit tests in \`ValuesOverridesTest\` covering: simple/nested/deep keys, merge order, file loading, combined files+set, null/empty inputs
- [x] 175 jhelm-core tests pass
- [x] 128 jhelm-app tests pass

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)