### PR TITLE
Add resource status watching with --show-resources, --wait, --timeout (Issue #12)

### DIFF
--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/InstallCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/InstallCommand.java
@@ -4,11 +4,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.Chart;
 import org.alexmond.jhelm.core.ChartLoader;
 import org.alexmond.jhelm.core.InstallAction;
+import org.alexmond.jhelm.core.KubeService;
 import org.alexmond.jhelm.core.Release;
+import org.alexmond.jhelm.core.ValuesOverrides;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
-
-import org.alexmond.jhelm.core.ValuesOverrides;
 import picocli.CommandLine.Option;
 
 import java.io.File;
@@ -22,6 +22,8 @@ import java.util.Map;
 public class InstallCommand implements Runnable {
 
 	private final InstallAction installAction;
+
+	private final KubeService kubeService;
 
 	@CommandLine.Parameters(index = "0", description = "release name")
 	private String name;
@@ -41,8 +43,15 @@ public class InstallCommand implements Runnable {
 	@Option(names = { "--set" }, description = "set values on the command line (key=value, dot notation supported)")
 	private List<String> setValues = new ArrayList<>();
 
-	public InstallCommand(InstallAction installAction) {
+	@Option(names = { "--wait" }, description = "wait until all resources are ready")
+	private boolean wait;
+
+	@Option(names = { "--timeout" }, defaultValue = "300", description = "timeout in seconds for --wait (default 300)")
+	private int timeout;
+
+	public InstallCommand(InstallAction installAction, KubeService kubeService) {
 		this.installAction = installAction;
+		this.kubeService = kubeService;
 	}
 
 	@Override
@@ -64,6 +73,9 @@ public class InstallCommand implements Runnable {
 			}
 			else {
 				log.info("Release \"{}\" has been installed.", name);
+				if (wait) {
+					kubeService.waitForReady(namespace, release.getManifest(), timeout);
+				}
 			}
 		}
 		catch (Exception ex) {

--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/StatusCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/StatusCommand.java
@@ -2,10 +2,12 @@ package org.alexmond.jhelm.app;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.Release;
+import org.alexmond.jhelm.core.ResourceStatus;
 import org.alexmond.jhelm.core.StatusAction;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -20,6 +22,9 @@ public class StatusCommand implements Runnable {
 
 	@CommandLine.Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
 	private String namespace;
+
+	@CommandLine.Option(names = { "--show-resources" }, description = "show resource readiness status")
+	private boolean showResources;
 
 	public StatusCommand(StatusAction statusAction) {
 		this.statusAction = statusAction;
@@ -40,6 +45,21 @@ public class StatusCommand implements Runnable {
 			log.info("NAMESPACE: {}", r.getNamespace());
 			log.info("STATUS: {}", r.getInfo().getStatus());
 			log.info("REVISION: {}", r.getVersion());
+
+			if (showResources) {
+				List<ResourceStatus> statuses = statusAction.getResourceStatuses(r);
+				if (statuses.isEmpty()) {
+					log.info("\nRESOURCES:\n  (none)");
+				}
+				else {
+					log.info("\nRESOURCES:");
+					for (ResourceStatus rs : statuses) {
+						String readyMark = rs.isReady() ? "✓" : "✗";
+						log.info("  {} {}/{}: {}", readyMark, rs.getKind(), rs.getName(), rs.getMessage());
+					}
+				}
+			}
+
 			log.info("\nMANIFEST:\n{}", r.getManifest());
 		}
 		catch (Exception ex) {

--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/UpgradeCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/UpgradeCommand.java
@@ -51,6 +51,12 @@ public class UpgradeCommand implements Runnable {
 	@Option(names = { "--set" }, description = "set values on the command line (key=value, dot notation supported)")
 	private List<String> setValues = new ArrayList<>();
 
+	@Option(names = { "--wait" }, description = "wait until all resources are ready")
+	private boolean wait;
+
+	@Option(names = { "--timeout" }, defaultValue = "300", description = "timeout in seconds for --wait (default 300)")
+	private int timeout;
+
 	public UpgradeCommand(KubeService kubeService, InstallAction installAction, UpgradeAction upgradeAction) {
 		this.kubeService = kubeService;
 		this.installAction = installAction;
@@ -73,6 +79,9 @@ public class UpgradeCommand implements Runnable {
 					}
 					else {
 						log.info("Release \"{}\" does not exist. Installing it now.", name);
+						if (wait) {
+							kubeService.waitForReady(namespace, release.getManifest(), timeout);
+						}
 					}
 				}
 				else {
@@ -88,6 +97,9 @@ public class UpgradeCommand implements Runnable {
 			}
 			else {
 				log.info("Release \"{}\" has been upgraded. Happy Helming!", name);
+				if (wait) {
+					kubeService.waitForReady(namespace, upgradedRelease.getManifest(), timeout);
+				}
 			}
 		}
 		catch (Exception ex) {

--- a/jhelm-app/src/test/java/org/alexmond/jhelm/app/InstallCommandTest.java
+++ b/jhelm-app/src/test/java/org/alexmond/jhelm/app/InstallCommandTest.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.app;
 
 import org.alexmond.jhelm.core.Chart;
 import org.alexmond.jhelm.core.ChartMetadata;
+import org.alexmond.jhelm.core.KubeService;
 import org.alexmond.jhelm.core.Release;
 import org.alexmond.jhelm.core.InstallAction;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,12 +20,17 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class InstallCommandTest {
 
 	@Mock
 	private InstallAction installAction;
+
+	@Mock
+	private KubeService kubeService;
 
 	private InstallCommand installCommand;
 
@@ -34,7 +40,7 @@ class InstallCommandTest {
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		installCommand = new InstallCommand(installAction);
+		installCommand = new InstallCommand(installAction, kubeService);
 	}
 
 	@Test
@@ -70,6 +76,35 @@ class InstallCommandTest {
 
 		CommandLine cmd = new CommandLine(installCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath());
+	}
+
+	@Test
+	void testInstallCommandWithWait() throws Exception {
+		File chartDir = createMockChart();
+		Release release = createMockRelease("my-release", 1);
+
+		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean()))
+			.thenReturn(release);
+
+		CommandLine cmd = new CommandLine(installCommand);
+		cmd.execute("my-release", chartDir.getAbsolutePath(), "--wait", "--timeout", "120");
+
+		verify(kubeService).waitForReady(eq("default"), anyString(), eq(120));
+	}
+
+	@Test
+	void testInstallCommandWithWaitDoesNotCallOnDryRun() throws Exception {
+		File chartDir = createMockChart();
+		Release release = createMockRelease("my-release", 1);
+
+		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean()))
+			.thenReturn(release);
+
+		CommandLine cmd = new CommandLine(installCommand);
+		cmd.execute("my-release", chartDir.getAbsolutePath(), "--wait", "--dry-run");
+
+		// waitForReady should NOT be called when --dry-run is active
+		verify(kubeService, org.mockito.Mockito.never()).waitForReady(anyString(), anyString(), anyInt());
 	}
 
 	private File createMockChart() throws Exception {

--- a/jhelm-app/src/test/java/org/alexmond/jhelm/app/StatusCommandTest.java
+++ b/jhelm-app/src/test/java/org/alexmond/jhelm/app/StatusCommandTest.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.app;
 import org.alexmond.jhelm.core.Chart;
 import org.alexmond.jhelm.core.ChartMetadata;
 import org.alexmond.jhelm.core.Release;
+import org.alexmond.jhelm.core.ResourceStatus;
 import org.alexmond.jhelm.core.StatusAction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,9 @@ import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -51,6 +54,42 @@ class StatusCommandTest {
 
 		CommandLine cmd = new CommandLine(statusCommand);
 		cmd.execute("my-release");
+	}
+
+	@Test
+	void testStatusCommandWithShowResources() throws Exception {
+		Release release = createMockRelease();
+		when(statusAction.status(anyString(), anyString())).thenReturn(Optional.of(release));
+
+		List<ResourceStatus> statuses = List.of(
+				ResourceStatus.builder()
+					.kind("Deployment")
+					.name("my-deploy")
+					.namespace("default")
+					.ready(true)
+					.message("3/3 replicas ready")
+					.build(),
+				ResourceStatus.builder()
+					.kind("Service")
+					.name("my-svc")
+					.namespace("default")
+					.ready(false)
+					.message("pending")
+					.build());
+		when(statusAction.getResourceStatuses(any(Release.class))).thenReturn(statuses);
+
+		CommandLine cmd = new CommandLine(statusCommand);
+		cmd.execute("my-release", "--show-resources");
+	}
+
+	@Test
+	void testStatusCommandWithShowResourcesEmpty() throws Exception {
+		Release release = createMockRelease();
+		when(statusAction.status(anyString(), anyString())).thenReturn(Optional.of(release));
+		when(statusAction.getResourceStatuses(any(Release.class))).thenReturn(List.of());
+
+		CommandLine cmd = new CommandLine(statusCommand);
+		cmd.execute("my-release", "--show-resources");
 	}
 
 	private Release createMockRelease() {

--- a/jhelm-app/src/test/java/org/alexmond/jhelm/app/UpgradeCommandTest.java
+++ b/jhelm-app/src/test/java/org/alexmond/jhelm/app/UpgradeCommandTest.java
@@ -124,7 +124,7 @@ class UpgradeCommandTest {
 	}
 
 	@Test
-	void testUpgradeCommandWithTimeout() throws Exception {
+	void testUpgradeCommandWithWait() throws Exception {
 		File chartDir = createMockChart();
 		Release existingRelease = createMockRelease("my-release", 1);
 		Release upgradedRelease = createMockRelease("my-release", 2);
@@ -134,7 +134,9 @@ class UpgradeCommandTest {
 			.thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
-		cmd.execute("my-release", chartDir.getAbsolutePath(), "--timeout", "5m");
+		cmd.execute("my-release", chartDir.getAbsolutePath(), "--wait", "--timeout", "120");
+
+		verify(kubeService).waitForReady(eq("default"), anyString(), eq(120));
 	}
 
 	@Test

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/KubeService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/KubeService.java
@@ -19,4 +19,25 @@ public interface KubeService {
 
 	void delete(String namespace, String yamlContent) throws Exception;
 
+	/**
+	 * Returns the readiness status of each Kubernetes resource described in the rendered
+	 * manifest.
+	 * @param namespace the namespace to query
+	 * @param manifest rendered YAML manifest (may contain multiple documents)
+	 * @return one {@link ResourceStatus} per resource found in the manifest
+	 * @throws Exception if the Kubernetes API cannot be reached
+	 */
+	List<ResourceStatus> getResourceStatuses(String namespace, String manifest) throws Exception;
+
+	/**
+	 * Blocks until all resources described in the manifest are ready, or until the
+	 * timeout elapses.
+	 * @param namespace the namespace to query
+	 * @param manifest rendered YAML manifest
+	 * @param timeoutSeconds maximum seconds to wait
+	 * @throws Exception if the timeout elapses before all resources are ready, or if the
+	 * Kubernetes API cannot be reached
+	 */
+	void waitForReady(String namespace, String manifest, int timeoutSeconds) throws Exception;
+
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/ResourceStatus.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/ResourceStatus.java
@@ -1,0 +1,35 @@
+package org.alexmond.jhelm.core;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Represents the readiness status of a single Kubernetes resource deployed by a Helm
+ * release.
+ */
+@Data
+@Builder
+public class ResourceStatus {
+
+	/** Kubernetes resource kind (e.g. {@code Deployment}, {@code Job}). */
+	private String kind;
+
+	/** Resource name within its namespace. */
+	private String name;
+
+	/** Namespace the resource lives in. */
+	private String namespace;
+
+	/**
+	 * {@code true} if the resource has reached a ready/complete state; {@code false} if
+	 * still pending or failed.
+	 */
+	private boolean ready;
+
+	/**
+	 * Human-readable status message (e.g. {@code "2/3 replicas ready"} or
+	 * {@code "ready"}).
+	 */
+	private String message;
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/StatusAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/StatusAction.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.core;
 
+import java.util.List;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,13 @@ public class StatusAction {
 
 	public Optional<Release> status(String name, String namespace) throws Exception {
 		return kubeService.getRelease(name, namespace);
+	}
+
+	public List<ResourceStatus> getResourceStatuses(Release release) throws Exception {
+		if (release.getManifest() == null || release.getManifest().isBlank()) {
+			return List.of();
+		}
+		return kubeService.getResourceStatuses(release.getNamespace(), release.getManifest());
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/StatusActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/StatusActionTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.List;
 import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,6 +45,50 @@ class StatusActionTest {
 		Optional<Release> result = statusAction.status("non-existent", "default");
 
 		assertFalse(result.isPresent());
+	}
+
+	@Test
+	void testGetResourceStatusesReturnsStatuses() throws Exception {
+		Release release = Release.builder()
+			.name("test-release")
+			.namespace("default")
+			.version(1)
+			.manifest("---\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-deploy\n")
+			.build();
+
+		List<ResourceStatus> expected = List.of(ResourceStatus.builder()
+			.kind("Deployment")
+			.name("my-deploy")
+			.namespace("default")
+			.ready(true)
+			.message("ready")
+			.build());
+
+		when(kubeService.getResourceStatuses(anyString(), anyString())).thenReturn(expected);
+
+		List<ResourceStatus> result = statusAction.getResourceStatuses(release);
+
+		assertEquals(1, result.size());
+		assertEquals("Deployment", result.get(0).getKind());
+		assertTrue(result.get(0).isReady());
+	}
+
+	@Test
+	void testGetResourceStatusesWithNullManifestReturnsEmpty() throws Exception {
+		Release release = Release.builder().name("test-release").namespace("default").version(1).build();
+
+		List<ResourceStatus> result = statusAction.getResourceStatuses(release);
+
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	void testGetResourceStatusesWithBlankManifestReturnsEmpty() throws Exception {
+		Release release = Release.builder().name("test-release").namespace("default").version(1).manifest("").build();
+
+		List<ResourceStatus> result = statusAction.getResourceStatuses(release);
+
+		assertTrue(result.isEmpty());
 	}
 
 }

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/HelmKubeService.java
@@ -5,20 +5,28 @@ import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.custom.V1Patch;
+import io.kubernetes.client.openapi.apis.AppsV1Api;
+import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapList;
+import io.kubernetes.client.openapi.models.V1Deployment;
+import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
+import io.kubernetes.client.openapi.models.V1StatefulSet;
 import io.kubernetes.client.util.PatchUtils;
 import io.kubernetes.client.util.Yaml;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.KubeService;
 import org.alexmond.jhelm.core.Release;
+import org.alexmond.jhelm.core.ResourceStatus;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -267,6 +275,158 @@ public class HelmKubeService implements KubeService {
 			if (!(ex instanceof ApiException ae && ae.getCode() == 404)) {
 				throw ex;
 			}
+		}
+	}
+
+	/**
+	 * Returns the readiness status for each resource in the rendered manifest.
+	 */
+	@Override
+	public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) throws Exception {
+		List<ResourceStatus> statuses = new ArrayList<>();
+		Iterable<Object> objects = Yaml.loadAll(manifest);
+		for (Object obj : objects) {
+			if (obj instanceof KubernetesObject k8sObj) {
+				statuses.add(checkResourceStatus(namespace, k8sObj));
+			}
+		}
+		return statuses;
+	}
+
+	private ResourceStatus checkResourceStatus(String namespace, KubernetesObject obj) {
+		String kind = obj.getKind();
+		String name = obj.getMetadata().getName();
+		try {
+			return switch (kind) {
+				case "Deployment" -> checkDeployment(namespace, name);
+				case "StatefulSet" -> checkStatefulSet(namespace, name);
+				case "Job" -> checkJob(namespace, name);
+				case "Pod" -> checkPod(namespace, name);
+				default -> ResourceStatus.builder()
+					.kind(kind)
+					.name(name)
+					.namespace(namespace)
+					.ready(true)
+					.message("ready")
+					.build();
+			};
+		}
+		catch (Exception ex) {
+			return ResourceStatus.builder()
+				.kind(kind)
+				.name(name)
+				.namespace(namespace)
+				.ready(false)
+				.message(ex.getMessage())
+				.build();
+		}
+	}
+
+	private ResourceStatus checkDeployment(String namespace, String name) throws ApiException {
+		AppsV1Api api = new AppsV1Api(apiClient);
+		V1Deployment dep = api.readNamespacedDeployment(name, namespace).execute();
+		int desired = (dep.getSpec().getReplicas() != null) ? dep.getSpec().getReplicas() : 1;
+		int ready = (dep.getStatus().getReadyReplicas() != null) ? dep.getStatus().getReadyReplicas() : 0;
+		int updated = (dep.getStatus().getUpdatedReplicas() != null) ? dep.getStatus().getUpdatedReplicas() : 0;
+		boolean isReady = (ready >= desired) && (updated >= desired);
+		String message = isReady ? "ready" : String.format("%d/%d replicas ready", ready, desired);
+		return ResourceStatus.builder()
+			.kind("Deployment")
+			.name(name)
+			.namespace(namespace)
+			.ready(isReady)
+			.message(message)
+			.build();
+	}
+
+	private ResourceStatus checkStatefulSet(String namespace, String name) throws ApiException {
+		AppsV1Api api = new AppsV1Api(apiClient);
+		V1StatefulSet sts = api.readNamespacedStatefulSet(name, namespace).execute();
+		int desired = (sts.getSpec().getReplicas() != null) ? sts.getSpec().getReplicas() : 1;
+		int ready = (sts.getStatus().getReadyReplicas() != null) ? sts.getStatus().getReadyReplicas() : 0;
+		boolean isReady = ready >= desired;
+		String message = isReady ? "ready" : String.format("%d/%d replicas ready", ready, desired);
+		return ResourceStatus.builder()
+			.kind("StatefulSet")
+			.name(name)
+			.namespace(namespace)
+			.ready(isReady)
+			.message(message)
+			.build();
+	}
+
+	private ResourceStatus checkJob(String namespace, String name) throws ApiException {
+		BatchV1Api api = new BatchV1Api(apiClient);
+		V1Job job = api.readNamespacedJob(name, namespace).execute();
+		int completions = (job.getSpec().getCompletions() != null) ? job.getSpec().getCompletions() : 1;
+		int succeeded = (job.getStatus().getSucceeded() != null) ? job.getStatus().getSucceeded() : 0;
+		int failed = (job.getStatus().getFailed() != null) ? job.getStatus().getFailed() : 0;
+		boolean isReady = succeeded >= completions;
+		String message = isReady ? "complete"
+				: (failed > 0) ? String.format("failed=%d, succeeded=%d/%d", failed, succeeded, completions)
+						: String.format("succeeded=%d/%d", succeeded, completions);
+		return ResourceStatus.builder()
+			.kind("Job")
+			.name(name)
+			.namespace(namespace)
+			.ready(isReady)
+			.message(message)
+			.build();
+	}
+
+	private ResourceStatus checkPod(String namespace, String name) throws ApiException {
+		CoreV1Api api = new CoreV1Api(apiClient);
+		V1Pod pod = api.readNamespacedPod(name, namespace).execute();
+		boolean isReady = "Running".equals(pod.getStatus().getPhase()) && pod.getStatus().getConditions() != null
+				&& pod.getStatus()
+					.getConditions()
+					.stream()
+					.filter((c) -> "Ready".equals(c.getType()))
+					.anyMatch((c) -> "True".equals(c.getStatus()));
+		String message = isReady ? "ready" : pod.getStatus().getPhase();
+		return ResourceStatus.builder()
+			.kind("Pod")
+			.name(name)
+			.namespace(namespace)
+			.ready(isReady)
+			.message(message)
+			.build();
+	}
+
+	/**
+	 * Polls until all resources in the manifest are ready or the timeout elapses.
+	 */
+	@Override
+	public void waitForReady(String namespace, String manifest, int timeoutSeconds) throws Exception {
+		long deadline = System.currentTimeMillis() + (long) timeoutSeconds * 1000;
+		int pollIntervalMs = 5000;
+
+		while (true) {
+			List<ResourceStatus> statuses = getResourceStatuses(namespace, manifest);
+			boolean allReady = statuses.stream().allMatch(ResourceStatus::isReady);
+			if (allReady) {
+				return;
+			}
+
+			long remaining = deadline - System.currentTimeMillis();
+			if (remaining <= 0) {
+				break;
+			}
+
+			statuses.stream()
+				.filter((s) -> !s.isReady())
+				.forEach((s) -> log.info("Waiting for {}/{}: {}", s.getKind(), s.getName(), s.getMessage()));
+
+			Thread.sleep(Math.min(pollIntervalMs, remaining));
+		}
+
+		List<ResourceStatus> finalStatuses = getResourceStatuses(namespace, manifest);
+		List<ResourceStatus> notReady = finalStatuses.stream().filter((s) -> !s.isReady()).toList();
+		if (!notReady.isEmpty()) {
+			String msg = notReady.stream()
+				.map((s) -> s.getKind() + "/" + s.getName() + ": " + s.getMessage())
+				.collect(Collectors.joining(", "));
+			throw new Exception("Timeout waiting for resources to be ready: " + msg);
 		}
 	}
 

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/HelmKubeServiceTest.java
@@ -5,15 +5,20 @@ import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiClient;
 import java.util.Base64;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapList;
+import io.kubernetes.client.openapi.models.V1Deployment;
+import io.kubernetes.client.openapi.models.V1DeploymentSpec;
+import io.kubernetes.client.openapi.models.V1DeploymentStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.util.PatchUtils;
 import org.alexmond.jhelm.core.Release;
+import org.alexmond.jhelm.core.ResourceStatus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,11 +33,12 @@ import org.mockito.MockitoAnnotations;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -50,6 +56,8 @@ class HelmKubeServiceTest {
 	private HelmKubeService kubeService;
 
 	private final JsonMapper objectMapper = JsonMapper.builder().build();
+
+	private MockedConstruction<AppsV1Api> appsV1ApiConstruction;
 
 	private MockedConstruction<CoreV1Api> coreV1ApiConstruction;
 
@@ -73,6 +81,9 @@ class HelmKubeServiceTest {
 
 	@AfterEach
 	void tearDown() {
+		if (appsV1ApiConstruction != null) {
+			appsV1ApiConstruction.close();
+		}
 		if (coreV1ApiConstruction != null) {
 			coreV1ApiConstruction.close();
 		}
@@ -621,6 +632,140 @@ class HelmKubeServiceTest {
 		});
 
 		assertThrows(RuntimeException.class, () -> kubeService.installConfigMap("default", yaml));
+	}
+
+	// --- getResourceStatuses ---
+
+	@Test
+	void testGetResourceStatusesServiceReturnsReady() throws Exception {
+		String manifest = """
+				apiVersion: v1
+				kind: Service
+				metadata:
+				  name: my-svc
+				  namespace: default
+				""";
+
+		List<ResourceStatus> statuses = kubeService.getResourceStatuses("default", manifest);
+
+		assertEquals(1, statuses.size());
+		assertEquals("Service", statuses.get(0).getKind());
+		assertEquals("my-svc", statuses.get(0).getName());
+		assertTrue(statuses.get(0).isReady());
+	}
+
+	@Test
+	void testGetResourceStatusesDeploymentReady() throws Exception {
+		String manifest = """
+				apiVersion: apps/v1
+				kind: Deployment
+				metadata:
+				  name: my-deploy
+				  namespace: default
+				""";
+
+		appsV1ApiConstruction = mockConstruction(AppsV1Api.class, (mock, ctx) -> {
+			V1Deployment dep = new V1Deployment().spec(new V1DeploymentSpec().replicas(2))
+				.status(new V1DeploymentStatus().readyReplicas(2).updatedReplicas(2));
+			var readReq = mock(AppsV1Api.APIreadNamespacedDeploymentRequest.class);
+			when(readReq.execute()).thenReturn(dep);
+			when(mock.readNamespacedDeployment(eq("my-deploy"), eq("default"))).thenReturn(readReq);
+		});
+
+		List<ResourceStatus> statuses = kubeService.getResourceStatuses("default", manifest);
+
+		assertEquals(1, statuses.size());
+		assertEquals("Deployment", statuses.get(0).getKind());
+		assertTrue(statuses.get(0).isReady());
+	}
+
+	@Test
+	void testGetResourceStatusesDeploymentNotReady() throws Exception {
+		String manifest = """
+				apiVersion: apps/v1
+				kind: Deployment
+				metadata:
+				  name: my-deploy
+				  namespace: default
+				""";
+
+		appsV1ApiConstruction = mockConstruction(AppsV1Api.class, (mock, ctx) -> {
+			V1Deployment dep = new V1Deployment().spec(new V1DeploymentSpec().replicas(3))
+				.status(new V1DeploymentStatus().readyReplicas(1).updatedReplicas(2));
+			var readReq = mock(AppsV1Api.APIreadNamespacedDeploymentRequest.class);
+			when(readReq.execute()).thenReturn(dep);
+			when(mock.readNamespacedDeployment(eq("my-deploy"), eq("default"))).thenReturn(readReq);
+		});
+
+		List<ResourceStatus> statuses = kubeService.getResourceStatuses("default", manifest);
+
+		assertEquals(1, statuses.size());
+		assertFalse(statuses.get(0).isReady());
+		assertEquals("1/3 replicas ready", statuses.get(0).getMessage());
+	}
+
+	@Test
+	void testGetResourceStatusesApiExceptionReturnsFalse() throws Exception {
+		String manifest = """
+				apiVersion: apps/v1
+				kind: Deployment
+				metadata:
+				  name: bad-deploy
+				  namespace: default
+				""";
+
+		appsV1ApiConstruction = mockConstruction(AppsV1Api.class, (mock, ctx) -> {
+			var readReq = mock(AppsV1Api.APIreadNamespacedDeploymentRequest.class);
+			when(readReq.execute()).thenThrow(new ApiException(404, "Not Found"));
+			when(mock.readNamespacedDeployment(eq("bad-deploy"), eq("default"))).thenReturn(readReq);
+		});
+
+		List<ResourceStatus> statuses = kubeService.getResourceStatuses("default", manifest);
+
+		assertEquals(1, statuses.size());
+		assertFalse(statuses.get(0).isReady());
+	}
+
+	@Test
+	void testGetResourceStatusesEmptyManifestReturnsEmpty() throws Exception {
+		List<ResourceStatus> statuses = kubeService.getResourceStatuses("default", "");
+		assertTrue(statuses.isEmpty());
+	}
+
+	// --- waitForReady ---
+
+	@Test
+	void testWaitForReadyWithImmediatelyReadyResources() {
+		String manifest = """
+				apiVersion: v1
+				kind: Service
+				metadata:
+				  name: my-svc
+				  namespace: default
+				""";
+
+		assertDoesNotThrow(() -> kubeService.waitForReady("default", manifest, 60));
+	}
+
+	@Test
+	void testWaitForReadyTimeoutThrowsException() {
+		String manifest = """
+				apiVersion: apps/v1
+				kind: Deployment
+				metadata:
+				  name: my-deploy
+				  namespace: default
+				""";
+
+		appsV1ApiConstruction = mockConstruction(AppsV1Api.class, (mock, ctx) -> {
+			V1Deployment dep = new V1Deployment().spec(new V1DeploymentSpec().replicas(3))
+				.status(new V1DeploymentStatus().readyReplicas(0).updatedReplicas(0));
+			var readReq = mock(AppsV1Api.APIreadNamespacedDeploymentRequest.class);
+			when(readReq.execute()).thenReturn(dep);
+			when(mock.readNamespacedDeployment(anyString(), anyString())).thenReturn(readReq);
+		});
+
+		assertThrows(Exception.class, () -> kubeService.waitForReady("default", manifest, 0));
 	}
 
 	// --- inferPlural ---


### PR DESCRIPTION
## Summary

- Add `ResourceStatus` POJO to `jhelm-core` tracking kind, name, namespace, readiness, and status message
- Extend `KubeService` interface with `getResourceStatuses()` and `waitForReady()` methods
- Implement readiness checks in `HelmKubeService` for Deployment, StatefulSet, Job, and Pod; polls every 5s and throws on timeout
- Add `--show-resources` flag to `status` command — prints per-resource readiness with ✓/✗ markers
- Add `--wait` / `--timeout` flags to `install` and `upgrade` commands — waits for all resources to be ready after deployment (skipped on `--dry-run`)

## Test plan

- [x] `StatusActionTest` — `getResourceStatuses()` with ready/empty/blank manifest
- [x] `StatusCommandTest` — `--show-resources` with resources, with empty list
- [x] `InstallCommandTest` — `--wait` triggers `waitForReady()`; `--wait --dry-run` does NOT call `waitForReady()`
- [x] `UpgradeCommandTest` — `--wait` triggers `waitForReady()`
- [x] `HelmKubeServiceTest` — `getResourceStatuses()` for Service (default), Deployment (ready), Deployment (not ready), ApiException; `waitForReady()` immediate success and timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)