### PR TITLE
Rename jhelm-app artifact to jhelm

### DIFF
--- a/jhelm-app/pom.xml
+++ b/jhelm-app/pom.xml
@@ -4,11 +4,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.alexmond</groupId>
-        <artifactId>jhelm</artifactId>
+        <artifactId>jhelm-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <artifactId>jhelm-app</artifactId>
-    <name>jhelm-app</name>
+    <artifactId>jhelm</artifactId>
+    <name>jhelm</name>
     <description>Spring Boot application for Helm Java</description>
 
     <dependencies>

--- a/jhelm-core/pom.xml
+++ b/jhelm-core/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.alexmond</groupId>
-        <artifactId>jhelm</artifactId>
+        <artifactId>jhelm-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>jhelm-core</artifactId>

--- a/jhelm-gotemplate/pom.xml
+++ b/jhelm-gotemplate/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.alexmond</groupId>
-        <artifactId>jhelm</artifactId>
+        <artifactId>jhelm-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>jhelm-gotemplate</artifactId>

--- a/jhelm-kube/pom.xml
+++ b/jhelm-kube/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.alexmond</groupId>
-        <artifactId>jhelm</artifactId>
+        <artifactId>jhelm-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>jhelm-kube</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,11 @@
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.alexmond</groupId>
-    <artifactId>jhelm</artifactId>
+    <artifactId>jhelm-parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>jhelm</name>
-    <description>jhelm</description>
+    <name>jhelm-parent</name>
+    <description>jhelm parent POM</description>
     <url>https://www.alexmond.org/jhelm/current/index.html</url>
 
 
@@ -92,7 +92,7 @@
             </dependency>
             <dependency>
                 <groupId>org.alexmond</groupId>
-                <artifactId>jhelm-app</artifactId>
+                <artifactId>jhelm</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
## Summary

- Renames parent POM artifact `jhelm` → `jhelm-parent` (avoids collision)
- Renames CLI module artifact `jhelm-app` → `jhelm`
- All four child module `<parent>` references updated to `jhelm-parent`
- Reactor now reports: `jhelm-parent`, `jhelm-gotemplate`, `jhelm-core`, `jhelm-kube`, `jhelm`
- Installed JAR: `jhelm-0.0.1-SNAPSHOT.jar` ✅

## Test plan

- [x] `./mvnw install` succeeds — BUILD SUCCESS
- [x] JAR installed as `jhelm-0.0.1-SNAPSHOT.jar`
- [x] No `jhelm-app` artifact ID references remain in any pom.xml

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)