### PR TITLE
Fix quote/squote null handling and regexMatch substring matching

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -805,4 +805,81 @@ class EngineTest {
 		assertTrue(result.contains("match=true"), "regexMatch should match 2.0.2-debian-12-r3: " + result);
 	}
 
+	// --- Issue #134: quote null and regexMatch substring ---
+
+	@Test
+	void testQuoteNullOmitsReplicas() {
+		// gitlab-runner pattern: {{- if and (not .Values.hpa) (not (quote
+		// .Values.replicas | empty)) }}
+		String helpers = """
+				{{- define "test.replicas" -}}
+				{{- if and (not .Values.hpa) (not (quote .Values.replicas | empty)) -}}
+				replicas: {{ .Values.replicas }}
+				{{- end -}}
+				{{- end -}}
+				""";
+		String deployment = """
+				spec:
+				  {{ include "test.replicas" . }}
+				  revisionHistoryLimit: 10
+				""";
+		// replicas and hpa not set (null)
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("_helpers.tpl", helpers), tmpl("deployment.yaml", deployment)), Map.of());
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertFalse(result.contains("replicas:"), "replicas should be omitted when null: " + result);
+		assertTrue(result.contains("revisionHistoryLimit: 10"), "other fields should render: " + result);
+	}
+
+	@Test
+	void testQuoteNullEnvValue() {
+		// gitlab-runner pattern: value: {{ include "gitlab-runner.gitlabUrl" . }}
+		// where gitlabUrl is: {{- .Values.gitlabUrl | quote -}}
+		String helpers = """
+				{{- define "test.url" -}}
+				{{- .Values.gitlabUrl | quote -}}
+				{{- end -}}
+				""";
+		String deployment = """
+				env:
+				- name: CI_SERVER_URL
+				  value: {{ include "test.url" . }}
+				""";
+		// gitlabUrl not set (null)
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("_helpers.tpl", helpers), tmpl("deployment.yaml", deployment)), Map.of());
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		// With null gitlabUrl, quote returns empty string, so value: has no content after
+		// it
+		assertFalse(result.contains("value: \"\""), "null gitlabUrl should not produce quoted empty: " + result);
+	}
+
+	@Test
+	void testRegexMatchSubstringInConfig() {
+		// gitlab-runner pattern: regexMatch "\\s*namespace\\s*=" .Values.runners.config
+		String helpers = """
+				{{- define "test.env" -}}
+				{{- if not (regexMatch "\\\\s*namespace\\\\s*=" .Values.runners.config) -}}
+				- name: KUBERNETES_NAMESPACE
+				  value: {{ .Release.Namespace | quote }}
+				{{- end -}}
+				{{- end -}}
+				""";
+		String deployment = """
+				env:
+				{{ include "test.env" . }}
+				""";
+		Map<String, Object> values = new HashMap<>();
+		Map<String, Object> runners = new HashMap<>();
+		runners.put("config", "[[runners]]\n  [runners.kubernetes]\n    namespace = \"default\"");
+		values.put("runners", runners);
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("_helpers.tpl", helpers), tmpl("deployment.yaml", deployment)), values);
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		// namespace = is in config, so regexMatch should be true, and
+		// KUBERNETES_NAMESPACE should be omitted
+		assertFalse(result.contains("KUBERNETES_NAMESPACE"),
+				"KUBERNETES_NAMESPACE should be omitted when namespace is in config: " + result);
+	}
+
 }

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -35,15 +35,6 @@ jhelmtest:
       - resource: "ClusterRole/*"
         path: "rules.*"
         reason: "BUG: conditional rules render differently — likely values-driven if/range evaluation gap"
