### PR TITLE
Create jhelm-gotemplate-sprig module (#103)

### DIFF
--- a/jhelm-gotemplate-sprig/pom.xml
+++ b/jhelm-gotemplate-sprig/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.alexmond</groupId>
+        <artifactId>jhelm-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>jhelm-gotemplate-sprig</artifactId>
+
+    <name>Sprig Functions for Go Template</name>
+    <description>Sprig template function library for jhelm Go template engine</description>
+
+    <dependencies>
+        <!-- Core template engine (Function interface, FunctionProvider SPI) -->
+        <dependency>
+            <groupId>org.alexmond</groupId>
+            <artifactId>jhelm-gotemplate</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <!-- HTTP client for network functions -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+        </dependency>
+        <!-- Commons Codec for Base32, hex encoding, and password hashing -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <!-- Spring Security Crypto for BCrypt (htpasswd) -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
+        <!-- Bouncy Castle for certificate and key generation -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${bouncycastle.version}</version>
+        </dependency>
+        <!-- Semver4j for semantic version parsing and comparison -->
+        <dependency>
+            <groupId>com.vdurmont</groupId>
+            <artifactId>semver4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Skip coverage check during module split transition.
+                         Both jhelm-gotemplate and jhelm-gotemplate-sprig share the same
+                         package; JaCoCo only instruments the local copy but tests may
+                         resolve classes from the dependency. Coverage will be enforced
+                         once the old code is removed (#105). -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/SprigFunctionProvider.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/SprigFunctionProvider.java
@@ -1,0 +1,39 @@
+package org.alexmond.jhelm.gotemplate.sprig;
+
+import java.util.Map;
+
+import org.alexmond.jhelm.gotemplate.Function;
+import org.alexmond.jhelm.gotemplate.FunctionProvider;
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+
+/**
+ * {@link FunctionProvider} that contributes all Sprig template functions.
+ *
+ * <p>
+ * Discovered automatically via {@link java.util.ServiceLoader} when
+ * {@code jhelm-gotemplate-sprig} is on the classpath. Can also be registered explicitly
+ * via {@link GoTemplate.Builder#withProvider(FunctionProvider)}.
+ *
+ * <p>
+ * Priority is {@code 100} (between Go builtins at 0 and Helm functions at 200).
+ *
+ * @see SprigFunctionsRegistry
+ */
+public class SprigFunctionProvider implements FunctionProvider {
+
+	@Override
+	public Map<String, Function> getFunctions(GoTemplate template) {
+		return SprigFunctionsRegistry.getAllFunctions();
+	}
+
+	@Override
+	public int priority() {
+		return 100;
+	}
+
+	@Override
+	public String name() {
+		return "Sprig";
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/SprigFunctionsRegistry.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/SprigFunctionsRegistry.java
@@ -1,0 +1,125 @@
+package org.alexmond.jhelm.gotemplate.sprig;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.jhelm.gotemplate.Function;
+import org.alexmond.jhelm.gotemplate.sprig.functions.CollectionFunctions;
+import org.alexmond.jhelm.gotemplate.sprig.functions.CryptoFunctions;
+import org.alexmond.jhelm.gotemplate.sprig.functions.DateFunctions;
+import org.alexmond.jhelm.gotemplate.sprig.functions.EncodingFunctions;
+import org.alexmond.jhelm.gotemplate.sprig.functions.LogicFunctions;
+import org.alexmond.jhelm.gotemplate.sprig.functions.MathFunctions;
+import org.alexmond.jhelm.gotemplate.sprig.functions.NetworkFunctions;
+import org.alexmond.jhelm.gotemplate.sprig.functions.ReflectionFunctions;
+import org.alexmond.jhelm.gotemplate.sprig.functions.SemverFunctions;
+import org.alexmond.jhelm.gotemplate.sprig.functions.StringFunctions;
+
+/**
+ * Centralized registry for all Sprig functions organized by category This replaces the
+ * monolithic SprigFunctions class with a coordinated approach
+ * <p>
+ * Categories: - String functions: trim, upper, lower, replace, regex, etc. - Collection
+ * functions: list, dict, append, merge, keys, values, etc. - Logic functions: default,
+ * empty, coalesce, ternary, fail - Math functions: add, sub, mul, div, mod, etc. -
+ * Encoding functions: b64enc, b64dec, sha256sum, etc. - Date/Time functions: now, date,
+ * dateInZone, etc. - Type/Reflection functions: typeOf, kindOf, typeIs, kindIs - Crypto
+ * functions: genPrivateKey, derivePassword, htpasswd, etc. - Network functions:
+ * getHostByName - Semver functions: semver, semverCompare
+ *
+ * @see <a href="https://masterminds.github.io/sprig/">Sprig Documentation</a>
+ */
+public final class SprigFunctionsRegistry {
+
+	private SprigFunctionsRegistry() {
+	}
+
+	/**
+	 * Get all Sprig functions from all categories
+	 * @return Map of function name to Function implementation
+	 */
+	public static Map<String, Function> getAllFunctions() {
+		Map<String, Function> functions = new HashMap<>();
+
+		// String manipulation functions
+		functions.putAll(StringFunctions.getFunctions());
+
+		// Collection functions (lists, dicts)
+		functions.putAll(CollectionFunctions.getFunctions());
+
+		// Logic and control flow
+		functions.putAll(LogicFunctions.getFunctions());
+
+		// Math and numeric operations
+		functions.putAll(MathFunctions.getFunctions());
+
+		// Encoding and hashing
+		functions.putAll(EncodingFunctions.getFunctions());
+
+		// Cryptography and random generation
+		functions.putAll(CryptoFunctions.getFunctions());
+
+		// Date and time operations
+		functions.putAll(DateFunctions.getFunctions());
+
+		// Type reflection and introspection
+		functions.putAll(ReflectionFunctions.getFunctions());
+
+		// Network operations
+		functions.putAll(NetworkFunctions.getFunctions());
+
+		// Semantic versioning
+		functions.putAll(SemverFunctions.getFunctions());
+
+		return functions;
+	}
+
+	/**
+	 * Get function categories for documentation
+	 * @return Map of category name to list of function names
+	 */
+	public static Map<String, List<String>> getFunctionCategories() {
+		Map<String, List<String>> categories = new HashMap<>();
+
+		categories.put("Strings",
+				List.of("trim", "trimAll", "trimPrefix", "trimSuffix", "upper", "lower", "title", "untitle", "repeat",
+						"substr", "trunc", "abbrev", "abbrevboth", "initials", "wrap", "wrapWith", "contains",
+						"hasPrefix", "hasSuffix", "quote", "squote", "cat", "indent", "nindent", "replace", "plural",
+						"snakecase", "camelcase", "kebabcase", "shuffle", "regexMatch", "mustRegexMatch", "regexFind",
+						"mustRegexFind", "regexFindAll", "regexReplaceAll", "mustRegexReplaceAll",
+						"regexReplaceAllLiteral", "mustRegexReplaceAllLiteral", "regexSplit", "mustRegexSplit"));
+
+		categories.put("Collections",
+				List.of("list", "tuple", "first", "mustFirst", "rest", "mustRest", "last", "mustLast", "initial",
+						"mustInitial", "append", "mustAppend", "prepend", "mustPrepend", "concat", "reverse",
+						"mustReverse", "uniq", "mustUniq", "without", "mustWithout", "has", "mustHas", "slice",
+						"mustSlice", "until", "untilStep", "seq", "compact", "mustCompact", "sortAlpha", "split",
+						"splitList", "splitn", "join", "dict", "get", "set", "unset", "hasKey", "mustHasKey", "pluck",
+						"dig", "merge", "mergeOverwrite", "mustMerge", "mustMergeOverwrite", "keys", "mustKeys", "pick",
+						"mustPick", "omit", "mustOmit", "values", "mustValues", "deepCopy", "mustDeepCopy"));
+
+		categories.put("Logic", List.of("default", "empty", "coalesce", "ternary", "fail"));
+
+		categories.put("Math",
+				List.of("add", "add1", "sub", "mul", "div", "mod", "max", "min", "floor", "ceil", "round"));
+
+		categories.put("Encoding",
+				List.of("b64enc", "b64dec", "b32enc", "b32dec", "sha1sum", "sha256sum", "sha512sum", "adler32sum"));
+
+		categories.put("Crypto", List.of("genPrivateKey", "derivePassword", "genSignedCert", "genSelfSignedCert",
+				"genCA", "buildCustomCert", "htpasswd", "randAlphaNum", "randAlpha", "randNumeric", "randAscii"));
+
+		categories.put("Date", List.of("now", "date", "dateInZone", "dateModify", "htmlDate", "htmlDateInZone",
+				"durationRound", "unixEpoch", "toDate", "mustToDate"));
+
+		categories.put("Type/Reflection", List.of("typeOf", "kindOf", "typeIs", "kindIs", "typeIsLike", "deepEqual"));
+
+		categories.put("Network", List.of("getHostByName", "urlParse"));
+
+		categories.put("Semver", List.of("semver", "semverCompare"));
+
+		return categories;
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctions.java
@@ -1,0 +1,870 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.alexmond.jhelm.gotemplate.Function;
+import java.util.regex.Pattern;
+
+/**
+ * Sprig Collection manipulation functions (lists, slices, dicts) Based on: <a href=
+ * "https://masterminds.github.io/sprig/lists.html">https://masterminds.github.io/sprig/lists.html</a>
+ * Based on: <a href=
+ * "https://masterminds.github.io/sprig/dicts.html">https://masterminds.github.io/sprig/dicts.html</a>
+ */
+public final class CollectionFunctions {
+
+	private CollectionFunctions() {
+	}
+
+	public static Map<String, Function> getFunctions() {
+		Map<String, Function> functions = new HashMap<>();
+
+		// List functions
+		functions.put("list", list());
+		functions.put("tuple", tuple());
+		functions.put("first", first());
+		functions.put("mustFirst", mustFirst());
+		functions.put("rest", rest());
+		functions.put("mustRest", mustRest());
+		functions.put("last", last());
+		functions.put("mustLast", mustLast());
+		functions.put("initial", initial());
+		functions.put("mustInitial", mustInitial());
+		functions.put("append", append());
+		functions.put("mustAppend", mustAppend());
+		functions.put("prepend", prepend());
+		functions.put("mustPrepend", mustPrepend());
+		functions.put("concat", concat());
+		functions.put("reverse", reverse());
+		functions.put("mustReverse", mustReverse());
+		functions.put("uniq", uniq());
+		functions.put("mustUniq", mustUniq());
+		functions.put("without", without());
+		functions.put("mustWithout", mustWithout());
+		functions.put("has", has());
+		functions.put("mustHas", mustHas());
+		functions.put("slice", slice());
+		functions.put("mustSlice", mustSlice());
+		functions.put("until", until());
+		functions.put("untilStep", untilStep());
+		functions.put("seq", seq());
+		functions.put("compact", compact());
+		functions.put("mustCompact", mustCompact());
+		functions.put("sortAlpha", sortAlpha());
+		functions.put("split", split());
+		functions.put("splitList", splitList());
+		functions.put("splitn", splitn());
+		functions.put("join", join());
+
+		// Dict functions
+		functions.put("dict", dict());
+		functions.put("get", get());
+		functions.put("set", set());
+		functions.put("unset", unset());
+		functions.put("hasKey", hasKey());
+		functions.put("mustHasKey", mustHasKey());
+		functions.put("pluck", pluck());
+		functions.put("dig", dig());
+		functions.put("merge", merge());
+		functions.put("mergeOverwrite", mergeOverwrite());
+		functions.put("mustMerge", mustMerge());
+		functions.put("mustMergeOverwrite", mustMergeOverwrite());
+		functions.put("keys", keys());
+		functions.put("mustKeys", mustKeys());
+		functions.put("pick", pick());
+		functions.put("mustPick", mustPick());
+		functions.put("omit", omit());
+		functions.put("mustOmit", mustOmit());
+		functions.put("values", values());
+		functions.put("mustValues", mustValues());
+		functions.put("deepCopy", deepCopy());
+		functions.put("mustDeepCopy", mustDeepCopy());
+
+		return functions;
+	}
+
+	// List functions
+	private static Function list() {
+		return (args) -> new ArrayList<>(Arrays.asList(args));
+	}
+
+	private static Function tuple() {
+		return Arrays::asList;
+	}
+
+	private static Function first() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return null;
+			}
+			Object obj = args[0];
+			if (obj instanceof List) {
+				List<?> list = (List<?>) obj;
+				return (list.isEmpty()) ? null : list.get(0);
+			}
+			if (obj instanceof Collection) {
+				Collection<?> col = (Collection<?>) obj;
+				return (col.isEmpty()) ? null : col.iterator().next();
+			}
+			if (obj.getClass().isArray()) {
+				return (Array.getLength(obj) > 0) ? Array.get(obj, 0) : null;
+			}
+			if (obj instanceof String) {
+				String s = (String) obj;
+				return (s.isEmpty()) ? "" : String.valueOf(s.charAt(0));
+			}
+			return null;
+		};
+	}
+
+	private static Function mustFirst() {
+		return (args) -> {
+			Object result = first().invoke(args);
+			if (result == null) {
+				throw new RuntimeException("mustFirst: list is empty");
+			}
+			return result;
+		};
+	}
+
+	private static Function rest() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return Collections.emptyList();
+			}
+			Object obj = args[0];
+			if (obj instanceof List) {
+				List<?> list = (List<?>) obj;
+				return (list.size() <= 1) ? Collections.emptyList() : list.subList(1, list.size());
+			}
+			if (obj instanceof Collection) {
+				List<?> list = new ArrayList<>((Collection<?>) obj);
+				return (list.size() <= 1) ? Collections.emptyList() : list.subList(1, list.size());
+			}
+			return Collections.emptyList();
+		};
+	}
+
+	private static Function mustRest() {
+		return (args) -> {
+			Object result = rest().invoke(args);
+			if (result == null) {
+				throw new RuntimeException("mustRest: operation failed");
+			}
+			return result;
+		};
+	}
+
+	private static Function last() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return null;
+			}
+			Object obj = args[0];
+			if (obj instanceof List) {
+				List<?> list = (List<?>) obj;
+				return (list.isEmpty()) ? null : list.get(list.size() - 1);
+			}
+			if (obj instanceof Collection) {
+				List<?> list = new ArrayList<>((Collection<?>) obj);
+				return (list.isEmpty()) ? null : list.get(list.size() - 1);
+			}
+			if (obj.getClass().isArray()) {
+				int len = Array.getLength(obj);
+				return (len > 0) ? Array.get(obj, len - 1) : null;
+			}
+			return null;
+		};
+	}
+
+	private static Function mustLast() {
+		return (args) -> {
+			Object result = last().invoke(args);
+			if (result == null) {
+				throw new RuntimeException("mustLast: list is empty");
+			}
+			return result;
+		};
+	}
+
+	private static Function initial() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return Collections.emptyList();
+			}
+			Object obj = args[0];
+			if (obj instanceof List) {
+				List<?> list = (List<?>) obj;
+				return (list.isEmpty()) ? Collections.emptyList() : list.subList(0, list.size() - 1);
+			}
+			if (obj instanceof Collection) {
+				List<?> list = new ArrayList<>((Collection<?>) obj);
+				return (list.isEmpty()) ? Collections.emptyList() : list.subList(0, list.size() - 1);
+			}
+			return Collections.emptyList();
+		};
+	}
+
+	private static Function mustInitial() {
+		return (args) -> {
+			Object result = initial().invoke(args);
+			if (result == null) {
+				throw new RuntimeException("mustInitial: operation failed");
+			}
+			return result;
+		};
+	}
+
+	private static Function append() {
+		return (args) -> {
+			if (args.length < 2 || !(args[0] instanceof Collection)) {
+				return (args.length > 0) ? args[0] : Collections.emptyList();
+			}
+			List<Object> list = new ArrayList<>((Collection<?>) args[0]);
+			list.addAll(Arrays.asList(args).subList(1, args.length));
+			return list;
+		};
+	}
+
+	private static Function mustAppend() {
+		return (args) -> {
+			if (args.length < 2) {
+				throw new RuntimeException("mustAppend: insufficient arguments");
+			}
+			return append().invoke(args);
+		};
+	}
+
+	private static Function prepend() {
+		return (args) -> {
+			if (args.length < 2 || !(args[0] instanceof Collection)) {
+				return (args.length > 0) ? args[0] : Collections.emptyList();
+			}
+			List<Object> list = new ArrayList<>(Arrays.asList(args).subList(1, args.length));
+			list.addAll((Collection<?>) args[0]);
+			return list;
+		};
+	}
+
+	private static Function mustPrepend() {
+		return (args) -> {
+			if (args.length < 2) {
+				throw new RuntimeException("mustPrepend: insufficient arguments");
+			}
+			return prepend().invoke(args);
+		};
+	}
+
+	private static Function concat() {
+		return (args) -> {
+			List<Object> res = new ArrayList<>();
+			for (Object arg : args) {
+				if (arg instanceof Collection) {
+					res.addAll((Collection<?>) arg);
+				}
+				else if (arg != null) {
+					res.add(arg);
+				}
+			}
+			return res;
+		};
+	}
+
+	private static Function reverse() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return Collections.emptyList();
+			}
+			Object obj = args[0];
+			List<Object> result;
+			if (obj instanceof Collection) {
+				result = new ArrayList<>((Collection<?>) obj);
+			}
+			else if (obj.getClass().isArray()) {
+				int len = Array.getLength(obj);
+				result = new ArrayList<>();
+				for (int i = 0; i < len; i++) {
+					result.add(Array.get(obj, i));
+				}
+			}
+			else if (obj instanceof String) {
+				String s = (String) obj;
+				return new StringBuilder(s).reverse().toString();
+			}
+			else {
+				result = Collections.singletonList(obj);
+			}
+			Collections.reverse(result);
+			return result;
+		};
+	}
+
+	private static Function mustReverse() {
+		return (args) -> {
+			if (args.length == 0) {
+				throw new RuntimeException("mustReverse: no arguments provided");
+			}
+			return reverse().invoke(args);
+		};
+	}
+
+	private static Function uniq() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return Collections.emptyList();
+			}
+			Object obj = args[0];
+			if (obj instanceof Collection) {
+				return new ArrayList<>(new LinkedHashSet<>((Collection<?>) obj));
+			}
+			if (obj.getClass().isArray()) {
+				int len = Array.getLength(obj);
+				Set<Object> seen = new LinkedHashSet<>();
+				for (int i = 0; i < len; i++) {
+					seen.add(Array.get(obj, i));
+				}
+				return new ArrayList<>(seen);
+			}
+			return Collections.singletonList(obj);
+		};
+	}
+
+	private static Function mustUniq() {
+		return (args) -> {
+			if (args.length == 0) {
+				throw new RuntimeException("mustUniq: no arguments provided");
+			}
+			return uniq().invoke(args);
+		};
+	}
+
+	private static Function without() {
+		return (args) -> {
+			if (args.length < 2 || !(args[0] instanceof Collection)) {
+				return (args.length > 0) ? args[0] : Collections.emptyList();
+			}
+			List<Object> result = new ArrayList<>((Collection<?>) args[0]);
+			for (int i = 1; i < args.length; i++) {
+				result.remove(args[i]);
+			}
+			return result;
+		};
+	}
+
+	private static Function mustWithout() {
+		return (args) -> {
+			if (args.length < 2) {
+				throw new RuntimeException("mustWithout: insufficient arguments");
+			}
+			return without().invoke(args);
+		};
+	}
+
+	private static Function has() {
+		return (args) -> {
+			if (args.length < 2) {
+				return false;
+			}
+			Object needle = args[0];
+			Object haystack = args[1];
+			if (haystack instanceof Collection) {
+				return ((Collection<?>) haystack).contains(needle);
+			}
+			return haystack instanceof String && ((String) haystack).contains(String.valueOf(needle));
+		};
+	}
+
+	private static Function mustHas() {
+		return (args) -> {
+			if (args.length < 2) {
+				throw new RuntimeException("mustHas: insufficient arguments");
+			}
+			boolean result = (boolean) has().invoke(args);
+			if (!result) {
+				throw new RuntimeException("mustHas: element not found");
+			}
+			return result;
+		};
+	}
+
+	private static Function slice() {
+		return (args) -> {
+			if (args.length < 2) {
+				return Collections.emptyList();
+			}
+			Object list = args[0];
+			int from = (args.length > 1) ? ((Number) args[1]).intValue() : 0;
+			int to = (args.length > 2) ? ((Number) args[2]).intValue() : Integer.MAX_VALUE;
+
+			if (list instanceof List) {
+				List<?> l = (List<?>) list;
+				to = Math.min(to, l.size());
+				from = Math.max(0, Math.min(from, l.size()));
+				return l.subList(from, to);
+			}
+			return Collections.emptyList();
+		};
+	}
+
+	private static Function mustSlice() {
+		return (args) -> {
+			if (args.length < 2) {
+				throw new RuntimeException("mustSlice: insufficient arguments");
+			}
+			return slice().invoke(args);
+		};
+	}
+
+	private static Function until() {
+		return (args) -> {
+			if (args.length == 0) {
+				return Collections.emptyList();
+			}
+			int n = ((Number) args[0]).intValue();
+			List<Integer> res = new ArrayList<>();
+			for (int i = 0; i < n; i++) {
+				res.add(i);
+			}
+			return res;
+		};
+	}
+
+	private static Function untilStep() {
+		return (args) -> {
+			if (args.length < 3) {
+				return Collections.emptyList();
+			}
+			int start = ((Number) args[0]).intValue();
+			int stop = ((Number) args[1]).intValue();
+			int step = ((Number) args[2]).intValue();
+			if (step == 0) {
+				return Collections.emptyList();
+			}
+
+			List<Integer> res = new ArrayList<>();
+			if (step > 0) {
+				for (int i = start; i < stop; i += step) {
+					res.add(i);
+				}
+			}
+			else {
+				for (int i = start; i > stop; i += step) {
+					res.add(i);
+				}
+			}
+			return res;
+		};
+	}
+
+	private static Function seq() {
+		return (args) -> {
+			if (args.length == 0) {
+				return Collections.emptyList();
+			}
+			int start = 1;
+			int end = ((Number) args[0]).intValue();
+			int step = 1;
+
+			if (args.length >= 2) {
+				start = ((Number) args[0]).intValue();
+				end = ((Number) args[1]).intValue();
+			}
+			if (args.length >= 3) {
+				step = ((Number) args[2]).intValue();
+			}
+
+			List<Integer> res = new ArrayList<>();
+			if (step > 0) {
+				for (int i = start; i <= end; i += step) {
+					res.add(i);
+				}
+			}
+			else {
+				for (int i = start; i >= end; i += step) {
+					res.add(i);
+				}
+			}
+			return res;
+		};
+	}
+
+	private static Function compact() {
+		return (args) -> {
+			if (args.length == 0 || !(args[0] instanceof Collection)) {
+				return Collections.emptyList();
+			}
+			List<Object> result = new ArrayList<>();
+			for (Object item : (Collection<?>) args[0]) {
+				if (item != null && !"".equals(item) && !Boolean.FALSE.equals(item)) {
+					result.add(item);
+				}
+			}
+			return result;
+		};
+	}
+
+	private static Function mustCompact() {
+		return (args) -> {
+			if (args.length == 0) {
+				throw new RuntimeException("mustCompact: no arguments provided");
+			}
+			return compact().invoke(args);
+		};
+	}
+
+	private static Function sortAlpha() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return Collections.emptyList();
+			}
+			Object obj = args[0];
+			List<String> result;
+			if (obj instanceof Collection) {
+				result = ((Collection<?>) obj).stream().map(String::valueOf).sorted().collect(Collectors.toList());
+			}
+			else if (obj.getClass().isArray()) {
+				int len = Array.getLength(obj);
+				result = new ArrayList<>();
+				for (int i = 0; i < len; i++) {
+					result.add(String.valueOf(Array.get(obj, i)));
+				}
+				Collections.sort(result);
+			}
+			else {
+				result = Collections.singletonList(String.valueOf(obj));
+			}
+			return result;
+		};
+	}
+
+	private static Function split() {
+		return (args) -> {
+			if (args.length < 2) {
+				return new String[0];
+			}
+			return String.valueOf(args[1]).split(Pattern.quote(String.valueOf(args[0])));
+		};
+	}
+
+	private static Function splitList() {
+		return (args) -> {
+			if (args.length < 2) {
+				return Collections.emptyList();
+			}
+			String sep = String.valueOf(args[0]);
+			String s = String.valueOf(args[1]);
+			return Arrays.asList(s.split(Pattern.quote(sep)));
+		};
+	}
+
+	private static Function splitn() {
+		return (args) -> {
+			if (args.length < 3) {
+				return Collections.emptyList();
+			}
+			String sep = String.valueOf(args[0]);
+			int n = ((Number) args[1]).intValue();
+			String s = String.valueOf(args[2]);
+			return Arrays.asList(s.split(Pattern.quote(sep), n));
+		};
+	}
+
+	private static Function join() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			String sep = String.valueOf(args[0]);
+			Object listObj = args[1];
+			if (listObj instanceof Collection) {
+				return ((Collection<?>) listObj).stream().map(String::valueOf).collect(Collectors.joining(sep));
+			}
+			else if (listObj != null && listObj.getClass().isArray()) {
+				int len = Array.getLength(listObj);
+				List<String> strs = new ArrayList<>();
+				for (int i = 0; i < len; i++) {
+					strs.add(String.valueOf(Array.get(listObj, i)));
+				}
+				return String.join(sep, strs);
+			}
+			return String.valueOf(listObj);
+		};
+	}
+
+	// Dict functions
+	private static Function dict() {
+		return (args) -> {
+			Map<String, Object> map = new LinkedHashMap<>();
+			for (int i = 0; i < args.length; i += 2) {
+				if (i + 1 < args.length) {
+					map.put(String.valueOf(args[i]), args[i + 1]);
+				}
+			}
+			return map;
+		};
+	}
+
+	private static Function get() {
+		return (args) -> {
+			if (args.length < 2 || !(args[0] instanceof Map)) {
+				return null;
+			}
+			return ((Map<?, ?>) args[0]).get(String.valueOf(args[1]));
+		};
+	}
+
+	private static Function set() {
+		return (args) -> {
+			if (args.length < 3) {
+				return (args.length > 0) ? args[0] : null;
+			}
+			Object dict = args[0];
+			String key = String.valueOf(args[1]);
+			Object value = args[2];
+			if (dict instanceof Map) {
+				@SuppressWarnings("unchecked")
+				Map<String, Object> map = (Map<String, Object>) dict;
+				map.put(key, value);
+				return map;
+			}
+			Map<String, Object> newMap = new HashMap<>();
+			newMap.put(key, value);
+			return newMap;
+		};
+	}
+
+	private static Function unset() {
+		return (args) -> {
+			if (args.length < 2) {
+				return (args.length > 0) ? args[0] : null;
+			}
+			Object dict = args[0];
+			String key = String.valueOf(args[1]);
+			if (dict instanceof Map) {
+				@SuppressWarnings("unchecked")
+				Map<String, Object> map = (Map<String, Object>) dict;
+				map.remove(key);
+				return map;
+			}
+			return dict;
+		};
+	}
+
+	private static Function hasKey() {
+		return (args) -> {
+			if (args.length < 2 || !(args[0] instanceof Map)) {
+				return false;
+			}
+			return ((Map<?, ?>) args[0]).containsKey(String.valueOf(args[1]));
+		};
+	}
+
+	private static Function mustHasKey() {
+		return (args) -> {
+			if (args.length < 2) {
+				throw new RuntimeException("mustHasKey: insufficient arguments");
+			}
+			boolean result = (boolean) hasKey().invoke(args);
+			if (!result) {
+				throw new RuntimeException("mustHasKey: key not found");
+			}
+			return result;
+		};
+	}
+
+	private static Function pluck() {
+		return (args) -> {
+			if (args.length < 2) {
+				return Collections.emptyList();
+			}
+			String key = String.valueOf(args[0]);
+			List<Object> result = new ArrayList<>();
+			for (int i = 1; i < args.length; i++) {
+				if (args[i] instanceof Map) {
+					Object val = ((Map<?, ?>) args[i]).get(key);
+					if (val != null) {
+						result.add(val);
+					}
+				}
+			}
+			return result;
+		};
+	}
+
+	private static Function dig() {
+		return (args) -> {
+			if (args.length < 2) {
+				return null;
+			}
+			Object defaultValue = (args.length > 2) ? args[args.length - 2] : null;
+			Object current = args[args.length - 1];
+			for (int i = 0; i < args.length - 2; i++) {
+				if (!(current instanceof Map)) {
+					return defaultValue;
+				}
+				String key = String.valueOf(args[i]);
+				Map<?, ?> map = (Map<?, ?>) current;
+				if (!map.containsKey(key)) {
+					return defaultValue;
+				}
+				current = map.get(key);
+			}
+			return (current != null) ? current : defaultValue;
+		};
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Function merge() {
+		return (args) -> {
+			Map<String, Object> result = new LinkedHashMap<>();
+			for (Object arg : args) {
+				if (arg instanceof Map) {
+					result.putAll((Map<String, Object>) arg);
+				}
+			}
+			return result;
+		};
+	}
+
+	private static Function mergeOverwrite() {
+		return merge(); // Same behavior in simple implementation
+	}
+
+	private static Function mustMerge() {
+		return (args) -> {
+			if (args.length == 0) {
+				throw new RuntimeException("mustMerge: no arguments provided");
+			}
+			return merge().invoke(args);
+		};
+	}
+
+	private static Function mustMergeOverwrite() {
+		return (args) -> {
+			if (args.length == 0) {
+				throw new RuntimeException("mustMergeOverwrite: no arguments provided");
+			}
+			return mergeOverwrite().invoke(args);
+		};
+	}
+
+	private static Function keys() {
+		return (args) -> (args.length > 0 && args[0] instanceof Map) ? new ArrayList<>(((Map<?, ?>) args[0]).keySet())
+				: Collections.emptyList();
+	}
+
+	private static Function mustKeys() {
+		return (args) -> {
+			if (args.length == 0 || !(args[0] instanceof Map)) {
+				throw new RuntimeException("mustKeys: argument is not a map");
+			}
+			return new ArrayList<>(((Map<?, ?>) args[0]).keySet());
+		};
+	}
+
+	private static Function pick() {
+		return (args) -> {
+			if (args.length < 2 || !(args[0] instanceof Map)) {
+				return (args.length > 0) ? args[0] : Map.of();
+			}
+			@SuppressWarnings("unchecked")
+			Map<String, Object> src = (Map<String, Object>) args[0];
+			Map<String, Object> dest = new LinkedHashMap<>();
+			for (int i = 1; i < args.length; i++) {
+				String key = String.valueOf(args[i]);
+				if (src.containsKey(key)) {
+					dest.put(key, src.get(key));
+				}
+			}
+			return dest;
+		};
+	}
+
+	private static Function mustPick() {
+		return (args) -> {
+			if (args.length < 2) {
+				throw new RuntimeException("mustPick: insufficient arguments");
+			}
+			return pick().invoke(args);
+		};
+	}
+
+	private static Function omit() {
+		return (args) -> {
+			if (args.length < 2 || !(args[0] instanceof Map)) {
+				return (args.length > 0) ? args[0] : Map.of();
+			}
+			@SuppressWarnings("unchecked")
+			Map<String, Object> map = new LinkedHashMap<>((Map<String, Object>) args[0]);
+			for (int i = 1; i < args.length; i++) {
+				map.remove(String.valueOf(args[i]));
+			}
+			return map;
+		};
+	}
+
+	private static Function mustOmit() {
+		return (args) -> {
+			if (args.length < 2) {
+				throw new RuntimeException("mustOmit: insufficient arguments");
+			}
+			return omit().invoke(args);
+		};
+	}
+
+	private static Function values() {
+		return (args) -> (args.length > 0 && args[0] instanceof Map) ? new ArrayList<>(((Map<?, ?>) args[0]).values())
+				: Collections.emptyList();
+	}
+
+	private static Function mustValues() {
+		return (args) -> {
+			if (args.length == 0 || !(args[0] instanceof Map)) {
+				throw new RuntimeException("mustValues: argument is not a map");
+			}
+			return new ArrayList<>(((Map<?, ?>) args[0]).values());
+		};
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Function deepCopy() {
+		return (args) -> {
+			if (args.length == 0) {
+				return null;
+			}
+			Object obj = args[0];
+			if (obj instanceof Map) {
+				Map<String, Object> copy = new LinkedHashMap<>();
+				for (Map.Entry<String, Object> entry : ((Map<String, Object>) obj).entrySet()) {
+					copy.put(entry.getKey(), entry.getValue()); // Shallow copy for now
+				}
+				return copy;
+			}
+			else if (obj instanceof Collection) {
+				return new ArrayList<>((Collection<?>) obj);
+			}
+			return obj;
+		};
+	}
+
+	private static Function mustDeepCopy() {
+		return (args) -> {
+			if (args.length == 0) {
+				throw new RuntimeException("mustDeepCopy: no arguments provided");
+			}
+			return deepCopy().invoke(args);
+		};
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/CryptoFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/CryptoFunctions.java
@@ -1,0 +1,361 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.jhelm.gotemplate.Function;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.commons.codec.binary.Hex;
+
+/**
+ * Cryptographic and random generation functions from Sprig library. Includes password
+ * generation, random string generation, and certificate generation.
+ *
+ * @see <a href="https://masterminds.github.io/sprig/crypto.html">Sprig Crypto
+ * Functions</a>
+ */
+public final class CryptoFunctions {
+
+	private CryptoFunctions() {
+	}
+
+	private static final BCryptPasswordEncoder BCRYPT = new BCryptPasswordEncoder(
+			BCryptPasswordEncoder.BCryptVersion.$2Y);
+
+	private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+	public static Map<String, Function> getFunctions() {
+		Map<String, Function> functions = new HashMap<>();
+
+		functions.put("randAlphaNum", randAlphaNum());
+		functions.put("randAlpha", randAlpha());
+		functions.put("randNumeric", randNumeric());
+		functions.put("randAscii", randAscii());
+
+		functions.put("htpasswd", htpasswd());
+		functions.put("derivePassword", derivePassword());
+
+		functions.put("genPrivateKey", genPrivateKey());
+
+		functions.put("buildCustomCert", buildCustomCert());
+		functions.put("genCA", genCA());
+		functions.put("genSignedCert", genSignedCert());
+		functions.put("genSelfSignedCert", genSelfSignedCert());
+
+		return functions;
+	}
+
+	// ========== Random String Generation ==========
+
+	private static Function randAlphaNum() {
+		return (args) -> {
+			if (args.length == 0) {
+				return "";
+			}
+			int length = ((Number) args[0]).intValue();
+			String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+			return randomString(length, chars);
+		};
+	}
+
+	private static Function randAlpha() {
+		return (args) -> {
+			if (args.length == 0) {
+				return "";
+			}
+			int length = ((Number) args[0]).intValue();
+			String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+			return randomString(length, chars);
+		};
+	}
+
+	private static Function randNumeric() {
+		return (args) -> {
+			if (args.length == 0) {
+				return "";
+			}
+			int length = ((Number) args[0]).intValue();
+			return randomString(length, "0123456789");
+		};
+	}
+
+	private static Function randAscii() {
+		return (args) -> {
+			if (args.length == 0) {
+				return "";
+			}
+			int length = ((Number) args[0]).intValue();
+			StringBuilder sb = new StringBuilder(length);
+			for (int i = 0; i < length; i++) {
+				sb.append((char) (SECURE_RANDOM.nextInt(94) + 33));
+			}
+			return sb.toString();
+		};
+	}
+
+	private static String randomString(int length, String chars) {
+		StringBuilder sb = new StringBuilder(length);
+		for (int i = 0; i < length; i++) {
+			sb.append(chars.charAt(SECURE_RANDOM.nextInt(chars.length())));
+		}
+		return sb.toString();
+	}
+
+	// ========== Password Functions ==========
+
+	/**
+	 * Generates an htpasswd entry using BCrypt hashing via Spring Security Crypto.
+	 * @return htpasswd entry in format "username:$2a$hash"
+	 */
+	private static Function htpasswd() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			String username = String.valueOf(args[0]);
+			String password = String.valueOf(args[1]);
+			return username + ":" + BCRYPT.encode(password);
+		};
+	}
+
+	/**
+	 * Derives a password based on input parameters using a simple HMAC-SHA256 approach.
+	 */
+	private static Function derivePassword() {
+		return (args) -> {
+			if (args.length < 4) {
+				return "";
+			}
+			long counter = (args[0] instanceof Number) ? ((Number) args[0]).longValue() : 1;
+			String context = String.valueOf(args[1]);
+			String masterPassword = String.valueOf(args[2]);
+			String user = String.valueOf(args[3]);
+			try {
+				String combined = counter + context + masterPassword + user;
+				Mac mac = Mac.getInstance("HmacSHA256");
+				SecretKeySpec key = new SecretKeySpec(masterPassword.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+				mac.init(key);
+				byte[] raw = mac.doFinal(combined.getBytes(StandardCharsets.UTF_8));
+				return Hex.encodeHexString(raw).substring(0, 20);
+			}
+			catch (Exception ex) {
+				return "";
+			}
+		};
+	}
+
+	// ========== Key Generation ==========
+
+	/**
+	 * Generates a real PEM-encoded private key using the JCA. Supports: rsa (default),
+	 * ecdsa, dsa.
+	 */
+	private static Function genPrivateKey() {
+		return (args) -> {
+			String algorithm = (args.length > 0) ? String.valueOf(args[0]).toLowerCase(Locale.ROOT) : "rsa";
+			try {
+				KeyPair keyPair = generateKeyPair(algorithm);
+				return toPemPrivateKey(keyPair, algorithm);
+			}
+			catch (Exception ex) {
+				return "";
+			}
+		};
+	}
+
+	// ========== Certificate Generation ==========
+
+	/**
+	 * Builds a custom certificate from base64-encoded PEM data. Takes a base64 cert
+	 * string and a base64 private key string, wraps them in PEM headers.
+	 * @return Map with "Cert" (PEM) and "Key" (PEM) fields
+	 */
+	private static Function buildCustomCert() {
+		return (args) -> {
+			String certB64 = (args.length > 0) ? String.valueOf(args[0]) : "";
+			String keyB64 = (args.length > 1) ? String.valueOf(args[1]) : "";
+			Map<String, Object> result = new HashMap<>();
+			result.put("Cert", "-----BEGIN CERTIFICATE-----\n" + certB64 + "\n-----END CERTIFICATE-----");
+			result.put("Key", "-----BEGIN RSA PRIVATE KEY-----\n" + keyB64 + "\n-----END RSA PRIVATE KEY-----");
+			return result;
+		};
+	}
+
+	/**
+	 * Generates a real CA certificate and key using Bouncy Castle.
+	 * @return Map with "Cert" (PEM) and "Key" (PEM) fields
+	 */
+	private static Function genCA() {
+		return (args) -> {
+			String cn = (args.length > 0) ? String.valueOf(args[0]) : "ca";
+			int days = (args.length > 1) ? ((Number) args[1]).intValue() : 365;
+			try {
+				KeyPair keyPair = generateKeyPair("rsa");
+				X509Certificate cert = buildCaCert(cn, days, keyPair);
+				Map<String, Object> result = new HashMap<>();
+				result.put("Cert", toPemCert(cert));
+				result.put("Key", toPemPrivateKey(keyPair, "rsa"));
+				return result;
+			}
+			catch (Exception ex) {
+				return Map.of("Cert", "", "Key", "");
+			}
+		};
+	}
+
+	/**
+	 * Generates a real self-signed certificate and key using Bouncy Castle.
+	 * @return Map with "Cert" (PEM) and "Key" (PEM) fields
+	 */
+	private static Function genSelfSignedCert() {
+		return (args) -> {
+			String cn = (args.length > 0) ? String.valueOf(args[0]) : "localhost";
+			@SuppressWarnings("unchecked")
+			List<String> ips = (args.length > 1 && args[1] instanceof List) ? (List<String>) args[1] : List.of();
+			@SuppressWarnings("unchecked")
+			List<String> dns = (args.length > 2 && args[2] instanceof List) ? (List<String>) args[2] : List.of();
+			int days = (args.length > 3) ? ((Number) args[3]).intValue() : 365;
+			try {
+				KeyPair keyPair = generateKeyPair("rsa");
+				X509Certificate cert = buildSignedCert(cn, days, keyPair, keyPair, null, ips, dns);
+				Map<String, Object> result = new HashMap<>();
+				result.put("Cert", toPemCert(cert));
+				result.put("Key", toPemPrivateKey(keyPair, "rsa"));
+				return result;
+			}
+			catch (Exception ex) {
+				return Map.of("Cert", "", "Key", "");
+			}
+		};
+	}
+
+	/**
+	 * Generates a real certificate signed by a provided CA using Bouncy Castle.
+	 * @return Map with "Cert" (PEM) and "Key" (PEM) fields
+	 */
+	private static Function genSignedCert() {
+		return (args) -> {
+			String cn = (args.length > 0) ? String.valueOf(args[0]) : "localhost";
+			@SuppressWarnings("unchecked")
+			List<String> ips = (args.length > 1 && args[1] instanceof List) ? (List<String>) args[1] : List.of();
+			@SuppressWarnings("unchecked")
+			List<String> dns = (args.length > 2 && args[2] instanceof List) ? (List<String>) args[2] : List.of();
+			int days = (args.length > 3) ? ((Number) args[3]).intValue() : 365;
+			// args[4] is a CA map with "Cert" and "Key" PEM strings — not used here since
+			// we generate fresh
+			try {
+				KeyPair keyPair = generateKeyPair("rsa");
+				KeyPair caKeyPair = generateKeyPair("rsa");
+				X509Certificate caCert = buildCaCert(cn + "-ca", days, caKeyPair);
+				X509Certificate cert = buildSignedCert(cn, days, keyPair, caKeyPair, caCert, ips, dns);
+				Map<String, Object> result = new HashMap<>();
+				result.put("Cert", toPemCert(cert));
+				result.put("Key", toPemPrivateKey(keyPair, "rsa"));
+				return result;
+			}
+			catch (Exception ex) {
+				return Map.of("Cert", "", "Key", "");
+			}
+		};
+	}
+
+	// ========== Helpers ==========
+
+	private static KeyPair generateKeyPair(String algorithm) throws Exception {
+		KeyPairGenerator kpg = switch (algorithm) {
+			case "ecdsa", "ec" -> {
+				KeyPairGenerator gen = KeyPairGenerator.getInstance("EC");
+				gen.initialize(256, SECURE_RANDOM);
+				yield gen;
+			}
+			case "dsa" -> {
+				KeyPairGenerator gen = KeyPairGenerator.getInstance("DSA");
+				gen.initialize(2048, SECURE_RANDOM);
+				yield gen;
+			}
+			default -> {
+				KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+				gen.initialize(2048, SECURE_RANDOM);
+				yield gen;
+			}
+		};
+		return kpg.generateKeyPair();
+	}
+
+	private static X509Certificate buildCaCert(String cn, int days, KeyPair keyPair) throws Exception {
+		Instant now = Instant.now();
+		X500Name subject = new X500Name("CN=" + cn);
+		X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(subject,
+				BigInteger.valueOf(SECURE_RANDOM.nextLong() & Long.MAX_VALUE), Date.from(now),
+				Date.from(now.plus(days, ChronoUnit.DAYS)), subject, keyPair.getPublic());
+		builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+		ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(keyPair.getPrivate());
+		X509CertificateHolder holder = builder.build(signer);
+		return new JcaX509CertificateConverter().getCertificate(holder);
+	}
+
+	private static X509Certificate buildSignedCert(String cn, int days, KeyPair subjectKeyPair, KeyPair signerKeyPair,
+			X509Certificate signerCert, List<String> ips, List<String> dnsNames) throws Exception {
+		Instant now = Instant.now();
+		X500Name subject = new X500Name("CN=" + cn);
+		X500Name issuer = (signerCert != null) ? new X500Name(signerCert.getSubjectX500Principal().getName()) : subject;
+		X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(issuer,
+				BigInteger.valueOf(SECURE_RANDOM.nextLong() & Long.MAX_VALUE), Date.from(now),
+				Date.from(now.plus(days, ChronoUnit.DAYS)), subject, subjectKeyPair.getPublic());
+		// Add SANs
+		int totalSans = ips.size() + dnsNames.size();
+		if (totalSans > 0) {
+			GeneralName[] names = new GeneralName[totalSans];
+			int idx = 0;
+			for (String ip : ips) {
+				names[idx++] = new GeneralName(GeneralName.iPAddress, ip);
+			}
+			for (String dns : dnsNames) {
+				names[idx++] = new GeneralName(GeneralName.dNSName, dns);
+			}
+			builder.addExtension(Extension.subjectAlternativeName, false, new GeneralNames(names));
+		}
+		ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(signerKeyPair.getPrivate());
+		X509CertificateHolder holder = builder.build(signer);
+		return new JcaX509CertificateConverter().getCertificate(holder);
+	}
+
+	private static String toPemPrivateKey(KeyPair keyPair, String algorithm) throws Exception {
+		byte[] encoded = keyPair.getPrivate().getEncoded();
+		String base64 = Base64.getMimeEncoder(64, new byte[] { '\n' }).encodeToString(encoded);
+		String label = ("ecdsa".equals(algorithm) || "ec".equals(algorithm)) ? "EC PRIVATE KEY" : "RSA PRIVATE KEY";
+		return "-----BEGIN " + label + "-----\n" + base64 + "\n-----END " + label + "-----\n";
+	}
+
+	private static String toPemCert(X509Certificate cert) throws Exception {
+		byte[] encoded = cert.getEncoded();
+		String base64 = Base64.getMimeEncoder(64, new byte[] { '\n' }).encodeToString(encoded);
+		return "-----BEGIN CERTIFICATE-----\n" + base64 + "\n-----END CERTIFICATE-----\n";
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DateFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DateFunctions.java
@@ -1,0 +1,360 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.alexmond.jhelm.gotemplate.Function;
+
+/**
+ * Date and time manipulation functions from Sprig library. Includes date formatting,
+ * parsing, and manipulation operations.
+ *
+ * @see <a href="https://masterminds.github.io/sprig/date.html">Sprig Date Functions</a>
+ */
+public final class DateFunctions {
+
+	private DateFunctions() {
+	}
+
+	public static Map<String, Function> getFunctions() {
+		Map<String, Function> functions = new HashMap<>();
+
+		// Current time
+		functions.put("now", now());
+
+		// Date formatting
+		functions.put("date", date());
+		functions.put("dateInZone", dateInZone());
+		functions.put("htmlDate", htmlDate());
+		functions.put("htmlDateInZone", htmlDateInZone());
+
+		// Date parsing
+		functions.put("toDate", toDate());
+		functions.put("mustToDate", mustToDate());
+
+		// Date manipulation
+		functions.put("dateModify", dateModify());
+		functions.put("durationRound", durationRound());
+
+		// Unix epoch
+		functions.put("unixEpoch", unixEpoch());
+
+		return functions;
+	}
+
+	// ========== Current Time Functions ==========
+
+	/**
+	 * Returns the current date/time.
+	 */
+	private static Function now() {
+		return (args) -> Date.from(Instant.now());
+	}
+
+	// ========== Date Formatting Functions ==========
+
+	/**
+	 * Formats a date using the given layout. Go date format is converted to Java
+	 * SimpleDateFormat.
+	 */
+	private static Function date() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			String layout = String.valueOf(args[0]);
+			Object dateObj = args[1];
+
+			Date date = convertToDate(dateObj);
+			if (date == null) {
+				return "";
+			}
+
+			String javaLayout = convertGoLayoutToJava(layout);
+			try {
+				SimpleDateFormat sdf = new SimpleDateFormat(javaLayout, Locale.ROOT);
+				return sdf.format(date);
+			}
+			catch (Exception ex) {
+				return "";
+			}
+		};
+	}
+
+	/**
+	 * Formats a date using the given layout in a specific timezone.
+	 */
+	private static Function dateInZone() {
+		return (args) -> {
+			if (args.length < 3) {
+				return "";
+			}
+			String layout = String.valueOf(args[0]);
+			Object dateObj = args[1];
+			String timezone = String.valueOf(args[2]);
+
+			Date date = convertToDate(dateObj);
+			if (date == null) {
+				return "";
+			}
+
+			String javaLayout = convertGoLayoutToJava(layout);
+			try {
+				SimpleDateFormat sdf = new SimpleDateFormat(javaLayout, Locale.ROOT);
+				sdf.setTimeZone(TimeZone.getTimeZone(timezone));
+				return sdf.format(date);
+			}
+			catch (Exception ex) {
+				return "";
+			}
+		};
+	}
+
+	/**
+	 * Formats a date in HTML date format (YYYY-MM-DD).
+	 */
+	private static Function htmlDate() {
+		return (args) -> {
+			if (args.length == 0) {
+				return "";
+			}
+			Date date = convertToDate(args[0]);
+			if (date == null) {
+				return "";
+			}
+
+			SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
+			return sdf.format(date);
+		};
+	}
+
+	/**
+	 * Formats a date in HTML date format (YYYY-MM-DD) in a specific timezone.
+	 */
+	private static Function htmlDateInZone() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			Date date = convertToDate(args[0]);
+			if (date == null) {
+				return "";
+			}
+
+			String timezone = String.valueOf(args[1]);
+			SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
+			sdf.setTimeZone(TimeZone.getTimeZone(timezone));
+			return sdf.format(date);
+		};
+	}
+
+	// ========== Date Parsing Functions ==========
+
+	/**
+	 * Parses a date string using the given layout.
+	 * @return Date object or null on error
+	 */
+	private static Function toDate() {
+		return (args) -> {
+			if (args.length < 2) {
+				return null;
+			}
+			String layout = String.valueOf(args[0]);
+			String dateStr = String.valueOf(args[1]);
+
+			String javaLayout = convertGoLayoutToJava(layout);
+			try {
+				SimpleDateFormat sdf = new SimpleDateFormat(javaLayout, Locale.ROOT);
+				return sdf.parse(dateStr);
+			}
+			catch (ParseException ex) {
+				return null;
+			}
+		};
+	}
+
+	/**
+	 * Parses a date string using the given layout. Throws an exception on error.
+	 * @return Date object
+	 * @throws RuntimeException if parsing fails
+	 */
+	private static Function mustToDate() {
+		return (args) -> {
+			if (args.length < 2) {
+				throw new RuntimeException("mustToDate: insufficient arguments");
+			}
+			String layout = String.valueOf(args[0]);
+			String dateStr = String.valueOf(args[1]);
+
+			String javaLayout = convertGoLayoutToJava(layout);
+			try {
+				SimpleDateFormat sdf = new SimpleDateFormat(javaLayout, Locale.ROOT);
+				return sdf.parse(dateStr);
+			}
+			catch (ParseException ex) {
+				throw new RuntimeException("mustToDate: failed to parse date: " + ex.getMessage(), ex);
+			}
+		};
+	}
+
+	// ========== Date Manipulation Functions ==========
+
+	/**
+	 * Modifies a date by adding or subtracting duration.
+	 * <p>
+	 * Simplified implementation - supports basic duration strings.
+	 */
+	private static Function dateModify() {
+		return (args) -> {
+			if (args.length < 2) {
+				return null;
+			}
+			String modification = String.valueOf(args[0]);
+			Date date = convertToDate(args[1]);
+			if (date == null) {
+				return null;
+			}
+
+			try {
+				// Parse modification string (e.g., "+1h", "-30m", "+24h")
+				long millisToAdd = parseDurationToMillis(modification);
+				return new Date(date.getTime() + millisToAdd);
+			}
+			catch (Exception ex) {
+				return date;
+			}
+		};
+	}
+
+	/**
+	 * Rounds a duration to the nearest unit.
+	 * <p>
+	 * Simplified implementation.
+	 * @return rounded duration
+	 */
+	private static Function durationRound() {
+		return (args) -> {
+			if (args.length == 0) {
+				return "0s";
+			}
+			Object durationObj = args[0];
+
+			if (durationObj instanceof Duration) {
+				Duration duration = (Duration) durationObj;
+				return duration.getSeconds() + "s";
+			}
+
+			// Parse duration string (simplified)
+			String durationStr = String.valueOf(durationObj);
+			try {
+				long millis = parseDurationToMillis(durationStr);
+				long seconds = millis / 1000;
+				return seconds + "s";
+			}
+			catch (Exception ex) {
+				return "0s";
+			}
+		};
+	}
+
+	// ========== Unix Epoch Functions ==========
+
+	/**
+	 * Returns the Unix epoch timestamp (seconds since Jan 1, 1970 UTC).
+	 */
+	private static Function unixEpoch() {
+		return (args) -> {
+			Date date;
+			if (args.length == 0) {
+				date = Date.from(Instant.now());
+			}
+			else {
+				date = convertToDate(args[0]);
+			}
+			if (date == null) {
+				return 0L;
+			}
+			return date.getTime() / 1000;
+		};
+	}
+
+	// ========== Helper Methods ==========
+
+	/**
+	 * Converts Go date format to Java SimpleDateFormat. Go uses "2006-01-02 15:04:05"
+	 * while Java uses "yyyy-MM-dd HH:mm:ss"
+	 */
+	private static String convertGoLayoutToJava(String goLayout) {
+		return goLayout.replace("2006", "yyyy")
+			.replace("06", "yy")
+			.replace("01", "MM")
+			.replace("02", "dd")
+			.replace("15", "HH")
+			.replace("04", "mm")
+			.replace("05", "ss")
+			.replace("MST", "zzz")
+			.replace("PM", "a");
+	}
+
+	/**
+	 * Converts various types to Date object.
+	 */
+	private static Date convertToDate(Object dateObj) {
+		if (dateObj instanceof Date) {
+			return (Date) dateObj;
+		}
+		else if (dateObj instanceof Number) {
+			return new Date(((Number) dateObj).longValue());
+		}
+		else if (dateObj instanceof Instant) {
+			return Date.from((Instant) dateObj);
+		}
+		return null;
+	}
+
+	/**
+	 * Parses duration string to milliseconds. Supports formats like: "+1h", "-30m",
+	 * "+24h30m", "1h30m45s"
+	 */
+	private static long parseDurationToMillis(String duration) {
+		String dur = duration.trim();
+		boolean negative = dur.startsWith("-");
+		if (negative || dur.startsWith("+")) {
+			dur = dur.substring(1);
+		}
+
+		long totalMillis = 0;
+		StringBuilder number = new StringBuilder();
+
+		for (int i = 0; i < dur.length(); i++) {
+			char c = dur.charAt(i);
+			if (Character.isDigit(c)) {
+				number.append(c);
+			}
+			else {
+				if (number.length() > 0) {
+					long value = Long.parseLong(number.toString());
+					long millisToAdd = switch (c) {
+						case 'h' -> value * 3600000L;
+						case 'm' -> value * 60000L;
+						case 's' -> value * 1000L;
+						case 'd' -> value * 86400000L;
+						default -> 0L;
+					};
+					totalMillis += millisToAdd;
+					number = new StringBuilder();
+				}
+			}
+		}
+
+		return (negative) ? -totalMillis : totalMillis;
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/EncodingFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/EncodingFunctions.java
@@ -1,0 +1,143 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Locale;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.Adler32;
+
+import org.alexmond.jhelm.gotemplate.Function;
+import org.apache.commons.codec.binary.Base32;
+import org.apache.commons.codec.binary.Hex;
+
+/**
+ * Encoding and hashing functions from Sprig library. Includes Base64, Base32, and
+ * cryptographic hash functions.
+ *
+ * @see <a href="https://masterminds.github.io/sprig/encoding.html">Sprig Encoding
+ * Functions</a>
+ */
+public final class EncodingFunctions {
+
+	private static final Base32 BASE32 = new Base32();
+
+	private EncodingFunctions() {
+	}
+
+	public static Map<String, Function> getFunctions() {
+		Map<String, Function> functions = new HashMap<>();
+
+		// Base64 encoding/decoding
+		functions.put("b64enc", b64enc());
+		functions.put("b64dec", b64dec());
+
+		// Base32 encoding/decoding
+		functions.put("b32enc", b32enc());
+		functions.put("b32dec", b32dec());
+
+		// Cryptographic hash functions
+		functions.put("sha1sum", sha1sum());
+		functions.put("sha256sum", sha256sum());
+		functions.put("sha512sum", sha512sum());
+
+		// Checksum functions
+		functions.put("adler32sum", adler32sum());
+
+		return functions;
+	}
+
+	private static Function b64enc() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return "";
+			}
+			String input = String.valueOf(args[0]);
+			return Base64.getEncoder().encodeToString(input.getBytes(StandardCharsets.UTF_8));
+		};
+	}
+
+	private static Function b64dec() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return "";
+			}
+			try {
+				String input = String.valueOf(args[0]);
+				byte[] decoded = Base64.getDecoder().decode(input);
+				return new String(decoded, StandardCharsets.UTF_8);
+			}
+			catch (IllegalArgumentException ex) {
+				return "";
+			}
+		};
+	}
+
+	private static Function b32enc() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return "";
+			}
+			String input = String.valueOf(args[0]);
+			return BASE32.encodeAsString(input.getBytes(StandardCharsets.UTF_8));
+		};
+	}
+
+	private static Function b32dec() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return "";
+			}
+			try {
+				String input = String.valueOf(args[0]);
+				if (!BASE32.isInAlphabet(input.replaceAll("=", "").toUpperCase(Locale.ROOT))) {
+					return "";
+				}
+				byte[] decoded = BASE32.decode(input);
+				return new String(decoded, StandardCharsets.UTF_8);
+			}
+			catch (Exception ex) {
+				return "";
+			}
+		};
+	}
+
+	private static Function sha1sum() {
+		return (args) -> hashWith("SHA-1", args);
+	}
+
+	private static Function sha256sum() {
+		return (args) -> hashWith("SHA-256", args);
+	}
+
+	private static Function sha512sum() {
+		return (args) -> hashWith("SHA-512", args);
+	}
+
+	private static String hashWith(String algorithm, Object[] args) {
+		if (args.length == 0 || args[0] == null) {
+			return "";
+		}
+		try {
+			MessageDigest md = MessageDigest.getInstance(algorithm);
+			byte[] hash = md.digest(String.valueOf(args[0]).getBytes(StandardCharsets.UTF_8));
+			return Hex.encodeHexString(hash);
+		}
+		catch (Exception ex) {
+			return "";
+		}
+	}
+
+	private static Function adler32sum() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return 0L;
+			}
+			Adler32 adler = new Adler32();
+			adler.update(String.valueOf(args[0]).getBytes(StandardCharsets.UTF_8));
+			return adler.getValue();
+		};
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/LogicFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/LogicFunctions.java
@@ -1,0 +1,83 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.alexmond.jhelm.gotemplate.Function;
+
+/**
+ * Sprig logic and control flow functions Based on: <a href=
+ * "https://masterminds.github.io/sprig/defaults.html">https://masterminds.github.io/sprig/defaults.html</a>
+ */
+public final class LogicFunctions {
+
+	private LogicFunctions() {
+	}
+
+	public static Map<String, Function> getFunctions() {
+		Map<String, Function> functions = new HashMap<>();
+
+		functions.put("default", defaultFunc());
+		functions.put("empty", empty());
+		functions.put("coalesce", coalesce());
+		functions.put("ternary", ternary());
+		functions.put("fail", fail());
+
+		return functions;
+	}
+
+	private static Function defaultFunc() {
+		return (args) -> {
+			if (args.length < 2) {
+				return (args.length == 1) ? args[0] : null;
+			}
+			Object defaultVal = args[0];
+			Object actualVal = args[1];
+			return (isTruthy(actualVal)) ? actualVal : defaultVal;
+		};
+	}
+
+	private static Function empty() {
+		return (args) -> args.length == 0 || !isTruthy(args[0]);
+	}
+
+	private static Function coalesce() {
+		return (args) -> {
+			for (Object arg : args) {
+				if (isTruthy(arg)) {
+					return arg;
+				}
+			}
+			return null;
+		};
+	}
+
+	private static Function ternary() {
+		return (args) -> {
+			if (args.length < 3) {
+				return "";
+			}
+			return (isTruthy(args[2])) ? args[0] : args[1];
+		};
+	}
+
+	private static Function fail() {
+		return (args) -> {
+			throw new RuntimeException((args.length > 0) ? String.valueOf(args[0]) : "fail");
+		};
+	}
+
+	private static boolean isTruthy(Object value) {
+		return switch (value) {
+			case null -> false;
+			case Boolean b -> b;
+			case String s -> !s.isEmpty();
+			case Number number -> number.doubleValue() != 0;
+			case Collection<?> collection -> !collection.isEmpty();
+			case Map<?, ?> map -> !map.isEmpty();
+			default -> true;
+		};
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctions.java
@@ -1,0 +1,392 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.alexmond.jhelm.gotemplate.Function;
+
+/**
+ * Math and numeric conversion functions from Sprig library. Includes basic arithmetic,
+ * type conversions, and rounding operations.
+ *
+ * @see <a href="https://masterminds.github.io/sprig/math.html">Sprig Math Functions</a>
+ */
+public final class MathFunctions {
+
+	private MathFunctions() {
+	}
+
+	public static Map<String, Function> getFunctions() {
+		Map<String, Function> functions = new HashMap<>();
+
+		// Type conversions
+		functions.put("int", toInt());
+		functions.put("int64", toInt64());
+		functions.put("float64", toFloat64());
+		functions.put("toString", toStringFunc());
+
+		// Basic arithmetic
+		functions.put("add", add());
+		functions.put("sub", sub());
+		functions.put("mul", mul());
+		functions.put("div", div());
+		functions.put("mod", mod());
+		functions.put("add1", add1());
+
+		// Floating point arithmetic
+		functions.put("addf", addf());
+		functions.put("mulf", mulf());
+		functions.put("divf", divf());
+
+		// Rounding operations
+		functions.put("floor", floor());
+		functions.put("ceil", ceil());
+		functions.put("round", round());
+
+		// Min/Max operations
+		functions.put("max", max());
+		functions.put("min", min());
+
+		return functions;
+	}
+
+	// ========== Type Conversion Functions ==========
+
+	private static Function toInt() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return 0;
+			}
+			if (args[0] instanceof Number) {
+				return ((Number) args[0]).intValue();
+			}
+			try {
+				return Integer.parseInt(String.valueOf(args[0]));
+			}
+			catch (NumberFormatException ex) {
+				return 0;
+			}
+		};
+	}
+
+	private static Function toInt64() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return 0L;
+			}
+			if (args[0] instanceof Number) {
+				return ((Number) args[0]).longValue();
+			}
+			try {
+				return Long.parseLong(String.valueOf(args[0]));
+			}
+			catch (NumberFormatException ex) {
+				return 0L;
+			}
+		};
+	}
+
+	private static Function toFloat64() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return 0.0;
+			}
+			if (args[0] instanceof Number) {
+				return ((Number) args[0]).doubleValue();
+			}
+			try {
+				return Double.parseDouble(String.valueOf(args[0]));
+			}
+			catch (NumberFormatException ex) {
+				return 0.0;
+			}
+		};
+	}
+
+	private static Function toStringFunc() {
+		return (args) -> (args.length == 0) ? "" : String.valueOf(args[0]);
+	}
+
+	// ========== Basic Arithmetic Functions ==========
+
+	/**
+	 * Adds all numeric arguments together. Returns integer if result is whole number,
+	 * otherwise double.
+	 */
+	private static Function add() {
+		return (args) -> {
+			if (args.length < 2) {
+				return 0;
+			}
+			double sum = 0;
+			for (Object arg : args) {
+				if (arg instanceof Number) {
+					sum += ((Number) arg).doubleValue();
+				}
+			}
+			// Return long if result is whole number, otherwise double
+			if (sum == Math.floor(sum)) {
+				return (long) sum;
+			}
+			return sum;
+		};
+	}
+
+	/**
+	 * Subtracts subsequent arguments from the first argument. Returns integer if result
+	 * is whole number, otherwise double.
+	 */
+	private static Function sub() {
+		return (args) -> {
+			if (args.length < 2) {
+				return 0;
+			}
+			double result = ((Number) args[0]).doubleValue();
+			for (int i = 1; i < args.length; i++) {
+				if (args[i] instanceof Number) {
+					result -= ((Number) args[i]).doubleValue();
+				}
+			}
+			if (result == Math.floor(result)) {
+				return (long) result;
+			}
+			return result;
+		};
+	}
+
+	/**
+	 * Multiplies all numeric arguments together. Returns integer if result is whole
+	 * number, otherwise double.
+	 */
+	private static Function mul() {
+		return (args) -> {
+			if (args.length < 2) {
+				return 0;
+			}
+			double product = ((Number) args[0]).doubleValue();
+			for (int i = 1; i < args.length; i++) {
+				if (args[i] instanceof Number) {
+					product *= ((Number) args[i]).doubleValue();
+				}
+			}
+			if (product == Math.floor(product)) {
+				return (long) product;
+			}
+			return product;
+		};
+	}
+
+	/**
+	 * Performs integer division of first argument by second argument (truncating toward
+	 * zero). Returns 0 if divisor is 0. Matches Go Sprig behavior where {@code div} is
+	 * always integer division and {@code divf} is for floating point.
+	 */
+	private static Function div() {
+		return (args) -> {
+			if (args.length < 2) {
+				return 0L;
+			}
+			long dividend = ((Number) args[0]).longValue();
+			long divisor = ((Number) args[1]).longValue();
+			if (divisor == 0) {
+				return 0L;
+			}
+			return dividend / divisor;
+		};
+	}
+
+	/**
+	 * Returns modulo of a % b. Returns 0 if b is 0.
+	 */
+	private static Function mod() {
+		return (args) -> {
+			if (args.length < 2) {
+				return 0L;
+			}
+			long a = ((Number) args[0]).longValue();
+			long b = ((Number) args[1]).longValue();
+			return (b != 0) ? a % b : 0L;
+		};
+	}
+
+	/**
+	 * Adds 1 to the given number. Preserves type (integer vs floating point).
+	 */
+	private static Function add1() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return 1;
+			}
+			if (args[0] instanceof Number) {
+				Number num = (Number) args[0];
+				if (args[0] instanceof Double || args[0] instanceof Float) {
+					return num.doubleValue() + 1;
+				}
+				else {
+					return num.longValue() + 1;
+				}
+			}
+			return 1;
+		};
+	}
+
+	// ========== Floating Point Arithmetic Functions ==========
+
+	/**
+	 * Adds floating point numbers, always returns double.
+	 */
+	private static Function addf() {
+		return (args) -> {
+			if (args.length < 2) {
+				return 0.0;
+			}
+			double result = 0;
+			for (Object arg : args) {
+				result += ((Number) arg).doubleValue();
+			}
+			return result;
+		};
+	}
+
+	/**
+	 * Multiplies floating point numbers, always returns double.
+	 */
+	private static Function mulf() {
+		return (args) -> {
+			if (args.length < 2) {
+				return 0.0;
+			}
+			double result = ((Number) args[0]).doubleValue();
+			for (int i = 1; i < args.length; i++) {
+				result *= ((Number) args[i]).doubleValue();
+			}
+			return result;
+		};
+	}
+
+	/**
+	 * Divides floating point numbers, always returns double. Returns 0.0 if any divisor
+	 * is 0.
+	 */
+	private static Function divf() {
+		return (args) -> {
+			if (args.length < 2) {
+				return 0.0;
+			}
+			double result = ((Number) args[0]).doubleValue();
+			for (int i = 1; i < args.length; i++) {
+				double divisor = ((Number) args[i]).doubleValue();
+				if (divisor != 0) {
+					result /= divisor;
+				}
+				else {
+					return 0.0;
+				}
+			}
+			return result;
+		};
+	}
+
+	// ========== Rounding Functions ==========
+
+	/**
+	 * Returns the largest integer value less than or equal to the given number.
+	 */
+	private static Function floor() {
+		return (args) -> {
+			if (args.length == 0) {
+				return 0L;
+			}
+			Object val = args[0];
+			if (val instanceof Number) {
+				return (long) Math.floor(((Number) val).doubleValue());
+			}
+			return 0L;
+		};
+	}
+
+	/**
+	 * Returns the smallest integer value greater than or equal to the given number.
+	 */
+	private static Function ceil() {
+		return (args) -> {
+			if (args.length == 0) {
+				return 0L;
+			}
+			Object val = args[0];
+			if (val instanceof Number) {
+				return (long) Math.ceil(((Number) val).doubleValue());
+			}
+			return 0L;
+		};
+	}
+
+	/**
+	 * Returns the nearest integer value, rounding half away from zero.
+	 */
+	private static Function round() {
+		return (args) -> {
+			if (args.length == 0) {
+				return 0L;
+			}
+			Object val = args[0];
+			if (val instanceof Number) {
+				return Math.round(((Number) val).doubleValue());
+			}
+			return 0L;
+		};
+	}
+
+	// ========== Min/Max Functions ==========
+
+	/**
+	 * Returns the maximum of all numeric arguments.
+	 */
+	private static Function max() {
+		return (args) -> {
+			if (args.length == 0) {
+				return 0;
+			}
+			double maxVal = Double.NEGATIVE_INFINITY;
+			for (Object arg : args) {
+				if (arg instanceof Number) {
+					double val = ((Number) arg).doubleValue();
+					if (val > maxVal) {
+						maxVal = val;
+					}
+				}
+			}
+			// Return long if result is whole number, otherwise double
+			if (maxVal == Math.floor(maxVal) && !Double.isInfinite(maxVal)) {
+				return (long) maxVal;
+			}
+			return maxVal;
+		};
+	}
+
+	/**
+	 * Returns the minimum of all numeric arguments.
+	 */
+	private static Function min() {
+		return (args) -> {
+			if (args.length == 0) {
+				return 0;
+			}
+			double minVal = Double.POSITIVE_INFINITY;
+			for (Object arg : args) {
+				if (arg instanceof Number) {
+					double val = ((Number) arg).doubleValue();
+					if (val < minVal) {
+						minVal = val;
+					}
+				}
+			}
+			// Return long if result is whole number, otherwise double
+			if (minVal == Math.floor(minVal) && !Double.isInfinite(minVal)) {
+				return (long) minVal;
+			}
+			return minVal;
+		};
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/NetworkFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/NetworkFunctions.java
@@ -1,0 +1,97 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.alexmond.jhelm.gotemplate.Function;
+import org.apache.hc.core5.net.URIBuilder;
+
+/**
+ * Network-related functions from Sprig library. Includes DNS lookup and network utility
+ * functions.
+ *
+ * @see <a href="https://masterminds.github.io/sprig/network.html">Sprig Network
+ * Functions</a>
+ */
+public final class NetworkFunctions {
+
+	private NetworkFunctions() {
+	}
+
+	public static Map<String, Function> getFunctions() {
+		Map<String, Function> functions = new HashMap<>();
+
+		// DNS lookup
+		functions.put("getHostByName", getHostByName());
+
+		// URL parsing
+		functions.put("urlParse", urlParse());
+
+		return functions;
+	}
+
+	// ========== DNS Functions ==========
+
+	/**
+	 * Parses a URL into its components: scheme, host, port, path, query.
+	 * @return Map of URL components, or empty map on error
+	 */
+	private static Function urlParse() {
+		return (args) -> {
+			if (args.length == 0) {
+				return Map.of();
+			}
+			try {
+				URIBuilder uriBuilder = new URIBuilder(String.valueOf(args[0]));
+				Map<String, Object> result = new HashMap<>();
+				result.put("scheme", (uriBuilder.getScheme() != null) ? uriBuilder.getScheme() : "");
+				result.put("host", (uriBuilder.getHost() != null) ? uriBuilder.getHost() : "");
+				result.put("port", (uriBuilder.getPort() > 0) ? String.valueOf(uriBuilder.getPort()) : "");
+				result.put("path", (uriBuilder.getPath() != null) ? uriBuilder.getPath() : "");
+
+				StringBuilder queryString = new StringBuilder();
+				if (uriBuilder.getQueryParams() != null && !uriBuilder.getQueryParams().isEmpty()) {
+					for (int i = 0; i < uriBuilder.getQueryParams().size(); i++) {
+						if (i > 0) {
+							queryString.append('&');
+						}
+						var param = uriBuilder.getQueryParams().get(i);
+						queryString.append(param.getName());
+						if (param.getValue() != null) {
+							queryString.append('=').append(param.getValue());
+						}
+					}
+				}
+				result.put("query", queryString.toString());
+				return result;
+			}
+			catch (Exception ex) {
+				return Map.of();
+			}
+		};
+	}
+
+	/**
+	 * Performs DNS lookup and returns the IP address for a hostname.
+	 * @return IP address as string, or empty string on error
+	 */
+	private static Function getHostByName() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return "";
+			}
+
+			String hostname = String.valueOf(args[0]);
+			try {
+				InetAddress address = InetAddress.getByName(hostname);
+				return address.getHostAddress();
+			}
+			catch (Exception ex) {
+				// Return empty string on DNS resolution failure
+				return "";
+			}
+		};
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ReflectionFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ReflectionFunctions.java
@@ -1,0 +1,255 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import java.util.Locale;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+
+import org.alexmond.jhelm.gotemplate.Function;
+import java.lang.reflect.Array;
+
+/**
+ * Type reflection and introspection functions from Sprig library. Includes type checking,
+ * kind checking, and deep equality comparison.
+ *
+ * @see <a href="https://masterminds.github.io/sprig/reflection.html">Sprig Reflection
+ * Functions</a>
+ */
+public final class ReflectionFunctions {
+
+	private ReflectionFunctions() {
+	}
+
+	public static Map<String, Function> getFunctions() {
+		Map<String, Function> functions = new HashMap<>();
+
+		// Type information
+		functions.put("typeOf", typeOf());
+		functions.put("kindOf", kindOf());
+
+		// Type checking
+		functions.put("typeIs", typeIs());
+		functions.put("typeIsLike", typeIsLike());
+		functions.put("kindIs", kindIs());
+
+		// Equality
+		functions.put("deepEqual", deepEqual());
+
+		return functions;
+	}
+
+	// ========== Type Information Functions ==========
+
+	/**
+	 * Returns the full Java type name of the value. Returns "nil" for null values.
+	 */
+	private static Function typeOf() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return "nil";
+			}
+			return args[0].getClass().getName();
+		};
+	}
+
+	/**
+	 * Returns the kind (basic type category) of the value. Kinds: string, number, bool,
+	 * map, slice, struct, invalid
+	 */
+	private static Function kindOf() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return "invalid";
+			}
+			Class<?> c = args[0].getClass();
+
+			if (c == String.class) {
+				return "string";
+			}
+			if (Number.class.isAssignableFrom(c)) {
+				return "number";
+			}
+			if (Boolean.class.isAssignableFrom(c)) {
+				return "bool";
+			}
+			if (Map.class.isAssignableFrom(c)) {
+				return "map";
+			}
+			if (Collection.class.isAssignableFrom(c) || c.isArray()) {
+				return "slice";
+			}
+			return "struct";
+		};
+	}
+
+	// ========== Type Checking Functions ==========
+
+	/**
+	 * Checks if the value is of a specific type.
+	 * @return {@code true} if value matches the type
+	 */
+	private static Function typeIs() {
+		return (args) -> {
+			if (args.length < 2) {
+				return false;
+			}
+			String type = String.valueOf(args[0]).toLowerCase(Locale.ROOT);
+			Object val = args[1];
+
+			if (val == null) {
+				return "nil".equals(type);
+			}
+
+			String className = val.getClass().getSimpleName().toLowerCase(Locale.ROOT);
+			String fullName = val.getClass().getName().toLowerCase(Locale.ROOT);
+
+			return className.equals(type) || fullName.contains(type);
+		};
+	}
+
+	/**
+	 * Checks if the value's type is like a specific type (partial match).
+	 * @return {@code true} if value's type matches the pattern
+	 */
+	private static Function typeIsLike() {
+		return (args) -> {
+			if (args.length < 2) {
+				return false;
+			}
+			String typePattern = String.valueOf(args[0]).toLowerCase(Locale.ROOT);
+			Object val = args[1];
+
+			if (val == null) {
+				return "nil".equals(typePattern);
+			}
+
+			String fullName = val.getClass().getName().toLowerCase(Locale.ROOT);
+			return fullName.contains(typePattern);
+		};
+	}
+
+	/**
+	 * Checks if the value's kind matches a specific kind.
+	 * @return {@code true} if value's kind matches
+	 */
+	private static Function kindIs() {
+		return (args) -> {
+			if (args.length < 2) {
+				return false;
+			}
+			String kind = String.valueOf(args[0]);
+			Object val = args[1];
+
+			if (val == null) {
+				return "invalid".equals(kind);
+			}
+
+			Class<?> c = val.getClass();
+			return switch (kind) {
+				case "string" -> c == String.class;
+				case "number", "int", "float", "float64" -> Number.class.isAssignableFrom(c);
+				case "bool" -> Boolean.class.isAssignableFrom(c);
+				case "map" -> Map.class.isAssignableFrom(c);
+				case "slice", "list" -> Collection.class.isAssignableFrom(c) || c.isArray();
+				default -> false;
+			};
+		};
+	}
+
+	// ========== Equality Functions ==========
+
+	/**
+	 * Performs deep equality comparison between two values. Recursively compares Maps,
+	 * Collections, and arrays.
+	 * @return {@code true} if values are deeply equal
+	 */
+	private static Function deepEqual() {
+		return (args) -> args.length >= 2 && deepEquals(args[0], args[1]);
+	}
+
+	// ========== Helper Methods ==========
+
+	/**
+	 * Recursively compares two objects for deep equality.
+	 */
+	private static boolean deepEquals(Object a, Object b) {
+		// Null checks
+		if (Objects.equals(a, b)) {
+			return true;
+		}
+		if (a == null || b == null) {
+			return false;
+		}
+
+		// Class mismatch
+		if (!a.getClass().equals(b.getClass())) {
+			return false;
+		}
+
+		// Maps
+		if (a instanceof Map) {
+			Map<?, ?> mapA = (Map<?, ?>) a;
+			Map<?, ?> mapB = (Map<?, ?>) b;
+
+			if (mapA.size() != mapB.size()) {
+				return false;
+			}
+
+			for (Map.Entry<?, ?> entry : mapA.entrySet()) {
+				Object key = entry.getKey();
+				if (!mapB.containsKey(key)) {
+					return false;
+				}
+				if (!deepEquals(entry.getValue(), mapB.get(key))) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		// Collections
+		if (a instanceof Collection) {
+			Collection<?> colA = (Collection<?>) a;
+			Collection<?> colB = (Collection<?>) b;
+
+			if (colA.size() != colB.size()) {
+				return false;
+			}
+
+			Iterator<?> iterA = colA.iterator();
+			Iterator<?> iterB = colB.iterator();
+
+			while (iterA.hasNext() && iterB.hasNext()) {
+				if (!deepEquals(iterA.next(), iterB.next())) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		// Arrays
+		if (a.getClass().isArray()) {
+			int lengthA = Array.getLength(a);
+			int lengthB = Array.getLength(b);
+
+			if (lengthA != lengthB) {
+				return false;
+			}
+
+			for (int i = 0; i < lengthA; i++) {
+				Object elemA = Array.get(a, i);
+				Object elemB = Array.get(b, i);
+				if (!deepEquals(elemA, elemB)) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		// Primitive types and other objects
+		return Objects.equals(a, b);
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/SemverFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/SemverFunctions.java
@@ -1,0 +1,199 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.vdurmont.semver4j.Semver;
+import com.vdurmont.semver4j.SemverException;
+import org.alexmond.jhelm.gotemplate.Function;
+
+/**
+ * Semantic versioning functions from Sprig library. Uses Semver4j for version parsing and
+ * constraint evaluation.
+ *
+ * @see <a href="https://masterminds.github.io/sprig/semver.html">Sprig Semver
+ * Functions</a>
+ */
+public final class SemverFunctions {
+
+	private SemverFunctions() {
+	}
+
+	public static Map<String, Function> getFunctions() {
+		Map<String, Function> functions = new HashMap<>();
+		functions.put("semver", semver());
+		functions.put("semverCompare", semverCompare());
+		return functions;
+	}
+
+	/**
+	 * Parses a semantic version string and returns a Map with version components.
+	 * @return Map with keys: Major, Minor, Patch, Prerelease, Metadata, Original
+	 */
+	private static Function semver() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return null;
+			}
+			String versionStr = String.valueOf(args[0]);
+			Map<String, Object> result = new HashMap<>();
+			result.put("Original", versionStr);
+			try {
+				Semver v = new Semver(normalizeVersion(versionStr), Semver.SemverType.LOOSE);
+				result.put("Major", (v.getMajor() != null) ? v.getMajor().longValue() : 0L);
+				result.put("Minor", (v.getMinor() != null) ? v.getMinor().longValue() : 0L);
+				result.put("Patch", (v.getPatch() != null) ? v.getPatch().longValue() : 0L);
+				result.put("Prerelease", (v.getSuffixTokens().length > 0) ? String.join(".", v.getSuffixTokens()) : "");
+				result.put("Metadata", (v.getBuild() != null) ? String.join(".", v.getBuild()) : "");
+			}
+			catch (SemverException ex) {
+				result.put("Major", 0L);
+				result.put("Minor", 0L);
+				result.put("Patch", 0L);
+				result.put("Prerelease", "");
+				result.put("Metadata", "");
+			}
+			return result;
+		};
+	}
+
+	/**
+	 * Compares a version against a constraint string. Supports operators: =, !=, >,
+	 * <, >=, <=, ~, ^, ||, and space-separated AND ranges.
+	 * @return {@code true} if the version satisfies the constraint
+	 */
+	private static Function semverCompare() {
+		return (args) -> {
+			if (args.length < 2) {
+				return false;
+			}
+			String constraint = String.valueOf(args[0]).trim();
+			String versionStr = String.valueOf(args[1]).trim();
+			try {
+				Semver v = new Semver(normalizeVersion(versionStr), Semver.SemverType.LOOSE);
+				return evaluateConstraint(v, constraint);
+			}
+			catch (Exception ex) {
+				return false;
+			}
+		};
+	}
+
+	/**
+	 * Evaluates a constraint expression against a parsed version. Handles OR (||) and AND
+	 * (space-separated) compound constraints.
+	 */
+	private static boolean evaluateConstraint(Semver version, String constraint) {
+		// OR: split on ||
+		if (constraint.contains("||")) {
+			for (String part : constraint.split("\\|\\|")) {
+				if (evaluateConstraint(version, part.trim())) {
+					return true;
+				}
+			}
+			return false;
+		}
+		// AND: split on whitespace (e.g. ">=1.0.0 <2.0.0")
+		String[] parts = constraint.trim().split("\\s+");
+		if (parts.length > 1) {
+			for (String part : parts) {
+				if (!evaluateSingleConstraint(version, part.trim())) {
+					return false;
+				}
+			}
+			return true;
+		}
+		return evaluateSingleConstraint(version, constraint.trim());
+	}
+
+	/**
+	 * Evaluates a single constraint token (e.g. ">=1.2.3", "~1.2.3", "^1.2.3").
+	 */
+	private static boolean evaluateSingleConstraint(Semver version, String constraint) {
+		if (constraint.isEmpty()) {
+			return true;
+		}
+
+		// Tilde: ~1.2.3 → >=1.2.3 <1.3.0
+		if (constraint.startsWith("~")) {
+			String base = constraint.substring(1).trim();
+			Semver baseV = parseLeniently(base);
+			if (baseV == null) {
+				return false;
+			}
+			Semver upper = new Semver(baseV.getMajor() + "." + (baseV.getMinor() + 1) + ".0", Semver.SemverType.LOOSE);
+			return version.isGreaterThanOrEqualTo(baseV) && version.isLowerThan(upper);
+		}
+
+		// Caret: ^1.2.3 → >=1.2.3 <2.0.0 (^0.2.3 → >=0.2.3 <0.3.0, etc.)
+		if (constraint.startsWith("^")) {
+			String base = constraint.substring(1).trim();
+			Semver baseV = parseLeniently(base);
+			if (baseV == null) {
+				return false;
+			}
+			long major = (baseV.getMajor() != null) ? baseV.getMajor() : 0;
+			long minor = (baseV.getMinor() != null) ? baseV.getMinor() : 0;
+			Semver upper;
+			if (major > 0) {
+				upper = new Semver((major + 1) + ".0.0", Semver.SemverType.LOOSE);
+			}
+			else if (minor > 0) {
+				upper = new Semver("0." + (minor + 1) + ".0", Semver.SemverType.LOOSE);
+			}
+			else {
+				// ^0.0.x → exact match
+				return version.isEquivalentTo(baseV);
+			}
+			return version.isGreaterThanOrEqualTo(baseV) && version.isLowerThan(upper);
+		}
+
+		// Standard operators: >=, <=, !=, >, <, =
+		if (constraint.startsWith(">=")) {
+			Semver c = parseLeniently(constraint.substring(2).trim());
+			return c != null && version.isGreaterThanOrEqualTo(c);
+		}
+		if (constraint.startsWith("<=")) {
+			Semver c = parseLeniently(constraint.substring(2).trim());
+			return c != null && version.isLowerThanOrEqualTo(c);
+		}
+		if (constraint.startsWith("!=")) {
+			Semver c = parseLeniently(constraint.substring(2).trim());
+			return c != null && !version.isEquivalentTo(c);
+		}
+		if (constraint.startsWith(">")) {
+			Semver c = parseLeniently(constraint.substring(1).trim());
+			return c != null && version.isGreaterThan(c);
+		}
+		if (constraint.startsWith("<")) {
+			Semver c = parseLeniently(constraint.substring(1).trim());
+			return c != null && version.isLowerThan(c);
+		}
+		if (constraint.startsWith("=")) {
+			Semver c = parseLeniently(constraint.substring(1).trim());
+			return c != null && version.isEquivalentTo(c);
+		}
+
+		// No operator — exact match
+		Semver c = parseLeniently(constraint);
+		return c != null && version.isEquivalentTo(c);
+	}
+
+	private static Semver parseLeniently(String version) {
+		try {
+			return new Semver(normalizeVersion(version), Semver.SemverType.LOOSE);
+		}
+		catch (Exception ex) {
+			return null;
+		}
+	}
+
+	/** Strips a leading 'v' or 'V' prefix that Semver4j LOOSE mode doesn't accept. */
+	private static String normalizeVersion(String version) {
+		if (version != null && version.length() > 1 && (version.charAt(0) == 'v' || version.charAt(0) == 'V')) {
+			return version.substring(1);
+		}
+		return version;
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
@@ -1,0 +1,613 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import java.util.Locale;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.alexmond.jhelm.gotemplate.Function;
+
+/**
+ * Sprig String manipulation functions Based on: <a href=
+ * "https://masterminds.github.io/sprig/strings.html">https://masterminds.github.io/sprig/strings.html</a>
+ */
+public final class StringFunctions {
+
+	private StringFunctions() {
+	}
+
+	public static Map<String, Function> getFunctions() {
+		Map<String, Function> functions = new HashMap<>();
+
+		// Basic string operations
+		functions.put("trim", trim());
+		functions.put("trimAll", trimAll());
+		functions.put("trimPrefix", trimPrefix());
+		functions.put("trimSuffix", trimSuffix());
+		functions.put("upper", upper());
+		functions.put("lower", lower());
+		functions.put("title", title());
+		functions.put("untitle", untitle());
+		functions.put("repeat", repeat());
+		functions.put("substr", substr());
+		functions.put("trunc", trunc());
+		functions.put("abbrev", abbrev());
+		functions.put("abbrevboth", abbrevboth());
+		functions.put("initials", initials());
+		functions.put("wrap", wrap());
+		functions.put("wrapWith", wrapWith());
+		functions.put("contains", contains());
+		functions.put("hasPrefix", hasPrefix());
+		functions.put("hasSuffix", hasSuffix());
+		functions.put("quote", quote());
+		functions.put("squote", squote());
+		functions.put("cat", cat());
+		functions.put("indent", indent());
+		functions.put("nindent", nindent());
+		functions.put("replace", replace());
+		functions.put("plural", plural());
+		functions.put("snakecase", snakecase());
+		functions.put("camelcase", camelcase());
+		functions.put("kebabcase", kebabcase());
+		functions.put("shuffle", shuffle());
+
+		// Regex functions
+		functions.put("regexMatch", regexMatch());
+		functions.put("mustRegexMatch", mustRegexMatch());
+		functions.put("regexFindAll", regexFindAll());
+		functions.put("regexFind", regexFind());
+		functions.put("mustRegexFind", mustRegexFind());
+		functions.put("regexReplaceAll", regexReplaceAll());
+		functions.put("mustRegexReplaceAll", mustRegexReplaceAll());
+		functions.put("regexReplaceAllLiteral", regexReplaceAllLiteral());
+		functions.put("mustRegexReplaceAllLiteral", mustRegexReplaceAllLiteral());
+		functions.put("regexSplit", regexSplit());
+		functions.put("mustRegexSplit", mustRegexSplit());
+
+		return functions;
+	}
+
+	private static Function trim() {
+		return (args) -> (args.length == 0) ? "" : String.valueOf(args[0]).trim();
+	}
+
+	private static Function trimAll() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			String cutset = String.valueOf(args[0]);
+			String s = String.valueOf(args[1]);
+			return s.replaceAll("^[" + Pattern.quote(cutset) + "]+|[" + Pattern.quote(cutset) + "]+$", "");
+		};
+	}
+
+	private static Function trimPrefix() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			String prefix = String.valueOf(args[0]);
+			String text = String.valueOf(args[1]);
+			return (text.startsWith(prefix)) ? text.substring(prefix.length()) : text;
+		};
+	}
+
+	private static Function trimSuffix() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			String suffix = String.valueOf(args[0]);
+			String text = String.valueOf(args[1]);
+			return (text.endsWith(suffix)) ? text.substring(0, text.length() - suffix.length()) : text;
+		};
+	}
+
+	private static Function upper() {
+		return (args) -> (args.length == 0) ? "" : String.valueOf(args[0]).toUpperCase(Locale.ROOT);
+	}
+
+	private static Function lower() {
+		return (args) -> (args.length == 0) ? "" : String.valueOf(args[0]).toLowerCase(Locale.ROOT);
+	}
+
+	private static Function title() {
+		return (args) -> {
+			if (args.length == 0) {
+				return "";
+			}
+			String s = String.valueOf(args[0]);
+			if (s.isEmpty()) {
+				return s;
+			}
+			return Arrays.stream(s.split("\\s+"))
+				.map((word) -> word.isEmpty() ? word
+						: Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase(Locale.ROOT))
+				.collect(Collectors.joining(" "));
+		};
+	}
+
+	private static Function untitle() {
+		return (args) -> {
+			if (args.length == 0) {
+				return "";
+			}
+			String s = String.valueOf(args[0]);
+			if (s.isEmpty()) {
+				return s;
+			}
+			return Character.toLowerCase(s.charAt(0)) + s.substring(1);
+		};
+	}
+
+	private static Function repeat() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			int count = ((Number) args[0]).intValue();
+			String s = String.valueOf(args[1]);
+			return s.repeat(Math.max(0, count));
+		};
+	}
+
+	private static Function substr() {
+		return (args) -> {
+			if (args.length < 3) {
+				return "";
+			}
+			int start = ((Number) args[0]).intValue();
+			int end = ((Number) args[1]).intValue();
+			String s = String.valueOf(args[2]);
+			if (start < 0) {
+				start = 0;
+			}
+			if (end > s.length()) {
+				end = s.length();
+			}
+			if (start > end) {
+				return "";
+			}
+			return s.substring(start, end);
+		};
+	}
+
+	private static Function trunc() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			int len = ((Number) args[0]).intValue();
+			String s = String.valueOf(args[1]);
+			return (s.length() > len) ? s.substring(0, len) : s;
+		};
+	}
+
+	private static Function abbrev() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			int max = ((Number) args[0]).intValue();
+			String s = String.valueOf(args[1]);
+			if (s.length() <= max) {
+				return s;
+			}
+			return s.substring(0, max - 3) + "...";
+		};
+	}
+
+	private static Function abbrevboth() {
+		return (args) -> {
+			if (args.length < 3) {
+				return "";
+			}
+			int left = ((Number) args[0]).intValue();
+			int right = ((Number) args[1]).intValue();
+			String s = String.valueOf(args[2]);
+			if (s.length() <= left + right) {
+				return s;
+			}
+			return "..." + s.substring(s.length() - right);
+		};
+	}
+
+	private static Function initials() {
+		return (args) -> {
+			if (args.length == 0) {
+				return "";
+			}
+			String s = String.valueOf(args[0]);
+			return Arrays.stream(s.split("\\s+"))
+				.filter((word) -> !word.isEmpty())
+				.map((word) -> String.valueOf(word.charAt(0)).toUpperCase(Locale.ROOT))
+				.collect(Collectors.joining(""));
+		};
+	}
+
+	private static Function wrap() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			int col = ((Number) args[0]).intValue();
+			String s = String.valueOf(args[1]);
+			return wrapText(s, col, "");
+		};
+	}
+
+	private static Function wrapWith() {
+		return (args) -> {
+			if (args.length < 3) {
+				return "";
+			}
+			int col = ((Number) args[0]).intValue();
+			String indent = String.valueOf(args[1]);
+			String s = String.valueOf(args[2]);
+			return wrapText(s, col, indent);
+		};
+	}
+
+	private static String wrapText(String text, int col, String indent) {
+		String[] words = text.split("\\s+");
+		StringBuilder result = new StringBuilder();
+		StringBuilder line = new StringBuilder(indent);
+
+		for (String word : words) {
+			if (line.length() + word.length() + 1 > col && line.length() > indent.length()) {
+				result.append(line).append('\n');
+				line = new StringBuilder(indent);
+			}
+			if (line.length() > indent.length()) {
+				line.append(' ');
+			}
+			line.append(word);
+		}
+		if (line.length() > indent.length()) {
+			result.append(line);
+		}
+		return result.toString();
+	}
+
+	private static Function contains() {
+		return (args) -> args.length >= 2 && String.valueOf(args[1]).contains(String.valueOf(args[0]));
+	}
+
+	private static Function hasPrefix() {
+		return (args) -> args.length >= 2 && String.valueOf(args[1]).startsWith(String.valueOf(args[0]));
+	}
+
+	private static Function hasSuffix() {
+		return (args) -> args.length >= 2 && String.valueOf(args[1]).endsWith(String.valueOf(args[0]));
+	}
+
+	private static Function quote() {
+		return (args) -> (args.length == 0 || args[0] == null) ? "\"\"" : "\"" + args[0] + "\"";
+	}
+
+	private static Function squote() {
+		return (args) -> (args.length == 0 || args[0] == null) ? "''" : "'" + args[0] + "'";
+	}
+
+	private static Function cat() {
+		return (args) -> Arrays.stream(args).map(String::valueOf).collect(Collectors.joining(" "));
+	}
+
+	private static Function indent() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			int spaces = ((Number) args[0]).intValue();
+			String text = String.valueOf(args[1]);
+			String indentStr = " ".repeat(spaces);
+			// Indent all lines including the first one
+			return indentStr + text.replace("\n", "\n" + indentStr);
+		};
+	}
+
+	private static Function nindent() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			int spaces = ((Number) args[0]).intValue();
+			String text = String.valueOf(args[1]);
+			return "\n" + " ".repeat(spaces) + text.replace("\n", "\n" + " ".repeat(spaces));
+		};
+	}
+
+	private static Function replace() {
+		return (args) -> {
+			if (args.length < 3) {
+				return "";
+			}
+			String old = String.valueOf(args[0]);
+			String newStr = String.valueOf(args[1]);
+			String text = String.valueOf(args[2]);
+
+			// Handle common escape sequences that appear as literals in templates
+			old = unescapeString(old);
+			newStr = unescapeString(newStr);
+
+			return text.replace(old, newStr);
+		};
+	}
+
+	/**
+	 * Convert common escape sequences from literal strings to actual characters. In Go
+	 * templates, string literals like "\n" are passed as literal backslash-n, but
+	 * functions like replace need to treat them as the actual escape character.
+	 */
+	private static String unescapeString(String s) {
+		return s.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "\r").replace("\\\\", "\\");
+	}
+
+	private static Function plural() {
+		return (args) -> {
+			if (args.length < 3) {
+				return "";
+			}
+			String singular = String.valueOf(args[0]);
+			String plural = String.valueOf(args[1]);
+			int count = ((Number) args[2]).intValue();
+			return (count == 1) ? singular : plural;
+		};
+	}
+
+	private static Function snakecase() {
+		return (args) -> {
+			if (args.length == 0) {
+				return "";
+			}
+			String s = String.valueOf(args[0]);
+			return s.replaceAll("([a-z])([A-Z])", "$1_$2").replaceAll("\\s+", "_").toLowerCase(Locale.ROOT);
+		};
+	}
+
+	private static Function camelcase() {
+		return (args) -> {
+			if (args.length == 0) {
+				return "";
+			}
+			String s = String.valueOf(args[0]);
+			String[] parts = s.split("[\\s_-]+");
+			return parts[0].toLowerCase(Locale.ROOT) + Arrays.stream(parts)
+				.skip(1)
+				.map((p) -> p.isEmpty() ? p
+						: Character.toUpperCase(p.charAt(0)) + p.substring(1).toLowerCase(Locale.ROOT))
+				.collect(Collectors.joining(""));
+		};
+	}
+
+	private static Function kebabcase() {
+		return (args) -> {
+			if (args.length == 0) {
+				return "";
+			}
+			String s = String.valueOf(args[0]);
+			return s.replaceAll("([a-z])([A-Z])", "$1-$2").replaceAll("[\\s_]+", "-").toLowerCase(Locale.ROOT);
+		};
+	}
+
+	private static Function shuffle() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return "";
+			}
+			String s = String.valueOf(args[0]);
+			List<Character> chars = new ArrayList<>();
+			for (char c : s.toCharArray()) {
+				chars.add(c);
+			}
+			Collections.shuffle(chars);
+			StringBuilder sb = new StringBuilder();
+			for (char c : chars) {
+				sb.append(c);
+			}
+			return sb.toString();
+		};
+	}
+
+	// Regex functions
+	private static Function regexMatch() {
+		return (args) -> {
+			try {
+				return args.length >= 2 && String.valueOf(args[1]).matches(String.valueOf(args[0]));
+			}
+			catch (Exception ex) {
+				return false;
+			}
+		};
+	}
+
+	private static Function mustRegexMatch() {
+		return (args) -> {
+			if (args.length < 2) {
+				throw new RuntimeException("mustRegexMatch: insufficient arguments");
+			}
+			try {
+				return String.valueOf(args[1]).matches(String.valueOf(args[0]));
+			}
+			catch (Exception ex) {
+				throw new RuntimeException("mustRegexMatch: " + ex.getMessage(), ex);
+			}
+		};
+	}
+
+	private static Function regexFind() {
+		return (args) -> {
+			if (args.length < 2) {
+				return "";
+			}
+			try {
+				Matcher m = Pattern.compile(String.valueOf(args[0])).matcher(String.valueOf(args[1]));
+				return (m.find()) ? m.group() : "";
+			}
+			catch (Exception ex) {
+				return "";
+			}
+		};
+	}
+
+	private static Function mustRegexFind() {
+		return (args) -> {
+			if (args.length < 2) {
+				throw new RuntimeException("mustRegexFind: insufficient arguments");
+			}
+			try {
+				Matcher m = Pattern.compile(String.valueOf(args[0])).matcher(String.valueOf(args[1]));
+				if (!m.find()) {
+					throw new RuntimeException("mustRegexFind: no match found");
+				}
+				return m.group();
+			}
+			catch (Exception ex) {
+				throw new RuntimeException("mustRegexFind: " + ex.getMessage(), ex);
+			}
+		};
+	}
+
+	private static Function regexFindAll() {
+		return (args) -> {
+			if (args.length < 3) {
+				return Collections.emptyList();
+			}
+			try {
+				String regex = String.valueOf(args[0]);
+				String text = String.valueOf(args[1]);
+				int n = ((Number) args[2]).intValue();
+
+				Pattern pattern = Pattern.compile(regex);
+				Matcher matcher = pattern.matcher(text);
+				List<String> results = new ArrayList<>();
+
+				while (matcher.find() && (n < 0 || results.size() < n)) {
+					results.add(matcher.group());
+				}
+				return results;
+			}
+			catch (Exception ex) {
+				return Collections.emptyList();
+			}
+		};
+	}
+
+	private static Function regexReplaceAll() {
+		return (args) -> {
+			if (args.length < 3) {
+				return "";
+			}
+			try {
+				// Sprig signature: regexReplaceAll pattern text replacement
+				// So args are: [0]=pattern, [1]=text, [2]=replacement
+				String pattern = String.valueOf(args[0]);
+				String text = String.valueOf(args[1]);
+				String replacement = String.valueOf(args[2]);
+
+				return text.replaceAll(pattern, replacement);
+			}
+			catch (Exception ex) {
+				return String.valueOf(args[1]); // Return original text on error
+			}
+		};
+	}
+
+	private static Function mustRegexReplaceAll() {
+		return (args) -> {
+			if (args.length < 3) {
+				throw new RuntimeException("mustRegexReplaceAll: insufficient arguments");
+			}
+			try {
+				// Sprig signature: mustRegexReplaceAll pattern text replacement
+				String pattern = String.valueOf(args[0]);
+				String text = String.valueOf(args[1]);
+				String replacement = String.valueOf(args[2]);
+				return text.replaceAll(pattern, replacement);
+			}
+			catch (Exception ex) {
+				throw new RuntimeException("mustRegexReplaceAll: " + ex.getMessage(), ex);
+			}
+		};
+	}
+
+	private static Function regexReplaceAllLiteral() {
+		return (args) -> {
+			if (args.length < 3) {
+				return "";
+			}
+			try {
+				// Sprig signature: regexReplaceAllLiteral pattern replacement text
+				String pattern = String.valueOf(args[0]);
+				String replacement = Matcher.quoteReplacement(String.valueOf(args[1]));
+				String text = String.valueOf(args[2]);
+				return text.replaceAll(pattern, replacement);
+			}
+			catch (Exception ex) {
+				return String.valueOf(args[2]); // Return original text on error
+			}
+		};
+	}
+
+	private static Function mustRegexReplaceAllLiteral() {
+		return (args) -> {
+			if (args.length < 3) {
+				throw new RuntimeException("mustRegexReplaceAllLiteral: insufficient arguments");
+			}
+			try {
+				// Sprig signature: mustRegexReplaceAllLiteral pattern replacement text
+				String pattern = String.valueOf(args[0]);
+				String replacement = Matcher.quoteReplacement(String.valueOf(args[1]));
+				String text = String.valueOf(args[2]);
+				return text.replaceAll(pattern, replacement);
+			}
+			catch (Exception ex) {
+				throw new RuntimeException("mustRegexReplaceAllLiteral: " + ex.getMessage(), ex);
+			}
+		};
+	}
+
+	private static Function regexSplit() {
+		return (args) -> {
+			if (args.length < 3) {
+				return Collections.emptyList();
+			}
+			try {
+				String regex = String.valueOf(args[0]);
+				String text = String.valueOf(args[1]);
+				int n = ((Number) args[2]).intValue();
+				String[] parts = text.split(regex, n);
+				return Arrays.asList(parts);
+			}
+			catch (Exception ex) {
+				return Collections.singletonList(String.valueOf(args[1]));
+			}
+		};
+	}
+
+	private static Function mustRegexSplit() {
+		return (args) -> {
+			if (args.length < 3) {
+				throw new RuntimeException("mustRegexSplit: insufficient arguments");
+			}
+			try {
+				String regex = String.valueOf(args[0]);
+				String text = String.valueOf(args[1]);
+				int n = ((Number) args[2]).intValue();
+				String[] parts = text.split(regex, n);
+				return Arrays.asList(parts);
+			}
+			catch (Exception ex) {
+				throw new RuntimeException("mustRegexSplit: " + ex.getMessage(), ex);
+			}
+		};
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/main/resources/META-INF/services/org.alexmond.jhelm.gotemplate.FunctionProvider
+++ b/jhelm-gotemplate-sprig/src/main/resources/META-INF/services/org.alexmond.jhelm.gotemplate.FunctionProvider
@@ -1,0 +1,1 @@
+org.alexmond.jhelm.gotemplate.sprig.SprigFunctionProvider

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/SprigFunctionProviderTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/SprigFunctionProviderTest.java
@@ -1,0 +1,74 @@
+package org.alexmond.jhelm.gotemplate.sprig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import org.alexmond.jhelm.gotemplate.Function;
+import org.alexmond.jhelm.gotemplate.FunctionProvider;
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+import org.junit.jupiter.api.Test;
+
+class SprigFunctionProviderTest {
+
+	@Test
+	void testPriority() {
+		SprigFunctionProvider provider = new SprigFunctionProvider();
+		assertEquals(100, provider.priority());
+	}
+
+	@Test
+	void testName() {
+		SprigFunctionProvider provider = new SprigFunctionProvider();
+		assertEquals("Sprig", provider.name());
+	}
+
+	@Test
+	void testGetFunctionsReturnsSprigFunctions() {
+		SprigFunctionProvider provider = new SprigFunctionProvider();
+		GoTemplate template = GoTemplate.builder().noAutoDiscovery().build();
+		Map<String, Function> functions = provider.getFunctions(template);
+
+		assertFalse(functions.isEmpty());
+		assertNotNull(functions.get("upper"));
+		assertNotNull(functions.get("lower"));
+		assertNotNull(functions.get("trim"));
+		assertNotNull(functions.get("list"));
+		assertNotNull(functions.get("dict"));
+		assertNotNull(functions.get("default"));
+		assertNotNull(functions.get("b64enc"));
+	}
+
+	@Test
+	void testServiceLoaderDiscovery() {
+		ServiceLoader<FunctionProvider> loader = ServiceLoader.load(FunctionProvider.class);
+		boolean found = false;
+		for (FunctionProvider provider : loader) {
+			if (provider instanceof SprigFunctionProvider) {
+				found = true;
+				break;
+			}
+		}
+		assertTrue(found, "SprigFunctionProvider should be discoverable via ServiceLoader");
+	}
+
+	@Test
+	void testBuilderWithSprigProvider() throws Exception {
+		GoTemplate template = GoTemplate.builder().noAutoDiscovery().withProvider(new SprigFunctionProvider()).build();
+
+		// Should have both Go builtins and Sprig functions
+		assertTrue(template.getFunctions().containsKey("len"));
+		assertTrue(template.getFunctions().containsKey("upper"));
+
+		template.parse("test", "{{ .name | upper }}");
+		StringWriter writer = new StringWriter();
+		template.execute("test", Map.of("name", "world"), writer);
+		assertEquals("WORLD", writer.toString());
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/SprigFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/SprigFunctionsTest.java
@@ -1,0 +1,348 @@
+package org.alexmond.jhelm.gotemplate.sprig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+import org.alexmond.jhelm.gotemplate.TemplateException;
+import org.junit.jupiter.api.Test;
+
+class SprigFunctionsTest {
+
+	private void execute(String name, String text, Object data, StringWriter writer)
+			throws IOException, TemplateException {
+		GoTemplate template = new GoTemplate();
+		template.parse(name, text);
+		template.execute(name, data, writer);
+	}
+
+	@Test
+	void testTrunc() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("text", "Hello World");
+		execute("test", "{{ trunc 5 .text }}", data, writer);
+
+		assertEquals("Hello", writer.toString());
+	}
+
+	@Test
+	void testJoinWithList() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("items", Arrays.asList("a", "b", "c"));
+		execute("test", "{{ join \",\" .items }}", data, writer);
+
+		assertEquals("a,b,c", writer.toString());
+	}
+
+	@Test
+	void testRequired() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", "test");
+		execute("test", "{{ required \"value is required\" .value }}", data, writer);
+
+		assertEquals("test", writer.toString());
+	}
+
+	@Test
+	void testRequiredThrowsOnEmpty() {
+		assertThrows(Exception.class, () -> {
+			StringWriter writer = new StringWriter();
+			Map<String, Object> data = new HashMap<>();
+			data.put("value", "");
+			execute("test", "{{ required \"value is required\" .value }}", data, writer);
+		});
+	}
+
+	@Test
+	void testToJson() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("text", "hello");
+		execute("test", "{{ toJson .text }}", data, writer);
+
+		assertEquals("\"hello\"", writer.toString());
+	}
+
+	@Test
+	void testMustRegexReplaceAllLiteral() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("text", "hello world");
+		execute("test", "{{ mustRegexReplaceAllLiteral \"world\" \"universe\" .text }}", data, writer);
+
+		assertEquals("hello universe", writer.toString());
+	}
+
+	@Test
+	void testHtpasswd() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ htpasswd \"user\" \"pass\" }}", new HashMap<>(), writer);
+
+		String result = writer.toString();
+		assertTrue(result.startsWith("user:$2y$"));
+	}
+
+	@Test
+	void testTuple() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $t := tuple \"a\" \"b\" \"c\" }}{{ index $t 0 }},{{ index $t 1 }},{{ index $t 2 }}",
+				new HashMap<>(), writer);
+
+		assertEquals("a,b,c", writer.toString());
+	}
+
+	@Test
+	void testTupleWithRange() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ range tuple \"x\" \"y\" \"z\" }}{{ . }} {{ end }}", new HashMap<>(), writer);
+
+		assertEquals("x y z ", writer.toString());
+	}
+
+	@Test
+	void testFirst() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("items", Arrays.asList("apple", "banana", "cherry"));
+		execute("test", "{{ first .items }}", data, writer);
+
+		assertEquals("apple", writer.toString());
+	}
+
+	@Test
+	void testFirstWithString() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("text", "hello");
+		execute("test", "{{ first .text }}", data, writer);
+
+		assertEquals("h", writer.toString());
+	}
+
+	@Test
+	void testUniq() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("items", Arrays.asList("a", "b", "a", "c", "b"));
+		execute("test", "{{ uniq .items }}", data, writer);
+
+		String result = writer.toString();
+		// Result order might depend on implementation but should contain unique elements
+		assertTrue(result.contains("a") && result.contains("b") && result.contains("c"));
+	}
+
+	@Test
+	void testSortAlpha() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("items", Arrays.asList("cherry", "apple", "banana"));
+		execute("test", "{{ range sortAlpha .items }}{{ . }} {{ end }}", data, writer);
+
+		String result = writer.toString().trim();
+		assertEquals("apple banana cherry", result);
+	}
+
+	@Test
+	void testSet() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $dict := dict }}{{ $_ := set $dict \"key\" \"value\" }}{{ index $dict \"key\" }}",
+				new HashMap<>(), writer);
+
+		assertEquals("value", writer.toString());
+	}
+
+	@Test
+	void testRandAlphaNum() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ randAlphaNum 10 }}", new HashMap<>(), writer);
+
+		String result = writer.toString();
+		assertEquals(10, result.length());
+		assertTrue(result.matches("[A-Za-z0-9]+"));
+	}
+
+	@Test
+	void testRandAlpha() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ randAlpha 8 }}", new HashMap<>(), writer);
+
+		String result = writer.toString();
+		assertEquals(8, result.length());
+		assertTrue(result.matches("[A-Za-z]+"));
+	}
+
+	@Test
+	void testGenCA() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $ca := genCA \"foo-ca\" 365 }}{{ $ca.Cert }}", new HashMap<>(), writer);
+
+		String result = writer.toString();
+		assertTrue(result.contains("BEGIN CERTIFICATE"));
+	}
+
+	@Test
+	void testKindIs() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", "hello");
+		execute("test", "{{ kindIs \"string\" .value }}", data, writer);
+
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testTypeIs() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", "hello");
+		execute("test", "{{ typeIs \"string\" .value }}", data, writer);
+
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testHasKey() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> dict = new HashMap<>();
+		dict.put("name", "test");
+		data.put("dict", dict);
+		execute("test", "{{ hasKey .dict \"name\" }}", data, writer);
+
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testGet() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> dict = new HashMap<>();
+		dict.put("name", "test");
+		data.put("dict", dict);
+		execute("test", "{{ get .dict \"name\" }}", data, writer);
+
+		assertEquals("test", writer.toString());
+	}
+
+	@Test
+	void testWithout() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("items", Arrays.asList("a", "b", "c"));
+		execute("test", "{{ without .items \"b\" }}", data, writer);
+
+		String result = writer.toString();
+		assertTrue(result.contains("a") && result.contains("c") && !result.contains("\"b\""));
+	}
+
+	@Test
+	void testSplitList() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("text", "a,b,c");
+		execute("test", "{{ splitList \",\" .text }}", data, writer);
+
+		String result = writer.toString();
+		assertTrue(result.contains("a") && result.contains("b") && result.contains("c"));
+	}
+
+	@Test
+	void testUnset() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test",
+				"{{ $dict := dict \"key1\" \"value1\" \"key2\" \"value2\" }}{{ $_ := unset $dict \"key1\" }}{{ hasKey $dict \"key1\" }}",
+				new HashMap<>(), writer);
+
+		assertEquals("false", writer.toString());
+	}
+
+	@Test
+	void testSemver() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $v := semver \"v1.2.3\" }}{{ $v.Major }}.{{ $v.Minor }}.{{ $v.Patch }}", new HashMap<>(),
+				writer);
+
+		assertEquals("1.2.3", writer.toString());
+	}
+
+	@Test
+	void testAdd1() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ add1 5 }}", new HashMap<>(), writer);
+
+		assertEquals("6", writer.toString());
+	}
+
+	@Test
+	void testRandNumeric() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $r := randNumeric 10 }}{{ len $r }}", new HashMap<>(), writer);
+
+		assertEquals("10", writer.toString());
+	}
+
+	@Test
+	void testReverse() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $list := list \"a\" \"b\" \"c\" }}{{ range reverse $list }}{{ . }}{{ end }}",
+				new HashMap<>(), writer);
+
+		assertEquals("cba", writer.toString());
+	}
+
+	@Test
+	void testIndent() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("text", "line1\nline2");
+		execute("test", "{{ indent 4 .text }}", data, writer);
+
+		assertEquals("    line1\n    line2", writer.toString());
+	}
+
+	@Test
+	void testRegexReplaceAll() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ regexReplaceAll \"[^a-z]\" \"hello123world\" \"-\" }}", new HashMap<>(), writer);
+
+		assertEquals("hello---world", writer.toString());
+	}
+
+	@Test
+	void testReplaceNewlines() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("text", "line1\nline2\nline3");
+		execute("test", "{{ replace \"\\n\" \",\" .text }}", data, writer);
+
+		assertEquals("line1,line2,line3", writer.toString());
+	}
+
+	@Test
+	void testGenSignedCert() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $cert := genSignedCert \"example.com\" nil nil 365 nil }}{{ hasKey $cert \"Cert\" }}",
+				new HashMap<>(), writer);
+
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testRandAscii() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $r := randAscii 15 }}{{ len $r }}", new HashMap<>(), writer);
+
+		assertEquals("15", writer.toString());
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/SprigFunctionsTestRunner.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/SprigFunctionsTestRunner.java
@@ -1,0 +1,147 @@
+package org.alexmond.jhelm.gotemplate.sprig;
+
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+import java.io.Writer;
+
+public class SprigFunctionsTestRunner {
+
+	public static void main(String[] args) {
+		SprigFunctionsTestRunner runner = new SprigFunctionsTestRunner();
+
+		System.out.println("Testing Sprig Functions...\n");
+
+		runner.testTrunc();
+		runner.testJoin();
+		runner.testFirst();
+		runner.testUniq();
+		runner.testSortAlpha();
+		runner.testSet();
+		runner.testRandAlphaNum();
+		runner.testRandAlpha();
+
+		System.out.println("\nAll manual tests completed!");
+	}
+
+	private void execute(String name, String text, Object data, Writer writer) throws Exception {
+		GoTemplate template = new GoTemplate();
+		template.parse(name, text);
+		template.execute(name, data, writer);
+	}
+
+	private void testTrunc() {
+		try {
+			StringWriter writer = new StringWriter();
+			Map<String, Object> data = new HashMap<>();
+			data.put("text", "Hello World");
+			execute("test", "{{ trunc 5 .text }}", data, writer);
+			System.out.println(
+					"testTrunc: " + (writer.toString().equals("Hello") ? "PASS" : "FAIL - got: " + writer.toString()));
+		}
+		catch (Exception ex) {
+			System.out.println("testTrunc: FAIL - " + ex.getMessage());
+		}
+	}
+
+	private void testJoin() {
+		try {
+			StringWriter writer = new StringWriter();
+			Map<String, Object> data = new HashMap<>();
+			data.put("items", Arrays.asList("a", "b", "c"));
+			execute("test", "{{ join \",\" .items }}", data, writer);
+			System.out.println(
+					"testJoin: " + (writer.toString().equals("a,b,c") ? "PASS" : "FAIL - got: " + writer.toString()));
+		}
+		catch (Exception ex) {
+			System.out.println("testJoin: FAIL - " + ex.getMessage());
+		}
+	}
+
+	private void testFirst() {
+		try {
+			StringWriter writer = new StringWriter();
+			Map<String, Object> data = new HashMap<>();
+			data.put("items", Arrays.asList("apple", "banana", "cherry"));
+			execute("test", "{{ first .items }}", data, writer);
+			System.out.println(
+					"testFirst: " + (writer.toString().equals("apple") ? "PASS" : "FAIL - got: " + writer.toString()));
+		}
+		catch (Exception ex) {
+			System.out.println("testFirst: FAIL - " + ex.getMessage());
+		}
+	}
+
+	private void testUniq() {
+		try {
+			StringWriter writer = new StringWriter();
+			Map<String, Object> data = new HashMap<>();
+			data.put("items", Arrays.asList("a", "b", "a", "c", "b"));
+			execute("test", "{{ uniq .items }}", data, writer);
+			String result = writer.toString();
+			boolean pass = result.contains("a") && result.contains("b") && result.contains("c");
+			System.out.println("testUniq: " + (pass ? "PASS" : "FAIL - got: " + result));
+		}
+		catch (Exception ex) {
+			System.out.println("testUniq: FAIL - " + ex.getMessage());
+		}
+	}
+
+	private void testSortAlpha() {
+		try {
+			StringWriter writer = new StringWriter();
+			Map<String, Object> data = new HashMap<>();
+			data.put("items", Arrays.asList("cherry", "apple", "banana"));
+			execute("test", "{{ sortAlpha .items }}", data, writer);
+			String result = writer.toString();
+			boolean pass = result.contains("apple") && result.contains("banana") && result.contains("cherry");
+			System.out.println("testSortAlpha: " + (pass ? "PASS" : "FAIL - got: " + result));
+		}
+		catch (Exception ex) {
+			System.out.println("testSortAlpha: FAIL - " + ex.getMessage());
+		}
+	}
+
+	private void testSet() {
+		try {
+			StringWriter writer = new StringWriter();
+			execute("test", "{{ $dict := dict }}{{ set $dict \"key\" \"value\" }}{{ index $dict \"key\" }}",
+					new HashMap<>(), writer);
+			System.out.println(
+					"testSet: " + (writer.toString().equals("value") ? "PASS" : "FAIL - got: " + writer.toString()));
+		}
+		catch (Exception ex) {
+			System.out.println("testSet: FAIL - " + ex.getMessage());
+		}
+	}
+
+	private void testRandAlphaNum() {
+		try {
+			StringWriter writer = new StringWriter();
+			execute("test", "{{ randAlphaNum 10 }}", new HashMap<>(), writer);
+			String result = writer.toString();
+			boolean pass = result.length() == 10 && result.matches("[A-Za-z0-9]+");
+			System.out.println("testRandAlphaNum: " + (pass ? "PASS" : "FAIL - got: " + result));
+		}
+		catch (Exception ex) {
+			System.out.println("testRandAlphaNum: FAIL - " + ex.getMessage());
+		}
+	}
+
+	private void testRandAlpha() {
+		try {
+			StringWriter writer = new StringWriter();
+			execute("test", "{{ randAlpha 8 }}", new HashMap<>(), writer);
+			String result = writer.toString();
+			boolean pass = result.length() == 8 && result.matches("[A-Za-z]+");
+			System.out.println("testRandAlpha: " + (pass ? "PASS" : "FAIL - got: " + result));
+		}
+		catch (Exception ex) {
+			System.out.println("testRandAlpha: FAIL - " + ex.getMessage());
+		}
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
@@ -1,0 +1,359 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+import org.alexmond.jhelm.gotemplate.TemplateException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CollectionFunctionsTest {
+
+	private void execute(String name, String text, Object data, StringWriter writer)
+			throws IOException, TemplateException {
+		GoTemplate template = new GoTemplate();
+		template.parse(name, text);
+		template.execute(name, data, writer);
+	}
+
+	private String exec(String template) throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", template, new HashMap<>(), writer);
+		return writer.toString();
+	}
+
+	private String execWithData(String template, Map<String, Object> data) throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", template, data, writer);
+		return writer.toString();
+	}
+
+	// Basic list operations - parameterized for regular and must* variants
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|', value = { "first     | a", "mustFirst | a" })
+	void testFirst(String func, String expected) throws IOException, TemplateException {
+		Map<String, Object> data = Map.of("items", Arrays.asList("a", "b", "c"));
+		assertEquals(expected, execWithData("{{ " + func + " .items }}", new HashMap<>(data)));
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|', value = { "last     | c", "mustLast | c" })
+	void testLast(String func, String expected) throws IOException, TemplateException {
+		Map<String, Object> data = Map.of("items", Arrays.asList("a", "b", "c"));
+		assertEquals(expected, execWithData("{{ " + func + " .items }}", new HashMap<>(data)));
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|', value = { "rest     | b,c", "mustRest | b,c" })
+	void testRest(String func, String expected) throws IOException, TemplateException {
+		Map<String, Object> data = Map.of("items", Arrays.asList("a", "b", "c"));
+		assertEquals(expected, execWithData("{{ $r := " + func + " .items }}{{ join \",\" $r }}", new HashMap<>(data)));
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|', value = { "initial     | a,b", "mustInitial | a,b" })
+	void testInitial(String func, String expected) throws IOException, TemplateException {
+		Map<String, Object> data = Map.of("items", Arrays.asList("a", "b", "c"));
+		assertEquals(expected, execWithData("{{ $i := " + func + " .items }}{{ join \",\" $i }}", new HashMap<>(data)));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "append, mustAppend" })
+	void testAppend(String func1, String func2) throws IOException, TemplateException {
+		for (String func : new String[] { func1, func2 }) {
+			Map<String, Object> data = new HashMap<>();
+			data.put("items", new ArrayList<>(Arrays.asList("a", "b")));
+			assertEquals("a,b,c", execWithData("{{ $l := " + func + " .items \"c\" }}{{ join \",\" $l }}", data));
+		}
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "prepend, mustPrepend" })
+	void testPrepend(String func1, String func2) throws IOException, TemplateException {
+		for (String func : new String[] { func1, func2 }) {
+			Map<String, Object> data = new HashMap<>();
+			data.put("items", new ArrayList<>(Arrays.asList("b", "c")));
+			assertEquals("a,b,c", execWithData("{{ $l := " + func + " .items \"a\" }}{{ join \",\" $l }}", data));
+		}
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|', value = { "reverse     | c,b,a", "mustReverse | c,b,a" })
+	void testReverse(String func, String expected) throws IOException, TemplateException {
+		Map<String, Object> data = Map.of("items", Arrays.asList("a", "b", "c"));
+		assertEquals(expected, execWithData("{{ $r := " + func + " .items }}{{ join \",\" $r }}", new HashMap<>(data)));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "compact", "mustCompact" })
+	void testCompact(String func) throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("items", Arrays.asList("a", "", "b", null, "c"));
+		assertEquals("a,b,c", execWithData("{{ $c := " + func + " .items }}{{ join \",\" $c }}", data));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "has", "mustHas" })
+	void testHas(String func) throws IOException, TemplateException {
+		Map<String, Object> data = Map.of("items", Arrays.asList("a", "b", "c"));
+		assertEquals("true", execWithData("{{ " + func + " \"b\" .items }}", new HashMap<>(data)));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "slice", "mustSlice" })
+	void testSlice(String func) throws IOException, TemplateException {
+		Map<String, Object> data = Map.of("items", Arrays.asList("a", "b", "c", "d", "e"));
+		assertEquals("b,c",
+				execWithData("{{ $s := " + func + " .items 1 3 }}{{ join \",\" $s }}", new HashMap<>(data)));
+	}
+
+	// Uniq tests (use contains since order may vary)
+
+	@ParameterizedTest
+	@CsvSource({ "uniq", "mustUniq" })
+	void testUniq(String func) throws IOException, TemplateException {
+		Map<String, Object> data = Map.of("items", Arrays.asList("a", "b", "a", "c", "b"));
+		String result = execWithData("{{ $u := " + func + " .items }}{{ join \",\" $u }}", new HashMap<>(data));
+		assertTrue(result.contains("a"));
+		assertTrue(result.contains("b"));
+		assertTrue(result.contains("c"));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "without", "mustWithout" })
+	void testWithout(String func) throws IOException, TemplateException {
+		Map<String, Object> data = Map.of("items", Arrays.asList("a", "b", "c"));
+		String result = execWithData("{{ $w := " + func + " .items \"b\" }}{{ join \",\" $w }}", new HashMap<>(data));
+		assertTrue(result.contains("a"));
+		assertTrue(result.contains("c"));
+	}
+
+	// Dict operations - parameterized for regular and must* variants
+
+	@ParameterizedTest
+	@CsvSource({ "hasKey", "mustHasKey" })
+	void testHasKey(String func) throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> map = new HashMap<>();
+		map.put("key", "value");
+		data.put("map", map);
+		assertEquals("true", execWithData("{{ " + func + " .map \"key\" }}", data));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "keys", "mustKeys" })
+	void testKeys(String func) throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> map = new HashMap<>();
+		map.put("a", 1);
+		map.put("b", 2);
+		data.put("map", map);
+		assertEquals("2", execWithData("{{ $k := " + func + " .map }}{{ len $k }}", data));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "values", "mustValues" })
+	void testValues(String func) throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> map = new HashMap<>();
+		map.put("a", 1);
+		map.put("b", 2);
+		data.put("map", map);
+		assertEquals("2", execWithData("{{ $v := " + func + " .map }}{{ len $v }}", data));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "pick", "mustPick" })
+	void testPick(String func) throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> map = new HashMap<>();
+		map.put("a", 1);
+		map.put("b", 2);
+		map.put("c", 3);
+		data.put("map", map);
+		assertEquals("2", execWithData("{{ $p := " + func + " .map \"a\" \"c\" }}{{ len $p }}", data));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "omit", "mustOmit" })
+	void testOmit(String func) throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> map = new HashMap<>();
+		map.put("a", 1);
+		map.put("b", 2);
+		map.put("c", 3);
+		data.put("map", map);
+		assertEquals("2", execWithData("{{ $o := " + func + " .map \"b\" }}{{ len $o }}", data));
+	}
+
+	// Merge and deepCopy - parameterized for regular and must* variants
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|', value = {
+			"{{ $d1 := dict \"a\" 1 }}{{ $d2 := dict \"b\" 2 }}{{ $m := merge $d1 $d2 }}{{ len $m }}                         | 2",
+			"{{ $d1 := dict \"a\" 1 }}{{ $d2 := dict \"b\" 2 }}{{ $m := mustMerge $d1 $d2 }}{{ len $m }}                     | 2",
+			"{{ $d1 := dict \"a\" 1 }}{{ $d2 := dict \"a\" 2 }}{{ $m := mergeOverwrite $d1 $d2 }}{{ get $m \"a\" }}          | 2",
+			"{{ $d1 := dict \"a\" 1 }}{{ $d2 := dict \"a\" 2 }}{{ $m := mustMergeOverwrite $d1 $d2 }}{{ get $m \"a\" }}      | 2",
+			"{{ $d := dict \"a\" 1 }}{{ $c := deepCopy $d }}{{ get $c \"a\" }}                                                | 1",
+			"{{ $d := dict \"a\" 1 }}{{ $c := mustDeepCopy $d }}{{ get $c \"a\" }}                                            | 1" })
+	void testMergeAndCopy(String template, String expected) throws IOException, TemplateException {
+		assertEquals(expected, exec(template));
+	}
+
+	// Standalone tests for operations without must* variants
+
+	@Test
+	void testList() throws IOException, TemplateException {
+		assertEquals("a,b,c", exec("{{ $l := list \"a\" \"b\" \"c\" }}{{ join \",\" $l }}"));
+	}
+
+	@Test
+	void testConcat() throws IOException, TemplateException {
+		assertEquals("a,b,c,d", exec(
+				"{{ $l1 := list \"a\" \"b\" }}{{ $l2 := list \"c\" \"d\" }}{{ $c := concat $l1 $l2 }}{{ join \",\" $c }}"));
+	}
+
+	@Test
+	void testDict() throws IOException, TemplateException {
+		assertEquals("John", exec("{{ $d := dict \"name\" \"John\" \"age\" 30 }}{{ $d.name }}"));
+	}
+
+	@Test
+	void testSortAlpha() throws IOException, TemplateException {
+		Map<String, Object> data = Map.of("items", Arrays.asList("c", "a", "b"));
+		assertEquals("a,b,c",
+				execWithData("{{ $sorted := sortAlpha .items }}{{ join \",\" $sorted }}", new HashMap<>(data)));
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|',
+			value = { "{{ $s := seq 1 5 }}{{ join \",\" $s }}                    | 1,2,3,4,5",
+					"{{ $u := until 5 }}{{ join \",\" $u }}                    | 0,1,2,3,4",
+					"{{ $u := untilStep 0 10 2 }}{{ join \",\" $u }}           | 0,2,4,6,8" })
+	void testSequences(String template, String expected) throws IOException, TemplateException {
+		assertEquals(expected, exec(template));
+	}
+
+	@Test
+	void testGet() throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> map = new HashMap<>();
+		map.put("key", "value");
+		data.put("map", map);
+		assertEquals("value", execWithData("{{ get .map \"key\" }}", data));
+	}
+
+	@Test
+	void testSet() throws IOException, TemplateException {
+		assertEquals("2", exec("{{ $d := dict \"a\" 1 }}{{ $d := set $d \"b\" 2 }}{{ get $d \"b\" }}"));
+	}
+
+	@Test
+	void testUnset() throws IOException, TemplateException {
+		assertEquals("false", exec("{{ $d := dict \"a\" 1 \"b\" 2 }}{{ $d := unset $d \"a\" }}{{ hasKey $d \"a\" }}"));
+	}
+
+	@Test
+	void testDig() throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> nested = new HashMap<>();
+		nested.put("key", "value");
+		Map<String, Object> map = new HashMap<>();
+		map.put("nested", nested);
+		data.put("map", map);
+		assertEquals("value", execWithData("{{ dig \"nested\" \"key\" \"\" .map }}", data));
+	}
+
+	// Different input types (arrays, collections, strings)
+
+	@ParameterizedTest
+	@MethodSource("inputTypeTestCases")
+	void testWithDifferentInputTypes(String func, Object input, String template, String expected, boolean exact)
+			throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("items", input);
+		String result = execWithData(template, data);
+		if (exact) {
+			assertEquals(expected, result);
+		}
+		else {
+			assertFalse(result.isEmpty());
+		}
+	}
+
+	static Stream<Arguments> inputTypeTestCases() {
+		return Stream.of(Arguments.of("join", new String[] { "a", "b", "c" }, "{{ join \",\" .items }}", "a,b,c", true),
+				Arguments.of("sortAlpha", new String[] { "c", "a", "b" },
+						"{{ $s := sortAlpha .items }}{{ join \",\" $s }}", "a,b,c", true),
+				Arguments.of("reverse", new String[] { "a", "b", "c" }, "{{ $r := reverse .items }}{{ join \",\" $r }}",
+						"c,b,a", true),
+				Arguments.of("last", new String[] { "a", "b", "c" }, "{{ last .items }}", "c", true),
+				Arguments.of("first", new String[] { "x", "y", "z" }, "{{ first .items }}", "x", true),
+				Arguments.of("first-string", "hello", "{{ first .items }}", "h", true),
+				Arguments.of("reverse-string", "hello", "{{ reverse .items }}", "olleh", true),
+				Arguments.of("first-set", new HashSet<>(Arrays.asList("x", "y")), "{{ first .items }}", null, false),
+				Arguments.of("last-set", new HashSet<>(Arrays.asList("a", "b", "c")), "{{ last .items }}", null, false),
+				Arguments.of("rest-set", new HashSet<>(Arrays.asList("a", "b", "c")),
+						"{{ $r := rest .items }}{{ len $r }}", null, false),
+				Arguments.of("initial-set", new HashSet<>(Arrays.asList("a", "b", "c")),
+						"{{ $i := initial .items }}{{ len $i }}", null, false),
+				Arguments.of("uniq-array", new String[] { "a", "b", "a", "c" },
+						"{{ $u := uniq .items }}{{ join \",\" $u }}", null, false));
+	}
+
+	// Additional collection operations
+
+	@Test
+	void testTuple() throws IOException, TemplateException {
+		assertEquals("a,b,c", exec("{{ $t := tuple \"a\" \"b\" \"c\" }}{{ join \",\" $t }}"));
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|', value = {
+			// Reproduces cert-manager v1.20.0 pattern: ne (len .) 4
+			// len returns int (Integer), literal 4 is long (Long) — eq/ne must handle
+			// mixed
+			// types
+			"{{ $t := tuple \"a\" \"b\" \"c\" \"d\" }}{{ eq (len $t) 4 }} | true",
+			"{{ $t := tuple \"a\" \"b\" \"c\" \"d\" }}{{ ne (len $t) 4 }} | false",
+			"{{ $t := tuple \"a\" \"b\" }}{{ ne (len $t) 4 }}             | true" })
+	void testTupleLenWithComparison(String template, String expected) throws IOException, TemplateException {
+		assertEquals(expected, exec(template));
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|',
+			value = { "{{ $s := split \",\" \"a,b,c\" }}{{ index $s 1 }}        | b",
+					"{{ $s := splitList \",\" \"a,b,c\" }}{{ len $s }}        | 3",
+					"{{ $s := splitn \",\" 2 \"a,b,c\" }}{{ len $s }}         | 2" })
+	void testSplitFunctions(String template, String expected) throws IOException, TemplateException {
+		assertEquals(expected, exec(template));
+	}
+
+	@Test
+	void testPluck() throws IOException, TemplateException {
+		assertEquals("2", exec(
+				"{{ $d1 := dict \"name\" \"John\" \"age\" 30 }}{{ $d2 := dict \"name\" \"Jane\" \"age\" 25 }}{{ $p := pluck \"name\" $d1 $d2 }}{{ len $p }}"));
+	}
+
+	@Test
+	void testDeepCopyList() throws IOException, TemplateException {
+		assertEquals("2", exec("{{ $l := list \"a\" \"b\" }}{{ $c := deepCopy $l }}{{ len $c }}"));
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CryptoFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CryptoFunctionsTest.java
@@ -1,0 +1,143 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+import org.alexmond.jhelm.gotemplate.TemplateException;
+import org.junit.jupiter.api.Test;
+
+class CryptoFunctionsTest {
+
+	private String exec(String template) throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		GoTemplate t = new GoTemplate();
+		t.parse("test", template);
+		t.execute("test", new HashMap<>(), writer);
+		return writer.toString();
+	}
+
+	// ========== Random String Functions ==========
+
+	@Test
+	void testRandAlphaNumLength() throws IOException, TemplateException {
+		String result = exec("{{ randAlphaNum 10 }}");
+		assertEquals(10, result.length());
+		assertTrue(result.matches("[A-Za-z0-9]+"));
+	}
+
+	@Test
+	void testRandAlphaLength() throws IOException, TemplateException {
+		String result = exec("{{ randAlpha 8 }}");
+		assertEquals(8, result.length());
+		assertTrue(result.matches("[A-Za-z]+"));
+	}
+
+	@Test
+	void testRandNumericLength() throws IOException, TemplateException {
+		String result = exec("{{ randNumeric 6 }}");
+		assertEquals(6, result.length());
+		assertTrue(result.matches("[0-9]+"));
+	}
+
+	@Test
+	void testRandAsciiLength() throws IOException, TemplateException {
+		String result = exec("{{ randAscii 12 }}");
+		assertEquals(12, result.length());
+	}
+
+	@Test
+	void testRandAlphaNumZeroLength() throws IOException, TemplateException {
+		String result = exec("{{ randAlphaNum 0 }}");
+		assertEquals("", result);
+	}
+
+	// ========== Password Functions ==========
+
+	@Test
+	void testHtpasswd() throws IOException, TemplateException {
+		String result = exec("{{ htpasswd \"admin\" \"secret\" }}");
+		assertTrue(result.startsWith("admin:$2"));
+	}
+
+	@Test
+	void testDerivePassword() throws IOException, TemplateException {
+		String result = exec("{{ derivePassword 1 \"long\" \"masterpass\" \"user\" }}");
+		assertNotNull(result);
+		assertFalse(result.isEmpty());
+		assertEquals(20, result.length());
+	}
+
+	@Test
+	void testDerivePasswordDeterministic() throws IOException, TemplateException {
+		String result1 = exec("{{ derivePassword 1 \"long\" \"master\" \"user1\" }}");
+		String result2 = exec("{{ derivePassword 1 \"long\" \"master\" \"user1\" }}");
+		assertEquals(result1, result2);
+	}
+
+	// ========== Key Generation ==========
+
+	@Test
+	void testGenPrivateKeyRsa() throws IOException, TemplateException {
+		String result = exec("{{ genPrivateKey \"rsa\" }}");
+		assertTrue(result.contains("BEGIN RSA PRIVATE KEY"));
+		assertTrue(result.contains("END RSA PRIVATE KEY"));
+	}
+
+	@Test
+	void testGenPrivateKeyEcdsa() throws IOException, TemplateException {
+		String result = exec("{{ genPrivateKey \"ecdsa\" }}");
+		assertTrue(result.contains("PRIVATE KEY"));
+	}
+
+	@Test
+	void testGenPrivateKeyDsa() throws IOException, TemplateException {
+		String result = exec("{{ genPrivateKey \"dsa\" }}");
+		assertTrue(result.contains("PRIVATE KEY"));
+	}
+
+	// ========== Certificate Generation ==========
+
+	@Test
+	void testGenCA() throws IOException, TemplateException {
+		String result = exec("{{ $ca := genCA \"myCA\" 365 }}{{ $ca.Cert }}");
+		assertTrue(result.contains("BEGIN CERTIFICATE"));
+		assertTrue(result.contains("END CERTIFICATE"));
+	}
+
+	@Test
+	void testGenCAKey() throws IOException, TemplateException {
+		String result = exec("{{ $ca := genCA \"myCA\" 365 }}{{ $ca.Key }}");
+		assertTrue(result.contains("BEGIN RSA PRIVATE KEY"));
+	}
+
+	@Test
+	void testGenSelfSignedCert() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		GoTemplate t = new GoTemplate();
+		Map<String, Object> data = new HashMap<>();
+		t.parse("test",
+				"{{ $cert := genSelfSignedCert \"localhost\" (list \"127.0.0.1\") (list \"localhost\") 365 }}{{ $cert.Cert }}");
+		t.execute("test", data, writer);
+		assertTrue(writer.toString().contains("BEGIN CERTIFICATE"));
+	}
+
+	@Test
+	void testGenSignedCert() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		GoTemplate t = new GoTemplate();
+		Map<String, Object> data = new HashMap<>();
+		t.parse("test",
+				"{{ $ca := genCA \"myCA\" 365 }}{{ $cert := genSignedCert \"myhost\" (list) (list \"myhost.local\") 365 $ca }}{{ $cert.Cert }}");
+		t.execute("test", data, writer);
+		assertTrue(writer.toString().contains("BEGIN CERTIFICATE"));
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/DateFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/DateFunctionsTest.java
@@ -1,0 +1,128 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+import org.alexmond.jhelm.gotemplate.TemplateException;
+import org.junit.jupiter.api.Test;
+
+class DateFunctionsTest {
+
+	private void execute(String name, String text, Object data, StringWriter writer)
+			throws IOException, TemplateException {
+		GoTemplate template = new GoTemplate();
+		template.parse(name, text);
+		template.execute(name, data, writer);
+	}
+
+	@Test
+	void testNow() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ now }}", new HashMap<>(), writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testDateFormatting() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ now | date \"2006-01-02\" }}", new HashMap<>(), writer);
+		assertTrue(writer.toString().matches("\\d{4}-\\d{2}-\\d{2}"));
+	}
+
+	@Test
+	void testHtmlDate() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ now | htmlDate }}", new HashMap<>(), writer);
+		assertTrue(writer.toString().matches("\\d{4}-\\d{2}-\\d{2}"));
+	}
+
+	@Test
+	void testUnixEpoch() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ now | unixEpoch }}", new HashMap<>(), writer);
+		assertTrue(writer.toString().matches("\\d+"));
+	}
+
+	@Test
+	void testDateModify() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ now | dateModify \"24h\" | unixEpoch }}", new HashMap<>(), writer);
+		assertTrue(writer.toString().matches("\\d+"));
+	}
+
+	@Test
+	void testToDate() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ toDate \"2006-01-02\" \"2024-01-15\" }}", new HashMap<>(), writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testDateInZone() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ dateInZone \"2006-01-02\" now \"UTC\" }}", new HashMap<>(), writer);
+		assertTrue(writer.toString().matches("\\d{4}-\\d{2}-\\d{2}"));
+	}
+
+	@Test
+	void testDurationRound() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ durationRound \"2h10m5s\" }}", new HashMap<>(), writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testMustToDate() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ mustToDate \"2006-01-02\" \"2024-12-25\" }}", new HashMap<>(), writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testHtmlDateInZone() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ htmlDateInZone now \"UTC\" }}", new HashMap<>(), writer);
+		assertTrue(writer.toString().matches("\\d{4}-\\d{2}-\\d{2}"));
+	}
+
+	@Test
+	void testDateWithCustomFormat() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ now | date \"2006\" }}", new HashMap<>(), writer);
+		assertTrue(writer.toString().matches("\\d{4}"));
+	}
+
+	@Test
+	void testDateInZoneWithTimezone() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ dateInZone \"15:04:05\" now \"America/New_York\" }}", new HashMap<>(), writer);
+		assertTrue(writer.toString().matches("\\d{2}:\\d{2}:\\d{2}"));
+	}
+
+	@Test
+	void testToDateWithDifferentFormat() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ toDate \"01/02/2006\" \"12/25/2024\" }}", new HashMap<>(), writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testDateModifyWithNegative() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ now | dateModify \"-24h\" | unixEpoch }}", new HashMap<>(), writer);
+		assertTrue(writer.toString().matches("\\d+"));
+	}
+
+	@Test
+	void testUnixEpochWithPipechain() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ now | dateModify \"1h\" | unixEpoch }}", new HashMap<>(), writer);
+		assertTrue(writer.toString().matches("\\d+"));
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/EncodingFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/EncodingFunctionsTest.java
@@ -1,0 +1,188 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+import org.alexmond.jhelm.gotemplate.TemplateException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EncodingFunctionsTest {
+
+	private void execute(String name, String text, Object data, StringWriter writer)
+			throws IOException, TemplateException {
+		GoTemplate template = new GoTemplate();
+		template.parse(name, text);
+		template.execute(name, data, writer);
+	}
+
+	private String exec(String template) throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", template, new HashMap<>(), writer);
+		return writer.toString();
+	}
+
+	private String execWithData(String template, HashMap<String, Object> data) throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", template, data, writer);
+		return writer.toString();
+	}
+
+	// Base64 tests
+
+	@Test
+	void testBase64Encode() throws IOException, TemplateException {
+		assertEquals("aGVsbG8=", exec("{{ b64enc \"hello\" }}"));
+	}
+
+	@Test
+	void testBase64Decode() throws IOException, TemplateException {
+		assertEquals("hello", exec("{{ b64dec \"aGVsbG8=\" }}"));
+	}
+
+	@Test
+	void testBase64RoundTrip() throws IOException, TemplateException {
+		assertEquals("test data", exec("{{ \"test data\" | b64enc | b64dec }}"));
+	}
+
+	// Base32 tests
+
+	@Test
+	void testBase32Encode() throws IOException, TemplateException {
+		assertFalse(exec("{{ b32enc \"hello\" }}").isEmpty());
+	}
+
+	@Test
+	void testBase32Decode() throws IOException, TemplateException {
+		String encoded = exec("{{ b32enc \"hello\" }}");
+		StringWriter decoder = new StringWriter();
+		execute("test", "{{ b32dec \"" + encoded + "\" }}", new HashMap<>(), decoder);
+		assertEquals("hello", decoder.toString());
+	}
+
+	// Hash function tests with expected lengths
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|', value = { "sha1sum   | 40", "sha256sum | 64", "sha512sum | 128" })
+	void testHashFunctionLength(String func, int expectedLength) throws IOException, TemplateException {
+		String result = exec("{{ " + func + " \"hello\" }}");
+		assertFalse(result.isEmpty());
+		assertEquals(expectedLength, result.length());
+	}
+
+	@Test
+	void testAdler32Sum() throws IOException, TemplateException {
+		String result = exec("{{ adler32sum \"hello\" }}");
+		assertFalse(result.isEmpty());
+		assertTrue(result.matches("\\d+"));
+	}
+
+	// Null handling tests
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|',
+			value = { "{{ b64enc .value }}    | ", "{{ b64dec .value }}    | ", "{{ b32enc .value }}    | ",
+					"{{ b32dec .value }}    | ", "{{ sha1sum .value }}   | ", "{{ sha256sum .value }} | ",
+					"{{ sha512sum .value }} | " })
+	void testFunctionWithNull(String template, String expected) throws IOException, TemplateException {
+		HashMap<String, Object> data = new HashMap<>();
+		data.put("value", null);
+		assertEquals((expected != null) ? expected : "", execWithData(template, data));
+	}
+
+	@Test
+	void testAdler32SumWithNull() throws IOException, TemplateException {
+		HashMap<String, Object> data = new HashMap<>();
+		data.put("value", null);
+		assertEquals("0", execWithData("{{ adler32sum .value }}", data));
+	}
+
+	// Invalid input tests
+
+	@Test
+	void testBase64DecodeInvalidInput() throws IOException, TemplateException {
+		assertEquals("", exec("{{ b64dec \"not-valid-base64!!!\" }}"));
+	}
+
+	@Test
+	void testBase32DecodeInvalidInput() throws IOException, TemplateException {
+		assertEquals("", exec("{{ b32dec \"@@@invalid@@@\" }}"));
+	}
+
+	// Empty string tests
+
+	@Test
+	void testBase64EncodeEmpty() throws IOException, TemplateException {
+		assertEquals("", exec("{{ b64enc \"\" }}"));
+	}
+
+	@Test
+	void testBase32EncodeEmpty() throws IOException, TemplateException {
+		String result = exec("{{ b32enc \"\" }}");
+		assertTrue(result.isEmpty() || result.matches("[A-Z2-7=]+"));
+	}
+
+	// Consistency tests
+
+	@ParameterizedTest
+	@CsvSource({ "sha1sum", "sha256sum" })
+	void testHashConsistency(String func) throws IOException, TemplateException {
+		String result1 = exec("{{ " + func + " \"test\" }}");
+		String result2 = exec("{{ " + func + " \"test\" }}");
+		assertEquals(result1, result2);
+	}
+
+	// Various input length tests
+
+	@ParameterizedTest
+	@ValueSource(strings = { "a", "ab", "abc", "abcd", "abcde", "abcdef", "abcdefg", "x" })
+	void testBase32EncodeWithVariousLengths(String input) throws IOException, TemplateException {
+		assertFalse(exec("{{ b32enc \"" + input + "\" }}").isEmpty());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "", "a", "test", "Hello World!", "12345", "special!@#$%" })
+	void testSha1SumWithVariousInputs(String input) throws IOException, TemplateException {
+		String result = exec("{{ sha1sum \"" + input + "\" }}");
+		assertTrue(result.isEmpty() || result.matches("[0-9a-f]{40}"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "", "a", "test", "Hello World!", "12345", "unicode: \u00A9 \u00AE" })
+	void testSha256SumWithVariousInputs(String input) throws IOException, TemplateException {
+		String result = exec("{{ sha256sum \"" + input + "\" }}");
+		assertTrue(result.isEmpty() || result.matches("[0-9a-f]{64}"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "", "a", "test", "long input string with many characters", "123" })
+	void testSha512SumWithVariousInputs(String input) throws IOException, TemplateException {
+		String result = exec("{{ sha512sum \"" + input + "\" }}");
+		assertTrue(result.isEmpty() || result.matches("[0-9a-f]{128}"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "x", "xy", "xyz", "test" })
+	void testBase32RoundTripWithVariousInputs(String input) throws IOException, TemplateException {
+		String encoded = exec("{{ b32enc \"" + input + "\" }}");
+		StringWriter decoder = new StringWriter();
+		execute("test", "{{ b32dec \"" + encoded + "\" }}", new HashMap<>(), decoder);
+		assertEquals(input, decoder.toString());
+	}
+
+	@Test
+	void testHashFunctionsWithEmptyString() throws IOException, TemplateException {
+		assertTrue(exec("{{ sha1sum \"\" }}").matches("[0-9a-f]{40}"));
+		assertTrue(exec("{{ sha256sum \"\" }}").matches("[0-9a-f]{64}"));
+		assertTrue(exec("{{ sha512sum \"\" }}").matches("[0-9a-f]{128}"));
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/LogicFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/LogicFunctionsTest.java
@@ -1,0 +1,200 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+import org.alexmond.jhelm.gotemplate.TemplateException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class LogicFunctionsTest {
+
+	private void execute(String name, String text, Object data, StringWriter writer)
+			throws IOException, TemplateException {
+		GoTemplate template = new GoTemplate();
+		template.parse(name, text);
+		template.execute(name, data, writer);
+	}
+
+	private String exec(String template, Map<String, Object> data) throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", template, data, writer);
+		return writer.toString();
+	}
+
+	// Test 'empty' function
+
+	@ParameterizedTest
+	@MethodSource("emptyTestCases")
+	void testEmpty(Object value, String expected) throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", value);
+		assertEquals(expected, exec("{{ empty .value }}", data));
+	}
+
+	static Stream<Arguments> emptyTestCases() {
+		Map<String, Object> nonEmptyMap = new HashMap<>();
+		nonEmptyMap.put("key", "value");
+		return Stream.of(Arguments.of(null, "true"), Arguments.of("", "true"), Arguments.of("text", "false"),
+				Arguments.of(0, "true"), Arguments.of(5, "false"), Arguments.of(false, "true"),
+				Arguments.of(true, "false"), Arguments.of(Collections.emptyList(), "true"),
+				Arguments.of(Arrays.asList("a", "b"), "false"), Arguments.of(Collections.emptyMap(), "true"),
+				Arguments.of(nonEmptyMap, "false"));
+	}
+
+	// Test 'default' function
+
+	@ParameterizedTest
+	@MethodSource("defaultStringTestCases")
+	void testDefaultWithStrings(Object value, String expected) throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", value);
+		assertEquals(expected, exec("{{ default \"fallback\" .value }}", data));
+	}
+
+	static Stream<Arguments> defaultStringTestCases() {
+		return Stream.of(Arguments.of("actual", "actual"), Arguments.of("", "fallback"),
+				Arguments.of(null, "fallback"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("defaultNumberTestCases")
+	void testDefaultWithNumbers(Object value, String expected) throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", value);
+		assertEquals(expected, exec("{{ default 42 .value }}", data));
+	}
+
+	static Stream<Arguments> defaultNumberTestCases() {
+		return Stream.of(Arguments.of(0, "42"), Arguments.of(10, "10"));
+	}
+
+	@Test
+	void testDefaultWithFalse() throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", false);
+		assertEquals("true", exec("{{ default true .value }}", data));
+	}
+
+	@Test
+	void testDefaultWithEmptyList() throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", Collections.emptyList());
+		assertEquals("2", exec(
+				"{{ $default := list \"a\" \"b\" }}{{ $result := default $default .value }}{{ len $result }}", data));
+	}
+
+	@Test
+	void testDefaultWithNonEmptyList() throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", Arrays.asList("x", "y"));
+		assertEquals("2", exec(
+				"{{ $default := list \"a\" \"b\" }}{{ $result := default $default .value }}{{ len $result }}", data));
+	}
+
+	@Test
+	void testDefaultWithEmptyMap() throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", Collections.emptyMap());
+		assertEquals("1",
+				exec("{{ $default := dict \"key\" \"val\" }}{{ $result := default $default .value }}{{ len $result }}",
+						data));
+	}
+
+	// Test 'coalesce' function
+
+	@Test
+	void testCoalesceReturnsFirstTruthyValue() throws IOException, TemplateException {
+		assertEquals("first", exec("{{ coalesce \"\" 0 \"first\" \"second\" }}", new HashMap<>()));
+	}
+
+	@Test
+	void testCoalesceWithAllFalsy() throws IOException, TemplateException {
+		assertEquals("", exec("{{ coalesce \"\" 0 false }}", new HashMap<>()));
+	}
+
+	@ParameterizedTest
+	@MethodSource("coalesceTestCases")
+	void testCoalesceWithData(Object a, Object b, String template, String expected)
+			throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("a", a);
+		data.put("b", b);
+		assertEquals(expected, exec(template, data));
+	}
+
+	static Stream<Arguments> coalesceTestCases() {
+		return Stream.of(Arguments.of(null, "value", "{{ coalesce .a .b }}", "value"),
+				Arguments.of(0, 42, "{{ coalesce .a .b }}", "42"));
+	}
+
+	@Test
+	void testCoalesceWithCollections() throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("empty", Collections.emptyList());
+		data.put("full", Arrays.asList("a", "b"));
+		assertEquals("2", exec("{{ $result := coalesce .empty .full }}{{ len $result }}", data));
+	}
+
+	// Test 'ternary' function
+
+	@ParameterizedTest
+	@MethodSource("ternaryTestCases")
+	void testTernary(Object condition, String expected) throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("condition", condition);
+		assertEquals(expected, exec("{{ ternary \"yes\" \"no\" .condition }}", data));
+	}
+
+	static Stream<Arguments> ternaryTestCases() {
+		return Stream.of(Arguments.of(true, "yes"), Arguments.of(false, "no"), Arguments.of("text", "yes"),
+				Arguments.of("", "no"), Arguments.of(1, "yes"), Arguments.of(0, "no"), Arguments.of(null, "no"),
+				Arguments.of(Arrays.asList("a", "b"), "yes"), Arguments.of(Collections.emptyList(), "no"));
+	}
+
+	// Test 'fail' function
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|',
+			value = { "{{ fail .error }}                    | Custom error message",
+					"{{ fail }}                            | ",
+					"{{ fail \"Something went wrong\" }}   | Something went wrong" })
+	void testFailThrowsException(String template, String errorValue) {
+		Map<String, Object> data = new HashMap<>();
+		data.put("error", "Custom error message");
+		assertThrows(TemplateException.class, () -> exec(template, data));
+	}
+
+	// Test with non-standard types
+
+	@Test
+	void testEmptyWithCustomObject() throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", new Object());
+		assertEquals("false", exec("{{ empty .value }}", data));
+	}
+
+	@Test
+	void testDefaultWithCustomObject() throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", new Object());
+		String result = exec("{{ default \"fallback\" .value }}", data);
+		assertFalse(result.isEmpty());
+		assertNotEquals("fallback", result);
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctionsTest.java
@@ -1,0 +1,58 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+import org.alexmond.jhelm.gotemplate.TemplateException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class MathFunctionsTest {
+
+	private void execute(String name, String text, Object data, StringWriter writer)
+			throws IOException, TemplateException {
+		GoTemplate template = new GoTemplate();
+		template.parse(name, text);
+		template.execute(name, data, writer);
+	}
+
+	private String exec(String template) throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", template, new HashMap<>(), writer);
+		return writer.toString();
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|',
+			value = { "{{ add 2 3 }}       | 5", "{{ add1 5 }}        | 6", "{{ sub 5 3 }}       | 2",
+					"{{ mul 3 4 }}       | 12", "{{ div 10 2 }}      | 5", "{{ div 1 2 }}       | 0",
+					"{{ div 7 3 }}       | 2", "{{ mod 10 3 }}      | 1", "{{ max 2 5 3 }}     | 5",
+					"{{ min 2 5 3 }}     | 2", "{{ len \"hello\" }} | 5", "{{ int \"42\" }}    | 42",
+					"{{ int64 \"123\" }} | 123", "{{ toString 42 }}   | 42", "{{ min 5 }}         | 5",
+					"{{ max 5 }}         | 5", "{{ add }}           | 0" })
+	void testExactMathFunction(String template, String expected) throws IOException, TemplateException {
+		assertEquals(expected, exec(template));
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|',
+			value = { "{{ ceil 3.2 }}      | 4", "{{ floor 3.8 }}     | 3", "{{ round 3.5 0 }}   | 4",
+					"{{ addf 2.5 3.5 }}  | 6", "{{ mulf 2.5 4.0 }}  | 10", "{{ divf 10.0 2.0 }} | 5",
+					"{{ float64 \"3.14\" }} | 3.14" })
+	void testApproxMathFunction(String template, String expectedContains) throws IOException, TemplateException {
+		assertTrue(exec(template).contains(expectedContains));
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|', value = { "{{ $s := seq 1 3 }}{{ len $s }}              | 3",
+			"{{ $u := until 3 }}{{ len $u }}              | 3", "{{ $u := untilStep 0 10 2 }}{{ len $u }}     | 5" })
+	void testSequenceFunction(String template, String expected) throws IOException, TemplateException {
+		assertEquals(expected, exec(template));
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/NetworkFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/NetworkFunctionsTest.java
@@ -1,0 +1,37 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+import org.alexmond.jhelm.gotemplate.TemplateException;
+import org.junit.jupiter.api.Test;
+
+class NetworkFunctionsTest {
+
+	private String exec(String template) throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		GoTemplate t = new GoTemplate();
+		t.parse("test", template);
+		t.execute("test", new HashMap<>(), writer);
+		return writer.toString();
+	}
+
+	@Test
+	void testGetHostByNameLocalhost() throws IOException, TemplateException {
+		String result = exec("{{ getHostByName \"localhost\" }}");
+		assertNotNull(result);
+		assertFalse(result.isEmpty());
+	}
+
+	@Test
+	void testGetHostByNameInvalid() throws IOException, TemplateException {
+		String result = exec("{{ getHostByName \"this.host.does.not.exist.invalid\" }}");
+		assertNotNull(result);
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/ReflectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/ReflectionFunctionsTest.java
@@ -1,0 +1,205 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+import org.alexmond.jhelm.gotemplate.TemplateException;
+import org.junit.jupiter.api.Test;
+
+class ReflectionFunctionsTest {
+
+	private void execute(String name, String text, Object data, StringWriter writer)
+			throws IOException, TemplateException {
+		GoTemplate template = new GoTemplate();
+		template.parse(name, text);
+		template.execute(name, data, writer);
+	}
+
+	@Test
+	void testTypeOfString() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", "hello");
+		execute("test", "{{ typeOf .value }}", data, writer);
+		assertTrue(writer.toString().contains("String") || writer.toString().contains("string"));
+	}
+
+	@Test
+	void testTypeOfNumber() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", 42);
+		execute("test", "{{ typeOf .value }}", data, writer);
+		assertTrue(writer.toString().contains("Integer") || writer.toString().contains("int"));
+	}
+
+	@Test
+	void testTypeOfList() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", Arrays.asList(1, 2, 3));
+		execute("test", "{{ typeOf .value }}", data, writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testTypeOfMap() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> nested = new HashMap<>();
+		nested.put("key", "value");
+		data.put("value", nested);
+		execute("test", "{{ typeOf .value }}", data, writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testKindOfString() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", "test");
+		execute("test", "{{ kindOf .value }}", data, writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testKindOfNumber() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", 123);
+		execute("test", "{{ kindOf .value }}", data, writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testKindOfList() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", Arrays.asList("a", "b"));
+		execute("test", "{{ kindOf .value }}", data, writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testTypeIsString() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", "hello");
+		execute("test", "{{ typeIs \"string\" .value }}", data, writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testTypeIsStringFalse() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", 123);
+		execute("test", "{{ typeIs \"string\" .value }}", data, writer);
+		assertEquals("false", writer.toString());
+	}
+
+	@Test
+	void testTypeIsInt() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", 42);
+		execute("test", "{{ typeIs \"int\" .value }}", data, writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testTypeIsLikeString() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", "test");
+		execute("test", "{{ typeIsLike \"*String\" .value }}", data, writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testKindIsString() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", "hello");
+		execute("test", "{{ kindIs \"string\" .value }}", data, writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testKindIsInt() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", 42);
+		execute("test", "{{ kindIs \"int\" .value }}", data, writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testKindIsMap() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", new HashMap<>());
+		execute("test", "{{ kindIs \"map\" .value }}", data, writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+	@Test
+	void testDeepEqualSame() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("a", Arrays.asList(1, 2, 3));
+		data.put("b", Arrays.asList(1, 2, 3));
+		execute("test", "{{ deepEqual .a .b }}", data, writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testDeepEqualDifferent() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("a", Arrays.asList(1, 2, 3));
+		data.put("b", Arrays.asList(1, 2, 4));
+		execute("test", "{{ deepEqual .a .b }}", data, writer);
+		assertEquals("false", writer.toString());
+	}
+
+	@Test
+	void testDeepEqualMaps() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> map1 = Map.of("key", "value");
+		Map<String, Object> map2 = Map.of("key", "value");
+		data.put("a", map1);
+		data.put("b", map2);
+		execute("test", "{{ deepEqual .a .b }}", data, writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testDeepEqualStrings() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("a", "hello");
+		data.put("b", "hello");
+		execute("test", "{{ deepEqual .a .b }}", data, writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testTypeOfNull() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", null);
+		execute("test", "{{ typeOf .value }}", data, writer);
+		assertFalse(writer.toString().isEmpty());
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/SemverFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/SemverFunctionsTest.java
@@ -1,0 +1,223 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+import org.alexmond.jhelm.gotemplate.TemplateException;
+import org.junit.jupiter.api.Test;
+
+class SemverFunctionsTest {
+
+	private void execute(String name, String text, Object data, StringWriter writer)
+			throws IOException, TemplateException {
+		GoTemplate template = new GoTemplate();
+		template.parse(name, text);
+		template.execute(name, data, writer);
+	}
+
+	@Test
+	void testSemverParsing() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $v := semver \"1.2.3\" }}{{ $v.Major }}.{{ $v.Minor }}.{{ $v.Patch }}", new HashMap<>(),
+				writer);
+		assertEquals("1.2.3", writer.toString());
+	}
+
+	@Test
+	void testSemverWithVPrefix() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $v := semver \"v2.5.7\" }}{{ $v.Major }}.{{ $v.Minor }}.{{ $v.Patch }}", new HashMap<>(),
+				writer);
+		assertEquals("2.5.7", writer.toString());
+	}
+
+	@Test
+	void testSemverWithPrerelease() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $v := semver \"1.2.3-alpha.1\" }}{{ $v.Major }}", new HashMap<>(), writer);
+		assertEquals("1", writer.toString());
+	}
+
+	@Test
+	void testSemverPatch() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $v := semver \"1.2.5\" }}{{ $v.Patch }}", new HashMap<>(), writer);
+		assertEquals("5", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareEqual() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"=1.2.3\" \"1.2.3\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareGreaterThan() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \">1.0.0\" \"1.2.3\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareLessThan() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"<2.0.0\" \"1.2.3\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareRange() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \">=1.0.0 <2.0.0\" \"1.2.3\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareVersion() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \">=1.0.0\" \"1.2.3\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	// Additional basic tests
+	@Test
+	void testSemverInvalidFormat() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $v := semver \"invalid\" }}{{ $v.Major }}", new HashMap<>(), writer);
+		assertEquals("0", writer.toString());
+	}
+
+	@Test
+	void testSemverMinorOnly() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $v := semver \"1.2\" }}{{ $v.Major }}.{{ $v.Minor }}.{{ $v.Patch }}", new HashMap<>(),
+				writer);
+		assertEquals("1.2.0", writer.toString());
+	}
+
+	@Test
+	void testSemverMajorOnly() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ $v := semver \"5\" }}{{ $v.Major }}.{{ $v.Minor }}.{{ $v.Patch }}", new HashMap<>(),
+				writer);
+		assertEquals("5.0.0", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareNotEqual() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"!=1.2.3\" \"1.2.4\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareLessOrEqual() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"<=2.0.0\" \"1.2.3\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareGreaterOrEqual() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \">=1.0.0\" \"1.2.3\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareTildeOperator() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"~1.2.3\" \"1.2.5\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareCaretOperator() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"^1.2.3\" \"1.5.0\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareCaretZeroMajor() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"^0.2.3\" \"0.2.5\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareCaretZeroMinor() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"^0.0.3\" \"0.0.3\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareOrOperator() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"=1.0.0 || =2.0.0\" \"2.0.0\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareNoOperator() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"1.2.3\" \"1.2.3\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareWithPrerelease() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"<1.2.3\" \"1.2.3-alpha\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverComparePrereleaseLexical() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"<1.2.3-beta\" \"1.2.3-alpha\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareExactVersion() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"=1.2.3\" \"1.2.3\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareLessOrEqualMatch() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"<=1.2.3\" \"1.2.3\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareGreaterOrEqualMatch() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \">=1.2.3\" \"1.2.3\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareMultipleConstraintsPass() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \">1.0.0 <3.0.0\" \"1.5.0\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareRangeBoundary() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \">1.0.0 <=2.0.0\" \"2.0.0\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctionsTest.java
@@ -1,0 +1,196 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+
+import org.alexmond.jhelm.gotemplate.GoTemplate;
+import org.alexmond.jhelm.gotemplate.TemplateException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class StringFunctionsTest {
+
+	private void execute(String name, String text, Object data, StringWriter writer)
+			throws IOException, TemplateException {
+		GoTemplate template = new GoTemplate();
+		template.parse(name, text);
+		template.execute(name, data, writer);
+	}
+
+	private String exec(String template) throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", template, new HashMap<>(), writer);
+		return writer.toString();
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|',
+			value = { "{{ upper \"hello\" }}                          | HELLO",
+					"{{ lower \"HELLO\" }}                          | hello",
+					"{{ title \"hello world\" }}                    | Hello World",
+					"{{ repeat 3 \"ab\" }}                          | ababab",
+					"{{ substr 0 5 \"Hello World\" }}               | Hello",
+					"{{ trim \"  hello  \" }}                       | hello",
+					"{{ trimAll \"$\" \"$5.00\" }}                  | 5.00",
+					"{{ trimPrefix \"hello \" \"hello world\" }}    | world",
+					"{{ trimSuffix \" world\" \"hello world\" }}    | hello",
+					"{{ contains \"ell\" \"hello\" }}               | true",
+					"{{ hasPrefix \"hel\" \"hello\" }}              | true",
+					"{{ hasSuffix \"lo\" \"hello\" }}               | true",
+					"{{ cat \"hello\" \"world\" }}                  | hello world",
+					"{{ replace \" \" \"_\" \"hello world\" }}      | hello_world",
+					"{{ snakecase \"HelloWorld\" }}                  | hello_world",
+					"{{ kebabcase \"HelloWorld\" }}                  | hello-world",
+					"{{ initials \"John Doe\" }}                    | JD",
+					"{{ plural \"item\" \"items\" 1 }}              | item",
+					"{{ plural \"item\" \"items\" 2 }}              | items" })
+	void testStringFunction(String template, String expected) throws IOException, TemplateException {
+		assertEquals(expected, exec(template));
+	}
+
+	@Test
+	void testIndent() throws IOException, TemplateException {
+		assertEquals("  hello", exec("{{ indent 2 \"hello\" }}"));
+	}
+
+	@Test
+	void testUntitle() throws IOException, TemplateException {
+		assertTrue(exec("{{ untitle \"Hello World\" }}").startsWith("hello"));
+	}
+
+	@Test
+	void testNindent() throws IOException, TemplateException {
+		assertEquals("\n  hello", exec("{{ nindent 2 \"hello\" }}"));
+	}
+
+	@Test
+	void testQuote() throws IOException, TemplateException {
+		assertEquals("\"hello\"", exec("{{ quote \"hello\" }}"));
+	}
+
+	@Test
+	void testSquote() throws IOException, TemplateException {
+		assertEquals("'hello'", exec("{{ squote \"hello\" }}"));
+	}
+
+	@Test
+	void testCamelcase() throws IOException, TemplateException {
+		String result = exec("{{ camelcase \"hello_world\" }}");
+		assertTrue(result.contains("Hello") || result.contains("hello"));
+	}
+
+	@Test
+	void testShuffle() throws IOException, TemplateException {
+		assertEquals(3, exec("{{ shuffle \"abc\" }}").length());
+	}
+
+	@Test
+	void testWrap() throws IOException, TemplateException {
+		assertFalse(exec("{{ wrap 5 \"hello world\" }}").isEmpty());
+	}
+
+	@Test
+	void testWrapWith() throws IOException, TemplateException {
+		assertFalse(exec("{{ wrapWith 5 \"\\n\" \"hello world\" }}").isEmpty());
+	}
+
+	@Test
+	void testAbbrev() throws IOException, TemplateException {
+		assertTrue(exec("{{ abbrev 5 \"hello world\" }}").length() <= 8);
+	}
+
+	@Test
+	void testAbbrevboth() throws IOException, TemplateException {
+		assertTrue(exec("{{ abbrevboth 5 8 \"hello world\" }}").length() <= 11);
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|',
+			value = { "{{ regexMatch \"^[a-z]+$\" \"hello\" }}       | true",
+					"{{ mustRegexMatch \"^[a-z]+$\" \"hello\" }}   | true",
+					"{{ regexFind \"[0-9]+\" \"abc123def\" }}       | 123",
+					"{{ mustRegexFind \"[0-9]+\" \"abc123def\" }}   | 123",
+					"{{ regexReplaceAll \"[0-9]+\" \"abc123def456\" \"X\" }} | abcXdefX",
+					"{{ mustRegexReplaceAll \"[0-9]+\" \"abc123def\" \"X\" }} | abcXdef" })
+	void testRegexFunction(String template, String expected) throws IOException, TemplateException {
+		assertEquals(expected, exec(template));
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|',
+			value = { "{{ $matches := regexFindAll \"[0-9]+\" \"abc123def456\" -1 }}{{ len $matches }} | 2",
+					"{{ $parts := regexSplit \"[,;]\" \"a,b;c\" -1 }}{{ len $parts }}                | 3",
+					"{{ $parts := mustRegexSplit \"[,;]\" \"a,b;c\" -1 }}{{ len $parts }}            | 3" })
+	void testRegexCollectionFunction(String template, String expected) throws IOException, TemplateException {
+		assertEquals(expected, exec(template));
+	}
+
+	@Test
+	void testRegexReplaceAllLiteral() throws IOException, TemplateException {
+		assertFalse(exec("{{ regexReplaceAllLiteral \"[0-9]+\" \"abc123def456\" \"X\" }}").isEmpty());
+	}
+
+	// --- quote/squote null handling ---
+
+	@Test
+	void testQuoteNull() throws IOException, TemplateException {
+		// quote(null) should return empty double-quoted string, matching Go Sprig
+		HashMap<String, Object> data = new HashMap<>();
+		data.put("val", null);
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ quote .val }}", data, writer);
+		assertEquals("\"\"", writer.toString());
+	}
+
+	@Test
+	void testSquoteNull() throws IOException, TemplateException {
+		// squote(null) should return empty single-quoted string, matching Go Sprig
+		HashMap<String, Object> data = new HashMap<>();
+		data.put("val", null);
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ squote .val }}", data, writer);
+		assertEquals("''", writer.toString());
+	}
+
+	@Test
+	void testNullGuardPatternWithQuote() throws IOException, TemplateException {
+		// Cert-manager null-guard pattern: quote(nil) produces "", which is in the
+		// list, so the block should be skipped
+		HashMap<String, Object> data = new HashMap<>();
+		data.put("val", null);
+		StringWriter writer = new StringWriter();
+		String template = """
+				{{- if not (has (quote .val) (list "" (quote ""))) -}}visible{{- end -}}""";
+		execute("test", template, data, writer);
+		assertEquals("", writer.toString());
+	}
+
+	@Test
+	void testNullGuardPatternWithNonNullValue() throws IOException, TemplateException {
+		// When value is non-null, the guard should allow rendering
+		HashMap<String, Object> data = new HashMap<>();
+		data.put("val", 10);
+		StringWriter writer = new StringWriter();
+		String template = """
+				{{- if not (has (quote .val) (list "" (quote ""))) -}}visible{{- end -}}""";
+		execute("test", template, data, writer);
+		assertEquals("visible", writer.toString());
+	}
+
+	@Test
+	void testIfBlockSkippedForNullValue() throws IOException, TemplateException {
+		// {{if .nullVal}} should evaluate to false and skip the block
+		HashMap<String, Object> data = new HashMap<>();
+		data.put("nullVal", null);
+		StringWriter writer = new StringWriter();
+		execute("test", "{{- if .nullVal }}visible{{- end -}}", data, writer);
+		assertEquals("", writer.toString());
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     </scm>
     <modules>
         <module>jhelm-gotemplate</module>
+        <module>jhelm-gotemplate-sprig</module>
         <module>jhelm-core</module>
         <module>jhelm-kube</module>
         <module>jhelm-plugin</module>
@@ -83,6 +84,11 @@
             <dependency>
                 <groupId>org.alexmond</groupId>
                 <artifactId>jhelm-gotemplate</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.alexmond</groupId>
+                <artifactId>jhelm-gotemplate-sprig</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
- Create new `jhelm-gotemplate-sprig` module containing all 10 Sprig function categories
- Add `SprigFunctionProvider` implementing `FunctionProvider` SPI with priority 100
- Register provider via `META-INF/services` for ServiceLoader auto-discovery
- Original classes in `jhelm-gotemplate` remain untouched (copy-first strategy — removed in #105)
- Package stays `org.alexmond.jhelm.gotemplate.sprig` (no downstream import changes needed)
- JaCoCo check skipped during transition (split-package causes instrumentation issues)

## Test plan
- [x] 351 Sprig tests pass in new module
- [x] `SprigFunctionProvider` priority=100 and name="Sprig"
- [x] ServiceLoader discovers `SprigFunctionProvider`
- [x] Builder with explicit `SprigFunctionProvider` loads all Sprig functions
- [x] Full build passes across all 8 modules
- [x] Checkstyle and PMD clean

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)