### PR TITLE
Add contextual error messages (#17)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/ChartLoadException.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/ChartLoadException.java
@@ -1,0 +1,39 @@
+package org.alexmond.jhelm.core.exception;
+
+import lombok.Getter;
+
+/**
+ * Exception thrown when a chart cannot be loaded. Provides contextual information
+ * including the chart path and an actionable suggestion for resolving the error.
+ */
+@Getter
+public class ChartLoadException extends JhelmException {
+
+	private final String chartPath;
+
+	private final String suggestion;
+
+	public ChartLoadException(String message, String chartPath, String suggestion) {
+		super(buildMessage(message, chartPath, suggestion));
+		this.chartPath = chartPath;
+		this.suggestion = suggestion;
+	}
+
+	public ChartLoadException(String message, Throwable cause, String chartPath, String suggestion) {
+		super(buildMessage(message, chartPath, suggestion), cause);
+		this.chartPath = chartPath;
+		this.suggestion = suggestion;
+	}
+
+	private static String buildMessage(String message, String chartPath, String suggestion) {
+		StringBuilder sb = new StringBuilder(message);
+		if (chartPath != null) {
+			sb.append(" [path: ").append(chartPath).append("]");
+		}
+		if (suggestion != null) {
+			sb.append(". Suggestion: ").append(suggestion);
+		}
+		return sb.toString();
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/TemplateRenderException.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/TemplateRenderException.java
@@ -1,0 +1,47 @@
+package org.alexmond.jhelm.core.exception;
+
+import lombok.Getter;
+
+/**
+ * Exception thrown when a template rendering error occurs. Provides contextual
+ * information including the chart name and template name to help diagnose the source of
+ * the error.
+ */
+@Getter
+public class TemplateRenderException extends RuntimeException {
+
+	private final String chartName;
+
+	private final String templateName;
+
+	public TemplateRenderException(String message, Throwable cause, String chartName, String templateName) {
+		super(buildMessage(message, chartName, templateName), cause);
+		this.chartName = chartName;
+		this.templateName = templateName;
+	}
+
+	public TemplateRenderException(String message, String chartName, String templateName) {
+		super(buildMessage(message, chartName, templateName));
+		this.chartName = chartName;
+		this.templateName = templateName;
+	}
+
+	private static String buildMessage(String message, String chartName, String templateName) {
+		StringBuilder sb = new StringBuilder();
+		if (chartName != null) {
+			sb.append("chart '").append(chartName).append("'");
+		}
+		if (templateName != null) {
+			if (sb.length() > 0) {
+				sb.append(", ");
+			}
+			sb.append("template '").append(templateName).append("'");
+		}
+		if (sb.length() > 0) {
+			sb.append(": ");
+		}
+		sb.append(message);
+		return sb.toString();
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.alexmond.jhelm.core.exception.ChartLoadException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.util.ValuesLoader;
@@ -19,15 +20,17 @@ public class ChartLoader {
 
 	private final YAMLMapper yamlMapper = YAMLMapper.builder().build();
 
-	public Chart load(File chartDir) throws IOException {
+	public Chart load(File chartDir) throws IOException, ChartLoadException {
 		if (!chartDir.exists() || !chartDir.isDirectory()) {
-			throw new IllegalArgumentException("Chart directory does not exist: " + chartDir.getPath());
+			throw new ChartLoadException("Chart directory does not exist", chartDir.getPath(),
+					"Verify the path is correct and points to a valid Helm chart directory");
 		}
 
 		// Load Chart.yaml
 		File metadataFile = new File(chartDir, "Chart.yaml");
 		if (!metadataFile.exists()) {
-			throw new IllegalArgumentException("Chart.yaml not found in " + chartDir.getPath());
+			throw new ChartLoadException("Chart.yaml not found", chartDir.getPath(),
+					"A valid Helm chart requires a Chart.yaml file. Run 'helm create' to scaffold a new chart");
 		}
 		ChartMetadata metadata = yamlMapper.readValue(metadataFile, ChartMetadata.class);
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.core.service;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.cache.TemplateCache;
+import org.alexmond.jhelm.core.exception.TemplateRenderException;
 import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.gotemplate.GoTemplate;
 import org.alexmond.jhelm.gotemplate.internal.parse.Node;
@@ -115,9 +116,11 @@ public class Engine {
 			return cleanManifest(rendered);
 		}
 		catch (StackOverflowError ex) {
-			log.error("Global StackOverflowError during rendering of chart {}: {}", chart.getMetadata().getName(),
-					ex.getMessage());
-			return "ERROR: Recursive template inclusion or too deep nesting";
+			String chartName = chart.getMetadata().getName();
+			log.error("StackOverflowError during rendering of chart '{}': recursive template inclusion detected",
+					chartName);
+			return "ERROR: chart '" + chartName
+					+ "': recursive template inclusion or too deep nesting. Check for circular {{ template }} calls.";
 		}
 	}
 
@@ -218,7 +221,8 @@ public class Engine {
 				}
 			}
 			catch (Exception ex) {
-				log.warn("Parse failure for {}: {}", name, ex.getMessage());
+				log.warn("Parse failure for template '{}' in chart '{}': {}", name, templateToChartName.get(name),
+						ex.getMessage());
 			}
 		}
 
@@ -300,7 +304,8 @@ public class Engine {
 				schemaValidator.validate(chart.getMetadata().getName(), chart.getValuesSchema(), mergedValues);
 			}
 			catch (SchemaValidationException ex) {
-				throw new RuntimeException(ex.getMessage(), ex);
+				throw new TemplateRenderException("Values schema validation failed: " + ex.getMessage(), ex,
+						chart.getMetadata().getName(), null);
 			}
 		}
 
@@ -380,11 +385,14 @@ public class Engine {
 				}
 			}
 			catch (StackOverflowError ex) {
-				log.error("StackOverflowError rendering template {}: {}", t.getName(), ex.getMessage());
+				log.error(
+						"StackOverflowError rendering chart '{}', template '{}': recursive template inclusion detected",
+						chart.getMetadata().getName(), t.getName());
 			}
 			catch (Exception ex) {
-				log.error("Failed to render template {}: {}", t.getName(), ex.getMessage());
-				throw new RuntimeException("Failed to render template " + t.getName(), ex);
+				String chartName = chart.getMetadata().getName();
+				log.error("Failed to render chart '{}', template '{}': {}", chartName, t.getName(), ex.getMessage());
+				throw new TemplateRenderException("Rendering failed: " + ex.getMessage(), ex, chartName, t.getName());
 			}
 		}
 	}
@@ -420,8 +428,8 @@ public class Engine {
 			return writer.toString();
 		}
 		catch (Exception ex) {
-			log.error("Template rendering failed for {}. Error: {}", template.getName(), ex.getMessage());
-			throw new RuntimeException("Failed to render template " + template.getName(), ex);
+			log.error("Template rendering failed for '{}': {}", template.getName(), ex.getMessage());
+			throw new TemplateRenderException("Rendering failed: " + ex.getMessage(), ex, null, template.getName());
 		}
 	}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
