### PR TITLE
Add JSON Schema validation for chart values (#11)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.service.RegistryManager;
 import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.core.service.SchemaValidator;
 
 /**
  * Auto-configuration for the jhelm core module. Registers all core Helm beans. Beans that
@@ -63,8 +64,14 @@ public class JhelmCoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public Engine engine(ObjectProvider<TemplateCache> templateCache) {
-		return new Engine(templateCache.getIfAvailable());
+	public SchemaValidator schemaValidator() {
+		return new SchemaValidator();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public Engine engine(ObjectProvider<TemplateCache> templateCache, SchemaValidator schemaValidator) {
+		return new Engine(templateCache.getIfAvailable(), schemaValidator);
 	}
 
 	@Bean

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Chart.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Chart.java
@@ -29,6 +29,9 @@ public class Chart {
 
 	private Map<String, Object> values;
 
+	/** Raw JSON content of {@code values.schema.json}, or {@code null} when absent. */
+	private String valuesSchema;
+
 	@Builder.Default
 	private List<Chart> dependencies = new ArrayList<>();
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
@@ -69,6 +69,13 @@ public class ChartLoader {
 			readme = Files.readString(readmeFile.toPath());
 		}
 
+		// Load values.schema.json
+		String valuesSchema = null;
+		File valuesSchemaFile = new File(chartDir, "values.schema.json");
+		if (valuesSchemaFile.exists()) {
+			valuesSchema = Files.readString(valuesSchemaFile.toPath());
+		}
+
 		// Load CRDs
 		File crdsDir = new File(chartDir, "crds");
 		List<Chart.Crd> crds = new ArrayList<>();
@@ -79,6 +86,7 @@ public class ChartLoader {
 		return Chart.builder()
 			.metadata(metadata)
 			.values(values)
+			.valuesSchema(valuesSchema)
 			.templates(templates)
 			.dependencies(dependencies)
 			.readme(readme)

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -21,14 +21,17 @@ public class Engine {
 
 	private final TemplateCache templateCache;
 
+	private final SchemaValidator schemaValidator;
+
 	private GoTemplate factory;
 
 	public Engine() {
-		this(null);
+		this(null, new SchemaValidator());
 	}
 
-	public Engine(TemplateCache templateCache) {
+	public Engine(TemplateCache templateCache, SchemaValidator schemaValidator) {
 		this.templateCache = templateCache;
+		this.schemaValidator = (schemaValidator != null) ? schemaValidator : new SchemaValidator();
 	}
 
 	private void parseWithCache(String name, String text) throws Exception {
@@ -270,6 +273,16 @@ public class Engine {
 		// Merge chart default values with provided values
 		Map<String, Object> chartValues = (chart.getValues() != null) ? chart.getValues() : new HashMap<>();
 		Map<String, Object> mergedValues = mergeValues(chartValues, values);
+
+		// Validate merged values against the chart's JSON Schema (if present)
+		if (chart.getValuesSchema() != null) {
+			try {
+				schemaValidator.validate(chart.getMetadata().getName(), chart.getValuesSchema(), mergedValues);
+			}
+			catch (SchemaValidationException ex) {
+				throw new RuntimeException(ex.getMessage(), ex);
+			}
+		}
 
 		Map<String, Object> context = new HashMap<>();
 		context.put("Values", mergedValues);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SchemaValidationException.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SchemaValidationException.java
@@ -1,0 +1,36 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.List;
+
+/**
+ * Thrown when user-supplied values fail JSON Schema validation against a chart's
+ * {@code values.schema.json}.
+ */
+public class SchemaValidationException extends Exception {
+
+	private final List<String> validationErrors;
+
+	public SchemaValidationException(String chartName, List<String> errors) {
+		super(buildMessage(chartName, errors));
+		this.validationErrors = List.copyOf(errors);
+	}
+
+	/**
+	 * Returns the individual validation error messages.
+	 * @return unmodifiable list of error messages
+	 */
+	public List<String> getValidationErrors() {
+		return validationErrors;
+	}
+
+	private static String buildMessage(String chartName, List<String> errors) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("values don't meet the specifications of the schema(s) in the following chart(s):\n");
+		sb.append(chartName).append(":\n");
+		for (String e : errors) {
+			sb.append("- ").append(e).append("\n");
+		}
+		return sb.toString();
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SchemaValidator.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SchemaValidator.java
@@ -1,0 +1,167 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import lombok.extern.slf4j.Slf4j;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Validates Helm chart values against a JSON Schema declared in
+ * {@code values.schema.json}. Supports the most common JSON Schema Draft-07 constraints:
+ * {@code type}, {@code required}, {@code properties}, {@code enum}, {@code minimum},
+ * {@code maximum}, {@code minLength}, {@code maxLength}, and {@code pattern}.
+ * <p>
+ * A malformed schema is logged as a warning and treated as absent — consistent with real
+ * Helm behaviour.
+ * </p>
+ */
+@Slf4j
+public class SchemaValidator {
+
+	private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
+
+	/**
+	 * Validates the given values map against the JSON Schema.
+	 * @param chartName chart name used in error messages
+	 * @param schemaJson raw JSON content of {@code values.schema.json}, or {@code null}
+	 * @param values merged values to validate
+	 * @throws SchemaValidationException if any constraint is violated
+	 */
+	public void validate(String chartName, String schemaJson, Map<String, Object> values)
+			throws SchemaValidationException {
+		if (schemaJson == null || schemaJson.isBlank()) {
+			return;
+		}
+		List<String> errors = new ArrayList<>();
+		try {
+			JsonNode schema = JSON_MAPPER.readTree(schemaJson);
+			JsonNode valuesNode = JSON_MAPPER.valueToTree(values);
+			validateNode(schema, valuesNode, "$", errors);
+		}
+		catch (Exception ex) {
+			log.warn("Could not parse values.schema.json for chart {}: {}", chartName, ex.getMessage());
+			return;
+		}
+		if (!errors.isEmpty()) {
+			throw new SchemaValidationException(chartName, errors);
+		}
+	}
+
+	private void validateNode(JsonNode schema, JsonNode value, String path, List<String> errors) {
+		if (schema == null || schema.isMissingNode()) {
+			return;
+		}
+		if (schema.has("type")) {
+			validateType(schema.get("type").asText(), value, path, errors);
+		}
+		if (schema.has("required") && value.isObject()) {
+			for (JsonNode req : schema.get("required")) {
+				if (!value.has(req.asText())) {
+					errors.add(path + "." + req.asText() + " is required");
+				}
+			}
+		}
+		if (schema.has("properties") && value.isObject()) {
+			JsonNode props = schema.get("properties");
+			Map<String, JsonNode> propsMap = JSON_MAPPER.convertValue(props,
+					new TypeReference<Map<String, JsonNode>>() {
+					});
+			for (Map.Entry<String, JsonNode> entry : propsMap.entrySet()) {
+				if (value.has(entry.getKey())) {
+					validateNode(entry.getValue(), value.get(entry.getKey()), path + "." + entry.getKey(), errors);
+				}
+			}
+		}
+		if (schema.has("enum")) {
+			boolean valid = false;
+			for (JsonNode enumVal : schema.get("enum")) {
+				if (enumVal.equals(value)) {
+					valid = true;
+					break;
+				}
+			}
+			if (!valid) {
+				errors.add(path + ": value " + value + " is not one of the allowed values " + schema.get("enum"));
+			}
+		}
+		if (value.isNumber()) {
+			double num = value.doubleValue();
+			if (schema.has("minimum") && num < schema.get("minimum").doubleValue()) {
+				errors.add(path + ": " + num + " must be >= " + schema.get("minimum").doubleValue());
+			}
+			if (schema.has("maximum") && num > schema.get("maximum").doubleValue()) {
+				errors.add(path + ": " + num + " must be <= " + schema.get("maximum").doubleValue());
+			}
+		}
+		if (value.isTextual()) {
+			String text = value.asText();
+			if (schema.has("minLength") && text.length() < schema.get("minLength").asInt()) {
+				errors
+					.add(path + ": string length " + text.length() + " must be >= " + schema.get("minLength").asInt());
+			}
+			if (schema.has("maxLength") && text.length() > schema.get("maxLength").asInt()) {
+				errors
+					.add(path + ": string length " + text.length() + " must be <= " + schema.get("maxLength").asInt());
+			}
+			if (schema.has("pattern")) {
+				String patternStr = schema.get("pattern").asText();
+				try {
+					if (!Pattern.compile(patternStr).matcher(text).find()) {
+						errors.add(path + ": string does not match pattern " + patternStr);
+					}
+				}
+				catch (PatternSyntaxException ex) {
+					log.warn("Invalid pattern '{}' in schema at {}: {}", patternStr, path, ex.getMessage());
+				}
+			}
+		}
+	}
+
+	private void validateType(String type, JsonNode value, String path, List<String> errors) {
+		boolean valid = switch (type) {
+			case "string" -> value.isTextual();
+			case "integer" -> value.isIntegralNumber();
+			case "number" -> value.isNumber();
+			case "boolean" -> value.isBoolean();
+			case "array" -> value.isArray();
+			case "object" -> value.isObject();
+			case "null" -> value.isNull();
+			default -> true;
+		};
+		if (!valid) {
+			errors.add(path + ": expected type " + type + " but was " + nodeTypeName(value));
+		}
+	}
+
+	private String nodeTypeName(JsonNode node) {
+		if (node.isTextual()) {
+			return "string";
+		}
+		if (node.isIntegralNumber()) {
+			return "integer";
+		}
+		if (node.isFloatingPointNumber()) {
+			return "number";
+		}
+		if (node.isBoolean()) {
+			return "boolean";
+		}
+		if (node.isArray()) {
+			return "array";
+		}
+		if (node.isObject()) {
+			return "object";
+		}
+		if (node.isNull()) {
+			return "null";
+		}
+		return "unknown";
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ChartLoaderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ChartLoaderTest.java
@@ -303,4 +303,48 @@ class ChartLoaderTest {
 		assertThrows(IllegalArgumentException.class, () -> chartLoader.load(chartDir.toFile()));
 	}
 
+	@Test
+	void testLoadChartWithValuesSchema() throws IOException {
+		Path chartDir = tempDir.resolve("chart-with-schema");
+		Files.createDirectories(chartDir);
+		Files.writeString(chartDir.resolve("Chart.yaml"), """
+				apiVersion: v2
+				name: chart-with-schema
+				version: 1.0.0
+				""");
+		Files.writeString(chartDir.resolve("values.yaml"), "replicas: 1\n");
+		Files.createDirectories(chartDir.resolve("templates"));
+		Files.writeString(chartDir.resolve("values.schema.json"), """
+				{
+				  "$schema": "https://json-schema.org/draft-07/schema",
+				  "type": "object",
+				  "properties": {
+				    "replicas": { "type": "integer", "minimum": 1 }
+				  }
+				}
+				""");
+
+		Chart chart = chartLoader.load(chartDir.toFile());
+
+		assertNotNull(chart.getValuesSchema());
+		assertTrue(chart.getValuesSchema().contains("$schema"));
+	}
+
+	@Test
+	void testLoadChartWithoutValuesSchema() throws IOException {
+		Path chartDir = tempDir.resolve("chart-without-schema");
+		Files.createDirectories(chartDir);
+		Files.writeString(chartDir.resolve("Chart.yaml"), """
+				apiVersion: v2
+				name: chart-without-schema
+				version: 1.0.0
+				""");
+		Files.writeString(chartDir.resolve("values.yaml"), "replicas: 1\n");
+		Files.createDirectories(chartDir.resolve("templates"));
+
+		Chart chart = chartLoader.load(chartDir.toFile());
+
+		assertNull(chart.getValuesSchema());
+	}
+
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineCacheTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineCacheTest.java
@@ -34,7 +34,7 @@ class EngineCacheTest {
 	void render_withCache_producesIdenticalOutput() throws Exception {
 		Chart chart = loadMinimalChart();
 		TemplateCache cache = new TemplateCache(64);
-		Engine engineWithCache = new Engine(cache);
+		Engine engineWithCache = new Engine(cache, null);
 		Engine engineWithout = new Engine();
 
 		String withCache = engineWithCache.render(chart, Map.of(), RELEASE_INFO);
@@ -49,7 +49,7 @@ class EngineCacheTest {
 	void render_twiceSameChart_cacheIsPopulated() throws Exception {
 		Chart chart = loadMinimalChart();
 		TemplateCache cache = new TemplateCache(64);
-		Engine engine = new Engine(cache);
+		Engine engine = new Engine(cache, null);
 
 		engine.render(chart, Map.of(), RELEASE_INFO);
 		assertTrue(cache.size() > 0, "Cache should be populated after first render");
@@ -63,7 +63,7 @@ class EngineCacheTest {
 	@Test
 	void render_contentChange_doesNotReturnStaleResult() throws Exception {
 		TemplateCache cache = new TemplateCache(64);
-		Engine engine = new Engine(cache);
+		Engine engine = new Engine(cache, null);
 
 		ChartMetadata metadata = ChartMetadata.builder().name("dynamic").version("1.0.0").build();
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/SchemaValidatorTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/SchemaValidatorTest.java
@@ -1,0 +1,171 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SchemaValidatorTest {
+
+	private SchemaValidator validator;
+
+	@BeforeEach
+	void setUp() {
+		validator = new SchemaValidator();
+	}
+
+	@Test
+	void validate_nullSchema_doesNothing() {
+		assertDoesNotThrow(() -> validator.validate("test-chart", null, Map.of("foo", "bar")));
+	}
+
+	@Test
+	void validate_blankSchema_doesNothing() {
+		assertDoesNotThrow(() -> validator.validate("test-chart", "  ", Map.of("foo", "bar")));
+	}
+
+	@Test
+	void validate_validValues_doesNotThrow() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": {
+				    "replicas": { "type": "integer" }
+				  }
+				}
+				""";
+		assertDoesNotThrow(() -> validator.validate("test-chart", schema, Map.of("replicas", 3)));
+	}
+
+	@Test
+	void validate_typeViolation_throwsException() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": {
+				    "replicas": { "type": "integer" }
+				  }
+				}
+				""";
+		SchemaValidationException ex = assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("replicas", "not-an-integer")));
+		assertFalse(ex.getValidationErrors().isEmpty());
+		assertTrue(ex.getMessage().contains("test-chart"));
+	}
+
+	@Test
+	void validate_missingRequiredField_throwsException() {
+		String schema = """
+				{
+				  "type": "object",
+				  "required": ["name"],
+				  "properties": {
+				    "name": { "type": "string" }
+				  }
+				}
+				""";
+		SchemaValidationException ex = assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of()));
+		assertTrue(ex.getValidationErrors().stream().anyMatch((e) -> e.contains("name") && e.contains("required")));
+	}
+
+	@Test
+	void validate_enumViolation_throwsException() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": {
+				    "color": { "enum": ["red", "green", "blue"] }
+				  }
+				}
+				""";
+		SchemaValidationException ex = assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("color", "yellow")));
+		assertFalse(ex.getValidationErrors().isEmpty());
+	}
+
+	@Test
+	void validate_minimumViolation_throwsException() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": {
+				    "replicas": { "type": "integer", "minimum": 1 }
+				  }
+				}
+				""";
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("replicas", 0)));
+	}
+
+	@Test
+	void validate_maximumViolation_throwsException() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": {
+				    "replicas": { "type": "integer", "maximum": 10 }
+				  }
+				}
+				""";
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("replicas", 100)));
+	}
+
+	@Test
+	void validate_patternViolation_throwsException() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": {
+				    "image": { "type": "string", "pattern": "^[a-z]+/[a-z]+" }
+				  }
+				}
+				""";
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("image", "UPPERCASE/IMAGE")));
+	}
+
+	@Test
+	void validate_malformedSchema_logsWarningOnly() {
+		assertDoesNotThrow(() -> validator.validate("test-chart", "not valid json { {", Map.of("foo", "bar")));
+	}
+
+	@Test
+	void validate_nestedObjectValidation_detectsViolation() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": {
+				    "image": {
+				      "type": "object",
+				      "properties": {
+				        "tag": { "type": "string" }
+				      }
+				    }
+				  }
+				}
+				""";
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("image", Map.of("tag", 123))));
+	}
+
+	@Test
+	void validate_exceptionMessage_containsChartNameAndErrors() {
+		String schema = """
+				{ "type": "object", "required": ["name"] }
+				""";
+		SchemaValidationException ex = assertThrows(SchemaValidationException.class,
+				() -> validator.validate("my-chart", schema, Map.of()));
+		assertTrue(ex.getMessage().contains("my-chart"));
+		assertNotNull(ex.getValidationErrors());
+		assertFalse(ex.getValidationErrors().isEmpty());
+	}
+
+}


### PR DESCRIPTION
## Summary
- Adds `SchemaValidationException` (checked exception with `List<String> validationErrors`)
- Adds `SchemaValidator` — Jackson 3-based validator supporting `type`, `required`, `properties`, `enum`, `minimum`/`maximum`, `minLength`/`maxLength`, `pattern`; malformed schemas are warned and skipped (matches real Helm behaviour)
- `Chart` gains a `valuesSchema` field; `ChartLoader` loads `values.schema.json` when present
- `Engine.renderWithSubcharts()` validates merged values against the schema before rendering; wraps `SchemaValidationException` in `RuntimeException` for transparent propagation
- `JhelmCoreAutoConfiguration` registers `SchemaValidator` bean; passes it to `Engine` bean
- No new dependencies — uses `tools.jackson.databind.JsonNode` (already on classpath)

## Test plan
- [x] `SchemaValidatorTest` (12 tests) — null/blank schema, valid values, type/required/enum/minimum/maximum/pattern violations, malformed schema warn-only, nested objects, error message content
- [x] `ChartLoaderTest` — `testLoadChartWithValuesSchema`, `testLoadChartWithoutValuesSchema`
- [x] `./mvnw test -pl jhelm-core` — 241 tests green
- [x] `./mvnw validate -pl jhelm-core` — 0 Checkstyle violations

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)