### PR TITLE
Add sample Spring Boot app for auto-config verification (#80)

### DIFF
--- a/jhelm-sample/pom.xml
+++ b/jhelm-sample/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.alexmond</groupId>
+		<artifactId>jhelm-parent</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+	<artifactId>jhelm-sample</artifactId>
+	<name>jhelm-sample</name>
+	<description>Sample Spring Boot application to verify jhelm auto-configuration wiring</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.alexmond</groupId>
+			<artifactId>jhelm-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/jhelm-sample/src/main/java/org/alexmond/jhelm/sample/JhelmSampleApplication.java
+++ b/jhelm-sample/src/main/java/org/alexmond/jhelm/sample/JhelmSampleApplication.java
@@ -1,0 +1,19 @@
+package org.alexmond.jhelm.sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Minimal Spring Boot application that depends on jhelm-core as a library. Used to verify
+ * that all beans are auto-wired without manual {@code @Import} or {@code @ComponentScan}
+ * configuration.
+ */
+@SpringBootApplication
+@SuppressWarnings("PMD.UseUtilityClass")
+public class JhelmSampleApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(JhelmSampleApplication.class, args);
+	}
+
+}

--- a/jhelm-sample/src/test/java/org/alexmond/jhelm/sample/AutoConfigurationWiringTest.java
+++ b/jhelm-sample/src/test/java/org/alexmond/jhelm/sample/AutoConfigurationWiringTest.java
@@ -1,0 +1,71 @@
+package org.alexmond.jhelm.sample;
+
+import org.alexmond.jhelm.core.action.CreateAction;
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.ShowAction;
+import org.alexmond.jhelm.core.action.TemplateAction;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.Engine;
+import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.core.service.SchemaValidator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Verifies that jhelm-core auto-configuration wires all expected beans into a plain
+ * Spring Boot application without any explicit {@code @Import} or {@code @ComponentScan}.
+ */
+@SpringBootTest
+class AutoConfigurationWiringTest {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Autowired
+	private Engine engine;
+
+	@Autowired
+	private RepoManager repoManager;
+
+	@Autowired
+	private ChartLoader chartLoader;
+
+	@Autowired
+	private TemplateAction templateAction;
+
+	@Autowired
+	private SchemaValidator schemaValidator;
+
+	@Autowired
+	private CreateAction createAction;
+
+	@Autowired
+	private ShowAction showAction;
+
+	@Test
+	void coreBeansAreAutoWired() {
+		assertNotNull(engine, "Engine should be auto-configured");
+		assertNotNull(repoManager, "RepoManager should be auto-configured");
+		assertNotNull(chartLoader, "ChartLoader should be auto-configured");
+		assertNotNull(templateAction, "TemplateAction should be auto-configured");
+		assertNotNull(schemaValidator, "SchemaValidator should be auto-configured");
+		assertNotNull(createAction, "CreateAction should be auto-configured");
+		assertNotNull(showAction, "ShowAction should be auto-configured");
+	}
+
+	@Test
+	void installActionAbsentWithoutKubeService() {
+		assertFalse(context.containsBean("installAction"), "InstallAction should not be present without KubeService");
+		assertFalse(context.getBeanNamesForType(InstallAction.class).length > 0,
+				"No InstallAction bean should exist without KubeService");
+		assertFalse(context.getBeanNamesForType(KubeService.class).length > 0,
+				"No KubeService bean should exist without jhelm-kube");
+	}
+
+}

--- a/jhelm-sample/src/test/java/org/alexmond/jhelm/sample/KubeServiceWiringTest.java
+++ b/jhelm-sample/src/test/java/org/alexmond/jhelm/sample/KubeServiceWiringTest.java
@@ -1,0 +1,74 @@
+package org.alexmond.jhelm.sample;
+
+import org.alexmond.jhelm.core.action.GetAction;
+import org.alexmond.jhelm.core.action.HistoryAction;
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.ListAction;
+import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.StatusAction;
+import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.service.KubeService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Verifies that providing a mock {@link KubeService} bean causes all Kubernetes-dependent
+ * actions to be auto-configured.
+ */
+@SpringBootTest
+class KubeServiceWiringTest {
+
+	@Autowired
+	private InstallAction installAction;
+
+	@Autowired
+	private UpgradeAction upgradeAction;
+
+	@Autowired
+	private UninstallAction uninstallAction;
+
+	@Autowired
+	private ListAction listAction;
+
+	@Autowired
+	private StatusAction statusAction;
+
+	@Autowired
+	private HistoryAction historyAction;
+
+	@Autowired
+	private RollbackAction rollbackAction;
+
+	@Autowired
+	private GetAction getAction;
+
+	@Test
+	void kubeActionsAvailableWithMockKubeService() {
+		assertNotNull(installAction, "InstallAction should be present when KubeService is available");
+		assertNotNull(upgradeAction, "UpgradeAction should be present when KubeService is available");
+		assertNotNull(uninstallAction, "UninstallAction should be present when KubeService is available");
+		assertNotNull(listAction, "ListAction should be present when KubeService is available");
+		assertNotNull(statusAction, "StatusAction should be present when KubeService is available");
+		assertNotNull(historyAction, "HistoryAction should be present when KubeService is available");
+		assertNotNull(rollbackAction, "RollbackAction should be present when KubeService is available");
+		assertNotNull(getAction, "GetAction should be present when KubeService is available");
+	}
+
+	@TestConfiguration
+	static class MockKubeConfig {
+
+		@Bean
+		KubeService kubeService() {
+			return mock(KubeService.class);
+		}
+
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <module>jhelm-kube</module>
         <module>jhelm-plugin</module>
         <module>jhelm-app</module>
+        <module>jhelm-sample</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary
- New `jhelm-sample` module added to reactor — minimal Spring Boot app that depends on `jhelm-core` as a library
- **AutoConfigurationWiringTest**: verifies 7 core beans (Engine, RepoManager, ChartLoader, TemplateAction, SchemaValidator, CreateAction, ShowAction) are auto-wired; confirms InstallAction is absent without KubeService
- **KubeServiceWiringTest**: provides mock KubeService and verifies all 8 Kubernetes-dependent actions become available
- No `@Import` or `@ComponentScan` — beans come purely from auto-configuration

## Test plan
- [x] `./mvnw clean install` passes all 7 modules
- [x] Core beans auto-wired without manual config
- [x] InstallAction absent without KubeService
- [x] All kube actions present with mock KubeService

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)