### PR TITLE
Add chart signing and verification support

### DIFF
--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
@@ -6,6 +6,7 @@ import org.alexmond.jhelm.app.command.GetCommand;
 import org.alexmond.jhelm.app.command.HistoryCommand;
 import org.alexmond.jhelm.app.command.InstallCommand;
 import org.alexmond.jhelm.app.command.ListCommand;
+import org.alexmond.jhelm.app.command.PackageCommand;
 import org.alexmond.jhelm.app.command.PluginCommand;
 import org.alexmond.jhelm.app.command.PullCommand;
 import org.alexmond.jhelm.app.command.PushCommand;
@@ -18,6 +19,7 @@ import org.alexmond.jhelm.app.command.TemplateCommand;
 import org.alexmond.jhelm.app.command.TestCommand;
 import org.alexmond.jhelm.app.command.UninstallCommand;
 import org.alexmond.jhelm.app.command.UpgradeCommand;
+import org.alexmond.jhelm.app.command.VerifyCommand;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
@@ -34,7 +36,8 @@ import picocli.CommandLine;
 		subcommands = { CreateCommand.class, TemplateCommand.class, InstallCommand.class, UpgradeCommand.class,
 				UninstallCommand.class, ListCommand.class, StatusCommand.class, HistoryCommand.class,
 				RollbackCommand.class, ShowCommand.class, GetCommand.class, TestCommand.class, DependencyCommand.class,
-				PullCommand.class, PushCommand.class, RepoCommand.class, RegistryCommand.class, PluginCommand.class })
+				PullCommand.class, PushCommand.class, PackageCommand.class, VerifyCommand.class, RepoCommand.class,
+				RegistryCommand.class, PluginCommand.class })
 public class JHelmCommand implements Runnable {
 
 	@CommandLine.Option(names = { "--no-color" }, description = "Disable colored output",

--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/PackageCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/PackageCommand.java
@@ -1,0 +1,87 @@
+package org.alexmond.jhelm.app.command;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.action.PackageAction;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+
+@Component
+@CommandLine.Command(name = "package", mixinStandardHelpOptions = true,
+		description = "Package a chart directory into a chart archive")
+@Slf4j
+public class PackageCommand implements Runnable {
+
+	private final PackageAction packageAction;
+
+	@CommandLine.Parameters(index = "0", description = "path to the chart directory")
+	private String chartPath;
+
+	@CommandLine.Option(names = { "-d", "--destination" }, defaultValue = ".",
+			description = "destination directory for the packaged chart")
+	private String destination;
+
+	@CommandLine.Option(names = { "--sign" }, description = "sign the package using a PGP key")
+	private boolean sign;
+
+	@CommandLine.Option(names = { "--key" }, description = "key UID to use when signing (substring match)")
+	private String keyId;
+
+	@CommandLine.Option(names = { "--keyring" }, description = "path to the PGP secret keyring file")
+	private String keyring;
+
+	@CommandLine.Option(names = { "--passphrase-file" },
+			description = "path to a file containing the passphrase for the signing key")
+	private String passphraseFile;
+
+	public PackageCommand(PackageAction packageAction) {
+		this.packageAction = packageAction;
+	}
+
+	@Override
+	public void run() {
+		try {
+			packageAction.setDestination(new File(destination));
+			File archive;
+
+			if (sign) {
+				if (keyId == null) {
+					CliOutput.errPrintln(CliOutput.error("--key is required when --sign is specified"));
+					return;
+				}
+				String resolvedKeyring = (keyring != null) ? keyring : defaultKeyringPath();
+				char[] passphrase = loadPassphrase();
+				archive = packageAction.packageChart(chartPath, resolvedKeyring, keyId, passphrase);
+			}
+			else {
+				archive = packageAction.packageChart(chartPath);
+			}
+
+			CliOutput.println(CliOutput.success("Successfully packaged chart: " + archive.getName()));
+		}
+		catch (Exception ex) {
+			CliOutput.errPrintln(CliOutput.error("Error packaging chart: " + ex.getMessage()));
+		}
+	}
+
+	private char[] loadPassphrase() throws Exception {
+		if (passphraseFile != null) {
+			return Files.readString(Path.of(passphraseFile)).trim().toCharArray();
+		}
+		String envPassphrase = System.getenv("HELM_PASSPHRASE");
+		if (envPassphrase != null) {
+			return envPassphrase.toCharArray();
+		}
+		throw new IllegalArgumentException(
+				"Passphrase required: use --passphrase-file or set HELM_PASSPHRASE environment variable");
+	}
+
+	private String defaultKeyringPath() {
+		return System.getProperty("user.home") + "/.gnupg/secring.gpg";
+	}
+
+}

--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/VerifyCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/VerifyCommand.java
@@ -1,0 +1,43 @@
+package org.alexmond.jhelm.app.command;
+
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.action.VerifyAction;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+
+@Component
+@CommandLine.Command(name = "verify", mixinStandardHelpOptions = true,
+		description = "Verify that a chart has a valid provenance file")
+@Slf4j
+public class VerifyCommand implements Runnable {
+
+	private final VerifyAction verifyAction;
+
+	@CommandLine.Parameters(index = "0", description = "path to the chart archive (.tgz)")
+	private String chartPath;
+
+	@CommandLine.Option(names = { "--keyring" }, description = "path to the PGP public keyring file")
+	private String keyring;
+
+	public VerifyCommand(VerifyAction verifyAction) {
+		this.verifyAction = verifyAction;
+	}
+
+	@Override
+	public void run() {
+		try {
+			String resolvedKeyring = (keyring != null) ? keyring : defaultKeyringPath();
+			verifyAction.verify(chartPath, resolvedKeyring);
+			CliOutput.println(CliOutput.success("Verification succeeded"));
+		}
+		catch (Exception ex) {
+			CliOutput.errPrintln(CliOutput.error("Error: " + ex.getMessage()));
+		}
+	}
+
+	private String defaultKeyringPath() {
+		return System.getProperty("user.home") + "/.gnupg/pubring.gpg";
+	}
+
+}

--- a/jhelm-app/src/test/java/org/alexmond/jhelm/app/command/PackageCommandTest.java
+++ b/jhelm-app/src/test/java/org/alexmond/jhelm/app/command/PackageCommandTest.java
@@ -1,0 +1,133 @@
+package org.alexmond.jhelm.app.command;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.alexmond.jhelm.core.action.PackageAction;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PackageCommandTest {
+
+	@Mock
+	private PackageAction packageAction;
+
+	private PackageCommand packageCommand;
+
+	private final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+
+	private final ByteArrayOutputStream errStream = new ByteArrayOutputStream();
+
+	private final PrintStream originalOut = System.out;
+
+	private final PrintStream originalErr = System.err;
+
+	@TempDir
+	Path tempDir;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		packageCommand = new PackageCommand(packageAction);
+		System.setOut(new PrintStream(outStream));
+		System.setErr(new PrintStream(errStream));
+	}
+
+	@AfterEach
+	void tearDown() {
+		System.setOut(originalOut);
+		System.setErr(originalErr);
+	}
+
+	@Test
+	void testPackageChart() throws Exception {
+		File archive = new File("test-chart-1.0.0.tgz");
+		when(packageAction.packageChart("./my-chart")).thenReturn(archive);
+
+		CommandLine cmd = new CommandLine(packageCommand);
+		cmd.execute("./my-chart");
+
+		verify(packageAction).setDestination(any(File.class));
+		verify(packageAction).packageChart("./my-chart");
+		assertTrue(outStream.toString().contains("Successfully packaged chart"));
+	}
+
+	@Test
+	void testPackageWithDestination() throws Exception {
+		File archive = new File("test-chart-1.0.0.tgz");
+		when(packageAction.packageChart("./my-chart")).thenReturn(archive);
+
+		CommandLine cmd = new CommandLine(packageCommand);
+		cmd.execute("./my-chart", "-d", "/tmp/output");
+
+		verify(packageAction).setDestination(new File("/tmp/output"));
+		verify(packageAction).packageChart("./my-chart");
+	}
+
+	@Test
+	void testPackageWithSigning() throws Exception {
+		Path passphraseFile = tempDir.resolve("passphrase.txt");
+		Files.writeString(passphraseFile, "secret123");
+
+		File archive = new File("test-chart-1.0.0.tgz");
+		when(packageAction.packageChart(eq("./my-chart"), anyString(), eq("user@example.com"), any(char[].class)))
+			.thenReturn(archive);
+
+		CommandLine cmd = new CommandLine(packageCommand);
+		cmd.execute("./my-chart", "--sign", "--key", "user@example.com", "--keyring", "/path/to/keyring.gpg",
+				"--passphrase-file", passphraseFile.toString());
+
+		verify(packageAction).packageChart(eq("./my-chart"), eq("/path/to/keyring.gpg"), eq("user@example.com"),
+				any(char[].class));
+	}
+
+	@Test
+	void testPackageSignRequiresKey() {
+		CommandLine cmd = new CommandLine(packageCommand);
+		cmd.execute("./my-chart", "--sign");
+
+		assertTrue(errStream.toString().contains("--key is required"));
+	}
+
+	@Test
+	void testPackageWithError() throws Exception {
+		when(packageAction.packageChart("./my-chart")).thenThrow(new RuntimeException("chart not found"));
+
+		CommandLine cmd = new CommandLine(packageCommand);
+		cmd.execute("./my-chart");
+
+		assertTrue(errStream.toString().contains("Error packaging chart"));
+	}
+
+	@Test
+	void testPackageSignWithEnvPassphrase() throws Exception {
+		// When no passphrase file and no env var, should error
+		File archive = new File("test-chart-1.0.0.tgz");
+		when(packageAction.packageChart(eq("./my-chart"), anyString(), eq("user@example.com"), any(char[].class)))
+			.thenReturn(archive);
+
+		CommandLine cmd = new CommandLine(packageCommand);
+		cmd.execute("./my-chart", "--sign", "--key", "user@example.com");
+
+		// Will fail because no passphrase source — error about passphrase expected
+		String output = errStream.toString();
+		assertTrue(output.contains("Error") || output.contains("Passphrase"),
+				"Expected passphrase error, got: " + output);
+	}
+
+}

--- a/jhelm-app/src/test/java/org/alexmond/jhelm/app/command/VerifyCommandTest.java
+++ b/jhelm-app/src/test/java/org/alexmond/jhelm/app/command/VerifyCommandTest.java
@@ -1,0 +1,93 @@
+package org.alexmond.jhelm.app.command;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.alexmond.jhelm.core.action.VerifyAction;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+class VerifyCommandTest {
+
+	@Mock
+	private VerifyAction verifyAction;
+
+	private VerifyCommand verifyCommand;
+
+	private final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+
+	private final ByteArrayOutputStream errStream = new ByteArrayOutputStream();
+
+	private final PrintStream originalOut = System.out;
+
+	private final PrintStream originalErr = System.err;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		verifyCommand = new VerifyCommand(verifyAction);
+		System.setOut(new PrintStream(outStream));
+		System.setErr(new PrintStream(errStream));
+	}
+
+	@AfterEach
+	void tearDown() {
+		System.setOut(originalOut);
+		System.setErr(originalErr);
+	}
+
+	@Test
+	void testVerifySuccess() throws Exception {
+		doNothing().when(verifyAction).verify(anyString(), anyString());
+
+		CommandLine cmd = new CommandLine(verifyCommand);
+		cmd.execute("chart-1.0.0.tgz");
+
+		verify(verifyAction).verify(eq("chart-1.0.0.tgz"), anyString());
+		assertTrue(outStream.toString().contains("Verification succeeded"));
+	}
+
+	@Test
+	void testVerifyWithKeyring() throws Exception {
+		doNothing().when(verifyAction).verify(anyString(), anyString());
+
+		CommandLine cmd = new CommandLine(verifyCommand);
+		cmd.execute("chart-1.0.0.tgz", "--keyring", "/path/to/pubring.gpg");
+
+		verify(verifyAction).verify("chart-1.0.0.tgz", "/path/to/pubring.gpg");
+	}
+
+	@Test
+	void testVerifyFailure() throws Exception {
+		doThrow(new RuntimeException("signature mismatch")).when(verifyAction).verify(anyString(), anyString());
+
+		CommandLine cmd = new CommandLine(verifyCommand);
+		cmd.execute("chart-1.0.0.tgz");
+
+		assertTrue(errStream.toString().contains("Error"));
+		assertTrue(errStream.toString().contains("signature mismatch"));
+	}
+
+	@Test
+	void testVerifyDefaultKeyring() throws Exception {
+		doNothing().when(verifyAction).verify(anyString(), anyString());
+
+		CommandLine cmd = new CommandLine(verifyCommand);
+		cmd.execute("chart-1.0.0.tgz");
+
+		String expectedKeyring = System.getProperty("user.home") + "/.gnupg/pubring.gpg";
+		verify(verifyAction).verify("chart-1.0.0.tgz", expectedKeyring);
+	}
+
+}