@@ -138,17 +138,17 @@ class KpsComparisonTest {
 
 	@ParameterizedTest
 	@CsvFileSource(resources = "/single.csv")
-	void compareSingleChart(String chartName, String repoId, String repoUrl) throws IOException {
+	void compareSingleChart(String chartName, String repoId, String repoUrl) throws Exception {
 		compareChart(chartName, "release-" + chartName, repoId, repoUrl);
 	}
 
 	@ParameterizedTest
 	@CsvFileSource(resources = "/charts.csv")
-	void compareAllTopCharts(String chartName, String repoId, String repoUrl) throws IOException {
+	void compareAllTopCharts(String chartName, String repoId, String repoUrl) throws Exception {
 		compareChart(chartName, "release-" + chartName, repoId, repoUrl);
 	}
 
-	private void compareChart(String chartName, String releaseName, String repoId, String repoUrl) throws IOException {
+	private void compareChart(String chartName, String releaseName, String repoId, String repoUrl) throws Exception {
 		// No charts skipped anymore
 
 		File chartDir = findChartDir(chartName);
@@ -350,7 +350,7 @@ class KpsComparisonTest {
 		}
 	}
 
-	private java.util.List<JsonNode> parseYamlDocuments(String yaml) throws IOException {
+	private java.util.List<JsonNode> parseYamlDocuments(String yaml) throws Exception {
 		java.util.List<JsonNode> docs = new java.util.ArrayList<>();
 		YAMLMapper yamlMapper = YAMLMapper.builder().build();
 
@@ -438,7 +438,7 @@ class KpsComparisonTest {
 		return null;
 	}
 
-	private void addHelmRepo(String repoId, String repoUrl) throws IOException {
+	private void addHelmRepo(String repoId, String repoUrl) throws Exception {
 		if (addedRepos.contains(repoId)) {
 			log.debug("Repo {} already added in this session, skipping", repoId);
 			return;
@@ -466,7 +466,7 @@ class KpsComparisonTest {
 		addedRepos.add(repoId);
 	}
 
-	private void fetchFromHelmRepo(String chartName) throws IOException {
+	private void fetchFromHelmRepo(String chartName) throws Exception {
 		log.info("Fetching chart {} via RepoManager...", chartName);
 		File tempDir = new File("target/temp-charts");
 		tempDir.mkdirs();
@@ -546,7 +546,7 @@ class KpsComparisonTest {
 		repoManager.untar(new File(testChartsDir, fileName), testChartsDir);
 	}
 
-	private JsonNode callApi(String urlString) throws IOException {
+	private JsonNode callApi(String urlString) throws Exception {
 		URL url = URI.create(urlString).toURL();
 		HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 		if (conn instanceof HttpsURLConnection httpsConn) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/exception/ExceptionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/exception/ExceptionTest.java
@@ -94,6 +94,48 @@ class ExceptionTest {
 	}
 
 	@Test
+	void testTemplateRenderExceptionWithChartAndTemplate() {
+		RuntimeException cause = new RuntimeException("parse error");
+		TemplateRenderException ex = new TemplateRenderException("Rendering failed: parse error", cause, "my-chart",
+				"deployment.yaml");
+		assertTrue(ex.getMessage().contains("my-chart"));
+		assertTrue(ex.getMessage().contains("deployment.yaml"));
+		assertTrue(ex.getMessage().contains("Rendering failed"));
+		assertEquals("my-chart", ex.getChartName());
+		assertEquals("deployment.yaml", ex.getTemplateName());
+		assertEquals(cause, ex.getCause());
+	}
+
+	@Test
+	void testTemplateRenderExceptionWithChartOnly() {
+		TemplateRenderException ex = new TemplateRenderException("Schema validation failed", "my-chart", null);
+		assertTrue(ex.getMessage().contains("my-chart"));
+		assertFalse(ex.getMessage().contains("template"));
+		assertEquals("my-chart", ex.getChartName());
+		assertNull(ex.getTemplateName());
+	}
+
+	@Test
+	void testChartLoadExceptionWithSuggestion() {
+		ChartLoadException ex = new ChartLoadException("Chart directory does not exist", "/tmp/bad-path",
+				"Verify the path is correct");
+		assertTrue(ex.getMessage().contains("does not exist"));
+		assertTrue(ex.getMessage().contains("/tmp/bad-path"));
+		assertTrue(ex.getMessage().contains("Verify the path"));
+		assertEquals("/tmp/bad-path", ex.getChartPath());
+		assertEquals("Verify the path is correct", ex.getSuggestion());
+	}
+
+	@Test
+	void testChartLoadExceptionWithCause() {
+		RuntimeException cause = new RuntimeException("io");
+		ChartLoadException ex = new ChartLoadException("Failed to parse", cause, "/charts/app", "Check YAML syntax");
+		assertEquals(cause, ex.getCause());
+		assertTrue(ex.getMessage().contains("/charts/app"));
+		assertTrue(ex.getMessage().contains("Check YAML syntax"));
+	}
+
+	@Test
 	void testWaitTimeoutException() {
 		List<ResourceStatus> pending = List.of(ResourceStatus.builder()
 			.kind("Deployment")

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ChartLoaderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ChartLoaderTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -14,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.alexmond.jhelm.core.exception.ChartLoadException;
 import org.alexmond.jhelm.core.model.Chart;
 
 class ChartLoaderTest {
@@ -29,7 +29,7 @@ class ChartLoaderTest {
 	}
 
 	@Test
-	void testLoadChartWithReadme() throws IOException {
+	void testLoadChartWithReadme() throws Exception {
 		// Create a minimal chart with README
 		Path chartDir = tempDir.resolve("test-chart");
 		Files.createDirectories(chartDir);
@@ -79,7 +79,7 @@ class ChartLoaderTest {
 	}
 
 	@Test
-	void testLoadChartWithCrds() throws IOException {
+	void testLoadChartWithCrds() throws Exception {
 		// Create a minimal chart with CRDs
 		Path chartDir = tempDir.resolve("test-chart-crds");
 		Files.createDirectories(chartDir);
@@ -167,7 +167,7 @@ class ChartLoaderTest {
 	}
 
 	@Test
-	void testLoadChartWithoutReadme() throws IOException {
+	void testLoadChartWithoutReadme() throws Exception {
 		// Create a minimal chart without README
 		Path chartDir = tempDir.resolve("test-chart-no-readme");
 		Files.createDirectories(chartDir);
@@ -197,7 +197,7 @@ class ChartLoaderTest {
 	}
 
 	@Test
-	void testLoadChartWithoutCrds() throws IOException {
+	void testLoadChartWithoutCrds() throws Exception {
 		// Create a minimal chart without CRDs
 		Path chartDir = tempDir.resolve("test-chart-no-crds");
 		Files.createDirectories(chartDir);
@@ -228,7 +228,7 @@ class ChartLoaderTest {
 	}
 
 	@Test
-	void testLoadChartWithEverything() throws IOException {
+	void testLoadChartWithEverything() throws Exception {
 		// Create a complete chart with README, CRDs, templates, and values
 		Path chartDir = tempDir.resolve("complete-chart");
 		Files.createDirectories(chartDir);
@@ -292,19 +292,24 @@ class ChartLoaderTest {
 	@Test
 	void testLoadNonExistentChartThrowsException() {
 		File nonExistentDir = new File("/nonexistent/path");
-		assertThrows(IllegalArgumentException.class, () -> chartLoader.load(nonExistentDir));
+		ChartLoadException ex = assertThrows(ChartLoadException.class, () -> chartLoader.load(nonExistentDir));
+		assertNotNull(ex.getChartPath());
+		assertNotNull(ex.getSuggestion());
+		assertTrue(ex.getMessage().contains("does not exist"));
 	}
 
 	@Test
-	void testLoadChartWithoutChartYamlThrowsException() throws IOException {
+	void testLoadChartWithoutChartYamlThrowsException() throws Exception {
 		Path chartDir = tempDir.resolve("no-chart-yaml");
 		Files.createDirectories(chartDir);
 
-		assertThrows(IllegalArgumentException.class, () -> chartLoader.load(chartDir.toFile()));
+		ChartLoadException ex = assertThrows(ChartLoadException.class, () -> chartLoader.load(chartDir.toFile()));
+		assertTrue(ex.getMessage().contains("Chart.yaml not found"));
+		assertNotNull(ex.getSuggestion());
 	}
 
 	@Test
-	void testLoadChartWithValuesSchema() throws IOException {
+	void testLoadChartWithValuesSchema() throws Exception {
 		Path chartDir = tempDir.resolve("chart-with-schema");
 		Files.createDirectories(chartDir);
 		Files.writeString(chartDir.resolve("Chart.yaml"), """
@@ -331,7 +336,7 @@ class ChartLoaderTest {
 	}
 
 	@Test
-	void testLoadChartWithoutValuesSchema() throws IOException {
+	void testLoadChartWithoutValuesSchema() throws Exception {
 		Path chartDir = tempDir.resolve("chart-without-schema");
 		Files.createDirectories(chartDir);
 		Files.writeString(chartDir.resolve("Chart.yaml"), """


### PR DESCRIPTION
## Summary
- Adds contextual error messages with chart name, template name, and actionable suggestions (closes #17)
- `TemplateRenderException` (unchecked) replaces `RuntimeException` in Engine with chart/template context
- `ChartLoadException` (checked) replaces `IllegalArgumentException` in ChartLoader with path and remediation hints
- Engine log messages enriched with chart and template names for better debugging

## Test plan
- [x] `ExceptionTest` — 4 new tests for TemplateRenderException and ChartLoadException
- [x] `ChartLoaderTest` — updated to verify ChartLoadException with suggestion and path fields
- [x] Full build passes: 132 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)