### PR TITLE
Add developer workflow skills: precommit, scaffold-action, plan-issue

### DIFF
--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: plan-issue
+description: Explore the codebase and produce an implementation plan for a GitHub issue
+argument-hint: <issue-number>
+allowed-tools: Bash(gh *)
+---
+
+## Plan Implementation for GitHub Issue #$ARGUMENTS
+
+Produce a detailed, approvable implementation plan before writing any code.
+
+---
+
+### Step 1: Read the issue
+
+```bash
+gh issue view $ARGUMENTS
+```
+
+Extract:
+- Goal / user-facing behaviour
+- Explicit requirements and acceptance criteria
+- Any referenced files, classes, or issues
+
+---
+
+### Step 2: Explore the codebase
+
+Use Glob and Grep (or the Explore agent for broad searches) to locate:
+
+1. **Files to create** — identify the right package and naming convention by finding similar classes
+2. **Files to modify** — find every call site or injection point that needs updating
+3. **Tests to create/update** — find the existing test class for each file being modified
+4. **Relevant patterns** — read 1–2 existing similar classes to match structure (imports, annotations, error handling)
+
+Key places to always check:
+- `jhelm-core/src/main/java/org/alexmond/jhelm/core/` — action classes, models, interfaces
+- `jhelm-kube/src/main/java/` — Kubernetes client implementation
+- `jhelm-app/src/main/java/` — CLI commands (Picocli)
+- Matching test directories for each module
+
+---
+
+### Step 3: Write the plan
+
+Write the plan to `/tmp/plan-$ARGUMENTS.md` using this structure:
+
+```markdown
+# Plan: <Issue Title> (Issue #$ARGUMENTS)
+
+## Context
+<2–3 sentences on what currently exists and what is missing>
+
+## Files to Create
+### 1. `path/to/NewClass.java`
+- Purpose and key methods
+- Important implementation notes
+
+## Files to Modify
+### N. `path/to/ExistingClass.java`
+- What changes and why
+- Code sketch if helpful
+
+## Test Files to Create/Update
+### N+1. `path/to/NewClassTest.java`
+- Test cases to cover (success, error, edge cases)
+
+## Verification
+```bash
+./mvnw test -pl <module>
+./mvnw install
+./mvnw spring-javaformat:apply && ./mvnw validate
+```
+```
+
+Be specific: include exact class names, method signatures, and field types.
+Flag any ambiguities or decisions that need the user's input before proceeding.
+
+---
+
+### Step 4: Present and seek approval
+
+Call `ExitPlanMode` to show the plan to the user for approval.
+
+**Do not write any production or test code until the plan is approved.**
+
+After approval, implement following the plan exactly, running `/precommit` between
+meaningful checkpoints.

--- a/.claude/skills/precommit/SKILL.md
+++ b/.claude/skills/precommit/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: precommit
+description: Format, validate checkstyle, and run tests before committing — in the correct order
+argument-hint: [module]
+allowed-tools: Bash(./mvnw *)
+---
+
+## Pre-commit Check: Format → Validate → Test
+
+Run this before every commit to catch format and checkstyle issues early.
+
+`$ARGUMENTS` is an optional module name (e.g. `jhelm-core`). If omitted, runs against all modules.
+
+---
+
+### Step 1: Auto-format
+
+**Single module:**
+```bash
+./mvnw spring-javaformat:apply -pl $ARGUMENTS
+```
+
+**All modules:**
+```bash
+./mvnw spring-javaformat:apply
+```
+
+---
+
+### Step 2: Validate (checkstyle)
+
+**Single module:**
+```bash
+./mvnw validate -pl $ARGUMENTS 2>&1 | grep -E "^\[ERROR\]|violations"
+```
+
+**All modules:**
+```bash
+./mvnw validate 2>&1 | grep -E "^\[ERROR\]|violations"
+```
+
+If violations remain after auto-format, invoke the `/checkstyle` skill to fix them manually. Do **not** proceed to Step 3 until `validate` passes cleanly.
+
+---
+
+### Step 3: Run tests
+
+**Single module:**
+```bash
+./mvnw test -pl $ARGUMENTS 2>&1 | tail -20
+```
+
+**All modules (full build):**
+```bash
+./mvnw install 2>&1 | tail -20
+```
+
+---
+
+### Outcome
+
+Report a summary:
+
+| Step | Result |
+|------|--------|
+| Format | Applied / Already clean |
+| Checkstyle | 0 violations / N violations (list them) |
+| Tests | X passed, 0 failures / list failures |
+
+If everything is green, the working tree is ready to commit.
+If anything fails, fix it before committing.

