### PR TITLE
Fix merge/mergeOverwrite dict function semantics

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -756,4 +756,53 @@ class EngineTest {
 		assertTrue(result.contains("apiVersion: apps/v1"), "deployment.apiVersion should render: " + result);
 	}
 
+	// --- Issue #135: subchart version labels ---
+
+	@Test
+	void testCommonImagesVersionWithSemverTag() {
+		// bitnami/minio common.images.version pattern with backtick regex
+		String helpers = """
+				{{- define "common.images.version" -}}
+				{{- $imageTag := .imageRoot.tag | toString -}}
+				{{- if regexMatch `^([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?$` $imageTag -}}
+				    {{- $version := semver $imageTag -}}
+				    {{- printf "%d.%d.%d" $version.Major $version.Minor $version.Patch -}}
+				{{- else -}}
+				    {{- print .chart.AppVersion -}}
+				{{- end -}}
+				{{- end -}}
+				""";
+		String deployment = """
+				version: {{ include "common.images.version" (dict "imageRoot" (dict "tag" "2.0.2-debian-12-r3") "chart" .Chart) }}
+				""";
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("_helpers.tpl", helpers), tmpl("deployment.yaml", deployment)), Map.of());
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("version: 2.0.2"),
+				"Should extract semver 2.0.2 from tag 2.0.2-debian-12-r3: " + result);
+	}
+
+	@Test
+	void testCommonImagesVersionDebug() {
+		// Test each step individually to find where it fails
+		String helpers = """
+				{{- define "test.debug" -}}
+				tag={{ .imageRoot.tag }}|toString={{ .imageRoot.tag | toString }}|match={{ regexMatch `^([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?$` (.imageRoot.tag | toString) }}
+				{{- end -}}
+				""";
+		Map<String, Object> consoleImage = new HashMap<>();
+		consoleImage.put("tag", "2.0.2-debian-12-r3");
+		Map<String, Object> values = new HashMap<>();
+		values.put("console", Map.of("image", consoleImage));
+
+		String deployment = """
+				{{ include "test.debug" (dict "imageRoot" .Values.console.image "chart" .Chart) }}
+				""";
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("_helpers.tpl", helpers), tmpl("deployment.yaml", deployment)), values);
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		// Check that regexMatch returns true
+		assertTrue(result.contains("match=true"), "regexMatch should match 2.0.2-debian-12-r3: " + result);
+	}
+
 }

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -59,11 +59,6 @@ jhelmtest:
       - resource: "*"
         path: "*"
         reason: "BUG: Complex chart — ConfigMap 15 diffs, DaemonSet 54 diffs, RBAC and service diffs"
-    "[bitnami/minio]":
-      # BUG: Subchart version labels show parent chart version instead of subchart version
-      - resource: "*"
-        path: "metadata.labels.app.kubernetes.io/version"
-        reason: "BUG: Subchart resources get parent chart version label instead of subchart version"
     "[argo/argo-workflows]":
       # BUG: CRD resources not rendered by JHelm
       - resource: "CustomResourceDefinition/*"
@@ -74,16 +69,6 @@ jhelmtest:
       - resource: "*"
         path: "*"
         reason: "BUG: Entire chart fails to render — likely non-standard chart structure"
