### PR TITLE
Add missing atoi, toStrings, toDecimal Sprig functions

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -645,4 +645,115 @@ class EngineTest {
 		assertTrue(result.contains("cache-port: 6379"));
 	}
 
+	// --- Issue #137: nested parenthesized expressions ---
+
+	@Test
+	void testNestedParenthesizedExpressionsWithTernary() {
+		// pgadmin4 pattern: tpl (ternary .toMap (.toMap | toYaml) (kindIs "string"
+		// .toMap)) .context
+		String helpers = """
+				{{- define "mychart.tplToMap" -}}
+				{{- tpl (ternary .toMap (.toMap | toYaml) (kindIs "string" .toMap)) .context -}}
+				{{- end -}}
+				""";
+		String deployment = """
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: test
+				  labels:
+				    {{ include "mychart.tplToMap" (dict "toMap" "app: myapp" "context" $) }}
+				""";
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("_helpers.tpl", helpers), tmpl("configmap.yaml", deployment)), Map.of());
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("app: myapp"), "tplToMap should resolve string input: " + result);
+	}
+
+	@Test
+	void testNestedParenthesizedExpressionsWithMapInput() {
+		// When input is a map, kindIs "string" → false, so (.toMap | toYaml) branch is
+		// chosen
+		String helpers = """
+				{{- define "mychart.tplToMap" -}}
+				{{- tpl (ternary .toMap (.toMap | toYaml) (kindIs "string" .toMap)) .context -}}
+				{{- end -}}
+				""";
+		String deployment = """
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: test
+				  labels:
+				    {{ include "mychart.tplToMap" (dict "toMap" (dict "app" "myapp") "context" $) }}
+				""";
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("_helpers.tpl", helpers), tmpl("configmap.yaml", deployment)), Map.of());
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("app: myapp"), "tplToMap should resolve map input via toYaml: " + result);
+	}
+
+	@Test
+	void testPgadmin4HelpersFullParse() {
+		// Test parsing the full pgadmin4 _helpers.tpl patterns
+		String helpers = """
+				{{- define "pgadmin.name" -}}
+				{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+				{{- end -}}
+
+				{{- define "pgadmin.fullname" -}}
+				{{- if .Values.fullnameOverride -}}
+				{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+				{{- else -}}
+				{{- $name := default .Chart.Name .Values.nameOverride -}}
+				{{- if contains $name .Release.Name -}}
+				{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+				{{- else -}}
+				{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+				{{- end -}}
+				{{- end -}}
+				{{- end -}}
+
+				{{- define "pgadmin.tplToMap" -}}
+				{{- tpl (ternary .toMap (.toMap | toYaml) (kindIs "string" .toMap)) .context -}}
+				{{- end -}}
+
+				{{- define "pgadmin.ingress.apiVersion" -}}
+				{{- if and ($.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version) }}
+				{{- print "networking.k8s.io/v1" }}
+				{{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+				{{- print "networking.k8s.io/v1beta1" }}
+				{{- else }}
+				{{- print "extensions/v1beta1" }}
+				{{- end }}
+				{{- end }}
+
+				{{- define "deployment.apiVersion" -}}
+				{{- print "apps/v1" -}}
+				{{- end -}}
+
+				{{- define "pgadmin.validateValues" -}}
+				{{- $problems := list -}}
+				{{- $_ := set $.Values "serverDefinitions" (default (dict) $.Values.serverDefinitions) -}}
+				{{- $type := default "" $.Values.serverDefinitions.resourceType -}}
+				{{- if and $.Values.serverDefinitions.enabled (not (or (eq $type "ConfigMap") (eq $type "Secret"))) -}}
+				{{- $problems = append $problems "serverDefinitions.resourceType must be 'ConfigMap' or 'Secret'" -}}
+				{{- end -}}
+				{{- if gt (len $problems) 0 -}}
+				{{- fail (printf "VALIDATION: %s" (join ", " $problems)) -}}
+				{{- end -}}
+				{{- end -}}
+				""";
+		String deployment = """
+				apiVersion: {{ template "deployment.apiVersion" . }}
+				kind: Deployment
+				metadata:
+				  name: {{ include "pgadmin.fullname" . }}
+				""";
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("_helpers.tpl", helpers), tmpl("deployment.yaml", deployment)), Map.of());
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("apiVersion: apps/v1"), "deployment.apiVersion should render: " + result);
+	}
+
 }

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -79,11 +79,6 @@ jhelmtest:
       - resource: "*"
         path: "*"
         reason: "BUG: Subchart version labels, StatefulSet 99 diffs, Secret content missing"