--- a/jhelm-core/pom.xml
+++ b/jhelm-core/pom.xml
@@ -64,6 +64,10 @@
             <artifactId>semver4j</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpg-jdk18on</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <optional>true</optional>

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -17,6 +17,7 @@ import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.HistoryAction;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.ListAction;
+import org.alexmond.jhelm.core.action.PackageAction;
 import org.alexmond.jhelm.core.action.RollbackAction;
 import org.alexmond.jhelm.core.action.ShowAction;
 import org.alexmond.jhelm.core.action.TestAction;
@@ -24,6 +25,7 @@ import org.alexmond.jhelm.core.action.StatusAction;
 import org.alexmond.jhelm.core.action.TemplateAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.action.VerifyAction;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
@@ -32,6 +34,7 @@ import org.alexmond.jhelm.core.service.PostRenderProcessor;
 import org.alexmond.jhelm.core.service.RegistryManager;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.core.service.SchemaValidator;
+import org.alexmond.jhelm.core.service.SignatureService;
 
 /**
  * Auto-configuration for the jhelm core module. Registers all core Helm beans. Beans that
@@ -194,6 +197,24 @@ public class JhelmCoreAutoConfiguration {
 	@ConditionalOnBean(KubeService.class)
 	public TestAction testAction(KubeService kubeService) {
 		return new TestAction(kubeService);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public SignatureService signatureService() {
+		return new SignatureService();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public PackageAction packageAction(ChartLoader chartLoader, SignatureService signatureService) {
+		return new PackageAction(chartLoader, signatureService);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public VerifyAction verifyAction(SignatureService signatureService) {
+		return new VerifyAction(signatureService);
 	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/PackageAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/PackageAction.java
@@ -1,0 +1,136 @@
+package org.alexmond.jhelm.core.action;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.bouncycastle.openpgp.PGPSecretKey;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.SignatureService;
+
+/**
+ * Packages a chart directory into a versioned {@code .tgz} archive and optionally
+ * produces a PGP provenance ({@code .prov}) file.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class PackageAction {
+
+	private final ChartLoader chartLoader;
+
+	private final SignatureService signatureService;
+
+	@Setter
+	private File destination;
+
+	/**
+	 * Packages a chart directory into a {@code .tgz} archive.
+	 * @param chartPath path to the chart directory
+	 * @return the created archive file
+	 */
+	public File packageChart(String chartPath) throws Exception {
+		return packageChart(chartPath, null, null);
+	}
+
+	/**
+	 * Packages a chart directory and signs it using the specified keyring and key ID.
+	 * @param chartPath path to the chart directory
+	 * @param keyringPath path to the PGP secret keyring file
+	 * @param keyId substring to match against key user IDs
+	 * @param passphrase the key passphrase
+	 * @return the created archive file
+	 */
+	public File packageChart(String chartPath, String keyringPath, String keyId, char[] passphrase) throws Exception {
+		PGPSecretKey secretKey = signatureService.loadSecretKey(keyringPath, keyId);
+		return packageChart(chartPath, secretKey, passphrase);
+	}
+
+	/**
+	 * Packages a chart directory into a {@code .tgz} archive and optionally signs it.
+	 * @param chartPath path to the chart directory
+	 * @param secretKey PGP secret key for signing, or {@code null} to skip signing
+	 * @param passphrase key passphrase, or {@code null} if not signing
+	 * @return the created archive file
+	 */
+	public File packageChart(String chartPath, PGPSecretKey secretKey, char[] passphrase) throws Exception {
+		Chart chart = chartLoader.load(new File(chartPath));
+		String archiveName = chart.getMetadata().getName() + "-" + chart.getMetadata().getVersion() + ".tgz";
+
+		File destDir = (destination != null) ? destination : new File(".");
+		File archiveFile = new File(destDir, archiveName);
+
+		createTgz(new File(chartPath), chart.getMetadata().getName(), archiveFile);
+		log.info("Successfully packaged chart and saved it to: {}", archiveFile.getAbsolutePath());
+
+		if (secretKey != null) {
+			String provContent = signatureService.sign(archiveFile, chart.getMetadata(), secretKey, passphrase);
+			File provFile = new File(destDir, archiveName + ".prov");
+			Files.writeString(provFile.toPath(), provContent);
+			log.info("Successfully signed chart and saved provenance to: {}", provFile.getAbsolutePath());
+		}
+
+		return archiveFile;
+	}
+
+	private void createTgz(File chartDir, String chartName, File outputFile) throws IOException {
+		try (OutputStream fos = Files.newOutputStream(outputFile.toPath());
+				BufferedOutputStream bos = new BufferedOutputStream(fos);
+				GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(bos);
+				TarArchiveOutputStream taos = new TarArchiveOutputStream(gzos)) {
+			taos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+			addDirectory(taos, chartDir, chartName);
+		}
+	}
+
+	private void addDirectory(TarArchiveOutputStream taos, File dir, String entryBase) throws IOException {
+		try (Stream<Path> paths = Files.walk(dir.toPath())) {
+			paths.forEach((path) -> {
+				try {
+					File file = path.toFile();
+					String entryName = entryBase + "/" + dir.toPath().relativize(path);
+					if (file.isDirectory()) {
+						return;
+					}
+					TarArchiveEntry entry = new TarArchiveEntry(file, entryName);
+					taos.putArchiveEntry(entry);
+					Files.copy(path, taos);
+					taos.closeArchiveEntry();
+				}
+				catch (IOException ex) {
+					throw new UncheckedIOException(ex);
+				}
+			});
+		}
+		catch (UncheckedIOException ex) {
+			throw ex.getCause();
+		}
+	}
+
+	private static class UncheckedIOException extends RuntimeException {
+
+		private final IOException cause;
+
+		UncheckedIOException(IOException cause) {
+			super(cause);
+			this.cause = cause;
+		}
+
+		@Override
+		public IOException getCause() {
+			return this.cause;
+		}
+
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/VerifyAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/VerifyAction.java
@@ -1,0 +1,43 @@
+package org.alexmond.jhelm.core.action;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
+import org.alexmond.jhelm.core.service.SignatureService;
+
+/**
+ * Verifies a packaged chart archive against its PGP provenance file.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class VerifyAction {
+
+	private final SignatureService signatureService;
+
+	/**
+	 * Verifies the PGP signature and digest of a chart archive.
+	 * @param chartTgzPath path to the chart {@code .tgz} archive
+	 * @param keyringPath path to the PGP public keyring file
+	 */
+	public void verify(String chartTgzPath, String keyringPath) throws Exception {
+		File chartFile = new File(chartTgzPath);
+		if (!chartFile.exists()) {
+			throw new IllegalArgumentException("Chart archive not found: " + chartTgzPath);
+		}
+
+		File provFile = new File(chartTgzPath + ".prov");
+		if (!provFile.exists()) {
+			throw new IllegalArgumentException("Provenance file not found: " + provFile.getAbsolutePath());
+		}
+
+		String provContent = Files.readString(provFile.toPath());
+		PGPPublicKeyRingCollection publicKeys = signatureService.loadPublicKeyring(keyringPath);
+
+		signatureService.verify(chartFile, provContent, publicKeys);
+		log.info("Verification succeeded for {}", chartFile.getName());
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SignatureService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SignatureService.java
@@ -1,0 +1,300 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.util.Iterator;
+
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.bcpg.ArmoredOutputStream;
+import org.bouncycastle.bcpg.BCPGOutputStream;
+import org.bouncycastle.bcpg.HashAlgorithmTags;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPObjectFactory;
+import org.bouncycastle.openpgp.PGPPrivateKey;
+import org.bouncycastle.openpgp.PGPPublicKey;
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
+import org.bouncycastle.openpgp.PGPSecretKey;
+import org.bouncycastle.openpgp.PGPSecretKeyRing;
+import org.bouncycastle.openpgp.PGPSecretKeyRingCollection;
+import org.bouncycastle.openpgp.PGPSignature;
+import org.bouncycastle.openpgp.PGPSignatureGenerator;
+import org.bouncycastle.openpgp.PGPSignatureList;
+import org.bouncycastle.openpgp.PGPUtil;
+import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPContentSignerBuilder;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPContentVerifierBuilderProvider;
+import org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyDecryptorBuilder;
+import org.alexmond.jhelm.core.model.ChartMetadata;
+
+/**
+ * PGP signing and verification service for Helm chart provenance files. Generates and
+ * verifies {@code .prov} files compatible with the Helm provenance format.
+ *
+ * @see <a href="https://helm.sh/docs/topics/provenance/">Helm Provenance and
+ * Integrity</a>
+ */
+@Slf4j
+public class SignatureService {
+
+	static {
+		if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+			Security.addProvider(new BouncyCastleProvider());
+		}
+	}
+
+	/**
+	 * Signs a chart archive and produces a Helm-compatible provenance file content.
+	 * @param chartTgz the chart archive file
+	 * @param metadata the chart metadata
+	 * @param secretKey the PGP secret key to sign with
+	 * @param passphrase the key passphrase
+	 * @return the provenance file content (PGP clear-signed YAML)
+	 * @throws IOException if the chart file cannot be read
+	 * @throws PGPException if signing fails
+	 */
+	public String sign(File chartTgz, ChartMetadata metadata, PGPSecretKey secretKey, char[] passphrase)
+			throws IOException, PGPException {
+		String digest = computeSha256(chartTgz);
+		String yamlContent = buildProvenanceYaml(metadata, chartTgz.getName(), digest);
+
+		PGPPrivateKey privateKey = secretKey
+			.extractPrivateKey(new JcePBESecretKeyDecryptorBuilder().setProvider("BC").build(passphrase));
+
+		PGPSignatureGenerator sigGen = new PGPSignatureGenerator(
+				new JcaPGPContentSignerBuilder(secretKey.getPublicKey().getAlgorithm(), HashAlgorithmTags.SHA256)
+					.setProvider("BC"));
+		sigGen.init(PGPSignature.CANONICAL_TEXT_DOCUMENT, privateKey);
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		try (ArmoredOutputStream armoredOut = new ArmoredOutputStream(out)) {
+			armoredOut.beginClearText(HashAlgorithmTags.SHA256);
+
+			byte[] yamlBytes = yamlContent.getBytes(StandardCharsets.UTF_8);
+			armoredOut.write(yamlBytes);
+			sigGen.update(yamlBytes);
+
+			armoredOut.endClearText();
+
+			try (BCPGOutputStream bcpgOut = new BCPGOutputStream(armoredOut)) {
+				sigGen.generate().encode(bcpgOut);
+			}
+		}
+
+		return out.toString(StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * Verifies a chart archive against its provenance file.
+	 * @param chartTgz the chart archive file
+	 * @param provContent the provenance file content
+	 * @param publicKeys the public keyring collection
+	 * @throws IOException if files cannot be read
+	 * @throws PGPException if verification fails
+	 * @throws SignatureVerificationException if the signature is invalid or the digest
+	 * does not match
+	 */
+	public void verify(File chartTgz, String provContent, PGPPublicKeyRingCollection publicKeys)
+			throws IOException, PGPException {
+		// Extract the signed data and signature from the clear-signed message
+		String signedData = extractSignedData(provContent);
+		byte[] signatureBytes = extractSignatureBytes(provContent);
+
+		// Verify the PGP signature
+		PGPObjectFactory pgpFactory = new PGPObjectFactory(signatureBytes, new JcaKeyFingerprintCalculator());
+		PGPSignatureList sigList = (PGPSignatureList) pgpFactory.nextObject();
+		if (sigList == null || sigList.isEmpty()) {
+			throw new SignatureVerificationException("No PGP signature found in provenance file");
+		}
+		PGPSignature signature = sigList.get(0);
+
+		PGPPublicKey verifyKey = publicKeys.getPublicKey(signature.getKeyID());
+		if (verifyKey == null) {
+			throw new SignatureVerificationException(
+					"No public key found for key ID " + Long.toHexString(signature.getKeyID()));
+		}
+
+		signature.init(new JcaPGPContentVerifierBuilderProvider().setProvider("BC"), verifyKey);
+		byte[] signedBytes = signedData.getBytes(StandardCharsets.UTF_8);
+		signature.update(signedBytes);
+
+		if (!signature.verify()) {
+			throw new SignatureVerificationException("PGP signature verification failed");
+		}
+		log.info("PGP signature verified successfully");
+
+		// Verify the chart digest
+		String expectedDigest = extractDigest(signedData);
+		if (expectedDigest == null) {
+			throw new SignatureVerificationException("No digest found in provenance YAML");
+		}
+
+		String actualDigest = "sha256:" + computeSha256(chartTgz);
+		if (!expectedDigest.equals(actualDigest)) {
+			throw new SignatureVerificationException(
+					"Digest mismatch: expected " + expectedDigest + ", got " + actualDigest);
+		}
+		log.info("Chart digest verified: {}", actualDigest);
+	}
+
+	/**
+	 * Loads a PGP secret key from a keyring file by matching a substring of the key's
+	 * user ID.
+	 * @param keyringPath path to the secret keyring file
+	 * @param keyId substring to match against key user IDs
+	 * @return the matching secret key
+	 * @throws IOException if the keyring cannot be read
+	 * @throws PGPException if the keyring is invalid
+	 */
+	public PGPSecretKey loadSecretKey(String keyringPath, String keyId) throws IOException, PGPException {
+		try (InputStream in = PGPUtil.getDecoderStream(new FileInputStream(keyringPath))) {
+			PGPSecretKeyRingCollection keyRings = new PGPSecretKeyRingCollection(in, new JcaKeyFingerprintCalculator());
+
+			for (PGPSecretKeyRing ring : keyRings) {
+				for (PGPSecretKey key : ring) {
+					if (!key.isSigningKey()) {
+						continue;
+					}
+					Iterator<String> userIds = key.getUserIDs();
+					while (userIds.hasNext()) {
+						if (userIds.next().contains(keyId)) {
+							return key;
+						}
+					}
+				}
+			}
+		}
+		throw new PGPException("No signing key found matching: " + keyId);
+	}
+
+	/**
+	 * Loads a PGP public keyring collection from a file.
+	 * @param keyringPath path to the public keyring file
+	 * @return the public keyring collection
+	 * @throws IOException if the keyring cannot be read
+	 * @throws PGPException if the keyring is invalid
+	 */
+	public PGPPublicKeyRingCollection loadPublicKeyring(String keyringPath) throws IOException, PGPException {
+		try (InputStream in = PGPUtil.getDecoderStream(new FileInputStream(keyringPath))) {
+			return new PGPPublicKeyRingCollection(in, new JcaKeyFingerprintCalculator());
+		}
+	}
+
+	/**
+	 * Builds the YAML content for a provenance file.
+	 */
+	String buildProvenanceYaml(ChartMetadata metadata, String archiveName, String digest) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("apiVersion: ").append((metadata.getApiVersion() != null) ? metadata.getApiVersion() : "v2");
+		sb.append('\n');
+		if (metadata.getAppVersion() != null) {
+			sb.append("appVersion: ").append(metadata.getAppVersion()).append('\n');
+		}
+		if (metadata.getDescription() != null) {
+			sb.append("description: ").append(metadata.getDescription()).append('\n');
+		}
+		sb.append("name: ").append(metadata.getName()).append('\n');
+		if (metadata.getType() != null) {
+			sb.append("type: ").append(metadata.getType()).append('\n');
+		}
+		sb.append("version: ")
+			.append(metadata.getVersion())
+			.append("\n...\nfiles:\n  ")
+			.append(archiveName)
+			.append(": sha256:")
+			.append(digest)
+			.append('\n');
+		return sb.toString();
+	}
+
+	private String computeSha256(File file) throws IOException {
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+			try (InputStream is = new FileInputStream(file)) {
+				byte[] buf = new byte[8192];
+				int read;
+				while ((read = is.read(buf)) != -1) {
+					md.update(buf, 0, read);
+				}
+			}
+			byte[] hash = md.digest();
+			StringBuilder hex = new StringBuilder();
+			for (byte b : hash) {
+				hex.append(String.format("%02x", b));
+			}
+			return hex.toString();
+		}
+		catch (NoSuchAlgorithmException ex) {
+			throw new IOException("SHA-256 algorithm not available", ex);
+		}
+	}
+
+	/**
+	 * Extracts the signed text body from a PGP clear-signed message.
+	 */
+	String extractSignedData(String clearSigned) {
+		int bodyStart = clearSigned.indexOf("Hash:");
+		if (bodyStart < 0) {
+			throw new SignatureVerificationException("Invalid clear-signed message: no Hash header");
+		}
+		// Skip to the blank line after Hash header
+		int blankLine = clearSigned.indexOf("\n\n", bodyStart);
+		if (blankLine < 0) {
+			throw new SignatureVerificationException("Invalid clear-signed message: no blank line after Hash header");
+		}
+
+		int sigStart = clearSigned.indexOf("-----BEGIN PGP SIGNATURE-----");
+		if (sigStart < 0) {
+			throw new SignatureVerificationException("Invalid clear-signed message: no signature block");
+		}
+		return clearSigned.substring(blankLine + 2, sigStart);
+	}
+
+	/**
+	 * Extracts the raw PGP signature bytes from a clear-signed message.
+	 */
+	private byte[] extractSignatureBytes(String clearSigned) throws IOException {
+		int sigStart = clearSigned.indexOf("-----BEGIN PGP SIGNATURE-----");
+		if (sigStart < 0) {
+			throw new SignatureVerificationException("No PGP signature block found");
+		}
+		String sigBlock = clearSigned.substring(sigStart);
+		return PGPUtil.getDecoderStream(new ByteArrayInputStream(sigBlock.getBytes(StandardCharsets.UTF_8)))
+			.readAllBytes();
+	}
+
+	/**
+	 * Extracts the digest value from the provenance YAML's files section.
+	 */
+	private String extractDigest(String yamlContent) {
+		// Look for pattern: filename: sha256:hexdigest
+		for (String line : yamlContent.split("\n")) {
+			String trimmed = line.trim();
+			if (trimmed.contains(": sha256:")) {
+				int idx = trimmed.indexOf(": sha256:");
+				return trimmed.substring(idx + 2);
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Exception thrown when signature verification fails.
+	 */
+	public static class SignatureVerificationException extends RuntimeException {
+
+		public SignatureVerificationException(String message) {
+			super(message);
+		}
+
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/PackageActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/PackageActionTest.java
@@ -1,0 +1,130 @@
+package org.alexmond.jhelm.core.action;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.util.Date;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.SignatureService;
+import org.bouncycastle.bcpg.HashAlgorithmTags;
+import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
+import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openpgp.PGPKeyRingGenerator;
+import org.bouncycastle.openpgp.PGPSecretKey;
+import org.bouncycastle.openpgp.PGPSignature;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPContentSignerBuilder;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPDigestCalculatorProviderBuilder;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPKeyPair;
+import org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyEncryptorBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PackageActionTest {
+
+	private static final char[] PASSPHRASE = "testpass".toCharArray();
+
+	private static PGPSecretKey secretKey;
+
+	private PackageAction packageAction;
+
+	@TempDir
+	Path tempDir;
+
+	@BeforeAll
+	static void generateKeys() throws Exception {
+		if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+			Security.addProvider(new BouncyCastleProvider());
+		}
+		KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "BC");
+		kpg.initialize(2048);
+		KeyPair keyPair = kpg.generateKeyPair();
+		var pgpKeyPair = new JcaPGPKeyPair(PublicKeyAlgorithmTags.RSA_GENERAL, keyPair, new Date());
+		PGPKeyRingGenerator gen = new PGPKeyRingGenerator(PGPSignature.POSITIVE_CERTIFICATION, pgpKeyPair,
+				"Test <test@example.com>",
+				new JcaPGPDigestCalculatorProviderBuilder().setProvider("BC").build().get(HashAlgorithmTags.SHA1), null,
+				null,
+				new JcaPGPContentSignerBuilder(pgpKeyPair.getPublicKey().getAlgorithm(), HashAlgorithmTags.SHA256)
+					.setProvider("BC"),
+				new JcePBESecretKeyEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_256,
+						new JcaPGPDigestCalculatorProviderBuilder().setProvider("BC")
+							.build()
+							.get(HashAlgorithmTags.SHA256))
+					.setProvider("BC")
+					.build(PASSPHRASE));
+		secretKey = gen.generateSecretKeyRing().getSecretKey();
+	}
+
+	@BeforeEach
+	void setUp() {
+		packageAction = new PackageAction(new ChartLoader(), new SignatureService());
+	}
+
+	@Test
+	void testPackageChartCreatesArchive() throws Exception {
+		Path chartDir = createMinimalChart("test-chart", "1.0.0");
+		packageAction.setDestination(tempDir.toFile());
+
+		File archive = packageAction.packageChart(chartDir.toString());
+
+		assertNotNull(archive);
+		assertTrue(archive.exists());
+		assertTrue(archive.getName().equals("test-chart-1.0.0.tgz"));
+		assertTrue(archive.length() > 0);
+	}
+
+	@Test
+	void testPackageChartWithSignatureCreatesProvFile() throws Exception {
+		Path chartDir = createMinimalChart("signed-chart", "2.0.0");
+		packageAction.setDestination(tempDir.toFile());
+
+		File archive = packageAction.packageChart(chartDir.toString(), secretKey, PASSPHRASE);
+
+		assertTrue(archive.exists());
+		File provFile = new File(archive.getAbsolutePath() + ".prov");
+		assertTrue(provFile.exists());
+		String provContent = Files.readString(provFile.toPath());
+		assertTrue(provContent.contains("-----BEGIN PGP SIGNED MESSAGE-----"));
+		assertTrue(provContent.contains("name: signed-chart"));
+	}
+
+	@Test
+	void testPackageChartWithoutSignatureNoProvFile() throws Exception {
+		Path chartDir = createMinimalChart("unsigned-chart", "1.0.0");
+		packageAction.setDestination(tempDir.toFile());
+
+		File archive = packageAction.packageChart(chartDir.toString());
+
+		assertTrue(archive.exists());
+		File provFile = new File(archive.getAbsolutePath() + ".prov");
+		assertTrue(!provFile.exists());
+	}
+
+	private Path createMinimalChart(String name, String version) throws Exception {
+		Path chartDir = tempDir.resolve(name);
+		Files.createDirectories(chartDir.resolve("templates"));
+		Files.writeString(chartDir.resolve("Chart.yaml"), """
+				apiVersion: v2
+				name: %s
+				version: %s
+				description: A test chart
+				""".formatted(name, version));
+		Files.writeString(chartDir.resolve("values.yaml"), "replicaCount: 1\n");
+		Files.writeString(chartDir.resolve("templates/deployment.yaml"), """
+				apiVersion: apps/v1
+				kind: Deployment
+				metadata:
+				  name: {{ .Release.Name }}
+				""");
+		return chartDir;
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/VerifyActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/VerifyActionTest.java
@@ -1,0 +1,153 @@
+package org.alexmond.jhelm.core.action;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.util.Date;
+import java.util.List;
+
+import org.alexmond.jhelm.core.service.SignatureService;
+import org.alexmond.jhelm.core.service.SignatureService.SignatureVerificationException;
+import org.bouncycastle.bcpg.ArmoredOutputStream;
+import org.bouncycastle.bcpg.HashAlgorithmTags;
+import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
+import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openpgp.PGPKeyRingGenerator;
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
+import org.bouncycastle.openpgp.PGPSecretKey;
+import org.bouncycastle.openpgp.PGPSignature;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPContentSignerBuilder;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPDigestCalculatorProviderBuilder;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPKeyPair;
+import org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyEncryptorBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.alexmond.jhelm.core.model.ChartMetadata;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VerifyActionTest {
+
+	private static final char[] PASSPHRASE = "testpass".toCharArray();
+
+	private static PGPSecretKey secretKey;
+
+	private static PGPPublicKeyRingCollection publicKeys;
+
+	private SignatureService signatureService;
+
+	private VerifyAction verifyAction;
+
+	@TempDir
+	Path tempDir;
+
+	@BeforeAll
+	static void generateKeys() throws Exception {
+		if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+			Security.addProvider(new BouncyCastleProvider());
+		}
+		KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "BC");
+		kpg.initialize(2048);
+		KeyPair keyPair = kpg.generateKeyPair();
+		var pgpKeyPair = new JcaPGPKeyPair(PublicKeyAlgorithmTags.RSA_GENERAL, keyPair, new Date());
+		PGPKeyRingGenerator gen = new PGPKeyRingGenerator(PGPSignature.POSITIVE_CERTIFICATION, pgpKeyPair,
+				"Test <test@example.com>",
+				new JcaPGPDigestCalculatorProviderBuilder().setProvider("BC").build().get(HashAlgorithmTags.SHA1), null,
+				null,
+				new JcaPGPContentSignerBuilder(pgpKeyPair.getPublicKey().getAlgorithm(), HashAlgorithmTags.SHA256)
+					.setProvider("BC"),
+				new JcePBESecretKeyEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_256,
+						new JcaPGPDigestCalculatorProviderBuilder().setProvider("BC")
+							.build()
+							.get(HashAlgorithmTags.SHA256))
+					.setProvider("BC")
+					.build(PASSPHRASE));
+		secretKey = gen.generateSecretKeyRing().getSecretKey();
+		publicKeys = new PGPPublicKeyRingCollection(List.of(gen.generatePublicKeyRing()));
+	}
+
+	@BeforeEach
+	void setUp() {
+		signatureService = new SignatureService();
+		verifyAction = new VerifyAction(signatureService);
+	}
+
+	@Test
+	void testVerifyValidSignature() throws Exception {
+		File chartFile = createSignedChart("valid-1.0.0.tgz", "chart-data");
+		Path keyringFile = writePublicKeyring();
+
+		assertDoesNotThrow(() -> verifyAction.verify(chartFile.getAbsolutePath(), keyringFile.toString()));
+	}
+
+	@Test
+	void testVerifyFailsWhenChartTampered() throws Exception {
+		File chartFile = createSignedChart("tampered-1.0.0.tgz", "original-data");
+		Path keyringFile = writePublicKeyring();
+
+		// Tamper with the chart
+		try (OutputStream os = new FileOutputStream(chartFile)) {
+			os.write("tampered-data".getBytes());
+		}
+
+		assertThrows(SignatureVerificationException.class,
+				() -> verifyAction.verify(chartFile.getAbsolutePath(), keyringFile.toString()));
+	}
+
+	@Test
+	void testVerifyFailsWhenChartNotFound() {
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> verifyAction.verify("/nonexistent/chart.tgz", "/some/keyring"));
+		assertTrue(ex.getMessage().contains("Chart archive not found"));
+	}
+
+	@Test
+	void testVerifyFailsWhenProvFileNotFound() throws Exception {
+		File chartFile = tempDir.resolve("noprov-1.0.0.tgz").toFile();
+		try (OutputStream os = new FileOutputStream(chartFile)) {
+			os.write("data".getBytes());
+		}
+
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> verifyAction.verify(chartFile.getAbsolutePath(), "/some/keyring"));
+		assertTrue(ex.getMessage().contains("Provenance file not found"));
+	}
+
+	private File createSignedChart(String name, String content) throws Exception {
+		File chartFile = tempDir.resolve(name).toFile();
+		try (OutputStream os = new FileOutputStream(chartFile)) {
+			os.write(content.getBytes());
+		}
+
+		ChartMetadata metadata = ChartMetadata.builder()
+			.name(name.replace(".tgz", ""))
+			.version("1.0.0")
+			.apiVersion("v2")
+			.build();
+
+		String provContent = signatureService.sign(chartFile, metadata, secretKey, PASSPHRASE);
+		Files.writeString(tempDir.resolve(name + ".prov"), provContent);
+
+		return chartFile;
+	}
+
+	private Path writePublicKeyring() throws Exception {
+		Path keyringFile = tempDir.resolve("pubring.gpg");
+		try (OutputStream out = new FileOutputStream(keyringFile.toFile());
+				ArmoredOutputStream armoredOut = new ArmoredOutputStream(out)) {
+			publicKeys.encode(armoredOut);
+		}
+		return keyringFile;
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/SignatureServiceTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/SignatureServiceTest.java
@@ -1,0 +1,288 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.util.Date;
+import java.util.List;
+
+import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.service.SignatureService.SignatureVerificationException;
+import org.bouncycastle.bcpg.ArmoredOutputStream;
+import org.bouncycastle.bcpg.HashAlgorithmTags;
+import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
+import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPKeyPair;
+import org.bouncycastle.openpgp.PGPKeyRingGenerator;
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
+import org.bouncycastle.openpgp.PGPSecretKey;
+import org.bouncycastle.openpgp.PGPSecretKeyRing;
+import org.bouncycastle.openpgp.PGPSecretKeyRingCollection;
+import org.bouncycastle.openpgp.PGPSignature;
+import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPContentSignerBuilder;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPDigestCalculatorProviderBuilder;
+import org.bouncycastle.openpgp.operator.jcajce.JcaPGPKeyPair;
+import org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyEncryptorBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SignatureServiceTest {
+
+	private static final char[] PASSPHRASE = "testpass".toCharArray();
+
+	private static final String USER_ID = "Test User <test@example.com>";
+
+	private static PGPSecretKey secretKey;
+
+	private static PGPPublicKeyRingCollection publicKeys;
+
+	private SignatureService signatureService;
+
+	@TempDir
+	Path tempDir;
+
+	@BeforeAll
+	static void generateKeys() throws Exception {
+		if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+			Security.addProvider(new BouncyCastleProvider());
+		}
+
+		PGPKeyRingGenerator keyRingGen = createKeyRingGenerator(USER_ID);
+		secretKey = keyRingGen.generateSecretKeyRing().getSecretKey();
+		publicKeys = new PGPPublicKeyRingCollection(List.of(keyRingGen.generatePublicKeyRing()));
+	}
+
+	@BeforeEach
+	void setUp() {
+		signatureService = new SignatureService();
+	}
+
+	@Test
+	void testSignProducesValidClearSignedMessage() throws Exception {
+		File chartFile = createTempChartFile("test-chart-0.1.0.tgz", "chart-content");
+		ChartMetadata metadata = ChartMetadata.builder().name("test-chart").version("0.1.0").apiVersion("v2").build();
+
+		String provContent = signatureService.sign(chartFile, metadata, secretKey, PASSPHRASE);
+
+		assertNotNull(provContent);
+		assertTrue(provContent.contains("-----BEGIN PGP SIGNED MESSAGE-----"));
+		assertTrue(provContent.contains("Hash: SHA256"));
+		assertTrue(provContent.contains("-----BEGIN PGP SIGNATURE-----"));
+		assertTrue(provContent.contains("-----END PGP SIGNATURE-----"));
+		assertTrue(provContent.contains("name: test-chart"));
+		assertTrue(provContent.contains("version: 0.1.0"));
+	}
+
+	@Test
+	void testSignAndVerifyRoundTrip() throws Exception {
+		File chartFile = createTempChartFile("mychart-1.0.0.tgz", "binary-chart-content-here");
+		ChartMetadata metadata = ChartMetadata.builder()
+			.name("mychart")
+			.version("1.0.0")
+			.apiVersion("v2")
+			.description("A test chart")
+			.appVersion("2.0.0")
+			.type("application")
+			.build();
+
+		String provContent = signatureService.sign(chartFile, metadata, secretKey, PASSPHRASE);
+
+		assertDoesNotThrow(() -> signatureService.verify(chartFile, provContent, publicKeys));
+	}
+
+	@Test
+	void testVerifyFailsWithTamperedChart() throws Exception {
+		File chartFile = createTempChartFile("tampered-1.0.0.tgz", "original-content");
+		ChartMetadata metadata = ChartMetadata.builder().name("tampered").version("1.0.0").apiVersion("v2").build();
+
+		String provContent = signatureService.sign(chartFile, metadata, secretKey, PASSPHRASE);
+
+		// Overwrite the chart file with different content
+		try (OutputStream os = new FileOutputStream(chartFile)) {
+			os.write("tampered-content".getBytes());
+		}
+
+		SignatureVerificationException ex = assertThrows(SignatureVerificationException.class,
+				() -> signatureService.verify(chartFile, provContent, publicKeys));
+		assertTrue(ex.getMessage().contains("Digest mismatch"));
+	}
+
+	@Test
+	void testVerifyFailsWithWrongPublicKey() throws Exception {
+		PGPKeyRingGenerator otherGen = createKeyRingGenerator("Other <other@example.com>");
+		PGPPublicKeyRingCollection wrongKeys = new PGPPublicKeyRingCollection(
+				List.of(otherGen.generatePublicKeyRing()));
+
+		File chartFile = createTempChartFile("wrongkey-1.0.0.tgz", "content");
+		ChartMetadata metadata = ChartMetadata.builder().name("wrongkey").version("1.0.0").apiVersion("v2").build();
+
+		String provContent = signatureService.sign(chartFile, metadata, secretKey, PASSPHRASE);
+
+		SignatureVerificationException ex = assertThrows(SignatureVerificationException.class,
+				() -> signatureService.verify(chartFile, provContent, wrongKeys));
+		assertTrue(ex.getMessage().contains("No public key found"));
+	}
+
+	@Test
+	void testBuildProvenanceYamlIncludesAllFields() {
+		ChartMetadata metadata = ChartMetadata.builder()
+			.name("full-chart")
+			.version("2.1.0")
+			.apiVersion("v2")
+			.appVersion("3.0.0")
+			.description("A full chart")
+			.type("application")
+			.build();
+
+		String yaml = signatureService.buildProvenanceYaml(metadata, "full-chart-2.1.0.tgz", "abc123");
+
+		assertTrue(yaml.contains("apiVersion: v2"));
+		assertTrue(yaml.contains("appVersion: 3.0.0"));
+		assertTrue(yaml.contains("description: A full chart"));
+		assertTrue(yaml.contains("name: full-chart"));
+		assertTrue(yaml.contains("type: application"));
+		assertTrue(yaml.contains("version: 2.1.0"));
+		assertTrue(yaml.contains("full-chart-2.1.0.tgz: sha256:abc123"));
+	}
+
+	@Test
+	void testBuildProvenanceYamlOmitsNullFields() {
+		ChartMetadata metadata = ChartMetadata.builder().name("minimal").version("1.0.0").build();
+
+		String yaml = signatureService.buildProvenanceYaml(metadata, "minimal-1.0.0.tgz", "def456");
+
+		assertTrue(yaml.contains("apiVersion: v2"));
+		assertTrue(yaml.contains("name: minimal"));
+		assertTrue(yaml.contains("version: 1.0.0"));
+		assertTrue(!yaml.contains("appVersion:"));
+		assertTrue(!yaml.contains("description:"));
+		assertTrue(!yaml.contains("type:"));
+	}
+
+	@Test
+	void testExtractSignedDataValid() throws Exception {
+		File chartFile = createTempChartFile("extract-1.0.0.tgz", "data");
+		ChartMetadata metadata = ChartMetadata.builder().name("extract").version("1.0.0").apiVersion("v2").build();
+
+		String provContent = signatureService.sign(chartFile, metadata, secretKey, PASSPHRASE);
+		String signedData = signatureService.extractSignedData(provContent);
+
+		assertNotNull(signedData);
+		assertTrue(signedData.contains("name: extract"));
+		assertTrue(signedData.contains("version: 1.0.0"));
+	}
+
+	@Test
+	void testExtractSignedDataInvalidNoHash() {
+		SignatureVerificationException ex = assertThrows(SignatureVerificationException.class,
+				() -> signatureService.extractSignedData("no hash here"));
+		assertTrue(ex.getMessage().contains("no Hash header"));
+	}
+
+	@Test
+	void testExtractSignedDataInvalidNoBlankLine() {
+		SignatureVerificationException ex = assertThrows(SignatureVerificationException.class,
+				() -> signatureService.extractSignedData("Hash: SHA256\nno blank line"));
+		assertTrue(ex.getMessage().contains("no blank line"));
+	}
+
+	@Test
+	void testExtractSignedDataInvalidNoSignatureBlock() {
+		SignatureVerificationException ex = assertThrows(SignatureVerificationException.class,
+				() -> signatureService.extractSignedData("Hash: SHA256\n\ndata but no sig"));
+		assertTrue(ex.getMessage().contains("no signature block"));
+	}
+
+	@Test
+	void testLoadSecretKeyFromFile() throws Exception {
+		// Write the secret key to a file
+		Path keyFile = tempDir.resolve("secret.gpg");
+		PGPSecretKeyRingCollection collection = new PGPSecretKeyRingCollection(
+				List.of(new PGPSecretKeyRing(secretKey.getEncoded(), new JcaKeyFingerprintCalculator())));
+		try (OutputStream out = new FileOutputStream(keyFile.toFile());
+				ArmoredOutputStream armoredOut = new ArmoredOutputStream(out)) {
+			collection.encode(armoredOut);
+		}
+
+		PGPSecretKey loaded = signatureService.loadSecretKey(keyFile.toString(), "test@example.com");
+		assertNotNull(loaded);
+		assertEquals(secretKey.getKeyID(), loaded.getKeyID());
+	}
+
+	@Test
+	void testLoadSecretKeyNotFound() throws Exception {
+		Path keyFile = tempDir.resolve("secret2.gpg");
+		PGPSecretKeyRingCollection collection = new PGPSecretKeyRingCollection(
+				List.of(new PGPSecretKeyRing(secretKey.getEncoded(), new JcaKeyFingerprintCalculator())));
+		try (OutputStream out = new FileOutputStream(keyFile.toFile());
+				ArmoredOutputStream armoredOut = new ArmoredOutputStream(out)) {
+			collection.encode(armoredOut);
+		}
+
+		assertThrows(PGPException.class,
+				() -> signatureService.loadSecretKey(keyFile.toString(), "nonexistent@example.com"));
+	}
+
+	@Test
+	void testLoadPublicKeyringFromFile() throws Exception {
+		Path keyFile = tempDir.resolve("public.gpg");
+		try (OutputStream out = new FileOutputStream(keyFile.toFile());
+				ArmoredOutputStream armoredOut = new ArmoredOutputStream(out)) {
+			publicKeys.encode(armoredOut);
+		}
+
+		PGPPublicKeyRingCollection loaded = signatureService.loadPublicKeyring(keyFile.toString());
+		assertNotNull(loaded);
+		assertTrue(loaded.contains(secretKey.getKeyID()));
+	}
+
+	@Test
+	void testVerifyRejectsNoSignatureContent() {
+		File chartFile = tempDir.resolve("nosig.tgz").toFile();
+		assertThrows(SignatureVerificationException.class,
+				() -> signatureService.verify(chartFile, "no signature content", publicKeys));
+	}
+
+	private static PGPKeyRingGenerator createKeyRingGenerator(String userId) throws Exception {
+		KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "BC");
+		kpg.initialize(2048);
+		KeyPair keyPair = kpg.generateKeyPair();
+		PGPKeyPair pgpKeyPair = new JcaPGPKeyPair(PublicKeyAlgorithmTags.RSA_GENERAL, keyPair, new Date());
+		return new PGPKeyRingGenerator(PGPSignature.POSITIVE_CERTIFICATION, pgpKeyPair, userId,
+				new JcaPGPDigestCalculatorProviderBuilder().setProvider("BC").build().get(HashAlgorithmTags.SHA1), null,
+				null,
+				new JcaPGPContentSignerBuilder(pgpKeyPair.getPublicKey().getAlgorithm(), HashAlgorithmTags.SHA256)
+					.setProvider("BC"),
+				new JcePBESecretKeyEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_256,
+						new JcaPGPDigestCalculatorProviderBuilder().setProvider("BC")
+							.build()
+							.get(HashAlgorithmTags.SHA256))
+					.setProvider("BC")
+					.build(PASSPHRASE));
+	}
+
+	private File createTempChartFile(String name, String content) throws IOException {
+		File file = tempDir.resolve(name).toFile();
+		try (OutputStream os = new FileOutputStream(file)) {
+			os.write(content.getBytes());
+		}
+		return file;
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,11 @@
                 <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpg-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Summary
- Implement `SignatureService` for PGP clear-signing and verification of Helm provenance (`.prov`) files
- Add `PackageAction` to package chart directories into `.tgz` archives with optional signing
- Add `VerifyAction` to verify chart archives against provenance files
- Wire CLI commands (`jhelm package`, `jhelm verify`) with full flag support (`--sign`, `--key`, `--keyring`, `--passphrase-file`)

## Test plan
- [x] 14 unit tests for `SignatureService` (sign, verify, round-trip, tamper detection, key loading)
- [x] 3 unit tests for `PackageAction` (archive creation, signing, no-sign)
- [x] 4 unit tests for `VerifyAction` (valid signature, tampered chart, missing files)
- [x] All 526 existing tests pass

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)