-    "[gitea/gitea]":
-      # BUG: Subchart rendering gaps — version labels, StatefulSet, Secrets
-      - resource: "*"
-        path: "*"
-        reason: "BUG: Subchart version labels, StatefulSet 99 diffs, Secret content missing"
-    "[goauthentik/authentik]":
-      # BUG: Missing RBAC resources and serviceAccountName
-      - resource: "*"
-        path: "*"
-        reason: "BUG: Missing ServiceAccount, ClusterRole, ClusterRoleBinding, Role, RoleBinding resources"
     "[artifact-hub/artifact-hub]":
       # BUG: Null values rendered as empty string in Secret stringData
       - resource: "Secret/*"

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
@@ -169,18 +169,53 @@ public final class DictFunctions {
 	@SuppressWarnings("unchecked")
 	private static Function merge() {
 		return (args) -> {
-			Map<String, Object> result = new LinkedHashMap<>();
-			for (Object arg : args) {
-				if (arg instanceof Map) {
-					result.putAll((Map<String, Object>) arg);
+			if (args.length == 0) {
+				return new LinkedHashMap<>();
+			}
+			Map<String, Object> dst = (args[0] instanceof Map) ? (Map<String, Object>) args[0] : new LinkedHashMap<>();
+			for (int i = 1; i < args.length; i++) {
+				if (args[i] instanceof Map) {
+					deepMerge(dst, (Map<String, Object>) args[i], false);
 				}
 			}
-			return result;
+			return dst;
 		};
 	}
 
+	@SuppressWarnings("unchecked")
 	private static Function mergeOverwrite() {
-		return merge(); // Same behavior in simple implementation
+		return (args) -> {
+			if (args.length == 0) {
+				return new LinkedHashMap<>();
+			}
+			Map<String, Object> dst = (args[0] instanceof Map) ? (Map<String, Object>) args[0] : new LinkedHashMap<>();
+			for (int i = 1; i < args.length; i++) {
+				if (args[i] instanceof Map) {
+					deepMerge(dst, (Map<String, Object>) args[i], true);
+				}
+			}
+			return dst;
+		};
+	}
+
+	@SuppressWarnings("unchecked")
+	private static void deepMerge(Map<String, Object> dst, Map<String, Object> src, boolean overwrite) {
+		for (Map.Entry<String, Object> entry : src.entrySet()) {
+			String key = entry.getKey();
+			Object srcVal = entry.getValue();
+			if (dst.containsKey(key)) {
+				Object dstVal = dst.get(key);
+				if (dstVal instanceof Map && srcVal instanceof Map) {
+					deepMerge((Map<String, Object>) dstVal, (Map<String, Object>) srcVal, overwrite);
+				}
+				else if (overwrite) {
+					dst.put(key, srcVal);
+				}
+			}
+			else {
+				dst.put(key, srcVal);
+			}
+		}
 	}
 
 	private static Function mustMerge() {

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
@@ -207,12 +207,48 @@ class CollectionFunctionsTest {
 	@CsvSource(delimiter = '|', value = {
 			"{{ $d1 := dict \"a\" 1 }}{{ $d2 := dict \"b\" 2 }}{{ $m := merge $d1 $d2 }}{{ len $m }}                         | 2",
 			"{{ $d1 := dict \"a\" 1 }}{{ $d2 := dict \"b\" 2 }}{{ $m := mustMerge $d1 $d2 }}{{ len $m }}                     | 2",
+			"{{ $d1 := dict \"a\" 1 }}{{ $d2 := dict \"a\" 2 }}{{ $m := merge $d1 $d2 }}{{ get $m \"a\" }}                    | 1",
+			"{{ $d1 := dict \"a\" 1 }}{{ $d2 := dict \"a\" 2 }}{{ $m := mustMerge $d1 $d2 }}{{ get $m \"a\" }}                | 1",
 			"{{ $d1 := dict \"a\" 1 }}{{ $d2 := dict \"a\" 2 }}{{ $m := mergeOverwrite $d1 $d2 }}{{ get $m \"a\" }}          | 2",
 			"{{ $d1 := dict \"a\" 1 }}{{ $d2 := dict \"a\" 2 }}{{ $m := mustMergeOverwrite $d1 $d2 }}{{ get $m \"a\" }}      | 2",
 			"{{ $d := dict \"a\" 1 }}{{ $c := deepCopy $d }}{{ get $c \"a\" }}                                                | 1",
 			"{{ $d := dict \"a\" 1 }}{{ $c := mustDeepCopy $d }}{{ get $c \"a\" }}                                            | 1" })
 	void testMergeAndCopy(String template, String expected) throws IOException, TemplateException {
 		assertEquals(expected, exec(template));
+	}
+
+	@Test
+	void testMergeDeepNested() throws IOException, TemplateException {
+		// Deep merge: nested maps should be merged recursively, dst values preserved
+		String template = """
+				{{ $d1 := dict "outer" (dict "a" 1 "b" 2) }}\
+				{{ $d2 := dict "outer" (dict "a" 99 "c" 3) }}\
+				{{ $m := merge $d1 $d2 }}\
+				{{ (get (get $m "outer") "a") }},{{ (get (get $m "outer") "b") }},{{ (get (get $m "outer") "c") }}""";
+		assertEquals("1,2,3", exec(template));
+	}
+
+	@Test
+	void testMergeOverwriteDeepNested() throws IOException, TemplateException {
+		// mergeOverwrite: source values should overwrite destination values
+		String template = """
+				{{ $d1 := dict "outer" (dict "a" 1 "b" 2) }}\
+				{{ $d2 := dict "outer" (dict "a" 99 "c" 3) }}\
+				{{ $m := mergeOverwrite $d1 $d2 }}\
+				{{ (get (get $m "outer") "a") }},{{ (get (get $m "outer") "b") }},{{ (get (get $m "outer") "c") }}""";
+		assertEquals("99,2,3", exec(template));
+	}
+
+	@Test
+	void testMergePipelineDestinationWins() throws IOException, TemplateException {
+		// Simulates the Helm pattern: pipeline value | merge $dst
+		// In this pattern, $dst is the first arg, pipeline value is the source
+		String template = """
+				{{ $dst := dict "version" "1.0" }}\
+				{{ $src := dict "version" "2.0" "name" "test" }}\
+				{{ $dst = merge $dst $src }}\
+				{{ get $dst "version" }},{{ get $dst "name" }}""";
+		assertEquals("1.0,test", exec(template));
 	}
 
 	// Standalone tests for operations without must* variants


### PR DESCRIPTION
## Summary
- Fix `merge` function to preserve destination (first arg) keys, matching Go Sprig behavior (previously `putAll` made last arg win)
- Fix `mergeOverwrite` to have proper source-wins semantics (was incorrectly aliased to `merge`)
- Add deep recursive merging of nested maps matching Go's mergo library behavior
- Remove comparison-ignores for `gitea/gitea` and `goauthentik/authentik` (now render correctly)

## Test plan
- [x] New parameterized tests for `merge` with conflicting keys (destination wins)
- [x] New tests for deep nested merge and mergeOverwrite behavior
- [x] New test for merge pipeline pattern (simulating Helm template usage)
- [x] Engine integration tests for `common.images.version` template with semver extraction
- [x] `KpsComparisonTest#compareSingleChart` — bitnami/minio renders all 11 resources correctly
- [x] `KpsComparisonTest#compareSingleChart` — gitea/gitea renders all 30 resources correctly
- [x] `KpsComparisonTest#compareSingleChart` — goauthentik/authentik renders all resources correctly
- [x] Full `KpsComparisonTest` — all top charts pass

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)