### PR TITLE
Add LRU template compilation cache (#23)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -1,11 +1,14 @@
 package org.alexmond.jhelm.core;
 
+import org.alexmond.jhelm.core.cache.TemplateCache;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.beans.factory.ObjectProvider;
 import org.alexmond.jhelm.core.action.CreateAction;
 import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.HistoryAction;
@@ -53,8 +56,15 @@ public class JhelmCoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public Engine engine() {
-		return new Engine();
+	@ConditionalOnProperty(name = "jhelm.template-cache-enabled", havingValue = "true", matchIfMissing = true)
+	public TemplateCache templateCache(JhelmCoreProperties props) {
+		return new TemplateCache(props.getTemplateCacheMaxSize());
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public Engine engine(ObjectProvider<TemplateCache> templateCache) {
+		return new Engine(templateCache.getIfAvailable());
 	}
 
 	@Bean

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/cache/TemplateCache.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/cache/TemplateCache.java
@@ -1,0 +1,68 @@
+package org.alexmond.jhelm.core.cache;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.gotemplate.internal.parse.Node;
+
+/**
+ * LRU cache for parsed template ASTs. Keyed by template name and content hash to avoid
+ * re-parsing identical template content across multiple render calls.
+ */
+@Slf4j
+public final class TemplateCache {
+
+	private final Map<String, Map<String, Node>> cache;
+
+	private final int maxSize;
+
+	public TemplateCache(int maxSize) {
+		this.maxSize = maxSize;
+		this.cache = Collections.synchronizedMap(new LinkedHashMap<>(maxSize, 0.75f, true) {
+			@Override
+			protected boolean removeEldestEntry(Map.Entry<String, Map<String, Node>> eldest) {
+				return size() > TemplateCache.this.maxSize;
+			}
+		});
+	}
+
+	/**
+	 * Look up cached nodes for the given key.
+	 * @param key the cache key
+	 * @return the cached node map, or {@code null} on a miss
+	 */
+	public Map<String, Node> get(String key) {
+		Map<String, Node> cached = cache.get(key);
+		if (cached != null) {
+			log.debug("Template cache hit for key: {}", key);
+		}
+		return cached;
+	}
+
+	/**
+	 * Store a defensive copy of the given nodes under the given key.
+	 * @param key the cache key
+	 * @param nodes the nodes to cache
+	 */
+	public void put(String key, Map<String, Node> nodes) {
+		cache.put(key, new HashMap<>(nodes));
+	}
+
+	/**
+	 * Return the number of entries currently in the cache.
+	 */
+	public int size() {
+		return cache.size();
+	}
+
+	/**
+	 * Clear all cached entries.
+	 */
+	public void clear() {
+		cache.clear();
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmCoreProperties.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmCoreProperties.java
@@ -30,4 +30,14 @@ public class JhelmCoreProperties {
 	 */
 	private boolean insecureSkipTlsVerify = false;
 
+	/**
+	 * Whether to cache parsed template ASTs. Defaults to {@code true}.
+	 */
+	private boolean templateCacheEnabled = true;
+
+	/**
+	 * Maximum number of parsed templates in the LRU cache. Defaults to 256.
+	 */
+	private int templateCacheMaxSize = 256;
+
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -2,12 +2,14 @@ package org.alexmond.jhelm.core.service;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.cache.TemplateCache;
 import org.alexmond.jhelm.gotemplate.GoTemplate;
 import org.alexmond.jhelm.gotemplate.internal.parse.Node;
 
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.alexmond.jhelm.core.model.Chart;
@@ -17,9 +19,39 @@ public class Engine {
 
 	private final Map<String, String> namedTemplates = new HashMap<>();
 
+	private final TemplateCache templateCache;
+
 	private GoTemplate factory;
 
 	public Engine() {
+		this(null);
+	}
+
+	public Engine(TemplateCache templateCache) {
+		this.templateCache = templateCache;
+	}
+
+	private void parseWithCache(String name, String text) throws Exception {
+		if (templateCache == null) {
+			factory.parse(name, text);
+			return;
+		}
+		String cacheKey = name + "|" + text.hashCode();
+		Map<String, Node> cached = templateCache.get(cacheKey);
+		if (cached != null) {
+			factory.getRootNodes().putAll(cached);
+			return;
+		}
+		Map<String, Node> before = new LinkedHashMap<>(factory.getRootNodes());
+		factory.parse(name, text);
+		Map<String, Node> after = factory.getRootNodes();
+		Map<String, Node> added = new LinkedHashMap<>();
+		for (Map.Entry<String, Node> entry : after.entrySet()) {
+			if (!before.containsKey(entry.getKey())) {
+				added.put(entry.getKey(), entry.getValue());
+			}
+		}
+		templateCache.put(cacheKey, added);
 	}
 
 	private boolean isTruthy(Object context) {
@@ -146,7 +178,7 @@ public class Engine {
 		for (String name : sortedNames) {
 			try {
 				String chartName = templateToChartName.get(name);
-				factory.parse(name, allTemplates.get(name));
+				parseWithCache(name, allTemplates.get(name));
 				log.info("Parsed template: {} (from chart: {})", name, chartName);
 
 				// After parsing, check if new named templates (defines) were added
@@ -291,7 +323,7 @@ public class Engine {
 				continue;
 			}
 			try {
-				factory.parse(t.getName(), t.getData());
+				parseWithCache(t.getName(), t.getData());
 				StringWriter writer = new StringWriter();
 
 				Map<String, Object> templateMap = new HashMap<>((Map<String, Object>) context.get("Template"));
@@ -349,7 +381,7 @@ public class Engine {
 
 	private String renderTemplate(Chart.Template template, Map<String, Object> context) {
 		try {
-			factory.parse(template.getName(), template.getData());
+			parseWithCache(template.getName(), template.getData());
 			StringWriter writer = new StringWriter();
 			factory.execute(template.getName(), context, writer);
 			return writer.toString();

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/cache/TemplateCacheTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/cache/TemplateCacheTest.java
@@ -1,0 +1,93 @@
+package org.alexmond.jhelm.core.cache;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.alexmond.jhelm.gotemplate.internal.parse.Node;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+class TemplateCacheTest {
+
+	private TemplateCache cache;
+
+	@BeforeEach
+	void setUp() {
+		cache = new TemplateCache(10);
+	}
+
+	@Test
+	void putAndGet_returnsCachedNodes() {
+		Node node = new TestNode();
+		Map<String, Node> nodes = Map.of("tmpl", node);
+
+		cache.put("key1", nodes);
+		Map<String, Node> result = cache.get("key1");
+
+		assertNotNull(result);
+		assertEquals(1, result.size());
+		assertEquals(node, result.get("tmpl"));
+	}
+
+	@Test
+	void get_returnsNullOnMiss() {
+		assertNull(cache.get("nonexistent"));
+	}
+
+	@Test
+	void lruEviction_removesOldestEntryWhenFull() {
+		TemplateCache smallCache = new TemplateCache(2);
+		Node node = new TestNode();
+
+		smallCache.put("a", Map.of("n", node));
+		smallCache.put("b", Map.of("n", node));
+		// Access "a" to make "b" the least-recently-used
+		smallCache.get("a");
+		// Adding "c" should evict "b"
+		smallCache.put("c", Map.of("n", node));
+
+		assertNotNull(smallCache.get("a"));
+		assertNull(smallCache.get("b"));
+		assertNotNull(smallCache.get("c"));
+		assertEquals(2, smallCache.size());
+	}
+
+	@Test
+	void clear_emptiesCache() {
+		Node node = new TestNode();
+		cache.put("k1", Map.of("n", node));
+		cache.put("k2", Map.of("n", node));
+
+		cache.clear();
+
+		assertEquals(0, cache.size());
+		assertNull(cache.get("k1"));
+	}
+
+	@Test
+	void put_storesDefensiveCopy() {
+		Node node = new TestNode();
+		Map<String, Node> original = new HashMap<>();
+		original.put("tmpl", node);
+
+		cache.put("key", original);
+		// Mutate the original map — the cache should not be affected
+		original.put("extra", node);
+
+		Map<String, Node> cached = cache.get("key");
+		assertNotNull(cached);
+		assertEquals(1, cached.size());
+		assertNotSame(original, cached);
+	}
+
+	// Minimal Node implementation for testing
+	private static final class TestNode implements Node {
+
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/config/JhelmCoreAutoConfigurationTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/config/JhelmCoreAutoConfigurationTest.java
@@ -1,6 +1,7 @@
 package org.alexmond.jhelm.core.config;
 
 import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
+import org.alexmond.jhelm.core.cache.TemplateCache;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -70,6 +71,30 @@ class JhelmCoreAutoConfigurationTest {
 	void testConfigPathPropertyPassedToRepoManager() {
 		contextRunner.withPropertyValues("jhelm.core.config-path=/tmp/test-repos.yaml")
 			.run((ctx) -> assertNotNull(ctx.getBean(RepoManager.class)));
+	}
+
+	@Test
+	void templateCacheBeanRegisteredByDefault() {
+		contextRunner.run((ctx) -> assertNotNull(ctx.getBean(TemplateCache.class)));
+	}
+
+	@Test
+	void templateCacheBeanAbsentWhenDisabled() {
+		contextRunner.withPropertyValues("jhelm.template-cache-enabled=false")
+			.run((ctx) -> assertEquals(0, ctx.getBeanNamesForType(TemplateCache.class).length));
+	}
+
+	@Test
+	void templateCacheMaxSizeApplied() {
+		contextRunner.withPropertyValues("jhelm.template-cache-max-size=10").run((ctx) -> {
+			TemplateCache cache = ctx.getBean(TemplateCache.class);
+			assertNotNull(cache);
+			// Populate beyond the max and verify oldest are evicted
+			for (int i = 0; i < 12; i++) {
+				cache.put("key" + i, java.util.Map.of());
+			}
+			assertEquals(10, cache.size());
+		});
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineCacheTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineCacheTest.java
@@ -1,0 +1,94 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.cache.TemplateCache;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EngineCacheTest {
+
+	private static final Map<String, Object> RELEASE_INFO = Map.of("Name", "test-release", "Namespace", "default",
+			"IsInstall", true, "IsUpgrade", false, "Revision", 1);
+
+	private ChartLoader chartLoader;
+
+	@BeforeEach
+	void setUp() {
+		chartLoader = new ChartLoader();
+	}
+
+	private Chart loadMinimalChart() throws Exception {
+		return chartLoader.load(new File("src/test/resources/test-charts/minimal"));
+	}
+
+	@Test
+	void render_withCache_producesIdenticalOutput() throws Exception {
+		Chart chart = loadMinimalChart();
+		TemplateCache cache = new TemplateCache(64);
+		Engine engineWithCache = new Engine(cache);
+		Engine engineWithout = new Engine();
+
+		String withCache = engineWithCache.render(chart, Map.of(), RELEASE_INFO);
+		String withoutCache = engineWithout.render(chart, Map.of(), RELEASE_INFO);
+
+		assertNotNull(withCache);
+		assertNotNull(withoutCache);
+		assertEquals(withoutCache, withCache);
+	}
+
+	@Test
+	void render_twiceSameChart_cacheIsPopulated() throws Exception {
+		Chart chart = loadMinimalChart();
+		TemplateCache cache = new TemplateCache(64);
+		Engine engine = new Engine(cache);
+
+		engine.render(chart, Map.of(), RELEASE_INFO);
+		assertTrue(cache.size() > 0, "Cache should be populated after first render");
+
+		int sizeAfterFirst = cache.size();
+		engine.render(chart, Map.of(), RELEASE_INFO);
+		// Cache size should not grow on second render (all hits)
+		assertEquals(sizeAfterFirst, cache.size(), "Cache size should be stable after repeated renders");
+	}
+
+	@Test
+	void render_contentChange_doesNotReturnStaleResult() throws Exception {
+		TemplateCache cache = new TemplateCache(64);
+		Engine engine = new Engine(cache);
+
+		ChartMetadata metadata = ChartMetadata.builder().name("dynamic").version("1.0.0").build();
+
+		Chart chartV1 = Chart.builder()
+			.metadata(metadata)
+			.templates(List.of(Chart.Template.builder()
+				.name("configmap.yaml")
+				.data("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: v1\n")
+				.build()))
+			.build();
+
+		String outputV1 = engine.render(chartV1, Map.of(), RELEASE_INFO);
+		assertTrue(outputV1.contains("name: v1"), "First render should contain v1 content");
+
+		// Different content → different hash → cache miss → fresh parse
+		Chart chartV2 = Chart.builder()
+			.metadata(metadata)
+			.templates(List.of(Chart.Template.builder()
+				.name("configmap.yaml")
+				.data("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: v2\n")
+				.build()))
+			.build();
+
+		String outputV2 = engine.render(chartV2, Map.of(), RELEASE_INFO);
+		assertTrue(outputV2.contains("name: v2"), "Second render should contain v2 content, not stale v1");
+	}
+
+}


### PR DESCRIPTION
## Summary
- Introduces `TemplateCache`: a synchronized LRU `LinkedHashMap` that stores parsed template ASTs (`Map<String, Node>`) keyed by `templateName|contentHash`
- Adds `Engine(TemplateCache)` constructor; `Engine()` delegates to it with `null` (cache-off fallback)
- `parseWithCache()` private helper: on hit injects cached nodes directly into `factory.getRootNodes()`; on miss snapshots before/after parse, diffs, and stores the added nodes
- Replaces all `factory.parse()` calls in `collectNamedTemplates`, `renderChartTemplates`, and `renderTemplate` with `parseWithCache()`
- Two new properties on `JhelmCoreProperties`: `templateCacheEnabled` (default `true`) and `templateCacheMaxSize` (default `256`)
- `JhelmCoreAutoConfiguration` registers a `TemplateCache` bean (conditional on `jhelm.template-cache-enabled=true`, missing = true) and passes it to the `Engine` bean via `ObjectProvider`

## Test plan
- [x] `TemplateCacheTest` — put/get, null on miss, LRU eviction at maxSize=2, clear, defensive copy
- [x] `EngineCacheTest` — cached vs uncached output identical, cache populated after render, stale content not returned
- [x] `JhelmCoreAutoConfigurationTest` — cache bean registered by default, absent when disabled, max-size property respected
- [x] `./mvnw install` — full build + all modules green
- [x] `./mvnw spring-javaformat:apply && ./mvnw validate` — 0 Checkstyle violations

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)