### PR TITLE
Upgrade dependencies and migrate semver4j (#118)

### DIFF
--- a/jhelm-core/pom.xml
+++ b/jhelm-core/pom.xml
@@ -54,14 +54,13 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.26.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.vdurmont</groupId>
+            <groupId>org.semver4j</groupId>
             <artifactId>semver4j</artifactId>
         </dependency>
         <dependency>

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/DependencyResolver.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/DependencyResolver.java
@@ -1,7 +1,6 @@
 package org.alexmond.jhelm.core.service;
 
-import com.vdurmont.semver4j.Requirement;
-import com.vdurmont.semver4j.Semver;
+import org.semver4j.Semver;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.model.ChartLock.LockDependency;
 
@@ -132,14 +131,12 @@ public class DependencyResolver {
 	 */
 	private String findBestMatchingVersion(String constraint, List<RepoManager.ChartVersion> availableVersions) {
 		try {
-			Requirement requirement = Requirement.buildNPM(constraint);
-
 			// Find all matching versions
 			List<Semver> matchingVersions = new ArrayList<>();
 			for (RepoManager.ChartVersion cv : availableVersions) {
 				try {
-					Semver semver = new Semver(cv.getChartVersion(), Semver.SemverType.NPM);
-					if (requirement.isSatisfiedBy(semver)) {
+					Semver semver = new Semver(cv.getChartVersion());
+					if (semver.satisfies(constraint)) {
 						matchingVersions.add(semver);
 					}
 				}
@@ -151,7 +148,7 @@ public class DependencyResolver {
 			// Return the highest matching version
 			if (!matchingVersions.isEmpty()) {
 				matchingVersions.sort(Semver::compareTo);
-				return matchingVersions.get(matchingVersions.size() - 1).getValue();
+				return matchingVersions.get(matchingVersions.size() - 1).getVersion();
 			}
 		}
 		catch (Exception ex) {

--- a/jhelm-gotemplate-sprig/pom.xml
+++ b/jhelm-gotemplate-sprig/pom.xml
@@ -47,11 +47,10 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>${bouncycastle.version}</version>
         </dependency>
         <!-- Semver4j for semantic version parsing and comparison -->
         <dependency>
-            <groupId>com.vdurmont</groupId>
+            <groupId>org.semver4j</groupId>
             <artifactId>semver4j</artifactId>
         </dependency>
         <dependency>

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/SemverFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/SemverFunctions.java
@@ -2,9 +2,11 @@ package org.alexmond.jhelm.gotemplate.sprig.functions;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import com.vdurmont.semver4j.Semver;
-import com.vdurmont.semver4j.SemverException;
+import org.semver4j.Semver;
+
 import org.alexmond.jhelm.gotemplate.Function;
 
 /**
@@ -38,15 +40,15 @@ public final class SemverFunctions {
 			String versionStr = String.valueOf(args[0]);
 			Map<String, Object> result = new HashMap<>();
 			result.put("Original", versionStr);
-			try {
-				Semver v = new Semver(normalizeVersion(versionStr), Semver.SemverType.LOOSE);
-				result.put("Major", (v.getMajor() != null) ? v.getMajor().longValue() : 0L);
-				result.put("Minor", (v.getMinor() != null) ? v.getMinor().longValue() : 0L);
-				result.put("Patch", (v.getPatch() != null) ? v.getPatch().longValue() : 0L);
-				result.put("Prerelease", (v.getSuffixTokens().length > 0) ? String.join(".", v.getSuffixTokens()) : "");
-				result.put("Metadata", (v.getBuild() != null) ? String.join(".", v.getBuild()) : "");
+			Semver v = Semver.coerce(normalizeVersion(versionStr));
+			if (v != null) {
+				result.put("Major", (long) v.getMajor());
+				result.put("Minor", (long) v.getMinor());
+				result.put("Patch", (long) v.getPatch());
+				result.put("Prerelease", !v.getPreRelease().isEmpty() ? String.join(".", v.getPreRelease()) : "");
+				result.put("Metadata", !v.getBuild().isEmpty() ? String.join(".", v.getBuild()) : "");
 			}
-			catch (SemverException ex) {
+			else {
 				result.put("Major", 0L);
 				result.put("Minor", 0L);
 				result.put("Patch", 0L);
@@ -70,8 +72,17 @@ public final class SemverFunctions {
 			String constraint = String.valueOf(args[0]).trim();
 			String versionStr = String.valueOf(args[1]).trim();
 			try {
-				Semver v = new Semver(normalizeVersion(versionStr), Semver.SemverType.LOOSE);
-				return evaluateConstraint(v, constraint);
+				Semver v = Semver.coerce(normalizeVersion(versionStr));
+				if (v == null) {
+					return false;
+				}
+				// Handle != operator (not supported by semver4j satisfies)
+				if (constraint.startsWith("!=")) {
+					String target = constraint.substring(2).trim();
+					Semver c = Semver.coerce(normalizeVersion(target));
+					return c != null && !v.isEquivalentTo(c);
+				}
+				return v.satisfies(normalizeConstraint(constraint), true);
 			}
 			catch (Exception ex) {
 				return false;
@@ -79,121 +90,34 @@ public final class SemverFunctions {
 		};
 	}
 
-	/**
-	 * Evaluates a constraint expression against a parsed version. Handles OR (||) and AND
-	 * (space-separated) compound constraints.
-	 */
-	private static boolean evaluateConstraint(Semver version, String constraint) {
-		// OR: split on ||
-		if (constraint.contains("||")) {
-			for (String part : constraint.split("\\|\\|")) {
-				if (evaluateConstraint(version, part.trim())) {
-					return true;
-				}
-			}
-			return false;
-		}
-		// AND: split on whitespace (e.g. ">=1.0.0 <2.0.0")
-		String[] parts = constraint.trim().split("\\s+");
-		if (parts.length > 1) {
-			for (String part : parts) {
-				if (!evaluateSingleConstraint(version, part.trim())) {
-					return false;
-				}
-			}
-			return true;
-		}
-		return evaluateSingleConstraint(version, constraint.trim());
-	}
-
-	/**
-	 * Evaluates a single constraint token (e.g. ">=1.2.3", "~1.2.3", "^1.2.3").
-	 */
-	private static boolean evaluateSingleConstraint(Semver version, String constraint) {
-		if (constraint.isEmpty()) {
-			return true;
-		}
-
-		// Tilde: ~1.2.3 → >=1.2.3 <1.3.0
-		if (constraint.startsWith("~")) {
-			String base = constraint.substring(1).trim();
-			Semver baseV = parseLeniently(base);
-			if (baseV == null) {
-				return false;
-			}
-			Semver upper = new Semver(baseV.getMajor() + "." + (baseV.getMinor() + 1) + ".0", Semver.SemverType.LOOSE);
-			return version.isGreaterThanOrEqualTo(baseV) && version.isLowerThan(upper);
-		}
-
-		// Caret: ^1.2.3 → >=1.2.3 <2.0.0 (^0.2.3 → >=0.2.3 <0.3.0, etc.)
-		if (constraint.startsWith("^")) {
-			String base = constraint.substring(1).trim();
-			Semver baseV = parseLeniently(base);
-			if (baseV == null) {
-				return false;
-			}
-			long major = (baseV.getMajor() != null) ? baseV.getMajor() : 0;
-			long minor = (baseV.getMinor() != null) ? baseV.getMinor() : 0;
-			Semver upper;
-			if (major > 0) {
-				upper = new Semver((major + 1) + ".0.0", Semver.SemverType.LOOSE);
-			}
-			else if (minor > 0) {
-				upper = new Semver("0." + (minor + 1) + ".0", Semver.SemverType.LOOSE);
-			}
-			else {
-				// ^0.0.x → exact match
-				return version.isEquivalentTo(baseV);
-			}
-			return version.isGreaterThanOrEqualTo(baseV) && version.isLowerThan(upper);
-		}
-
-		// Standard operators: >=, <=, !=, >, <, =
-		if (constraint.startsWith(">=")) {
-			Semver c = parseLeniently(constraint.substring(2).trim());
-			return c != null && version.isGreaterThanOrEqualTo(c);
-		}
-		if (constraint.startsWith("<=")) {
-			Semver c = parseLeniently(constraint.substring(2).trim());
-			return c != null && version.isLowerThanOrEqualTo(c);
-		}
-		if (constraint.startsWith("!=")) {
-			Semver c = parseLeniently(constraint.substring(2).trim());
-			return c != null && !version.isEquivalentTo(c);
-		}
-		if (constraint.startsWith(">")) {
-			Semver c = parseLeniently(constraint.substring(1).trim());
-			return c != null && version.isGreaterThan(c);
-		}
-		if (constraint.startsWith("<")) {
-			Semver c = parseLeniently(constraint.substring(1).trim());
-			return c != null && version.isLowerThan(c);
-		}
-		if (constraint.startsWith("=")) {
-			Semver c = parseLeniently(constraint.substring(1).trim());
-			return c != null && version.isEquivalentTo(c);
-		}
-
-		// No operator — exact match
-		Semver c = parseLeniently(constraint);
-		return c != null && version.isEquivalentTo(c);
-	}
-
-	private static Semver parseLeniently(String version) {
-		try {
-			return new Semver(normalizeVersion(version), Semver.SemverType.LOOSE);
-		}
-		catch (Exception ex) {
-			return null;
-		}
-	}
-
-	/** Strips a leading 'v' or 'V' prefix that Semver4j LOOSE mode doesn't accept. */
+	/** Strips a leading 'v' or 'V' prefix. */
 	private static String normalizeVersion(String version) {
 		if (version != null && version.length() > 1 && (version.charAt(0) == 'v' || version.charAt(0) == 'V')) {
 			return version.substring(1);
 		}
 		return version;
+	}
+
+	/**
+	 * Normalizes incomplete version numbers in constraints. Helm's Go semver library
+	 * accepts 2-part versions like "1.13-0" (meaning 1.13.0-0), but semver4j requires
+	 * strict 3-part versions. This adds the missing ".0" patch component.
+	 */
+	private static final Pattern TWO_PART_VERSION = Pattern.compile("(?<!\\d\\.)(\\d+\\.\\d+)(-\\S+)?(?=\\s|$|\\|)");
+
+	private static String normalizeConstraint(String constraint) {
+		Matcher m = TWO_PART_VERSION.matcher(constraint);
+		StringBuilder sb = new StringBuilder();
+		while (m.find()) {
+			String majorMinor = m.group(1);
+			String suffix = (m.group(2) != null) ? m.group(2) : "";
+			// Only add .0 if there's no third part already
+			if (!majorMinor.matches(".*\\.\\d+\\.\\d+.*")) {
+				m.appendReplacement(sb, majorMinor + ".0" + suffix);
+			}
+		}
+		m.appendTail(sb);
+		return sb.toString();
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.alexmond</groupId>
@@ -38,10 +38,11 @@
     <properties>
         <kubernetes-client.version>25.0.0</kubernetes-client.version>
         <picocli.version>4.7.7</picocli.version>
-        <semver4j.version>3.1.0</semver4j.version>
-        <bouncycastle.version>1.80</bouncycastle.version>
+        <semver4j.version>6.0.0</semver4j.version>
+        <bouncycastle.version>1.83</bouncycastle.version>
+        <commons-compress.version>1.26.1</commons-compress.version>
         <chicory.version>1.7.2</chicory.version>
-        <spring-retry.version>2.0.11</spring-retry.version>
+        <spring-retry.version>2.0.12</spring-retry.version>
 
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
@@ -49,7 +50,7 @@
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
-        <spring-javaformat.version>0.0.43</spring-javaformat.version>
+        <spring-javaformat.version>0.0.47</spring-javaformat.version>
         <checkstyle.version>9.3</checkstyle.version>
 
         <java.version>21</java.version>
@@ -120,7 +121,7 @@
                 <version>${kubernetes-client.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.vdurmont</groupId>
+                <groupId>org.semver4j</groupId>
                 <artifactId>semver4j</artifactId>
                 <version>${semver4j.version}</version>
             </dependency>
@@ -143,6 +144,16 @@
                 <groupId>org.springframework.retry</groupId>
                 <artifactId>spring-retry</artifactId>
                 <version>${spring-retry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons-compress.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary

- Upgrade Spring Boot 4.0.2 → 4.0.3, spring-javaformat 0.0.43 → 0.0.47, spring-retry 2.0.11 → 2.0.12, bouncycastle 1.80 → 1.83
- Migrate semver4j from com.vdurmont:3.1.0 to org.semver4j:6.0.0 (new package, simplified API using `satisfies()`)
- Centralize `commons-compress` and `bcpkix-jdk18on` versions in parent POM `<dependencyManagement>`

## Test plan

- [x] All 8 modules build and pass (`./mvnw clean install`)
- [x] All 28 SemverFunctionsTest cases pass (including `!=`, pre-release, tilde, caret operators)
- [x] All 27 KpsComparisonTest chart comparisons pass (including prometheus `>=1.13-0` constraint)
- [x] DependencyResolverTest passes with new `satisfies()` API

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)