### PR TITLE
Implement Helm hooks support (Issue #9)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/HelmHook.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/HelmHook.java
@@ -1,0 +1,43 @@
+package org.alexmond.jhelm.core;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a Helm hook resource parsed from a chart manifest.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HelmHook {
+
+	/** Kubernetes resource kind (e.g. {@code Job}). */
+	private String kind;
+
+	/** Resource name within its namespace. */
+	private String name;
+
+	/** Namespace the resource lives in. */
+	private String namespace;
+
+	/** Hook phases this resource participates in (e.g. {@code pre-install}). */
+	private List<String> phases;
+
+	/** Execution order — lower values run first. Default is {@code 0}. */
+	private int weight;
+
+	/**
+	 * Delete policies from {@code helm.sh/hook-delete-policy} (e.g.
+	 * {@code before-hook-creation}, {@code hook-succeeded}).
+	 */
+	private List<String> deletePolicy;
+
+	/** Raw YAML document for this hook resource. */
+	private String yaml;
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/HookExecutor.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/HookExecutor.java
@@ -1,0 +1,55 @@
+package org.alexmond.jhelm.core;
+
+import java.util.Comparator;
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Executes Helm hooks for a given lifecycle phase.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class HookExecutor {
+
+	private final KubeService kubeService;
+
+	/**
+	 * Runs all hooks matching the given phase in weight order.
+	 * @param namespace the target namespace
+	 * @param hooks all parsed hooks for this release
+	 * @param phase the lifecycle phase (e.g. {@code pre-install})
+	 * @param timeoutSeconds how long to wait for each hook to become ready
+	 * @throws Exception if a hook apply or wait fails
+	 */
+	public void run(String namespace, List<HelmHook> hooks, String phase, int timeoutSeconds) throws Exception {
+		List<HelmHook> phaseHooks = hooks.stream()
+			.filter((h) -> h.getPhases().contains(phase))
+			.sorted(Comparator.comparingInt(HelmHook::getWeight))
+			.toList();
+
+		for (HelmHook hook : phaseHooks) {
+			List<String> policy = hook.getDeletePolicy();
+			boolean defaultPolicy = policy == null || policy.isEmpty();
+
+			if (defaultPolicy || policy.contains("before-hook-creation")) {
+				try {
+					kubeService.delete(namespace, hook.getYaml());
+				}
+				catch (Exception ex) {
+					log.debug("Pre-creation delete of hook {}/{} failed (ignored): {}", hook.getKind(), hook.getName(),
+							ex.getMessage());
+				}
+			}
+
+			kubeService.apply(namespace, hook.getYaml());
+			kubeService.waitForReady(namespace, hook.getYaml(), timeoutSeconds);
+
+			if (policy != null && policy.contains("hook-succeeded")) {
+				kubeService.delete(namespace, hook.getYaml());
+			}
+		}
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/HookParser.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/HookParser.java
@@ -1,0 +1,122 @@
+package org.alexmond.jhelm.core;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+/**
+ * Parses Helm hook resources from rendered chart manifests.
+ */
+public final class HookParser {
+
+	private static final YAMLMapper YAML_MAPPER = YAMLMapper.builder().build();
+
+	private HookParser() {
+	}
+
+	/**
+	 * Parses all hook resources from a rendered manifest.
+	 * @param manifest the full rendered YAML manifest (may be null or blank)
+	 * @return list of parsed hooks, empty if none found
+	 */
+	@SuppressWarnings("unchecked")
+	public static List<HelmHook> parseHooks(String manifest) {
+		if (manifest == null || manifest.isBlank()) {
+			return Collections.emptyList();
+		}
+
+		List<HelmHook> hooks = new ArrayList<>();
+		String[] docs = manifest.split("---");
+
+		for (String doc : docs) {
+			if (doc.isBlank() || !doc.contains("helm.sh/hook")) {
+				continue;
+			}
+
+			try {
+				Map<String, Object> parsed = YAML_MAPPER.readValue(doc, Map.class);
+				if (parsed == null) {
+					continue;
+				}
+
+				Map<String, Object> metadata = (Map<String, Object>) parsed.get("metadata");
+				if (metadata == null) {
+					continue;
+				}
+
+				Map<String, Object> annotations = (Map<String, Object>) metadata.get("annotations");
+				if (annotations == null || !annotations.containsKey("helm.sh/hook")) {
+					continue;
+				}
+
+				String hookValue = (String) annotations.get("helm.sh/hook");
+				List<String> phases = Arrays.asList(hookValue.split(","));
+
+				int weight = 0;
+				Object weightObj = annotations.get("helm.sh/hook-weight");
+				if (weightObj != null) {
+					try {
+						weight = Integer.parseInt(weightObj.toString().trim());
+					}
+					catch (NumberFormatException ignored) {
+					}
+				}
+
+				List<String> deletePolicy = Collections.emptyList();
+				Object policyObj = annotations.get("helm.sh/hook-delete-policy");
+				if (policyObj != null) {
+					deletePolicy = Arrays.asList(policyObj.toString().split(","));
+				}
+
+				String kind = (String) parsed.get("kind");
+				String name = (String) metadata.get("name");
+				String namespace = (String) metadata.get("namespace");
+
+				hooks.add(HelmHook.builder()
+					.kind(kind)
+					.name(name)
+					.namespace(namespace)
+					.phases(phases)
+					.weight(weight)
+					.deletePolicy(deletePolicy)
+					.yaml(doc.trim())
+					.build());
+			}
+			catch (Exception ignored) {
+			}
+		}
+
+		return hooks;
+	}
+
+	/**
+	 * Returns only the non-hook documents from a manifest, rejoined with {@code ---}.
+	 * @param manifest the full rendered YAML manifest (may be null or blank)
+	 * @return manifest with hook documents removed
+	 */
+	public static String stripHooks(String manifest) {
+		if (manifest == null) {
+			return "";
+		}
+		if (manifest.isBlank()) {
+			return manifest;
+		}
+
+		String[] docs = manifest.split("---");
+		StringBuilder result = new StringBuilder();
+
+		for (String doc : docs) {
+			if (doc.isBlank() || doc.contains("helm.sh/hook")) {
+				continue;
+			}
+			result.append("---\n").append(doc.trim()).append("\n");
+		}
+
+		return result.toString();
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/InstallAction.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.core;
 
 import java.time.OffsetDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
@@ -48,8 +49,13 @@ public class InstallAction {
 		release.setManifest(manifest);
 
 		if (kubeService != null && !dryRun) {
-			kubeService.apply(namespace, manifest);
+			List<HelmHook> hooks = HookParser.parseHooks(manifest);
+			String regularManifest = HookParser.stripHooks(manifest);
+			HookExecutor hookExecutor = new HookExecutor(kubeService);
+			hookExecutor.run(namespace, hooks, "pre-install", 300);
+			kubeService.apply(namespace, regularManifest);
 			kubeService.storeRelease(release);
+			hookExecutor.run(namespace, hooks, "post-install", 300);
 		}
 
 		return release;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/RollbackAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/RollbackAction.java
@@ -1,10 +1,10 @@
 package org.alexmond.jhelm.core;
 
-import lombok.RequiredArgsConstructor;
-
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class RollbackAction {
@@ -39,8 +39,14 @@ public class RollbackAction {
 				.build())
 			.build();
 
-		kubeService.apply(namespace, newRelease.getManifest());
+		String manifest = newRelease.getManifest();
+		List<HelmHook> hooks = HookParser.parseHooks(manifest);
+		String regularManifest = HookParser.stripHooks(manifest);
+		HookExecutor hookExecutor = new HookExecutor(kubeService);
+		hookExecutor.run(namespace, hooks, "pre-rollback", 300);
+		kubeService.apply(namespace, regularManifest);
 		kubeService.storeRelease(newRelease);
+		hookExecutor.run(namespace, hooks, "post-rollback", 300);
 	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/UninstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/UninstallAction.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.core;
 
+import java.util.List;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
@@ -16,7 +17,12 @@ public class UninstallAction {
 		}
 
 		Release release = releaseOpt.get();
-		kubeService.delete(namespace, release.getManifest());
+		List<HelmHook> hooks = HookParser.parseHooks(release.getManifest());
+		String regularManifest = HookParser.stripHooks(release.getManifest());
+		HookExecutor hookExecutor = new HookExecutor(kubeService);
+		hookExecutor.run(namespace, hooks, "pre-delete", 300);
+		kubeService.delete(namespace, regularManifest);
+		hookExecutor.run(namespace, hooks, "post-delete", 300);
 		kubeService.deleteReleaseHistory(releaseName, namespace);
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/UpgradeAction.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.core;
 
 import java.time.OffsetDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
@@ -46,8 +47,13 @@ public class UpgradeAction {
 		newRelease.setManifest(manifest);
 
 		if (kubeService != null && !dryRun) {
-			kubeService.apply(newRelease.getNamespace(), manifest);
+			List<HelmHook> hooks = HookParser.parseHooks(manifest);
+			String regularManifest = HookParser.stripHooks(manifest);
+			HookExecutor hookExecutor = new HookExecutor(kubeService);
+			hookExecutor.run(newRelease.getNamespace(), hooks, "pre-upgrade", 300);
+			kubeService.apply(newRelease.getNamespace(), regularManifest);
 			kubeService.storeRelease(newRelease);
+			hookExecutor.run(newRelease.getNamespace(), hooks, "post-upgrade", 300);
 		}
 
 		return newRelease;

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/HookExecutorTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/HookExecutorTest.java
@@ -1,0 +1,179 @@
+package org.alexmond.jhelm.core;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class HookExecutorTest {
+
+	@Mock
+	private KubeService kubeService;
+
+	private HookExecutor hookExecutor;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		hookExecutor = new HookExecutor(kubeService);
+	}
+
+	private HelmHook hookWithWeight(String name, String phase, int weight, List<String> policy) {
+		return HelmHook.builder()
+			.kind("Job")
+			.name(name)
+			.namespace("default")
+			.phases(List.of(phase))
+			.weight(weight)
+			.deletePolicy(policy)
+			.yaml("---\nkind: Job\nmetadata:\n  name: " + name)
+			.build();
+	}
+
+	@Test
+	void testHooksSortedByWeightAscending() throws Exception {
+		HelmHook heavy = hookWithWeight("heavy-hook", "pre-install", 10, Collections.emptyList());
+		HelmHook light = hookWithWeight("light-hook", "pre-install", 1, Collections.emptyList());
+
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
+
+		hookExecutor.run("default", List.of(heavy, light), "pre-install", 300);
+
+		InOrder order = inOrder(kubeService);
+		order.verify(kubeService).apply("default", light.getYaml());
+		order.verify(kubeService).apply("default", heavy.getYaml());
+	}
+
+	@Test
+	void testHooksFilteredByPhase() throws Exception {
+		HelmHook preInstall = hookWithWeight("pre-hook", "pre-install", 0, Collections.emptyList());
+		HelmHook postInstall = hookWithWeight("post-hook", "post-install", 0, Collections.emptyList());
+
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
+
+		hookExecutor.run("default", List.of(preInstall, postInstall), "pre-install", 300);
+
+		verify(kubeService).apply("default", preInstall.getYaml());
+		verify(kubeService, never()).apply("default", postInstall.getYaml());
+	}
+
+	@Test
+	void testBeforeHookCreationCallsDeleteBeforeApply() throws Exception {
+		HelmHook hook = hookWithWeight("my-hook", "pre-install", 0, List.of("before-hook-creation"));
+
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
+
+		hookExecutor.run("default", List.of(hook), "pre-install", 300);
+
+		InOrder order = inOrder(kubeService);
+		order.verify(kubeService).delete("default", hook.getYaml());
+		order.verify(kubeService).apply("default", hook.getYaml());
+	}
+
+	@Test
+	void testDefaultPolicyCallsDeleteBeforeApply() throws Exception {
+		HelmHook hook = hookWithWeight("my-hook", "pre-install", 0, Collections.emptyList());
+
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
+
+		hookExecutor.run("default", List.of(hook), "pre-install", 300);
+
+		verify(kubeService).delete("default", hook.getYaml());
+		verify(kubeService).apply("default", hook.getYaml());
+	}
+
+	@Test
+	void testHookSucceededCallsDeleteAfterWait() throws Exception {
+		HelmHook hook = hookWithWeight("my-hook", "pre-install", 0, List.of("hook-succeeded"));
+
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
+		doNothing().when(kubeService).delete(anyString(), anyString());
+
+		hookExecutor.run("default", List.of(hook), "pre-install", 300);
+
+		InOrder order = inOrder(kubeService);
+		order.verify(kubeService).apply("default", hook.getYaml());
+		order.verify(kubeService).waitForReady(eq("default"), eq(hook.getYaml()), eq(300));
+		order.verify(kubeService).delete("default", hook.getYaml());
+	}
+
+	@Test
+	void testPreCreationDeleteExceptionIsSwallowed() throws Exception {
+		HelmHook hook = hookWithWeight("my-hook", "pre-install", 0, List.of("before-hook-creation"));
+
+		doThrow(new RuntimeException("not found")).when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
+
+		hookExecutor.run("default", List.of(hook), "pre-install", 300);
+
+		verify(kubeService).apply("default", hook.getYaml());
+	}
+
+	@Test
+	void testNoHooksForPhaseNoInteraction() throws Exception {
+		HelmHook hook = hookWithWeight("post-hook", "post-install", 0, Collections.emptyList());
+
+		hookExecutor.run("default", List.of(hook), "pre-install", 300);
+
+		verify(kubeService, never()).apply(anyString(), anyString());
+		verify(kubeService, never()).delete(anyString(), anyString());
+		verify(kubeService, never()).waitForReady(anyString(), anyString(), anyInt());
+	}
+
+	@Test
+	void testEmptyHooksListNoInteraction() throws Exception {
+		hookExecutor.run("default", Collections.emptyList(), "pre-install", 300);
+
+		verify(kubeService, never()).apply(anyString(), anyString());
+	}
+
+	@Test
+	void testWaitForReadyCalledWithTimeoutSeconds() throws Exception {
+		HelmHook hook = hookWithWeight("my-hook", "pre-install", 0, Collections.emptyList());
+
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
+
+		hookExecutor.run("default", List.of(hook), "pre-install", 120);
+
+		verify(kubeService).waitForReady("default", hook.getYaml(), 120);
+	}
+
+	@Test
+	void testBothBeforeHookCreationAndHookSucceeded() throws Exception {
+		HelmHook hook = hookWithWeight("my-hook", "pre-install", 0, List.of("before-hook-creation", "hook-succeeded"));
+
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
+
+		hookExecutor.run("default", List.of(hook), "pre-install", 300);
+
+		// delete called twice: before creation and after success
+		verify(kubeService, times(2)).delete("default", hook.getYaml());
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/HookParserTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/HookParserTest.java
@@ -1,0 +1,213 @@
+package org.alexmond.jhelm.core;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HookParserTest {
+
+	private static final String HOOK_DOC = """
+			apiVersion: batch/v1
+			kind: Job
+			metadata:
+			  name: pre-install-job
+			  namespace: default
+			  annotations:
+			    helm.sh/hook: pre-install
+			    helm.sh/hook-weight: "5"
+			    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+			spec:
+			  template:
+			    spec:
+			      restartPolicy: Never
+			""";
+
+	private static final String REGULAR_DOC = """
+			apiVersion: v1
+			kind: ConfigMap
+			metadata:
+			  name: my-config
+			  namespace: default
+			data:
+			  key: value
+			""";
+
+	@Test
+	void testParseHooksReturnsEmptyForNull() {
+		List<HelmHook> hooks = HookParser.parseHooks(null);
+		assertTrue(hooks.isEmpty());
+	}
+
+	@Test
+	void testParseHooksReturnsEmptyForBlank() {
+		List<HelmHook> hooks = HookParser.parseHooks("   ");
+		assertTrue(hooks.isEmpty());
+	}
+
+	@Test
+	void testParseHooksReturnsEmptyForNoHooks() {
+		String manifest = "---\n" + REGULAR_DOC;
+		List<HelmHook> hooks = HookParser.parseHooks(manifest);
+		assertTrue(hooks.isEmpty());
+	}
+
+	@Test
+	void testParseHooksExtractsPhases() {
+		String manifest = "---\n" + HOOK_DOC;
+		List<HelmHook> hooks = HookParser.parseHooks(manifest);
+		assertEquals(1, hooks.size());
+		assertEquals(List.of("pre-install"), hooks.get(0).getPhases());
+	}
+
+	@Test
+	void testParseHooksExtractsWeight() {
+		String manifest = "---\n" + HOOK_DOC;
+		List<HelmHook> hooks = HookParser.parseHooks(manifest);
+		assertEquals(5, hooks.get(0).getWeight());
+	}
+
+	@Test
+	void testParseHooksExtractsDeletePolicy() {
+		String manifest = "---\n" + HOOK_DOC;
+		List<HelmHook> hooks = HookParser.parseHooks(manifest);
+		List<String> policy = hooks.get(0).getDeletePolicy();
+		assertTrue(policy.contains("before-hook-creation"));
+		assertTrue(policy.contains("hook-succeeded"));
+	}
+
+	@Test
+	void testParseHooksExtractsKindAndName() {
+		String manifest = "---\n" + HOOK_DOC;
+		List<HelmHook> hooks = HookParser.parseHooks(manifest);
+		assertEquals("Job", hooks.get(0).getKind());
+		assertEquals("pre-install-job", hooks.get(0).getName());
+	}
+
+	@Test
+	void testParseHooksExtractsNamespace() {
+		String manifest = "---\n" + HOOK_DOC;
+		List<HelmHook> hooks = HookParser.parseHooks(manifest);
+		assertEquals("default", hooks.get(0).getNamespace());
+	}
+
+	@Test
+	void testParseHooksIgnoresNonHookDocs() {
+		String manifest = "---\n" + REGULAR_DOC + "---\n" + HOOK_DOC;
+		List<HelmHook> hooks = HookParser.parseHooks(manifest);
+		assertEquals(1, hooks.size());
+	}
+
+	@Test
+	void testParseHooksMultiplePhases() {
+		String multiPhasedHook = """
+				apiVersion: batch/v1
+				kind: Job
+				metadata:
+				  name: multi-hook
+				  annotations:
+				    helm.sh/hook: pre-install,post-install
+				spec:
+				  template:
+				    spec:
+				      restartPolicy: Never
+				""";
+		List<HelmHook> hooks = HookParser.parseHooks("---\n" + multiPhasedHook);
+		assertEquals(1, hooks.size());
+		assertEquals(List.of("pre-install", "post-install"), hooks.get(0).getPhases());
+	}
+
+	@Test
+	void testParseHooksDefaultWeight() {
+		String hookNoWeight = """
+				apiVersion: batch/v1
+				kind: Job
+				metadata:
+				  name: no-weight-hook
+				  annotations:
+				    helm.sh/hook: pre-install
+				spec:
+				  template:
+				    spec:
+				      restartPolicy: Never
+				""";
+		List<HelmHook> hooks = HookParser.parseHooks("---\n" + hookNoWeight);
+		assertEquals(0, hooks.get(0).getWeight());
+	}
+
+	@Test
+	void testParseHooksEmptyDeletePolicy() {
+		String hookNoPolicy = """
+				apiVersion: batch/v1
+				kind: Job
+				metadata:
+				  name: no-policy-hook
+				  annotations:
+				    helm.sh/hook: pre-install
+				spec:
+				  template:
+				    spec:
+				      restartPolicy: Never
+				""";
+		List<HelmHook> hooks = HookParser.parseHooks("---\n" + hookNoPolicy);
+		assertTrue(hooks.get(0).getDeletePolicy().isEmpty());
+	}
+
+	@Test
+	void testParseHooksMultipleHooks() {
+		String hook2 = """
+				apiVersion: batch/v1
+				kind: Job
+				metadata:
+				  name: post-install-job
+				  annotations:
+				    helm.sh/hook: post-install
+				    helm.sh/hook-weight: "10"
+				spec:
+				  template:
+				    spec:
+				      restartPolicy: Never
+				""";
+		String manifest = "---\n" + HOOK_DOC + "---\n" + hook2;
+		List<HelmHook> hooks = HookParser.parseHooks(manifest);
+		assertEquals(2, hooks.size());
+	}
+
+	@Test
+	void testStripHooksReturnsEmptyForNull() {
+		String result = HookParser.stripHooks(null);
+		assertEquals("", result);
+	}
+
+	@Test
+	void testStripHooksReturnsBlankForBlank() {
+		String result = HookParser.stripHooks("   ");
+		assertEquals("   ", result);
+	}
+
+	@Test
+	void testStripHooksRemovesHookDocs() {
+		String manifest = "---\n" + REGULAR_DOC + "---\n" + HOOK_DOC;
+		String stripped = HookParser.stripHooks(manifest);
+		assertFalse(stripped.contains("helm.sh/hook"));
+		assertTrue(stripped.contains("ConfigMap"));
+	}
+
+	@Test
+	void testStripHooksPreservesNonHookDocs() {
+		String manifest = "---\n" + REGULAR_DOC + "---\n" + HOOK_DOC;
+		String stripped = HookParser.stripHooks(manifest);
+		assertTrue(stripped.contains("my-config"));
+	}
+
+	@Test
+	void testStripHooksOnlyHooks() {
+		String manifest = "---\n" + HOOK_DOC;
+		String stripped = HookParser.stripHooks(manifest);
+		assertTrue(stripped.isBlank() || stripped.equals(""));
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/InstallActionTest.java
@@ -1,0 +1,128 @@
+package org.alexmond.jhelm.core;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class InstallActionTest {
+
+	@Mock
+	private Engine engine;
+
+	@Mock
+	private KubeService kubeService;
+
+	private InstallAction installAction;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		installAction = new InstallAction(engine, kubeService);
+	}
+
+	@Test
+	void testInstallSuccess() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		String manifest = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(manifest);
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		Release release = installAction.install(chart, "my-release", "default", null, 1, false);
+
+		assertNotNull(release);
+		assertEquals("my-release", release.getName());
+		assertEquals("default", release.getNamespace());
+		assertEquals(1, release.getVersion());
+		assertEquals("deployed", release.getInfo().getStatus());
+		assertEquals(manifest, release.getManifest());
+
+		verify(kubeService).apply("default", HookParser.stripHooks(manifest));
+		verify(kubeService).storeRelease(any(Release.class));
+	}
+
+	@Test
+	void testInstallDryRunSkipsKube() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("---\nkind: ConfigMap\n");
+
+		Release release = installAction.install(chart, "my-release", "default", null, 1, true);
+
+		assertEquals("pending-install", release.getInfo().getStatus());
+		verify(kubeService, never()).apply(anyString(), anyString());
+		verify(kubeService, never()).storeRelease(any(Release.class));
+	}
+
+	@Test
+	void testInstallRunsHooksAndStripsManifest() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		String hookYaml = """
+				apiVersion: batch/v1
+				kind: Job
+				metadata:
+				  name: my-release-pre-install
+				  namespace: default
+				  annotations:
+				    helm.sh/hook: pre-install
+				    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+				spec:
+				  template:
+				    spec:
+				      restartPolicy: Never
+				""";
+		String regularYaml = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
+		String fullManifest = "---\n" + hookYaml + regularYaml;
+
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(fullManifest);
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		installAction.install(chart, "my-release", "default", null, 1, false);
+
+		List<HelmHook> hooks = HookParser.parseHooks(fullManifest);
+		String strippedManifest = HookParser.stripHooks(fullManifest);
+
+		// Hook apply called for pre-install hook
+		verify(kubeService).apply("default", hooks.get(0).getYaml());
+		// Regular apply called with stripped manifest
+		verify(kubeService).apply("default", strippedManifest);
+	}
+
+	@Test
+	void testInstallWithNullKubeServiceNoop() throws Exception {
+		InstallAction noKubeInstall = new InstallAction(engine, null);
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("---\nkind: ConfigMap\n");
+
+		Release release = noKubeInstall.install(chart, "my-release", "default", null, 1, false);
+
+		assertNotNull(release);
+		assertEquals("my-release", release.getName());
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/RollbackActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/RollbackActionTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -90,7 +91,9 @@ class RollbackActionTest {
 
 		rollbackAction.rollback("myapp", "default", 1);
 
-		verify(kubeService).apply("default", "---\nv1 manifest");
+		// apply receives the hook-stripped manifest (HookParser normalises docs with
+		// trailing \n)
+		verify(kubeService).apply("default", HookParser.stripHooks("---\nv1 manifest"));
 
 		ArgumentCaptor<Release> releaseCaptor = ArgumentCaptor.forClass(Release.class);
 		verify(kubeService).storeRelease(releaseCaptor.capture());
@@ -98,6 +101,58 @@ class RollbackActionTest {
 		Release storedRelease = releaseCaptor.getValue();
 		assertEquals(4, storedRelease.getVersion());
 		assertEquals("Rollback to 1", storedRelease.getInfo().getDescription());
+	}
+
+	@Test
+	void testRollbackRunsHooksAndStripsManifest() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).build();
+
+		String hookYaml = """
+				apiVersion: batch/v1
+				kind: Job
+				metadata:
+				  name: myapp-pre-rollback
+				  namespace: default
+				  annotations:
+				    helm.sh/hook: pre-rollback
+				    helm.sh/hook-delete-policy: before-hook-creation
+				spec:
+				  template:
+				    spec:
+				      restartPolicy: Never
+				""";
+		String regularYaml = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: myapp-cfg\n";
+		String manifest = "---\n" + hookYaml + regularYaml;
+
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status("deployed")
+			.build();
+
+		Release v1 = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.manifest(manifest)
+			.info(info)
+			.build();
+
+		when(kubeService.getReleaseHistory(anyString(), anyString())).thenReturn(Arrays.asList(v1));
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		rollbackAction.rollback("myapp", "default", 1);
+
+		List<HelmHook> hooks = HookParser.parseHooks(manifest);
+		String strippedManifest = HookParser.stripHooks(manifest);
+
+		verify(kubeService).apply("default", hooks.get(0).getYaml());
+		verify(kubeService).apply("default", strippedManifest);
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/UninstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/UninstallActionTest.java
@@ -5,9 +5,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.List;
 import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -38,6 +40,45 @@ class UninstallActionTest {
 		uninstallAction.uninstall("myapp", "default");
 
 		verify(kubeService).delete("default", "---\nkind: Service\n");
+		verify(kubeService).deleteReleaseHistory("myapp", "default");
+	}
+
+	@Test
+	void testUninstallRunsHooksAndStripsManifest() throws Exception {
+		String hookYaml = """
+				apiVersion: batch/v1
+				kind: Job
+				metadata:
+				  name: myapp-pre-delete
+				  namespace: default
+				  annotations:
+				    helm.sh/hook: pre-delete
+				    helm.sh/hook-delete-policy: before-hook-creation
+				spec:
+				  template:
+				    spec:
+				      restartPolicy: Never
+				""";
+		String regularYaml = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: myapp-cfg\n";
+		String fullManifest = "---\n" + hookYaml + regularYaml;
+
+		Release release = Release.builder().name("myapp").namespace("default").manifest(fullManifest).build();
+
+		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
+		doNothing().when(kubeService).deleteReleaseHistory(anyString(), anyString());
+
+		uninstallAction.uninstall("myapp", "default");
+
+		List<HelmHook> hooks = HookParser.parseHooks(fullManifest);
+		String strippedManifest = HookParser.stripHooks(fullManifest);
+
+		// Pre-delete hook: delete (before-hook-creation) + apply + waitForReady
+		verify(kubeService).apply("default", hooks.get(0).getYaml());
+		// Regular resource deletion uses stripped manifest
+		verify(kubeService).delete("default", strippedManifest);
 		verify(kubeService).deleteReleaseHistory("myapp", "default");
 	}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/UpgradeActionTest.java
@@ -8,10 +8,12 @@ import org.mockito.MockitoAnnotations;
 
 import java.time.OffsetDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
@@ -80,7 +82,9 @@ class UpgradeActionTest {
 		assertEquals("Upgrade complete", upgradedRelease.getInfo().getDescription());
 		assertEquals(renderedManifest, upgradedRelease.getManifest());
 
-		verify(kubeService).apply("default", renderedManifest);
+		// apply receives the hook-stripped manifest (HookParser normalises docs with
+		// trailing \n)
+		verify(kubeService).apply("default", HookParser.stripHooks(renderedManifest));
 		verify(kubeService).storeRelease(any(Release.class));
 
 		ArgumentCaptor<Map<String, Object>> releaseDataCaptor = ArgumentCaptor.forClass(Map.class);
@@ -159,6 +163,58 @@ class UpgradeActionTest {
 
 		verify(kubeService, never()).apply(anyString(), anyString());
 		verify(kubeService, never()).storeRelease(any(Release.class));
+	}
+
+	@Test
+	void testUpgradeRunsHooksAndStripsManifest() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("2.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status("deployed")
+			.build();
+
+		Release currentRelease = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.info(info)
+			.build();
+
+		String hookYaml = """
+				apiVersion: batch/v1
+				kind: Job
+				metadata:
+				  name: myapp-pre-upgrade
+				  namespace: default
+				  annotations:
+				    helm.sh/hook: pre-upgrade
+				    helm.sh/hook-delete-policy: before-hook-creation
+				spec:
+				  template:
+				    spec:
+				      restartPolicy: Never
+				""";
+		String regularYaml = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: myapp-svc\n";
+		String fullManifest = "---\n" + hookYaml + regularYaml;
+
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(fullManifest);
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		upgradeAction.upgrade(currentRelease, chart, null, false);
+
+		List<HelmHook> hooks = HookParser.parseHooks(fullManifest);
+		String strippedManifest = HookParser.stripHooks(fullManifest);
+
+		// Hook apply called with hook yaml, regular apply called with stripped manifest
+		verify(kubeService).apply("default", hooks.get(0).getYaml());
+		verify(kubeService).apply("default", strippedManifest);
 	}
 
 	@Test

--- a/jhelm-core/src/test/resources/test-charts/hooks-test/Chart.yaml
+++ b/jhelm-core/src/test/resources/test-charts/hooks-test/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: hooks-test
+description: A test chart for Helm hooks support
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/jhelm-core/src/test/resources/test-charts/hooks-test/templates/configmap.yaml
+++ b/jhelm-core/src/test/resources/test-charts/hooks-test/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+  namespace: {{ .Release.Namespace }}
+data:
+  replicaCount: "{{ .Values.replicaCount }}"

--- a/jhelm-core/src/test/resources/test-charts/hooks-test/templates/post-install-hook.yaml
+++ b/jhelm-core/src/test/resources/test-charts/hooks-test/templates/post-install-hook.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-post-install
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: post-install
+          image: busybox
+          command: ["sh", "-c", "echo post-install hook"]
+      restartPolicy: Never

--- a/jhelm-core/src/test/resources/test-charts/hooks-test/templates/pre-install-hook.yaml
+++ b/jhelm-core/src/test/resources/test-charts/hooks-test/templates/pre-install-hook.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-pre-install
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: pre-install
+          image: busybox
+          command: ["sh", "-c", "echo pre-install hook"]
+      restartPolicy: Never

--- a/jhelm-core/src/test/resources/test-charts/hooks-test/values.yaml
+++ b/jhelm-core/src/test/resources/test-charts/hooks-test/values.yaml
@@ -1,0 +1,4 @@
+replicaCount: 1
+image:
+  repository: nginx
+  tag: latest


### PR DESCRIPTION
## Summary
- Add `HelmHook` POJO (`kind`, `name`, `namespace`, `phases`, `weight`, `deletePolicy`, `yaml`)
- Add `HookParser` utility: `parseHooks()` extracts hook docs from a rendered manifest; `stripHooks()` removes them so regular resources are applied separately
- Add `HookExecutor`: filters hooks by lifecycle phase, sorts by weight ascending, applies `before-hook-creation` (delete before re-run) and `hook-succeeded` (delete after ready) delete policies
- Wire hooks into `InstallAction` (pre/post-install), `UpgradeAction` (pre/post-upgrade), `UninstallAction` (pre/post-delete), `RollbackAction` (pre/post-rollback)
- Full manifest (hooks + regular) is still stored in the release for `helm get hooks` display

## New files
| File | Role |
|------|------|
| `HelmHook.java` | Data model |
| `HookParser.java` | Parse & strip hook documents |
| `HookExecutor.java` | Lifecycle execution with delete policies |
| `HookParserTest.java` | 16 unit tests |
| `HookExecutorTest.java` | 10 Mockito-based unit tests |
| `InstallActionTest.java` | 4 tests (new) |
| `test-charts/hooks-test/` | Chart with pre/post-install hook jobs |

## Test plan
- [x] `./mvnw test -pl jhelm-core` — 222 tests, 0 failures
- [x] `./mvnw install` — full build passes, all coverage checks met
- [x] `./mvnw spring-javaformat:apply && ./mvnw validate` — 0 checkstyle violations

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)