### PR TITLE
Implement post-renderers (#20)

### DIFF
--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -1,20 +1,21 @@
 package org.alexmond.jhelm.app.command;
 
-import lombok.extern.slf4j.Slf4j;
-import org.alexmond.jhelm.core.model.Chart;
-import org.alexmond.jhelm.core.service.ChartLoader;
-import org.alexmond.jhelm.core.action.InstallAction;
-import org.alexmond.jhelm.core.service.KubeService;
-import org.alexmond.jhelm.core.model.Release;
-import org.alexmond.jhelm.core.util.ValuesOverrides;
-import org.springframework.stereotype.Component;
-import picocli.CommandLine;
-import picocli.CommandLine.Option;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
+import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.core.util.ValuesOverrides;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
 
 @Component
 @CommandLine.Command(name = "install", description = "install a chart")
@@ -51,6 +52,9 @@ public class InstallCommand implements Runnable {
 	@Option(names = { "--timeout" }, defaultValue = "300", description = "timeout in seconds for --wait (default 300)")
 	private int timeout;
 
+	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
+	private List<String> postRenderers = new ArrayList<>();
+
 	public InstallCommand(InstallAction installAction, KubeService kubeService, ChartLoader chartLoader) {
 		this.installAction = installAction;
 		this.kubeService = kubeService;
@@ -64,6 +68,7 @@ public class InstallCommand implements Runnable {
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues);
 
 			Release release = installAction.install(chart, name, namespace, overrides, 1, dryRun);
+			applyCliPostRenderers(release);
 
 			if (dryRun) {
 				log.info("NAME: {}", release.getName());
@@ -83,6 +88,17 @@ public class InstallCommand implements Runnable {
 		catch (Exception ex) {
 			log.error("Error installing chart: {}", ex.getMessage(), ex);
 		}
+	}
+
+	private void applyCliPostRenderers(Release release) throws Exception {
+		if (postRenderers.isEmpty()) {
+			return;
+		}
+		String manifest = release.getManifest();
+		for (String renderer : postRenderers) {
+			manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
+		}
+		release.setManifest(manifest);
 	}
 
 }

--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
@@ -1,15 +1,16 @@
 package org.alexmond.jhelm.app.command;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.action.TemplateAction;
+import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
 import org.alexmond.jhelm.core.util.ValuesOverrides;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 @Component
 @CommandLine.Command(name = "template", description = "locally render templates")
@@ -33,6 +34,9 @@ public class TemplateCommand implements Runnable {
 	@Option(names = { "--set" }, description = "set values on the command line (key=value, dot notation supported)")
 	private List<String> setValues = new ArrayList<>();
 
+	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
+	private List<String> postRenderers = new ArrayList<>();
+
 	public TemplateCommand(TemplateAction templateAction) {
 		this.templateAction = templateAction;
 	}
@@ -42,6 +46,9 @@ public class TemplateCommand implements Runnable {
 		try {
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues);
 			String manifest = templateAction.render(chartPath, name, namespace, overrides);
+			for (String renderer : postRenderers) {
+				manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
+			}
 			log.info("\n{}", manifest);
 		}
 		catch (Exception ex) {

--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -1,23 +1,23 @@
 package org.alexmond.jhelm.app.command;
 
-import lombok.extern.slf4j.Slf4j;
-import org.alexmond.jhelm.core.model.Chart;
-import org.alexmond.jhelm.core.service.ChartLoader;
-import org.alexmond.jhelm.core.model.Release;
-import org.alexmond.jhelm.core.service.KubeService;
-import org.alexmond.jhelm.core.action.InstallAction;
-import org.alexmond.jhelm.core.action.UpgradeAction;
-import org.springframework.stereotype.Component;
-import picocli.CommandLine;
-
-import org.alexmond.jhelm.core.util.ValuesOverrides;
-import picocli.CommandLine.Option;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
+import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.core.util.ValuesOverrides;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
 
 @Component
 @CommandLine.Command(name = "upgrade", description = "upgrade a release")
@@ -59,6 +59,9 @@ public class UpgradeCommand implements Runnable {
 	@Option(names = { "--timeout" }, defaultValue = "300", description = "timeout in seconds for --wait (default 300)")
 	private int timeout;
 
+	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
+	private List<String> postRenderers = new ArrayList<>();
+
 	public UpgradeCommand(KubeService kubeService, InstallAction installAction, UpgradeAction upgradeAction,
 			ChartLoader chartLoader) {
 		this.kubeService = kubeService;
@@ -77,6 +80,7 @@ public class UpgradeCommand implements Runnable {
 			if (currentReleaseOpt.isEmpty()) {
 				if (install) {
 					Release release = installAction.install(chart, name, namespace, overrides, 1, dryRun);
+					applyCliPostRenderers(release);
 					if (dryRun) {
 						printRelease(release);
 					}
@@ -94,6 +98,7 @@ public class UpgradeCommand implements Runnable {
 			}
 
 			Release upgradedRelease = upgradeAction.upgrade(currentReleaseOpt.get(), chart, overrides, dryRun);
+			applyCliPostRenderers(upgradedRelease);
 
 			if (dryRun) {
 				printRelease(upgradedRelease);
@@ -108,6 +113,17 @@ public class UpgradeCommand implements Runnable {
 		catch (Exception ex) {
 			log.error("Error upgrading release: {}", ex.getMessage(), ex);
 		}
+	}
+
+	private void applyCliPostRenderers(Release release) throws Exception {
+		if (postRenderers.isEmpty()) {
+			return;
+		}
+		String manifest = release.getManifest();
+		for (String renderer : postRenderers) {
+			manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
+		}
+		release.setManifest(manifest);
 	}
 
 	private void printRelease(Release release) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ExternalCommandPostRenderer.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ExternalCommandPostRenderer.java
@@ -1,0 +1,113 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A {@link PostRenderProcessor} that pipes the rendered manifest through an external
+ * command via stdin/stdout. This mirrors the Helm {@code --post-renderer} behavior.
+ *
+ * <p>
+ * The command receives the rendered manifest on standard input and is expected to produce
+ * the transformed manifest on standard output. If the command exits with a non-zero
+ * status, an exception is thrown.
+ */
+@Slf4j
+public class ExternalCommandPostRenderer implements PostRenderProcessor {
+
+	private final List<String> command;
+
+	private final long timeoutSeconds;
+
+	/**
+	 * Create a post-renderer that invokes the given command.
+	 * @param command the command and its arguments
+	 */
+	public ExternalCommandPostRenderer(List<String> command) {
+		this(command, 300);
+	}
+
+	/**
+	 * Create a post-renderer with a custom timeout.
+	 * @param command the command and its arguments
+	 * @param timeoutSeconds maximum time to wait for the command
+	 */
+	public ExternalCommandPostRenderer(List<String> command, long timeoutSeconds) {
+		this.command = command;
+		this.timeoutSeconds = timeoutSeconds;
+	}
+
+	@Override
+	public String process(String renderedManifest) throws Exception {
+		ProcessBuilder pb = new ProcessBuilder(command);
+		pb.redirectErrorStream(false);
+
+		log.debug("Running post-renderer: {}", String.join(" ", command));
+
+		Process process = pb.start();
+		try {
+			// Write stdin in a separate thread to avoid deadlock with stdout/stderr
+			CompletableFuture<Void> stdinFuture = CompletableFuture.runAsync(() -> {
+				try (OutputStream stdin = process.getOutputStream()) {
+					stdin.write(renderedManifest.getBytes(StandardCharsets.UTF_8));
+				}
+				catch (IOException ex) {
+					throw new RuntimeException(ex);
+				}
+			});
+
+			// Read stdout and stderr concurrently
+			CompletableFuture<String> stdoutFuture = CompletableFuture
+				.supplyAsync(() -> readStreamUnchecked(process.getInputStream()));
+			CompletableFuture<String> stderrFuture = CompletableFuture
+				.supplyAsync(() -> readStreamUnchecked(process.getErrorStream()));
+
+			boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
+			if (!finished) {
+				process.destroyForcibly();
+				throw new IOException(
+						"Post-renderer command timed out after " + timeoutSeconds + "s: " + String.join(" ", command));
+			}
+
+			stdinFuture.join();
+			String stdout = stdoutFuture.join();
+			String stderr = stderrFuture.join();
+
+			int exitCode = process.exitValue();
+			if (exitCode != 0) {
+				throw new IOException("Post-renderer command exited with code " + exitCode + ": "
+						+ String.join(" ", command) + (stderr.isBlank() ? "" : "\nstderr: " + stderr));
+			}
+
+			log.debug("Post-renderer completed successfully");
+			return stdout;
+		}
+		finally {
+			process.destroyForcibly();
+		}
+	}
+
+	private String readStreamUnchecked(InputStream stream) {
+		try (stream) {
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			byte[] buffer = new byte[8192];
+			int read;
+			while ((read = stream.read(buffer)) != -1) {
+				bos.write(buffer, 0, read);
+			}
+			return bos.toString(StandardCharsets.UTF_8);
+		}
+		catch (IOException ex) {
+			throw new RuntimeException(ex);
+		}
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ExternalCommandPostRendererTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ExternalCommandPostRendererTest.java
@@ -1,0 +1,78 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExternalCommandPostRendererTest {
+
+	@TempDir
+	File tempDir;
+
+	@Test
+	void processPassesManifestThroughCommand() throws Exception {
+		// 'cat' passes stdin to stdout unchanged
+		ExternalCommandPostRenderer renderer = new ExternalCommandPostRenderer(List.of("cat"));
+		String input = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\n";
+		String result = renderer.process(input);
+		assertEquals(input, result);
+	}
+
+	@Test
+	void processTransformsManifest() throws Exception {
+		// Use sed to add a label
+		ExternalCommandPostRenderer renderer = new ExternalCommandPostRenderer(
+				List.of("sed", "s/name: test/name: transformed/"));
+		String input = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\n";
+		String result = renderer.process(input);
+		assertTrue(result.contains("name: transformed"));
+	}
+
+	@Test
+	void processChainMultipleRenderers() throws Exception {
+		String input = "original";
+		ExternalCommandPostRenderer first = new ExternalCommandPostRenderer(List.of("sed", "s/original/step1/"));
+		ExternalCommandPostRenderer second = new ExternalCommandPostRenderer(List.of("sed", "s/step1/step2/"));
+		String result = second.process(first.process(input));
+		assertTrue(result.trim().equals("step2"));
+	}
+
+	@Test
+	void processThrowsOnNonZeroExitCode() throws Exception {
+		ExternalCommandPostRenderer renderer = new ExternalCommandPostRenderer(List.of("false"));
+		assertThrows(IOException.class, () -> renderer.process("input"));
+	}
+
+	@Test
+	void processThrowsOnTimeout() throws Exception {
+		// Use bash -c to read stdin first (so the process doesn't exit when stdin closes)
+		// then sleep
+		ExternalCommandPostRenderer renderer = new ExternalCommandPostRenderer(
+				List.of("bash", "-c", "cat > /dev/null && sleep 30"), 1);
+		assertThrows(IOException.class, () -> renderer.process("input"));
+	}
+
+	@Test
+	void processWithScriptPostRenderer() throws Exception {
+		File script = new File(tempDir, "post-render.sh");
+		Files.writeString(script.toPath(), """
+				#!/bin/sh
+				sed 's/replicas: 1/replicas: 3/'
+				""");
+		script.setExecutable(true);
+
+		ExternalCommandPostRenderer renderer = new ExternalCommandPostRenderer(List.of(script.getAbsolutePath()));
+		String input = "apiVersion: apps/v1\nkind: Deployment\nspec:\n  replicas: 1\n";
+		String result = renderer.process(input);
+		assertTrue(result.contains("replicas: 3"));
+	}
+
+}


### PR DESCRIPTION
## Summary

- Adds `ExternalCommandPostRenderer` that pipes rendered manifests through external commands via stdin/stdout, matching Helm's `--post-renderer` behavior
- Adds `--post-renderer` CLI flag to `template`, `install`, and `upgrade` commands with support for chaining multiple renderers
- Uses concurrent I/O (CompletableFuture) to prevent deadlocks between stdin/stdout/stderr streams

## Usage

```bash
# Single post-renderer
jhelm template my-release ./chart --post-renderer ./kustomize

# Chained post-renderers  
jhelm install my-release ./chart --post-renderer ./label-injector --post-renderer ./kustomize

# Programmatic API
PostRenderProcessor renderer = new ExternalCommandPostRenderer(List.of("./my-renderer"));
String transformed = renderer.process(manifest);
```

## Test plan

- [x] stdin/stdout passthrough (cat)
- [x] Manifest transformation (sed)
- [x] Chaining multiple post-renderers
- [x] Non-zero exit code handling
- [x] Timeout enforcement
- [x] Script-based post-renderer
- [x] Full build passes with all tests

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)