### PR TITLE
Fix semverCompare regex corrupting 3-part versions with pre-release

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -40,17 +40,6 @@ jhelmtest:
       - resource: "ClusterRole/*"
         path: "rules.*"
         reason: "BUG: conditional rules render differently — likely values-driven if/range evaluation gap"
-    "[ingress-nginx/ingress-nginx]":
-      # Service fields populated by Helm but not by JHelm
-      - resource: "Service/*"
-        path: "spec.ipFamilyPolicy"
-        reason: "JHelm does not populate ipFamilyPolicy default"
-      - resource: "Service/*"
-        path: "spec.ipFamilies"
-        reason: "JHelm does not populate ipFamilies default"
-      - resource: "Service/*"
-        path: "spec.ports.*"
-        reason: "JHelm does not populate appProtocol on service ports"
     "[gitlab/gitlab-runner]":
       # BUG: JHelm renders empty string instead of null for env values
       - resource: "Deployment/*"
@@ -95,11 +84,6 @@ jhelmtest:
       - resource: "*"
         path: "*"
         reason: "BUG: Subchart version labels, StatefulSet 99 diffs, Secret content missing"
-    "[datadog/datadog]":
-      # BUG: Template-level semver check causes fail() — agent image version comparison
-      - resource: "*"
-        path: "*"
-        reason: "BUG: semverCompare in template triggers fail() for agent image version check"
     "[runix/pgadmin4]":
       # BUG: Parser fails on nested parenthesized expressions in _helpers.tpl
       - resource: "*"

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/SemverFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/SemverFunctions.java
@@ -103,7 +103,8 @@ public final class SemverFunctions {
 	 * accepts 2-part versions like "1.13-0" (meaning 1.13.0-0), but semver4j requires
 	 * strict 3-part versions. This adds the missing ".0" patch component.
 	 */
-	private static final Pattern TWO_PART_VERSION = Pattern.compile("(?<!\\d\\.)(\\d+\\.\\d+)(-\\S+)?(?=\\s|$|\\|)");
+	private static final Pattern TWO_PART_VERSION = Pattern
+		.compile("(?<![.\\d])(\\d+\\.\\d+)(?!\\.\\d)(-\\S+)?(?=\\s|$|\\|)");
 
 	private static String normalizeConstraint(String constraint) {
 		Matcher m = TWO_PART_VERSION.matcher(constraint);
@@ -111,10 +112,7 @@ public final class SemverFunctions {
 		while (m.find()) {
 			String majorMinor = m.group(1);
 			String suffix = (m.group(2) != null) ? m.group(2) : "";
-			// Only add .0 if there's no third part already
-			if (!majorMinor.matches(".*\\.\\d+\\.\\d+.*")) {
-				m.appendReplacement(sb, majorMinor + ".0" + suffix);
-			}
+			m.appendReplacement(sb, Matcher.quoteReplacement(majorMinor + ".0" + suffix));
 		}
 		m.appendTail(sb);
 		return sb.toString();

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/SemverFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/SemverFunctionsTest.java
@@ -220,4 +220,37 @@ class SemverFunctionsTest {
 		assertEquals("true", writer.toString());
 	}
 
+	// --- Datadog pattern: caret + OR + pre-release suffix ---
+
+	@Test
+	void testSemverCompareCaretOrWithPrerelease() throws IOException, TemplateException {
+		// datadog/datadog pattern: semverCompare "^6.36.0-0 || ^7.36.0-0" "7.76.1"
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"^6.36.0-0 || ^7.36.0-0\" \"7.76.1\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareCaretOrFirstBranch() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"^6.36.0-0 || ^7.36.0-0\" \"6.50.0\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareCaretOrNeitherMatch() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"^6.36.0-0 || ^7.36.0-0\" \"5.0.0\" }}", new HashMap<>(), writer);
+		assertEquals("false", writer.toString());
+	}
+
+	// --- ingress-nginx pattern: semverCompare with v-prefix ---
+
+	@Test
+	void testSemverCompareWithVPrefix() throws IOException, TemplateException {
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \">=1.21.0-0\" \"v1.35.0\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
 }


### PR DESCRIPTION
## Summary
- Fixed `normalizeConstraint()` regex that was matching partial version numbers within 3-part versions (e.g. matching `6.0` inside `36.0-0`), corrupting constraints like `^6.36.0-0 || ^7.36.0-0`
- Added negative lookbehind for dots (`(?<![.\d])`) and negative lookahead (`(?!\.\d)`) to only match true 2-part versions
- Removed now-unnecessary comparison ignores for `datadog/datadog` and `ingress-nginx` charts

Fixes #138

## Test plan
- [x] All 32 existing `SemverFunctionsTest` tests pass
- [x] 4 new test cases added: caret+OR with pre-release (datadog pattern), first branch match, neither match, v-prefix (ingress-nginx pattern)
- [x] `KpsComparisonTest` passes with 5 charts
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)