--- a/.claude/skills/scaffold-action/SKILL.md
+++ b/.claude/skills/scaffold-action/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: scaffold-action
+description: Generate a new jhelm action class and matching test file from a name
+argument-hint: <ActionName>
+allowed-tools: Bash(./mvnw *)
+---
+
+## Scaffold a new jhelm Action class
+
+`$ARGUMENTS` is the action name in PascalCase **without** the `Action` suffix.
+Example: `/scaffold-action Lint` → creates `LintAction.java` + `LintActionTest.java`.
+
+Package: `org.alexmond.jhelm.core`
+Source root: `jhelm-core/src/main/java/org/alexmond/jhelm/core/`
+Test root: `jhelm-core/src/test/java/org/alexmond/jhelm/core/`
+
+---
+
+### Step 1: Determine dependencies
+
+Ask (or infer from context) whether the action needs:
+- `Engine engine` — only if it renders templates (install, upgrade, template)
+- `KubeService kubeService` — only if it talks to Kubernetes (install, upgrade, uninstall, rollback, status, list, history)
+
+Use only the fields actually required.
+
+---
+
+### Step 2: Create the action class
+
+File: `jhelm-core/src/main/java/org/alexmond/jhelm/core/$ARGUMENTS${"Action"}.java`
+
+```java
+package org.alexmond.jhelm.core;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ${ARGUMENTS}Action {
+
+	// Include only the dependencies determined in Step 1:
+	private final Engine engine;           // if template rendering needed
+	private final KubeService kubeService; // if Kubernetes access needed
+
+	public <ReturnType> <methodName>(<params>) throws Exception {
+		// TODO: implement
+	}
+
+}
+```
+
+Rules:
+- `@RequiredArgsConstructor` — never write a constructor by hand
+- `@Slf4j` — use `log.debug/info/warn/error`, never `System.out.println`
+- Throw descriptive `RuntimeException` (with cause) for error cases
+- For dry-run actions, skip `kubeService` calls when `dryRun == true`
+
+---
+
+### Step 3: Create the test class
+
+File: `jhelm-core/src/test/java/org/alexmond/jhelm/core/${ARGUMENTS}ActionTest.java`
+
+```java
+package org.alexmond.jhelm.core;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ${ARGUMENTS}ActionTest {
+
+	@Mock
+	private Engine engine; // include only if used
+
+	@Mock
+	private KubeService kubeService; // include only if used
+
+	private ${ARGUMENTS}Action ${argumentsCamel}Action;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		${argumentsCamel}Action = new ${ARGUMENTS}Action(/* inject mocks */);
+	}
+
+	@Test
+	void testSuccess() throws Exception {
+		// Arrange
+		// Act
+		// Assert
+	}
+
+	@Test
+	void testThrowsWhenNotFound() throws Exception {
+		// cover error/not-found path
+	}
+
+	// Add dryRun test if applicable:
+	@Test
+	void testDryRunSkipsKube() throws Exception {
+		// verify(kubeService, never()).apply(anyString(), anyString());
+	}
+
+}
+```
+
+Test rules:
+- One `@BeforeEach setUp()` that calls `MockitoAnnotations.openMocks(this)`
+- Use `doNothing().when(mock).voidMethod(...)` not `when(...).thenReturn(null)` for void methods
+- Use `ArgumentCaptor` when you need to assert on what was passed to a mock
+- Always test: success path, error/not-found path, and dry-run (if applicable)
+- Prefer real data (manifest strings, release builders) over excessive mocking
+
+---
+
+### Step 4: Run precommit check
+```bash
+./mvnw spring-javaformat:apply -pl jhelm-core && ./mvnw test -pl jhelm-core 2>&1 | tail -10
+```


### PR DESCRIPTION
## Summary
- `/precommit [module]` — runs `spring-javaformat:apply` → `mvnw validate` → `mvnw test` in the right order, reporting a pass/fail summary per step; prevents the common pattern of hitting checkstyle failures after running tests first
- `/scaffold-action <Name>` — generates `FooAction.java` + `FooActionTest.java` with standard jhelm boilerplate (`@RequiredArgsConstructor`, `@Slf4j`, mocked deps, `setUp()`, success/error/dryRun test stubs)
- `/plan-issue <number>` — fetches a GitHub issue, explores codebase, writes a structured implementation plan, then exits to plan mode for approval before any code is written

## Test plan
- [ ] Verify all three skills appear in the available skills list after merge
- [ ] Run `/precommit jhelm-core` and confirm it executes format → validate → test in order
- [ ] Run `/scaffold-action Foo` and confirm both files are generated with correct structure
- [ ] Run `/plan-issue 9` and confirm it fetches the issue and enters plan mode

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)