### PR TITLE
Add SPI tests and enable JaCoCo for split modules (#107)

### DIFF
--- a/jhelm-gotemplate-helm/pom.xml
+++ b/jhelm-gotemplate-helm/pom.xml
@@ -44,19 +44,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <configuration>
-                    <!-- Skip coverage check during module split transition.
-                         Both jhelm-gotemplate and jhelm-gotemplate-helm share the same
-                         package; coverage will be enforced once old code is removed (#105). -->
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -2,13 +2,18 @@ package org.alexmond.jhelm.gotemplate.helm.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.alexmond.jhelm.gotemplate.Function;
 import org.alexmond.jhelm.gotemplate.GoTemplate;
 import org.alexmond.jhelm.gotemplate.TemplateException;
 import org.junit.jupiter.api.Test;
@@ -135,6 +140,163 @@ class ConversionFunctionsTest {
 		assertTrue(result.contains("replicas: 3"), "non-null integer field should be present");
 		assertFalse(result.contains("revisionHistoryLimit"), "null field should be omitted");
 		assertFalse(result.contains("dnsPolicy"), "null field should be omitted");
+	}
+
+	// --- Direct function invocation tests for edge cases ---
+
+	private Map<String, Function> functions() {
+		return ConversionFunctions.getFunctions();
+	}
+
+	@Test
+	void testToYamlNullAndEmpty() {
+		Function toYaml = functions().get("toYaml");
+		assertEquals("", toYaml.invoke(new Object[] {}));
+		assertEquals("", toYaml.invoke(new Object[] { null }));
+	}
+
+	@Test
+	void testToJsonNullReturnsNullString() {
+		Function toJson = functions().get("toJson");
+		assertEquals("null", toJson.invoke(new Object[] {}));
+		assertEquals("null", toJson.invoke(new Object[] { null }));
+	}
+
+	@Test
+	void testToRawJsonNullReturnsNullString() {
+		Function toRawJson = functions().get("toRawJson");
+		assertEquals("null", toRawJson.invoke(new Object[] {}));
+		assertEquals("null", toRawJson.invoke(new Object[] { null }));
+	}
+
+	@Test
+	void testToPrettyJsonNullReturnsNullString() {
+		Function fn = functions().get("toPrettyJson");
+		assertEquals("null", fn.invoke(new Object[] {}));
+		assertEquals("null", fn.invoke(new Object[] { null }));
+	}
+
+	@Test
+	void testFromYamlNullAndEmpty() {
+		Function fromYaml = functions().get("fromYaml");
+		assertEquals(Map.of(), fromYaml.invoke(new Object[] {}));
+		assertEquals(Map.of(), fromYaml.invoke(new Object[] { null }));
+		assertEquals(Map.of(), fromYaml.invoke(new Object[] { "  " }));
+	}
+
+	@Test
+	void testFromJsonNullAndEmpty() {
+		Function fromJson = functions().get("fromJson");
+		assertEquals(Map.of(), fromJson.invoke(new Object[] {}));
+		assertEquals(Map.of(), fromJson.invoke(new Object[] { null }));
+		assertEquals(Map.of(), fromJson.invoke(new Object[] { "  " }));
+		assertEquals(Map.of(), fromJson.invoke(new Object[] { "null" }));
+	}
+
+	@Test
+	void testFromYamlArrayNullAndEmpty() {
+		Function fn = functions().get("fromYamlArray");
+		assertEquals(Collections.emptyList(), fn.invoke(new Object[] {}));
+		assertEquals(Collections.emptyList(), fn.invoke(new Object[] { null }));
+		assertEquals(Collections.emptyList(), fn.invoke(new Object[] { "  " }));
+	}
+
+	@Test
+	void testFromJsonArrayNullAndEmpty() {
+		Function fn = functions().get("fromJsonArray");
+		assertEquals(Collections.emptyList(), fn.invoke(new Object[] {}));
+		assertEquals(Collections.emptyList(), fn.invoke(new Object[] { null }));
+		assertEquals(Collections.emptyList(), fn.invoke(new Object[] { "  " }));
+		assertEquals(Collections.emptyList(), fn.invoke(new Object[] { "null" }));
+	}
+
+	// must* variants throw on null/empty
+
+	@Test
+	void testMustToYamlThrowsOnNull() {
+		Function fn = functions().get("mustToYaml");
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] {}));
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { null }));
+	}
+
+	@Test
+	void testMustToJsonThrowsOnNull() {
+		Function fn = functions().get("mustToJson");
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] {}));
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { null }));
+	}
+
+	@Test
+	void testMustToPrettyJsonThrowsOnNull() {
+		Function fn = functions().get("mustToPrettyJson");
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] {}));
+	}
+
+	@Test
+	void testMustToRawJsonThrowsOnNull() {
+		Function fn = functions().get("mustToRawJson");
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] {}));
+	}
+
+	@Test
+	void testMustFromYamlThrowsOnNull() {
+		Function fn = functions().get("mustFromYaml");
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] {}));
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { null }));
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { "  " }));
+	}
+
+	@Test
+	void testMustFromJsonThrowsOnNull() {
+		Function fn = functions().get("mustFromJson");
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] {}));
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { null }));
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { "  " }));
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { "null" }));
+	}
+
+	@Test
+	void testMustFromYamlArrayThrowsOnNull() {
+		Function fn = functions().get("mustFromYamlArray");
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] {}));
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { null }));
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { "  " }));
+	}
+
+	@Test
+	void testMustFromJsonArrayThrowsOnNull() {
+		Function fn = functions().get("mustFromJsonArray");
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] {}));
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { null }));
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { "  " }));
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { "null" }));
+	}
+
+	@Test
+	void testGetFunctionsReturnsAllExpected() {
+		Map<String, Function> fns = functions();
+		List<String> expected = List.of("toYaml", "mustToYaml", "fromYaml", "mustFromYaml", "fromYamlArray",
+				"mustFromYamlArray", "toJson", "mustToJson", "toPrettyJson", "mustToPrettyJson", "toRawJson",
+				"mustToRawJson", "fromJson", "mustFromJson", "fromJsonArray", "mustFromJsonArray");
+		for (String name : expected) {
+			assertTrue(fns.containsKey(name), "missing function: " + name);
+		}
+		assertEquals(expected.size(), fns.size());
+	}
+
+	@Test
+	void testFromJsonReturnsMap() {
+		Function fn = functions().get("fromJson");
+		Object result = fn.invoke(new Object[] { "{\"a\":1}" });
+		assertInstanceOf(Map.class, result);
+	}
+
+	@Test
+	void testFromJsonArrayReturnsList() {
+		Function fn = functions().get("fromJsonArray");
+		Object result = fn.invoke(new Object[] { "[1,2,3]" });
+		assertInstanceOf(List.class, result);
+		assertEquals(3, ((List<?>) result).size());
 	}
 
 }

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/KubernetesFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/KubernetesFunctionsTest.java
@@ -1,0 +1,146 @@
+package org.alexmond.jhelm.gotemplate.helm.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.alexmond.jhelm.gotemplate.Function;
+import org.junit.jupiter.api.Test;
+
+class KubernetesFunctionsTest {
+
+	@Test
+	void testGetFunctionsContainsExpected() {
+		Map<String, Function> fns = KubernetesFunctions.getFunctions();
+		assertTrue(fns.containsKey("lookup"));
+		assertTrue(fns.containsKey("kubeVersion"));
+		assertEquals(2, fns.size());
+	}
+
+	@Test
+	void testLookupWithoutProviderReturnsEmptyMap() {
+		Function lookup = KubernetesFunctions.getFunctions().get("lookup");
+		Object result = lookup.invoke(new Object[] { "v1", "Pod", "default", "mypod" });
+		assertInstanceOf(Map.class, result);
+		assertTrue(((Map<?, ?>) result).isEmpty());
+	}
+
+	@Test
+	void testKubeVersionWithoutProviderReturnsStub() {
+		Function kubeVersion = KubernetesFunctions.getFunctions().get("kubeVersion");
+		Object result = kubeVersion.invoke(new Object[] {});
+		assertInstanceOf(Map.class, result);
+		@SuppressWarnings("unchecked")
+		Map<String, Object> version = (Map<String, Object>) result;
+		assertEquals("1", version.get("Major"));
+		assertEquals("28", version.get("Minor"));
+		assertEquals("v1.28.0", version.get("GitVersion"));
+	}
+
+	@Test
+	void testLookupWithProviderDelegates() {
+		KubernetesProvider provider = new KubernetesProvider() {
+			@Override
+			public boolean isAvailable() {
+				return true;
+			}
+
+			@Override
+			public Map<String, Object> lookup(String apiVersion, String kind, String namespace, String name) {
+				return Map.of("metadata", Map.of("name", name));
+			}
+
+			@Override
+			public Map<String, Object> getVersion() {
+				return Map.of("Major", "1", "Minor", "29");
+			}
+		};
+
+		Function lookup = KubernetesFunctions.getFunctions(provider).get("lookup");
+		@SuppressWarnings("unchecked")
+		Map<String, Object> result = (Map<String, Object>) lookup
+			.invoke(new Object[] { "v1", "Pod", "default", "mypod" });
+		@SuppressWarnings("unchecked")
+		Map<String, Object> metadata = (Map<String, Object>) result.get("metadata");
+		assertEquals("mypod", metadata.get("name"));
+	}
+
+	@Test
+	void testLookupWithProviderInsufficientArgs() {
+		KubernetesProvider provider = new KubernetesProvider() {
+			@Override
+			public boolean isAvailable() {
+				return true;
+			}
+
+			@Override
+			public Map<String, Object> lookup(String apiVersion, String kind, String namespace, String name) {
+				return Map.of();
+			}
+
+			@Override
+			public Map<String, Object> getVersion() {
+				return Map.of();
+			}
+		};
+
+		Function lookup = KubernetesFunctions.getFunctions(provider).get("lookup");
+		assertThrows(RuntimeException.class, () -> lookup.invoke(new Object[] { "v1", "Pod" }));
+	}
+
+	@Test
+	void testKubeVersionWithProviderDelegates() {
+		KubernetesProvider provider = new KubernetesProvider() {
+			@Override
+			public boolean isAvailable() {
+				return true;
+			}
+
+			@Override
+			public Map<String, Object> lookup(String apiVersion, String kind, String namespace, String name) {
+				return Map.of();
+			}
+
+			@Override
+			public Map<String, Object> getVersion() {
+				return Map.of("Major", "1", "Minor", "30", "GitVersion", "v1.30.0");
+			}
+		};
+
+		Function kubeVersion = KubernetesFunctions.getFunctions(provider).get("kubeVersion");
+		@SuppressWarnings("unchecked")
+		Map<String, Object> result = (Map<String, Object>) kubeVersion.invoke(new Object[] {});
+		assertEquals("1", result.get("Major"));
+		assertEquals("30", result.get("Minor"));
+		assertEquals("v1.30.0", result.get("GitVersion"));
+	}
+
+	@Test
+	void testLookupWithUnavailableProviderReturnsEmpty() {
+		KubernetesProvider provider = new KubernetesProvider() {
+			@Override
+			public boolean isAvailable() {
+				return false;
+			}
+
+			@Override
+			public Map<String, Object> lookup(String apiVersion, String kind, String namespace, String name) {
+				throw new RuntimeException("should not be called");
+			}
+
+			@Override
+			public Map<String, Object> getVersion() {
+				throw new RuntimeException("should not be called");
+			}
+		};
+
+		Function lookup = KubernetesFunctions.getFunctions(provider).get("lookup");
+		Object result = lookup.invoke(new Object[] { "v1", "Pod", "default", "test" });
+		assertInstanceOf(Map.class, result);
+		assertTrue(((Map<?, ?>) result).isEmpty());
+	}
+
+}