-    "[runix/pgadmin4]":
-      # BUG: Parser fails on nested parenthesized expressions in _helpers.tpl
-      - resource: "*"
-        path: "*"
-        reason: "BUG: Parser cannot handle nested parenthesized expressions like (kindIs \"string\" .toMap)"
     "[goauthentik/authentik]":
       # BUG: Missing RBAC resources and serviceAccountName
       - resource: "*"

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctions.java
@@ -1,6 +1,9 @@
 package org.alexmond.jhelm.gotemplate.sprig.functions;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.alexmond.jhelm.gotemplate.Function;
@@ -23,7 +26,10 @@ public final class MathFunctions {
 		functions.put("int", toInt());
 		functions.put("int64", toInt64());
 		functions.put("float64", toFloat64());
+		functions.put("atoi", atoi());
 		functions.put("toString", toStringFunc());
+		functions.put("toStrings", toStrings());
+		functions.put("toDecimal", toDecimal());
 
 		// Basic arithmetic
 		functions.put("add", add());
@@ -105,6 +111,52 @@ public final class MathFunctions {
 
 	private static Function toStringFunc() {
 		return (args) -> (args.length == 0) ? "" : String.valueOf(args[0]);
+	}
+
+	private static Function atoi() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return 0;
+			}
+			try {
+				return Integer.parseInt(String.valueOf(args[0]).trim());
+			}
+			catch (NumberFormatException ex) {
+				return 0;
+			}
+		};
+	}
+
+	private static Function toStrings() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return List.of();
+			}
+			Object arg = args[0];
+			if (arg instanceof Collection<?> coll) {
+				List<String> result = new ArrayList<>(coll.size());
+				for (Object item : coll) {
+					result.add(String.valueOf(item));
+				}
+				return result;
+			}
+			return List.of(String.valueOf(arg));
+		};
+	}
+
+	private static Function toDecimal() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return 0L;
+			}
+			String s = String.valueOf(args[0]).trim();
+			try {
+				return Long.parseLong(s, 8);
+			}
+			catch (NumberFormatException ex) {
+				return 0L;
+			}
+		};
 	}
 
 	// ========== Basic Arithmetic Functions ==========

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/LogicFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/LogicFunctionsTest.java
@@ -197,4 +197,36 @@ class LogicFunctionsTest {
 		assertNotEquals("fallback", result);
 	}
 
+	// Issue #137: nested parenthesized function calls as arguments
+
+	@Test
+	void testTernaryWithParenthesizedFunctionArg() throws IOException, TemplateException {
+		// kindIs "string" "hello" → true, so ternary returns first arg "a"
+		assertEquals("a", exec("{{ ternary \"a\" \"b\" (kindIs \"string\" \"hello\") }}", new HashMap<>()));
+	}
+
+	@Test
+	void testTernaryWithParenthesizedPipeline() throws IOException, TemplateException {
+		// (.value | upper) → "HELLO", so ternary returns first arg "yes"
+		Map<String, Object> data = new HashMap<>();
+		data.put("value", "hello");
+		assertEquals("yes", exec("{{ ternary \"yes\" \"no\" (.value | upper) }}", data));
+	}
+
+	@Test
+	void testTernaryWithMultipleParenthesizedArgs() throws IOException, TemplateException {
+		// Full pgadmin4-style: tpl (ternary arg1 arg2 (kindIs ...))
+		Map<String, Object> data = new HashMap<>();
+		data.put("toMap", "hello");
+		assertEquals("hello", exec("{{ ternary .toMap (.toMap | upper) (kindIs \"string\" .toMap) }}", data));
+	}
+
+	@Test
+	void testNestedParensInsideParens() throws IOException, TemplateException {
+		// Issue #137: parens inside parens — (ternary X (Y | Z) (kindIs ...))
+		Map<String, Object> data = new HashMap<>();
+		data.put("toMap", "hello");
+		assertEquals("hello", exec("{{ (ternary .toMap (.toMap | upper) (kindIs \"string\" .toMap)) }}", data));
+	}
+
 }

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctionsTest.java
@@ -1,14 +1,18 @@
 package org.alexmond.jhelm.gotemplate.sprig.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
