### PR TITLE
Add enhanced error recovery with retry logic (#16)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -7,6 +7,8 @@ import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.exception.DeploymentFailedException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
@@ -18,6 +20,7 @@ import org.alexmond.jhelm.core.util.HookExecutor;
 import org.alexmond.jhelm.core.util.HookParser;
 
 @RequiredArgsConstructor
+@Slf4j
 public class InstallAction {
 
 	private final Engine engine;
@@ -75,12 +78,29 @@ public class InstallAction {
 			HookExecutor hookExecutor = new HookExecutor(kubeService);
 			hookExecutor.run(namespace, hooks, "pre-install", 300);
 			kubeService.apply(namespace, regularManifest);
-			kubeService.storeRelease(release);
+			try {
+				kubeService.storeRelease(release);
+			}
+			catch (Exception ex) {
+				rollbackAppliedResources(namespace, regularManifest);
+				throw new DeploymentFailedException("Failed to store release after apply; resources rolled back", ex,
+						regularManifest);
+			}
 			hookExecutor.run(namespace, hooks, "post-install", 300);
 			fireLifecycleEvent("post-install", releaseName, namespace);
 		}
 
 		return release;
+	}
+
+	private void rollbackAppliedResources(String namespace, String manifest) {
+		try {
+			log.warn("Rolling back applied resources in namespace {}", namespace);
+			kubeService.delete(namespace, manifest);
+		}
+		catch (Exception rollbackEx) {
+			log.error("Failed to rollback applied resources: {}", rollbackEx.getMessage(), rollbackEx);
+		}
 	}
 
 	private void fireLifecycleEvent(String phase, String releaseName, String namespace) throws Exception {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.KubeService;
@@ -12,6 +14,7 @@ import org.alexmond.jhelm.core.util.HookExecutor;
 import org.alexmond.jhelm.core.util.HookParser;
 
 @RequiredArgsConstructor
+@Slf4j
 public class RollbackAction {
 
 	private final KubeService kubeService;
@@ -21,7 +24,7 @@ public class RollbackAction {
 		Optional<Release> targetReleaseOpt = history.stream().filter((r) -> r.getVersion() == revision).findFirst();
 
 		if (targetReleaseOpt.isEmpty()) {
-			throw new RuntimeException("revision " + revision + " not found for release " + name);
+			throw ReleaseNotFoundException.forRevision(name, revision);
 		}
 
 		Optional<Release> currentReleaseOpt = history.stream().findFirst(); // History is

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.KubeService;
@@ -11,6 +13,7 @@ import org.alexmond.jhelm.core.util.HookExecutor;
 import org.alexmond.jhelm.core.util.HookParser;
 
 @RequiredArgsConstructor
+@Slf4j
 public class UninstallAction {
 
 	private final KubeService kubeService;
@@ -18,7 +21,7 @@ public class UninstallAction {
 	public void uninstall(String releaseName, String namespace) throws Exception {
 		Optional<Release> releaseOpt = kubeService.getRelease(releaseName, namespace);
 		if (releaseOpt.isEmpty()) {
-			throw new RuntimeException("Release not found: " + releaseName);
+			throw ReleaseNotFoundException.forRelease(releaseName, namespace);
 		}
 
 		Release release = releaseOpt.get();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -7,6 +7,8 @@ import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.exception.DeploymentFailedException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
@@ -18,6 +20,7 @@ import org.alexmond.jhelm.core.util.HookExecutor;
 import org.alexmond.jhelm.core.util.HookParser;
 
 @RequiredArgsConstructor
+@Slf4j
 public class UpgradeAction {
 
 	private final Engine engine;
@@ -74,12 +77,33 @@ public class UpgradeAction {
 			HookExecutor hookExecutor = new HookExecutor(kubeService);
 			hookExecutor.run(newRelease.getNamespace(), hooks, "pre-upgrade", 300);
 			kubeService.apply(newRelease.getNamespace(), regularManifest);
-			kubeService.storeRelease(newRelease);
+			try {
+				kubeService.storeRelease(newRelease);
+			}
+			catch (Exception ex) {
+				reapplyPreviousRelease(currentRelease);
+				throw new DeploymentFailedException("Failed to store release after apply; previous release re-applied",
+						ex, regularManifest);
+			}
 			hookExecutor.run(newRelease.getNamespace(), hooks, "post-upgrade", 300);
 			fireLifecycleEvent("post-upgrade", newRelease.getName(), newRelease.getNamespace());
 		}
 
 		return newRelease;
+	}
+
+	private void reapplyPreviousRelease(Release previousRelease) {
+		if (previousRelease.getManifest() == null) {
+			return;
+		}
+		try {
+			log.warn("Re-applying previous release {} v{}", previousRelease.getName(), previousRelease.getVersion());
+			String regularManifest = HookParser.stripHooks(previousRelease.getManifest());
+			kubeService.apply(previousRelease.getNamespace(), regularManifest);
+		}
+		catch (Exception rollbackEx) {
+			log.error("Failed to re-apply previous release: {}", rollbackEx.getMessage(), rollbackEx);
+		}
 	}
 
 	private void fireLifecycleEvent(String phase, String releaseName, String namespace) throws Exception {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/DeploymentFailedException.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/DeploymentFailedException.java
@@ -1,0 +1,24 @@
+package org.alexmond.jhelm.core.exception;
+
+/**
+ * Thrown when a deployment (install or upgrade) fails after resources have been partially
+ * applied. Contains the manifest that was applied so callers can attempt cleanup.
+ */
+public class DeploymentFailedException extends JhelmException {
+
+	private final String appliedManifest;
+
+	public DeploymentFailedException(String message, Throwable cause, String appliedManifest) {
+		super(message, cause);
+		this.appliedManifest = appliedManifest;
+	}
+
+	/**
+	 * Returns the manifest that was (partially) applied before the failure, or
+	 * {@code null} if nothing was applied.
+	 */
+	public String getAppliedManifest() {
+		return appliedManifest;
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/JhelmException.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/JhelmException.java
@@ -1,0 +1,16 @@
+package org.alexmond.jhelm.core.exception;
+
+/**
+ * Base exception for all jhelm operations.
+ */
+public class JhelmException extends Exception {
+
+	public JhelmException(String message) {
+		super(message);
+	}
+
+	public JhelmException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/KubernetesOperationException.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/KubernetesOperationException.java
@@ -1,0 +1,38 @@
+package org.alexmond.jhelm.core.exception;
+
+/**
+ * Thrown when a Kubernetes API operation (apply, delete, etc.) fails. Wraps the
+ * underlying API error and includes the HTTP status code when available.
+ */
+public class KubernetesOperationException extends JhelmException {
+
+	private final int statusCode;
+
+	public KubernetesOperationException(String message) {
+		super(message);
+		this.statusCode = -1;
+	}
+
+	public KubernetesOperationException(String message, Throwable cause) {
+		super(message, cause);
+		this.statusCode = -1;
+	}
+
+	public KubernetesOperationException(String message, Throwable cause, int statusCode) {
+		super(message, cause);
+		this.statusCode = statusCode;
+	}
+
+	public int getStatusCode() {
+		return statusCode;
+	}
+
+	/**
+	 * Returns {@code true} if the error is transient and may succeed on retry (5xx server
+	 * errors and 429 rate-limiting).
+	 */
+	public boolean isTransient() {
+		return statusCode == 429 || (statusCode >= 500 && statusCode < 600);
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/ReleaseNotFoundException.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/ReleaseNotFoundException.java
@@ -1,0 +1,24 @@
+package org.alexmond.jhelm.core.exception;
+
+/**
+ * Thrown when a requested release or release revision cannot be found in the cluster.
+ */
+public class ReleaseNotFoundException extends JhelmException {
+
+	public ReleaseNotFoundException(String message) {
+		super(message);
+	}
+
+	public static ReleaseNotFoundException forRelease(String releaseName) {
+		return new ReleaseNotFoundException("Release not found: " + releaseName);
+	}
+
+	public static ReleaseNotFoundException forRelease(String releaseName, String namespace) {
+		return new ReleaseNotFoundException("Release not found: " + releaseName + " in namespace " + namespace);
+	}
+
+	public static ReleaseNotFoundException forRevision(String releaseName, int revision) {
+		return new ReleaseNotFoundException("Revision " + revision + " not found for release " + releaseName);
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/ReleaseStorageException.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/ReleaseStorageException.java
@@ -1,0 +1,16 @@
+package org.alexmond.jhelm.core.exception;
+
+/**
+ * Thrown when storing or retrieving release data from the cluster fails.
+ */
+public class ReleaseStorageException extends JhelmException {
+
+	public ReleaseStorageException(String message) {
+		super(message);
+	}
+
+	public ReleaseStorageException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/WaitTimeoutException.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/WaitTimeoutException.java
@@ -1,0 +1,27 @@
+package org.alexmond.jhelm.core.exception;
+
+import java.util.List;
+
+import org.alexmond.jhelm.core.model.ResourceStatus;
+
+/**
+ * Thrown when a wait-for-ready operation exceeds the configured timeout. Carries the
+ * last-known resource statuses so callers can inspect what was not ready.
+ */
+public class WaitTimeoutException extends JhelmException {
+
+	private final List<ResourceStatus> pendingResources;
+
+	public WaitTimeoutException(String message, List<ResourceStatus> pendingResources) {
+		super(message);
+		this.pendingResources = pendingResources;
+	}
+
+	/**
+	 * Returns the resources that were not ready when the timeout elapsed.
+	 */
+	public List<ResourceStatus> getPendingResources() {
+		return pendingResources;
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
@@ -10,14 +10,17 @@ import org.mockito.MockitoAnnotations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.alexmond.jhelm.core.exception.DeploymentFailedException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.HelmHook;
@@ -130,6 +133,25 @@ class InstallActionTest {
 
 		assertNotNull(release);
 		assertEquals("my-release", release.getName());
+	}
+
+	@Test
+	void testInstallRollsBackOnStoreFailure() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		String manifest = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(manifest);
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doThrow(new RuntimeException("storage failed")).when(kubeService).storeRelease(any(Release.class));
+		doNothing().when(kubeService).delete(anyString(), anyString());
+
+		DeploymentFailedException ex = assertThrows(DeploymentFailedException.class,
+				() -> installAction.install(chart, "my-release", "default", null, 1, false));
+
+		assertEquals(HookParser.stripHooks(manifest), ex.getAppliedManifest());
+		// Verify rollback was attempted
+		verify(kubeService).delete("default", HookParser.stripHooks(manifest));
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
+import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.HelmHook;
@@ -166,10 +167,10 @@ class RollbackActionTest {
 		Release v1 = Release.builder().name("myapp").version(1).build();
 		when(kubeService.getReleaseHistory(anyString(), anyString())).thenReturn(Arrays.asList(v1));
 
-		RuntimeException exception = assertThrows(RuntimeException.class,
+		ReleaseNotFoundException exception = assertThrows(ReleaseNotFoundException.class,
 				() -> rollbackAction.rollback("myapp", "default", 99));
 
-		assertTrue(exception.getMessage().contains("revision 99 not found"));
+		assertTrue(exception.getMessage().contains("Revision 99 not found"));
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UninstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UninstallActionTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.anyString;
+import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.KubeService;
@@ -90,7 +91,7 @@ class UninstallActionTest {
 	void testUninstallThrowsWhenReleaseNotFound() throws Exception {
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
 
-		RuntimeException exception = assertThrows(RuntimeException.class,
+		ReleaseNotFoundException exception = assertThrows(ReleaseNotFoundException.class,
 				() -> uninstallAction.uninstall("non-existent", "default"));
 
 		assertTrue(exception.getMessage().contains("Release not found"));

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -20,11 +21,14 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import org.alexmond.jhelm.core.exception.DeploymentFailedException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.HelmHook;
@@ -249,6 +253,38 @@ class UpgradeActionTest {
 
 		assertEquals(43, upgradedRelease.getVersion());
 		assertEquals(info.getFirstDeployed(), upgradedRelease.getInfo().getFirstDeployed());
+	}
+
+	@Test
+	void testUpgradeReappliesPreviousOnStoreFailure() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		String previousManifest = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: old-svc\n";
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status("deployed")
+			.build();
+
+		Release currentRelease = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.manifest(previousManifest)
+			.info(info)
+			.build();
+
+		String newManifest = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: new-svc\n";
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(newManifest);
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doThrow(new RuntimeException("storage failed")).when(kubeService).storeRelease(any(Release.class));
+
+		assertThrows(DeploymentFailedException.class, () -> upgradeAction.upgrade(currentRelease, chart, null, false));
+
+		// Verify: new manifest applied, then previous manifest re-applied on rollback
+		verify(kubeService, times(2)).apply(eq("default"), anyString());
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/exception/ExceptionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/exception/ExceptionTest.java
@@ -1,0 +1,111 @@
+package org.alexmond.jhelm.core.exception;
+
+import java.util.List;
+
+import org.alexmond.jhelm.core.model.ResourceStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExceptionTest {
+
+	@Test
+	void testJhelmExceptionMessage() {
+		JhelmException ex = new JhelmException("test error");
+		assertEquals("test error", ex.getMessage());
+	}
+
+	@Test
+	void testJhelmExceptionWithCause() {
+		RuntimeException cause = new RuntimeException("root");
+		JhelmException ex = new JhelmException("wrapped", cause);
+		assertEquals("wrapped", ex.getMessage());
+		assertEquals(cause, ex.getCause());
+	}
+
+	@Test
+	void testReleaseNotFoundForRelease() {
+		ReleaseNotFoundException ex = ReleaseNotFoundException.forRelease("myapp");
+		assertEquals("Release not found: myapp", ex.getMessage());
+	}
+
+	@Test
+	void testReleaseNotFoundForReleaseWithNamespace() {
+		ReleaseNotFoundException ex = ReleaseNotFoundException.forRelease("myapp", "prod");
+		assertEquals("Release not found: myapp in namespace prod", ex.getMessage());
+	}
+
+	@Test
+	void testReleaseNotFoundForRevision() {
+		ReleaseNotFoundException ex = ReleaseNotFoundException.forRevision("myapp", 3);
+		assertEquals("Revision 3 not found for release myapp", ex.getMessage());
+	}
+
+	@Test
+	void testReleaseStorageException() {
+		RuntimeException cause = new RuntimeException("io");
+		ReleaseStorageException ex = new ReleaseStorageException("store failed", cause);
+		assertEquals("store failed", ex.getMessage());
+		assertEquals(cause, ex.getCause());
+	}
+
+	@Test
+	void testKubernetesOperationExceptionTransient() {
+		KubernetesOperationException ex = new KubernetesOperationException("err", null, 500);
+		assertTrue(ex.isTransient());
+		assertEquals(500, ex.getStatusCode());
+	}
+
+	@Test
+	void testKubernetesOperationExceptionNonTransient() {
+		KubernetesOperationException ex = new KubernetesOperationException("err", null, 404);
+		assertFalse(ex.isTransient());
+	}
+
+	@Test
+	void testKubernetesOperationException429IsTransient() {
+		KubernetesOperationException ex = new KubernetesOperationException("rate limited", null, 429);
+		assertTrue(ex.isTransient());
+	}
+
+	@Test
+	void testKubernetesOperationExceptionNoStatusCode() {
+		KubernetesOperationException ex = new KubernetesOperationException("generic");
+		assertEquals(-1, ex.getStatusCode());
+		assertFalse(ex.isTransient());
+	}
+
+	@Test
+	void testDeploymentFailedException() {
+		RuntimeException cause = new RuntimeException("store failed");
+		DeploymentFailedException ex = new DeploymentFailedException("deploy failed", cause, "yaml-manifest");
+		assertEquals("deploy failed", ex.getMessage());
+		assertEquals(cause, ex.getCause());
+		assertEquals("yaml-manifest", ex.getAppliedManifest());
+	}
+
+	@Test
+	void testDeploymentFailedExceptionNullManifest() {
+		DeploymentFailedException ex = new DeploymentFailedException("deploy failed", null, null);
+		assertNull(ex.getAppliedManifest());
+	}
+
+	@Test
+	void testWaitTimeoutException() {
+		List<ResourceStatus> pending = List.of(ResourceStatus.builder()
+			.kind("Deployment")
+			.name("app")
+			.namespace("default")
+			.ready(false)
+			.message("0/3 replicas ready")
+			.build());
+		WaitTimeoutException ex = new WaitTimeoutException("timeout", pending);
+		assertEquals("timeout", ex.getMessage());
+		assertEquals(1, ex.getPendingResources().size());
+		assertEquals("app", ex.getPendingResources().get(0).getName());
+	}
+
+}

--- a/jhelm-kube/pom.xml
+++ b/jhelm-kube/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
             <optional>true</optional>

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
@@ -10,16 +10,21 @@ import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
 import org.alexmond.jhelm.kube.service.AsyncHelmKubeService;
+import org.alexmond.jhelm.kube.service.RetryableKubeService;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
 
 /**
  * Auto-configuration for the jhelm Kubernetes integration module. Registers an
- * {@link ApiClient} and a {@link KubeService} implementation. Runs before
- * {@link JhelmCoreAutoConfiguration} so that the {@link KubeService} bean is available
- * for its {@code @ConditionalOnBean} checks.
+ * {@link ApiClient} and a {@link KubeService} implementation. When retry is enabled (the
+ * default), the service is wrapped with {@link RetryableKubeService} for transient
+ * failure recovery. Runs before {@link JhelmCoreAutoConfiguration} so that the
+ * {@link KubeService} bean is available for its {@code @ConditionalOnBean} checks.
  */
 @AutoConfiguration(before = JhelmCoreAutoConfiguration.class)
 @EnableConfigurationProperties(JhelmKubernetesProperties.class)
@@ -36,8 +41,49 @@ public class JhelmKubeAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(KubeService.class)
-	public AsyncHelmKubeService asyncHelmKubeService(ApiClient apiClient) {
-		return new AsyncHelmKubeService(apiClient);
+	public KubeService kubeService(ApiClient apiClient, JhelmKubernetesProperties props) {
+		AsyncHelmKubeService base = new AsyncHelmKubeService(apiClient);
+		JhelmKubernetesProperties.Retry retryConfig = props.getRetry();
+		if (retryConfig.isEnabled()) {
+			return new RetryableKubeService(base, buildRetryTemplate(retryConfig));
+		}
+		return base;
+	}
+
+	private RetryTemplate buildRetryTemplate(JhelmKubernetesProperties.Retry config) {
+		SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy(config.getMaxAttempts());
+
+		ExponentialBackOffPolicy backOff = new ExponentialBackOffPolicy();
+		backOff.setInitialInterval(config.getInitialIntervalMs());
+		backOff.setMultiplier(config.getMultiplier());
+		backOff.setMaxInterval(config.getMaxIntervalMs());
+
+		RetryTemplate template = new RetryTemplate();
+		template.setRetryPolicy(retryPolicy);
+		template.setBackOffPolicy(backOff);
+		template.registerListener(new TransientRetryListener());
+		return template;
+	}
+
+	/**
+	 * A retry listener that only allows retries for transient errors.
+	 */
+	private static class TransientRetryListener implements org.springframework.retry.RetryListener {
+
+		@Override
+		public <T, E extends Throwable> boolean open(org.springframework.retry.RetryContext context,
+				org.springframework.retry.RetryCallback<T, E> callback) {
+			return true;
+		}
+
+		@Override
+		public <T, E extends Throwable> void onError(org.springframework.retry.RetryContext context,
+				org.springframework.retry.RetryCallback<T, E> callback, Throwable throwable) {
+			if (!RetryableKubeService.isTransient(throwable)) {
+				context.setExhaustedOnly();
+			}
+		}
+
 	}
 
 }

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
@@ -18,4 +18,40 @@ public class JhelmKubernetesProperties {
 	 */
 	private String kubeconfigPath;
 
+	/**
+	 * Retry configuration for transient Kubernetes API failures.
+	 */
+	private Retry retry = new Retry();
+
+	@Getter
+	@Setter
+	public static class Retry {
+
+		/**
+		 * Whether retry is enabled for Kubernetes API calls.
+		 */
+		private boolean enabled = true;
+
+		/**
+		 * Maximum number of retry attempts (including the initial call).
+		 */
+		private int maxAttempts = 3;
+
+		/**
+		 * Initial interval between retries in milliseconds.
+		 */
+		private long initialIntervalMs = 1000;
+
+		/**
+		 * Multiplier for exponential backoff between retries.
+		 */
+		private double multiplier = 2.0;
+
+		/**
+		 * Maximum interval between retries in milliseconds.
+		 */
+		private long maxIntervalMs = 10000;
+
+	}
+
 }

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
@@ -21,6 +21,9 @@ import io.kubernetes.client.util.PatchUtils;
 import io.kubernetes.client.util.Yaml;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.exception.KubernetesOperationException;
+import org.alexmond.jhelm.core.exception.ReleaseStorageException;
+import org.alexmond.jhelm.core.exception.WaitTimeoutException;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
@@ -44,7 +47,7 @@ public class HelmKubeService implements KubeService {
 	/**
 	 * Stores a release as a ConfigMap in Kubernetes.
 	 */
-	public void storeRelease(Release release) throws ApiException {
+	public void storeRelease(Release release) throws ReleaseStorageException {
 		CoreV1Api api = new CoreV1Api(apiClient);
 		String name = "sh.helm.release.v1." + release.getName() + ".v" + release.getVersion();
 
@@ -74,38 +77,35 @@ public class HelmKubeService implements KubeService {
 			}
 		}
 		catch (Exception ex) {
-			throw new RuntimeException("Failed to store release", ex);
+			throw new ReleaseStorageException("Failed to store release: " + release.getName(), ex);
 		}
 	}
 
 	/**
 	 * Retrieves the latest version of a release from Kubernetes.
 	 */
-	public Optional<Release> getRelease(String name, String namespace) throws ApiException {
+	public Optional<Release> getRelease(String name, String namespace) throws Exception {
 		CoreV1Api api = new CoreV1Api(apiClient);
 		String labelSelector = "owner=helm,name=" + name;
 
 		V1ConfigMapList list = api.listNamespacedConfigMap(namespace).labelSelector(labelSelector).execute();
 
-		return list.getItems().stream().sorted((s1, s2) -> {
+		Optional<V1ConfigMap> latest = list.getItems().stream().sorted((s1, s2) -> {
 			int v1 = Integer.parseInt(s1.getMetadata().getLabels().get("version"));
 			int v2 = Integer.parseInt(s2.getMetadata().getLabels().get("version"));
 			return Integer.compare(v2, v1); // Descending
-		}).findFirst().map((cm) -> {
-			try {
-				byte[] decoded = Base64.getDecoder().decode(cm.getData().get("release"));
-				return objectMapper.readValue(decoded, Release.class);
-			}
-			catch (Exception ex) {
-				throw new RuntimeException("Failed to decode release", ex);
-			}
-		});
+		}).findFirst();
+
+		if (latest.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(decodeRelease(latest.get()));
 	}
 
 	/**
 	 * Retrieves all releases in a namespace.
 	 */
-	public List<Release> listReleases(String namespace) throws ApiException {
+	public List<Release> listReleases(String namespace) throws Exception {
 		CoreV1Api api = new CoreV1Api(apiClient);
 		String labelSelector = "owner=helm";
 
@@ -116,49 +116,48 @@ public class HelmKubeService implements KubeService {
 			.stream()
 			.collect(Collectors.groupingBy((cm) -> cm.getMetadata().getLabels().get("name")));
 
-		return grouped.values()
+		List<V1ConfigMap> latestPerName = grouped.values()
 			.stream()
 			.map((cms) -> cms.stream()
 				.max(Comparator.comparingInt((cm) -> Integer.parseInt(cm.getMetadata().getLabels().get("version"))))
 				.orElse(null))
 			.filter(Objects::nonNull)
-			.map((cm) -> {
-				try {
-					byte[] decoded = Base64.getDecoder().decode(cm.getData().get("release"));
-					return objectMapper.readValue(decoded, Release.class);
-				}
-				catch (Exception ex) {
-					log.error("Failed to decode release from ConfigMap {}: {}", cm.getMetadata().getName(),
-							ex.getMessage());
-					return null;
-				}
-			})
-			.filter(Objects::nonNull)
-			.collect(Collectors.toList());
+			.toList();
+
+		List<Release> releases = new ArrayList<>();
+		for (V1ConfigMap cm : latestPerName) {
+			try {
+				releases.add(decodeRelease(cm));
+			}
+			catch (ReleaseStorageException ex) {
+				log.error("Failed to decode release from ConfigMap {}: {}", cm.getMetadata().getName(),
+						ex.getMessage());
+			}
+		}
+		return releases;
 	}
 
 	/**
 	 * Retrieves all versions of a specific release.
 	 */
-	public List<Release> getReleaseHistory(String name, String namespace) throws ApiException {
+	public List<Release> getReleaseHistory(String name, String namespace) throws Exception {
 		CoreV1Api api = new CoreV1Api(apiClient);
 		String labelSelector = "owner=helm,name=" + name;
 
 		V1ConfigMapList list = api.listNamespacedConfigMap(namespace).labelSelector(labelSelector).execute();
 
-		return list.getItems().stream().sorted((s1, s2) -> {
-			int v1 = Integer.parseInt(s1.getMetadata().getLabels().get("version"));
-			int v2 = Integer.parseInt(s2.getMetadata().getLabels().get("version"));
-			return Integer.compare(v2, v1); // Descending
-		}).map((cm) -> {
-			try {
-				byte[] decoded = Base64.getDecoder().decode(cm.getData().get("release"));
-				return objectMapper.readValue(decoded, Release.class);
-			}
-			catch (Exception ex) {
-				throw new RuntimeException("Failed to decode release", ex);
-			}
-		}).collect(Collectors.toList());
+		List<V1ConfigMap> sorted = list.getItems()
+			.stream()
+			.sorted(Comparator
+				.comparingInt((V1ConfigMap cm) -> Integer.parseInt(cm.getMetadata().getLabels().get("version")))
+				.reversed())
+			.toList();
+
+		List<Release> history = new ArrayList<>();
+		for (V1ConfigMap cm : sorted) {
+			history.add(decodeRelease(cm));
+		}
+		return history;
 	}
 
 	/**
@@ -186,7 +185,7 @@ public class HelmKubeService implements KubeService {
 	/**
 	 * Applies a YAML manifest which can contain multiple resources.
 	 */
-	public void apply(String namespace, String yamlContent) throws ApiException {
+	public void apply(String namespace, String yamlContent) throws Exception {
 		try {
 			Iterable<Object> objects = Yaml.loadAll(yamlContent);
 			for (Object obj : objects) {
@@ -195,11 +194,11 @@ public class HelmKubeService implements KubeService {
 				}
 			}
 		}
+		catch (ApiException ex) {
+			throw new KubernetesOperationException("Failed to apply manifest", ex, ex.getCode());
+		}
 		catch (Exception ex) {
-			if (ex instanceof ApiException) {
-				throw (ApiException) ex;
-			}
-			throw new RuntimeException("Failed to apply manifest", ex);
+			throw new KubernetesOperationException("Failed to apply manifest", ex);
 		}
 	}
 
@@ -233,7 +232,7 @@ public class HelmKubeService implements KubeService {
 	/**
 	 * Deletes resources in a YAML manifest.
 	 */
-	public void delete(String namespace, String yamlContent) throws ApiException {
+	public void delete(String namespace, String yamlContent) throws Exception {
 		try {
 			Iterable<Object> objects = Yaml.loadAll(yamlContent);
 			for (Object obj : objects) {
@@ -242,11 +241,11 @@ public class HelmKubeService implements KubeService {
 				}
 			}
 		}
+		catch (ApiException ex) {
+			throw new KubernetesOperationException("Failed to delete manifest", ex, ex.getCode());
+		}
 		catch (Exception ex) {
-			if (ex instanceof ApiException) {
-				throw (ApiException) ex;
-			}
-			throw new RuntimeException("Failed to delete manifest", ex);
+			throw new KubernetesOperationException("Failed to delete manifest", ex);
 		}
 	}
 
@@ -423,7 +422,18 @@ public class HelmKubeService implements KubeService {
 			String msg = notReady.stream()
 				.map((s) -> s.getKind() + "/" + s.getName() + ": " + s.getMessage())
 				.collect(Collectors.joining(", "));
-			throw new Exception("Timeout waiting for resources to be ready: " + msg);
+			throw new WaitTimeoutException("Timeout waiting for resources to be ready: " + msg, notReady);
+		}
+	}
+
+	private Release decodeRelease(V1ConfigMap cm) throws ReleaseStorageException {
+		try {
+			byte[] decoded = Base64.getDecoder().decode(cm.getData().get("release"));
+			return objectMapper.readValue(decoded, Release.class);
+		}
+		catch (Exception ex) {
+			throw new ReleaseStorageException("Failed to decode release from ConfigMap: " + cm.getMetadata().getName(),
+					ex);
 		}
 	}
 

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/RetryableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/RetryableKubeService.java
@@ -1,0 +1,128 @@
+package org.alexmond.jhelm.kube.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.kubernetes.client.openapi.ApiException;
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.exception.KubernetesOperationException;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ResourceStatus;
+import org.alexmond.jhelm.core.service.KubeService;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * A {@link KubeService} decorator that retries transient Kubernetes API failures using a
+ * {@link RetryTemplate}. Transient errors include 5xx server errors, 429 rate-limiting
+ * responses, and connection-level exceptions.
+ * <p>
+ * Only operations that hit the Kubernetes API are retried. Non-transient errors (4xx
+ * client errors) are propagated immediately.
+ * </p>
+ */
+@Slf4j
+public class RetryableKubeService implements KubeService {
+
+	private final KubeService delegate;
+
+	private final RetryTemplate retryTemplate;
+
+	public RetryableKubeService(KubeService delegate, RetryTemplate retryTemplate) {
+		this.delegate = delegate;
+		this.retryTemplate = retryTemplate;
+	}
+
+	@Override
+	public void storeRelease(Release release) throws Exception {
+		executeWithRetry("storeRelease", (ctx) -> {
+			delegate.storeRelease(release);
+			return null;
+		});
+	}
+
+	@Override
+	public Optional<Release> getRelease(String name, String namespace) throws Exception {
+		return executeWithRetry("getRelease", (ctx) -> delegate.getRelease(name, namespace));
+	}
+
+	@Override
+	public List<Release> listReleases(String namespace) throws Exception {
+		return executeWithRetry("listReleases", (ctx) -> delegate.listReleases(namespace));
+	}
+
+	@Override
+	public List<Release> getReleaseHistory(String name, String namespace) throws Exception {
+		return executeWithRetry("getReleaseHistory", (ctx) -> delegate.getReleaseHistory(name, namespace));
+	}
+
+	@Override
+	public void deleteReleaseHistory(String name, String namespace) throws Exception {
+		executeWithRetry("deleteReleaseHistory", (ctx) -> {
+			delegate.deleteReleaseHistory(name, namespace);
+			return null;
+		});
+	}
+
+	@Override
+	public void apply(String namespace, String yamlContent) throws Exception {
+		executeWithRetry("apply", (ctx) -> {
+			delegate.apply(namespace, yamlContent);
+			return null;
+		});
+	}
+
+	@Override
+	public void delete(String namespace, String yamlContent) throws Exception {
+		executeWithRetry("delete", (ctx) -> {
+			delegate.delete(namespace, yamlContent);
+			return null;
+		});
+	}
+
+	@Override
+	public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) throws Exception {
+		return executeWithRetry("getResourceStatuses", (ctx) -> delegate.getResourceStatuses(namespace, manifest));
+	}
+
+	@Override
+	public void waitForReady(String namespace, String manifest, int timeoutSeconds) throws Exception {
+		// waitForReady already polls internally; do not retry the entire operation
+		delegate.waitForReady(namespace, manifest, timeoutSeconds);
+	}
+
+	private <T> T executeWithRetry(String operation, RetryCallback<T, Exception> callback) throws Exception {
+		return retryTemplate.execute(callback, (ctx) -> {
+			Throwable last = ctx.getLastThrowable();
+			log.error("All retry attempts exhausted for {}", operation, last);
+			if (last instanceof Exception ex) {
+				throw ex;
+			}
+			throw new KubernetesOperationException("Retry exhausted for " + operation, last);
+		});
+	}
+
+	/**
+	 * Returns {@code true} if the given exception represents a transient Kubernetes API
+	 * error that may succeed on retry.
+	 */
+	public static boolean isTransient(Throwable ex) {
+		if (ex instanceof ApiException apiEx) {
+			int code = apiEx.getCode();
+			return code == 429 || (code >= 500 && code < 600);
+		}
+		if (ex instanceof KubernetesOperationException kubeEx) {
+			return kubeEx.isTransient();
+		}
+		// Connection-level errors (SocketException, ConnectException, etc.)
+		if (ex instanceof java.net.SocketException || ex instanceof java.net.ConnectException) {
+			return true;
+		}
+		// Check wrapped cause
+		if (ex.getCause() != null && ex.getCause() != ex) {
+			return isTransient(ex.getCause());
+		}
+		return false;
+	}
+
+}

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfigurationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfigurationTest.java
@@ -1,14 +1,14 @@
 package org.alexmond.jhelm.kube;
 
 import io.kubernetes.client.openapi.ApiClient;
-import org.alexmond.jhelm.core.service.AsyncKubeService;
 import org.alexmond.jhelm.core.service.KubeService;
-import org.alexmond.jhelm.kube.service.AsyncHelmKubeService;
 import org.alexmond.jhelm.kube.service.HelmKubeService;
+import org.alexmond.jhelm.kube.service.RetryableKubeService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
@@ -18,21 +18,43 @@ class JhelmKubeAutoConfigurationTest {
 		.withConfiguration(AutoConfigurations.of(JhelmKubeAutoConfiguration.class));
 
 	@Test
-	void testApiClientAndKubeServiceRegistered() {
+	@KubeClusterAvailable
+	void testKubeServiceIsRetryableByDefaultWithCluster() {
 		contextRunner.run((ctx) -> {
 			assertNotNull(ctx.getBean(ApiClient.class));
-			assertNotNull(ctx.getBean(KubeService.class));
-			assertNotNull(ctx.getBean(AsyncKubeService.class));
-			assertNotNull(ctx.getBean(AsyncHelmKubeService.class));
-			// AsyncHelmKubeService extends HelmKubeService, so both are accessible
-			assertNotNull(ctx.getBean(HelmKubeService.class));
+			KubeService kubeService = ctx.getBean(KubeService.class);
+			assertInstanceOf(RetryableKubeService.class, kubeService);
 		});
 	}
 
 	@Test
+	void testKubeServiceIsRetryableByDefaultWithMockedClient() {
+		ApiClient mockClient = mock(ApiClient.class);
+		contextRunner.withBean(ApiClient.class, () -> mockClient).run((ctx) -> {
+			assertNotNull(ctx.getBean(ApiClient.class));
+			KubeService kubeService = ctx.getBean(KubeService.class);
+			assertInstanceOf(RetryableKubeService.class, kubeService);
+		});
+	}
+
+	@Test
+	void testRetryDisabledReturnsBaseService() {
+		ApiClient mockClient = mock(ApiClient.class);
+		contextRunner.withBean(ApiClient.class, () -> mockClient)
+			.withPropertyValues("jhelm.kubernetes.retry.enabled=false")
+			.run((ctx) -> {
+				KubeService kubeService = ctx.getBean(KubeService.class);
+				assertNotNull(kubeService);
+				assertInstanceOf(HelmKubeService.class, kubeService);
+			});
+	}
+
+	@Test
 	void testConditionalOnMissingBeanKubeServiceAllowsOverride() {
+		ApiClient mockClient = mock(ApiClient.class);
 		KubeService custom = mock(KubeService.class);
-		contextRunner.withBean("customKubeService", KubeService.class, () -> custom)
+		contextRunner.withBean(ApiClient.class, () -> mockClient)
+			.withBean("customKubeService", KubeService.class, () -> custom)
 			.run((ctx) -> assertNotNull(ctx.getBean(ApiClient.class)));
 	}
 

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
@@ -17,6 +17,9 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.util.PatchUtils;
+import org.alexmond.jhelm.core.exception.KubernetesOperationException;
+import org.alexmond.jhelm.core.exception.ReleaseStorageException;
+import org.alexmond.jhelm.core.exception.WaitTimeoutException;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.junit.jupiter.api.AfterEach;
@@ -204,7 +207,7 @@ class HelmKubeServiceTest {
 			when(mock.createNamespacedConfigMap(eq("default"), any(V1ConfigMap.class))).thenReturn(createReq);
 		});
 
-		assertThrows(RuntimeException.class, () -> kubeService.storeRelease(release));
+		assertThrows(ReleaseStorageException.class, () -> kubeService.storeRelease(release));
 	}
 
 	// --- getRelease ---
@@ -236,14 +239,16 @@ class HelmKubeServiceTest {
 	void testGetReleaseThrowsOnDecodeError() throws Exception {
 		// ConfigMap with invalid base64 data
 		V1ConfigMap badCm = new V1ConfigMap()
-			.metadata(new V1ObjectMeta().putLabelsItem("version", "1").putLabelsItem("name", "myapp"))
+			.metadata(new V1ObjectMeta().name("sh.helm.release.v1.myapp.v1")
+				.putLabelsItem("version", "1")
+				.putLabelsItem("name", "myapp"))
 			.putDataItem("release", "not-valid-base64!!!");
 
 		V1ConfigMapList list = new V1ConfigMapList().items(List.of(badCm));
 
 		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> setupListRequest(mock, list));
 
-		assertThrows(RuntimeException.class, () -> kubeService.getRelease("myapp", "default"));
+		assertThrows(ReleaseStorageException.class, () -> kubeService.getRelease("myapp", "default"));
 	}
 
 	// --- listReleases ---
@@ -271,7 +276,9 @@ class HelmKubeServiceTest {
 		// Mix of good and bad ConfigMaps
 		Release good = createTestRelease("good-app", "default", 1, "deployed");
 		V1ConfigMap badCm = new V1ConfigMap()
-			.metadata(new V1ObjectMeta().putLabelsItem("version", "1").putLabelsItem("name", "bad-app"))
+			.metadata(new V1ObjectMeta().name("sh.helm.release.v1.bad-app.v1")
+				.putLabelsItem("version", "1")
+				.putLabelsItem("name", "bad-app"))
 			.putDataItem("release", "invalid-base64");
 
 		V1ConfigMapList list = new V1ConfigMapList().items(List.of(createConfigMapForRelease(good), badCm));
@@ -316,14 +323,16 @@ class HelmKubeServiceTest {
 	@Test
 	void testGetReleaseHistoryThrowsOnDecodeError() throws Exception {
 		V1ConfigMap badCm = new V1ConfigMap()
-			.metadata(new V1ObjectMeta().putLabelsItem("version", "1").putLabelsItem("name", "myapp"))
+			.metadata(new V1ObjectMeta().name("sh.helm.release.v1.myapp.v1")
+				.putLabelsItem("version", "1")
+				.putLabelsItem("name", "myapp"))
 			.putDataItem("release", "bad-data");
 
 		V1ConfigMapList list = new V1ConfigMapList().items(List.of(badCm));
 
 		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> setupListRequest(mock, list));
 
-		assertThrows(RuntimeException.class, () -> kubeService.getReleaseHistory("myapp", "default"));
+		assertThrows(ReleaseStorageException.class, () -> kubeService.getReleaseHistory("myapp", "default"));
 	}
 
 	// --- deleteReleaseHistory ---
@@ -453,7 +462,7 @@ class HelmKubeServiceTest {
 			return null;
 		});
 
-		assertThrows(Exception.class, () -> kubeService.apply("default", yaml));
+		assertThrows(KubernetesOperationException.class, () -> kubeService.apply("default", yaml));
 	}
 
 	// --- delete ---
@@ -519,7 +528,7 @@ class HelmKubeServiceTest {
 				.thenReturn(deleteReq);
 		});
 
-		assertThrows(Exception.class, () -> kubeService.delete("default", yaml));
+		assertThrows(KubernetesOperationException.class, () -> kubeService.delete("default", yaml));
 	}
 
 	@Test
@@ -748,7 +757,7 @@ class HelmKubeServiceTest {
 	}
 
 	@Test
-	void testWaitForReadyTimeoutThrowsException() {
+	void testWaitForReadyTimeoutThrowsWaitTimeoutException() {
 		String manifest = """
 				apiVersion: apps/v1
 				kind: Deployment
@@ -765,7 +774,10 @@ class HelmKubeServiceTest {
 			when(mock.readNamespacedDeployment(anyString(), anyString())).thenReturn(readReq);
 		});
 
-		assertThrows(Exception.class, () -> kubeService.waitForReady("default", manifest, 0));
+		WaitTimeoutException ex = assertThrows(WaitTimeoutException.class,
+				() -> kubeService.waitForReady("default", manifest, 0));
+		assertFalse(ex.getPendingResources().isEmpty());
+		assertEquals("Deployment", ex.getPendingResources().get(0).getKind());
 	}
 
 	// --- inferPlural ---

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/RetryableKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/RetryableKubeServiceTest.java
@@ -1,0 +1,182 @@
+package org.alexmond.jhelm.kube.service;
+
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.util.List;
+import java.util.Optional;
+
+import io.kubernetes.client.openapi.ApiException;
+import org.alexmond.jhelm.core.exception.KubernetesOperationException;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.KubeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RetryableKubeServiceTest {
+
+	@Mock
+	private KubeService delegate;
+
+	private RetryableKubeService retryableService;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		// Simple retry: up to 3 attempts with no backoff for fast tests
+		RetryTemplate template = new RetryTemplate();
+		SimpleRetryPolicy policy = new SimpleRetryPolicy(3);
+		FixedBackOffPolicy backOff = new FixedBackOffPolicy();
+		backOff.setBackOffPeriod(0);
+		template.setRetryPolicy(policy);
+		template.setBackOffPolicy(backOff);
+
+		retryableService = new RetryableKubeService(delegate, template);
+	}
+
+	@Test
+	void testDelegatesSuccessfulCalls() throws Exception {
+		when(delegate.getRelease("app", "default")).thenReturn(Optional.of(mock(Release.class)));
+		when(delegate.listReleases("default")).thenReturn(List.of(mock(Release.class)));
+
+		assertTrue(retryableService.getRelease("app", "default").isPresent());
+		assertEquals(1, retryableService.listReleases("default").size());
+
+		verify(delegate).getRelease("app", "default");
+		verify(delegate).listReleases("default");
+	}
+
+	@Test
+	void testRetriesOnTransientException() throws Exception {
+		when(delegate.listReleases("default")).thenThrow(new RuntimeException(new ApiException(500, "Server Error")))
+			.thenThrow(new RuntimeException(new ApiException(503, "Unavailable")))
+			.thenReturn(List.of());
+
+		List<Release> result = retryableService.listReleases("default");
+		assertTrue(result.isEmpty());
+		verify(delegate, times(3)).listReleases("default");
+	}
+
+	@Test
+	void testExhaustsRetriesAndThrows() throws Exception {
+		when(delegate.listReleases("default")).thenThrow(new RuntimeException("fail 1"))
+			.thenThrow(new RuntimeException("fail 2"))
+			.thenThrow(new RuntimeException("fail 3"));
+
+		assertThrows(RuntimeException.class, () -> retryableService.listReleases("default"));
+		verify(delegate, times(3)).listReleases("default");
+	}
+
+	@Test
+	void testApplyDelegatesToWrapped() throws Exception {
+		retryableService.apply("default", "yaml-content");
+		verify(delegate).apply("default", "yaml-content");
+	}
+
+	@Test
+	void testDeleteDelegatesToWrapped() throws Exception {
+		retryableService.delete("default", "yaml-content");
+		verify(delegate).delete("default", "yaml-content");
+	}
+
+	@Test
+	void testStoreReleaseDelegatesToWrapped() throws Exception {
+		Release release = mock(Release.class);
+		retryableService.storeRelease(release);
+		verify(delegate).storeRelease(release);
+	}
+
+	@Test
+	void testGetReleaseHistoryDelegatesToWrapped() throws Exception {
+		when(delegate.getReleaseHistory("app", "ns")).thenReturn(List.of());
+		retryableService.getReleaseHistory("app", "ns");
+		verify(delegate).getReleaseHistory("app", "ns");
+	}
+
+	@Test
+	void testDeleteReleaseHistoryDelegatesToWrapped() throws Exception {
+		retryableService.deleteReleaseHistory("app", "ns");
+		verify(delegate).deleteReleaseHistory("app", "ns");
+	}
+
+	@Test
+	void testGetResourceStatusesDelegatesToWrapped() throws Exception {
+		when(delegate.getResourceStatuses("ns", "manifest")).thenReturn(List.of());
+		retryableService.getResourceStatuses("ns", "manifest");
+		verify(delegate).getResourceStatuses("ns", "manifest");
+	}
+
+	@Test
+	void testWaitForReadyDelegatesDirectlyWithoutRetry() throws Exception {
+		retryableService.waitForReady("ns", "manifest", 60);
+		verify(delegate).waitForReady("ns", "manifest", 60);
+	}
+
+	// --- isTransient tests ---
+
+	@Test
+	void testIsTransientFor500ApiException() {
+		assertTrue(RetryableKubeService.isTransient(new ApiException(500, "Internal")));
+	}
+
+	@Test
+	void testIsTransientFor503ApiException() {
+		assertTrue(RetryableKubeService.isTransient(new ApiException(503, "Unavailable")));
+	}
+
+	@Test
+	void testIsTransientFor429ApiException() {
+		assertTrue(RetryableKubeService.isTransient(new ApiException(429, "Too Many")));
+	}
+
+	@Test
+	void testIsNotTransientFor404ApiException() {
+		assertFalse(RetryableKubeService.isTransient(new ApiException(404, "Not Found")));
+	}
+
+	@Test
+	void testIsNotTransientFor400ApiException() {
+		assertFalse(RetryableKubeService.isTransient(new ApiException(400, "Bad Request")));
+	}
+
+	@Test
+	void testIsTransientForKubernetesOperationException() {
+		assertTrue(RetryableKubeService
+			.isTransient(new KubernetesOperationException("err", new ApiException(502, ""), 502)));
+	}
+
+	@Test
+	void testIsTransientForSocketException() {
+		assertTrue(RetryableKubeService.isTransient(new SocketException("Connection reset")));
+	}
+
+	@Test
+	void testIsTransientForConnectException() {
+		assertTrue(RetryableKubeService.isTransient(new ConnectException("Connection refused")));
+	}
+
+	@Test
+	void testIsTransientForWrappedCause() {
+		assertTrue(RetryableKubeService.isTransient(new RuntimeException(new ApiException(500, "wrapped"))));
+	}
+
+	@Test
+	void testIsNotTransientForGenericException() {
+		assertFalse(RetryableKubeService.isTransient(new IllegalArgumentException("bad arg")));
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <semver4j.version>3.1.0</semver4j.version>
         <bouncycastle.version>1.80</bouncycastle.version>
         <chicory.version>1.7.0</chicory.version>
+        <spring-retry.version>2.0.11</spring-retry.version>
 
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
@@ -123,6 +124,11 @@
                 <groupId>com.dylibso.chicory</groupId>
                 <artifactId>wasi</artifactId>
                 <version>${chicory.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.retry</groupId>
+                <artifactId>spring-retry</artifactId>
+                <version>${spring-retry.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary
- Custom exception hierarchy in `jhelm-core/exception/` package: `JhelmException`, `ReleaseNotFoundException`, `ReleaseStorageException`, `KubernetesOperationException`, `DeploymentFailedException`, `WaitTimeoutException`
- `RetryableKubeService` decorator wrapping `KubeService` with Spring Retry's `RetryTemplate` for transient Kubernetes API failures (5xx, 429, connection errors)
- Configurable retry properties (`jhelm.kubernetes.retry.*`) with exponential backoff
- Atomic rollback in `InstallAction` and `UpgradeAction` when `storeRelease` fails after resources have been applied
- Replaced generic `RuntimeException` usage with typed exceptions across `HelmKubeService`, `UninstallAction`, and `RollbackAction`
- Auto-configuration wires `RetryableKubeService` by default with a transient-only retry listener

## Test plan
- [x] `ExceptionTest` — 13 tests covering all custom exception types
- [x] `RetryableKubeServiceTest` — 20 tests covering delegation, retry behavior, and `isTransient()` classification
- [x] `JhelmKubeAutoConfigurationTest` — Updated to verify RetryableKubeService wrapping and retry-disabled fallback
- [x] `HelmKubeServiceTest` — Updated assertions for new exception types
- [x] `InstallActionTest` — New test for atomic rollback on store failure
- [x] `UpgradeActionTest` — New test for re-applying previous release on store failure
- [x] `UninstallActionTest`, `RollbackActionTest` — Updated for `ReleaseNotFoundException`
- [x] Full build passes (398 tests, 0 failures)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)