### PR TITLE
Wire up new gotemplate modules in jhelm-core (#106)

### DIFF
--- a/jhelm-core/pom.xml
+++ b/jhelm-core/pom.xml
@@ -44,6 +44,14 @@
             <artifactId>jhelm-gotemplate</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.alexmond</groupId>
+            <artifactId>jhelm-gotemplate-sprig</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.alexmond</groupId>
+            <artifactId>jhelm-gotemplate-helm</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>1.26.1</version>


### PR DESCRIPTION
## Summary
- Add `jhelm-gotemplate-sprig` and `jhelm-gotemplate-helm` dependencies to `jhelm-core/pom.xml`
- No code changes — only pom.xml modification
- New modules are now on the classpath for ServiceLoader discovery in jhelm-core

## Test plan
- [x] Full build passes across all 9 modules
- [x] `KpsComparisonTest` passes
- [x] No code changes — only dependency additions

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)