+import java.util.List;
 
+import org.alexmond.jhelm.gotemplate.Function;
 import org.alexmond.jhelm.gotemplate.GoTemplate;
 import org.alexmond.jhelm.gotemplate.TemplateException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -53,6 +57,51 @@ class MathFunctionsTest {
 			"{{ $u := until 3 }}{{ len $u }}              | 3", "{{ $u := untilStep 0 10 2 }}{{ len $u }}     | 5" })
 	void testSequenceFunction(String template, String expected) throws IOException, TemplateException {
 		assertEquals(expected, exec(template));
+	}
+
+	// --- atoi, toStrings, toDecimal ---
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|', value = { "{{ atoi \"42\" }}     | 42", "{{ atoi \"0\" }}      | 0",
+			"{{ atoi \"-7\" }}     | -7", "{{ atoi \"abc\" }}    | 0" })
+	void testAtoi(String template, String expected) throws IOException, TemplateException {
+		assertEquals(expected, exec(template));
+	}
+
+	@Test
+	void testAtoiNullReturnsZero() {
+		Function fn = MathFunctions.getFunctions().get("atoi");
+		assertEquals(0, fn.invoke(new Object[] {}));
+		assertEquals(0, fn.invoke(new Object[] { null }));
+	}
+
+	@Test
+	void testToStringsReturnsList() {
+		Function fn = MathFunctions.getFunctions().get("toStrings");
+		Object result = fn.invoke(new Object[] { List.of(1, 2, 3) });
+		assertInstanceOf(List.class, result);
+		assertEquals(List.of("1", "2", "3"), result);
+	}
+
+	@Test
+	void testToStringsNullReturnsEmptyList() {
+		Function fn = MathFunctions.getFunctions().get("toStrings");
+		assertEquals(List.of(), fn.invoke(new Object[] {}));
+		assertEquals(List.of(), fn.invoke(new Object[] { null }));
+	}
+
+	@ParameterizedTest
+	@CsvSource(delimiter = '|', value = { "0777 | 511", "0644 | 420", "0755 | 493" })
+	void testToDecimal(String input, long expected) {
+		Function fn = MathFunctions.getFunctions().get("toDecimal");
+		assertEquals(expected, fn.invoke(new Object[] { input }));
+	}
+
+	@Test
+	void testToDecimalNullReturnsZero() {
+		Function fn = MathFunctions.getFunctions().get("toDecimal");
+		assertEquals(0L, fn.invoke(new Object[] {}));
+		assertEquals(0L, fn.invoke(new Object[] { null }));
 	}
 
 }


### PR DESCRIPTION
## Summary
- Adds three missing Sprig type conversion functions: `atoi`, `toStrings`, `toDecimal`
- Fixes pgadmin4 chart rendering — `_helpers.tpl` failed to parse due to missing `atoi`, causing all named templates to be lost
- Removes pgadmin4 comparison-ignores entry (chart now renders with all resources matching Helm output)
- Adds EngineTest cases for nested parenthesized expression patterns used by pgadmin4

## Test plan
- [x] MathFunctionsTest: 38 tests pass (7 new for atoi/toStrings/toDecimal)
- [x] LogicFunctionsTest: 46 tests pass (4 new for parenthesized function args)
- [x] EngineTest: 45 tests pass (3 new for pgadmin4 patterns)
- [x] KpsComparisonTest: pgadmin4 renders all 6 resources matching Helm output
- [x] Full build: all modules pass

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)