### PR TITLE
push skill: wait for CI checks after PR creation

### DIFF
--- a/.claude/skills/push/skill.md
+++ b/.claude/skills/push/skill.md
@@ -124,3 +124,21 @@ Now implement the work described in the issue:
   ```bash
   gh pr ready
   ```
+
+---
+
+### Step 8: Wait for CI to pass
+
+After the PR has real commits (not draft), wait for all checks to succeed:
+```bash
+gh pr checks --watch
+```
+
+This streams live check status until all checks complete. If any check fails:
+1. View the failing run logs:
+   ```bash
+   gh run view --log-failed
+   ```
+2. Fix the issue, commit, and push — then repeat `gh pr checks --watch`
+
+Only report success to the user once **all checks pass**.


### PR DESCRIPTION
## Summary

- Adds Step 8 to the `/push` skill: run `gh pr checks --watch` after the PR is non-draft
- On failure, instructs use of `gh run view --log-failed` to inspect logs
- Only reports success to the user once all checks pass

## Test plan

- [ ] Invoke `/push` on a real branch and verify Step 8 runs `gh pr checks --watch`

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)