-    "[gitlab/gitlab-runner]":
-      # BUG: JHelm renders empty string instead of null for env values
-      - resource: "Deployment/*"
-        path: "spec.template.spec.containers[0].env.*"
-        reason: "BUG: env value/name ordering and null-vs-empty-string differences"
-      # BUG: JHelm emits explicit null for spec.replicas that Helm omits
-      - resource: "Deployment/*"
-        path: "spec.replicas"
-        reason: "BUG: JHelm emits explicit null fields that Helm omits"
     "[apache-airflow/airflow]":
       # BUG: Complex chart with many rendering gaps — worker resources, volumeMount ordering, etc.
       - resource: "*"

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
@@ -290,21 +290,40 @@ public final class StringFunctions {
 
 	private static Function quote() {
 		return (args) -> {
-			if (args.length == 0 || args[0] == null) {
-				return "\"\"";
+			StringBuilder out = new StringBuilder();
+			for (Object arg : args) {
+				if (arg == null) {
+					continue;
+				}
+				if (!out.isEmpty()) {
+					out.append(' ');
+				}
+				String escaped = String.valueOf(arg)
+					.replace("\\", "\\\\")
+					.replace("\"", "\\\"")
+					.replace("\n", "\\n")
+					.replace("\r", "\\r")
+					.replace("\t", "\\t");
+				out.append('"').append(escaped).append('"');
 			}
-			String escaped = String.valueOf(args[0])
-				.replace("\\", "\\\\")
-				.replace("\"", "\\\"")
-				.replace("\n", "\\n")
-				.replace("\r", "\\r")
-				.replace("\t", "\\t");
-			return "\"" + escaped + "\"";
+			return out.toString();
 		};
 	}
 
 	private static Function squote() {
-		return (args) -> (args.length == 0 || args[0] == null) ? "''" : "'" + args[0] + "'";
+		return (args) -> {
+			StringBuilder out = new StringBuilder();
+			for (Object arg : args) {
+				if (arg == null) {
+					continue;
+				}
+				if (!out.isEmpty()) {
+					out.append(' ');
+				}
+				out.append('\'').append(arg).append('\'');
+			}
+			return out.toString();
+		};
 	}
 
 	private static Function cat() {
@@ -431,7 +450,8 @@ public final class StringFunctions {
 	private static Function regexMatch() {
 		return (args) -> {
 			try {
-				return args.length >= 2 && String.valueOf(args[1]).matches(String.valueOf(args[0]));
+				return args.length >= 2
+						&& Pattern.compile(String.valueOf(args[0])).matcher(String.valueOf(args[1])).find();
 			}
 			catch (Exception ex) {
 				return false;
@@ -445,7 +465,7 @@ public final class StringFunctions {
 				throw new RuntimeException("mustRegexMatch: insufficient arguments");
 			}
 			try {
-				return String.valueOf(args[1]).matches(String.valueOf(args[0]));
+				return Pattern.compile(String.valueOf(args[0])).matcher(String.valueOf(args[1])).find();
 			}
 			catch (Exception ex) {
 				throw new RuntimeException("mustRegexMatch: " + ex.getMessage(), ex);

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctionsTest.java
@@ -134,12 +134,34 @@ class StringFunctionsTest {
 	@CsvSource(delimiter = '|',
 			value = { "{{ regexMatch \"^[a-z]+$\" \"hello\" }}       | true",
 					"{{ mustRegexMatch \"^[a-z]+$\" \"hello\" }}   | true",
+					"{{ regexMatch \"[0-9]+\" \"abc123def\" }}      | true",
+					"{{ mustRegexMatch \"[0-9]+\" \"abc123def\" }}  | true",
+					"{{ regexMatch \"xyz\" \"abc123def\" }}          | false",
 					"{{ regexFind \"[0-9]+\" \"abc123def\" }}       | 123",
 					"{{ mustRegexFind \"[0-9]+\" \"abc123def\" }}   | 123",
 					"{{ regexReplaceAll \"[0-9]+\" \"abc123def456\" \"X\" }} | abcXdefX",
 					"{{ mustRegexReplaceAll \"[0-9]+\" \"abc123def\" \"X\" }} | abcXdef" })
 	void testRegexFunction(String template, String expected) throws IOException, TemplateException {
 		assertEquals(expected, exec(template));
+	}
+
+	@Test
+	void testRegexMatchSubstring() throws IOException, TemplateException {
+		// Go's regexMatch finds pattern anywhere in string, not full-string match
+		HashMap<String, Object> data = new HashMap<>();
+		data.put("config", "  [runners.kubernetes]\n    namespace = \"default\"\n    image = \"alpine\"");
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ regexMatch \"\\\\s*namespace\\\\s*=\" .config }}", data, writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testMustRegexMatchSubstring() throws IOException, TemplateException {
+		HashMap<String, Object> data = new HashMap<>();
+		data.put("config", "  [runners.kubernetes]\n    namespace = \"default\"");
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ mustRegexMatch \"\\\\s*namespace\\\\s*=\" .config }}", data, writer);
+		assertEquals("true", writer.toString());
 	}
 
 	@ParameterizedTest
@@ -160,22 +182,46 @@ class StringFunctionsTest {
 
 	@Test
 	void testQuoteNull() throws IOException, TemplateException {
-		// quote(null) should return empty double-quoted string, matching Go Sprig
+		// Go Sprig quote skips nil values entirely, returning empty string
 		HashMap<String, Object> data = new HashMap<>();
 		data.put("val", null);
 		StringWriter writer = new StringWriter();
 		execute("test", "{{ quote .val }}", data, writer);
-		assertEquals("\"\"", writer.toString());
+		assertEquals("", writer.toString());
 	}
 
 	@Test
 	void testSquoteNull() throws IOException, TemplateException {
-		// squote(null) should return empty single-quoted string, matching Go Sprig
+		// Go Sprig squote skips nil values entirely, returning empty string
 		HashMap<String, Object> data = new HashMap<>();
 		data.put("val", null);
 		StringWriter writer = new StringWriter();
 		execute("test", "{{ squote .val }}", data, writer);
-		assertEquals("''", writer.toString());
+		assertEquals("", writer.toString());
+	}
+
+	@Test
+	void testQuoteMultipleArgs() throws IOException, TemplateException {
+		// Go Sprig quote joins multiple non-nil args with space
+		assertEquals("\"a\" \"b\" \"c\"", exec("{{ quote \"a\" \"b\" \"c\" }}"));
+	}
+
+	@Test
+	void testQuoteMultipleArgsWithNull() throws IOException, TemplateException {
+		// Go Sprig quote skips nil values in multi-arg call
+		HashMap<String, Object> data = new HashMap<>();
+		data.put("a", "hello");
+		data.put("b", null);
+		data.put("c", "world");
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ quote .a .b .c }}", data, writer);
+		assertEquals("\"hello\" \"world\"", writer.toString());
+	}
+
+	@Test
+	void testQuoteEmptyString() throws IOException, TemplateException {
+		// Empty string (not null) should produce quoted empty string
+		assertEquals("\"\"", exec("{{ quote \"\" }}"));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- `quote(null)` and `squote(null)` now return empty string instead of `""` / `''` — Go Sprig skips nil values entirely
- `quote`/`squote` support multi-arg calls with proper null skipping and space-separated joining
- `regexMatch`/`mustRegexMatch` now use `Pattern.find()` for substring matching instead of `String.matches()` (full-string match), matching Go's `regexp.MatchString()` behavior
- Removes all gitlab-runner comparison ignores — chart now passes KpsComparisonTest

## Test plan
- [x] Unit tests for quote/squote null, multi-arg, empty string in `StringFunctionsTest`
- [x] Unit tests for regexMatch/mustRegexMatch substring matching in `StringFunctionsTest`
- [x] Engine integration tests for gitlab-runner chart patterns (replicas, env value, namespace regex) in `EngineTest`
- [x] KpsComparisonTest passes with gitlab-runner ignores removed
- [x] Full test suite passes

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)