--- a/jhelm-gotemplate-sprig/pom.xml
+++ b/jhelm-gotemplate-sprig/pom.xml
@@ -61,21 +61,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <configuration>
-                    <!-- Skip coverage check during module split transition.
-                         Both jhelm-gotemplate and jhelm-gotemplate-sprig share the same
-                         package; JaCoCo only instruments the local copy but tests may
-                         resolve classes from the dependency. Coverage will be enforced
-                         once the old code is removed (#105). -->
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>


### PR DESCRIPTION
## Summary
- Enable JaCoCo coverage enforcement for `jhelm-gotemplate-sprig` and `jhelm-gotemplate-helm` (split-package issue resolved after #105)
- Add `KubernetesFunctionsTest` with 7 tests covering stub behavior, provider delegation, unavailable provider, and insufficient args
- Add 18 edge-case tests to `ConversionFunctionsTest` covering null/empty handling, must* throw behavior, and function inventory

## Context
Most SPI/builder tests were already added in PRs #111, #112, #113:
- `GoTemplateTest`: 6 builder tests (noAutoDiscovery, withProvider, withFunctions override, priority ordering, autoDiscovery, independent instances)
- `SprigFunctionProviderTest`: priority, name, function loading, ServiceLoader discovery, builder integration
- `HelmFunctionProviderTest`: priority, name, function loading, stub K8s, ServiceLoader discovery, builder integration

This PR fills the remaining coverage gaps and enables JaCoCo for the new modules.

## Test plan
- [x] `./mvnw clean install` — all tests pass across all modules
- [x] JaCoCo coverage checks pass for all modules including sprig and helm

🤖 Generated with [Claude Code](https://claude.com/claude-code)