### PR TITLE
Fix toYaml to preserve null map entries matching Go yaml.Marshal

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -548,11 +548,11 @@ class EngineTest {
 		assertTrue(result.contains("containers: []"));
 	}
 
-	// --- toYaml null suppression ---
+	// --- toYaml null preservation ---
 
 	@Test
-	void testToYamlOmitsNullValues() {
-		// toYaml should omit null-valued map entries to match Helm's Go yaml.Marshal
+	void testToYamlPreservesNullValues() {
+		// Go yaml.Marshal preserves nil map entries as "null" (no omitempty on maps)
 		Map<String, Object> spec = new HashMap<>();
 		spec.put("replicas", 3);
 		spec.put("revisionHistoryLimit", null);
@@ -563,7 +563,7 @@ class EngineTest {
 		String result = engine.render(chart, Map.of(), releaseInfo());
 		assertTrue(result.contains("replicas: 3"), "non-null field should be present");
 		assertTrue(result.contains("selector: app=test"), "non-null field should be present");
-		assertFalse(result.contains("revisionHistoryLimit"), "null field should be omitted by toYaml");
+		assertTrue(result.contains("revisionHistoryLimit: null"), "null field should be rendered as null by toYaml");
 	}
 
 	// --- quote null-guard pattern (cert-manager) ---
@@ -880,6 +880,63 @@ class EngineTest {
 		// KUBERNETES_NAMESPACE should be omitted
 		assertFalse(result.contains("KUBERNETES_NAMESPACE"),
 				"KUBERNETES_NAMESPACE should be omitted when namespace is in config: " + result);
+	}
+
+	// --- Issue #130: explicit null fields via fromYaml | toYaml ---
+
+	@Test
+	void testNullFieldPreservedInFromYamlToYamlPipeline() {
+		// Traefik pattern: include template | fromYaml | toYaml preserves null fields
+		// When lifecycle:{} is passed through with(empty) → key: with no value → fromYaml
+		// parses as null → toYaml should serialize as "lifecycle: null"
+		String helpers = """
+				{{- define "pod" -}}
+				lifecycle:
+				  {{- with .Values.deployment.lifecycle }}
+				  {{- toYaml . | nindent 2 }}
+				  {{- end }}
+				ports:
+				- containerPort: 80
+				{{- end -}}""";
+		String deploy = """
+				spec:
+				  {{ include "pod" . | fromYaml | toYaml | nindent 2 }}""";
+		Map<String, Object> values = new HashMap<>();
+		Map<String, Object> deployment = new HashMap<>();
+		deployment.put("lifecycle", new HashMap<>());
+		values.put("deployment", deployment);
+
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("_helpers.tpl", helpers), tmpl("deploy.yaml", deploy)), values);
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("lifecycle: null"),
+				"lifecycle: null should be preserved through fromYaml | toYaml: " + result);
+	}
+
+	@Test
+	void testNullFieldPreservedWithNullValue() {
+		// When lifecycle value is null (not empty map), same behavior expected
+		String helpers = """
+				{{- define "pod" -}}
+				lifecycle:
+				  {{- with .Values.deployment.lifecycle }}
+				  {{- toYaml . | nindent 2 }}
+				  {{- end }}
+				name: test
+				{{- end -}}""";
+		String deploy = """
+				spec:
+				  {{ include "pod" . | fromYaml | toYaml | nindent 2 }}""";
+		Map<String, Object> values = new HashMap<>();
+		Map<String, Object> deployment = new HashMap<>();
+		deployment.put("lifecycle", null);
+		values.put("deployment", deployment);
+
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("_helpers.tpl", helpers), tmpl("deploy.yaml", deploy)), values);
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("lifecycle: null"),
+				"lifecycle: null should be preserved when value is null: " + result);
 	}
 
 }

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -20,13 +20,6 @@ jhelmtest:
         path: "*"
         reason: "Subchart rendering gaps produce missing resources and field diffs"
     "[traefik/traefik]":
-      # BUG: JHelm omits explicit null fields (lifecycle, resources) that Helm emits
-      - resource: "Deployment/*"
-        path: "spec.template.spec.containers[0].lifecycle"
-        reason: "BUG: JHelm does not emit explicit null fields in rendered YAML"
-      - resource: "Deployment/*"
-        path: "spec.template.spec.containers[0].resources"
-        reason: "BUG: JHelm does not emit explicit null fields in rendered YAML"
       # BUG: JHelm does not render service ports from traefik range-over-map template
       - resource: "Service/*"
         path: "spec.ports"

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import org.alexmond.jhelm.gotemplate.Function;
 import tools.jackson.core.json.JsonWriteFeature;
 import tools.jackson.databind.SerializationFeature;
@@ -34,9 +33,6 @@ public final class ConversionFunctions {
 		.enable(YAMLWriteFeature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)
 		// Sort keys alphabetically for consistent, predictable output
 		.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
-		// Omit null-valued fields/entries to match Helm's Go yaml.Marshal behavior
-		.changeDefaultPropertyInclusion((v) -> v.withValueInclusion(JsonInclude.Include.NON_NULL)
-			.withContentInclusion(JsonInclude.Include.NON_NULL))
 		.build());
 
 	/** Pattern matching a YAML line with a double-quoted scalar value. */

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -125,7 +125,8 @@ class ConversionFunctionsTest {
 
 	@ParameterizedTest
 	@CsvSource({ "toYaml", "mustToYaml" })
-	void testYamlNullSuppression(String func) throws IOException, TemplateException {
+	void testYamlNullPreservation(String func) throws IOException, TemplateException {
+		// Go yaml.Marshal preserves nil map entries as "null" (no omitempty on maps)
 		Map<String, Object> obj = new HashMap<>();
 		obj.put("name", "myapp");
 		obj.put("replicas", 3);
@@ -138,8 +139,8 @@ class ConversionFunctionsTest {
 		String result = execWithData("{{ " + func + " .obj }}", data);
 		assertTrue(result.contains("name: myapp"), "non-null string field should be present");
 		assertTrue(result.contains("replicas: 3"), "non-null integer field should be present");
-		assertFalse(result.contains("revisionHistoryLimit"), "null field should be omitted");
-		assertFalse(result.contains("dnsPolicy"), "null field should be omitted");
+		assertTrue(result.contains("revisionHistoryLimit: null"), "null field should be rendered as null");
+		assertTrue(result.contains("dnsPolicy: null"), "null field should be rendered as null");
 	}
 
 	// --- Direct function invocation tests for edge cases ---

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/GoTemplateTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/GoTemplateTest.java
@@ -441,4 +441,19 @@ class GoTemplateTest {
 		assertFalse(t2.hasTemplate("only-in-t1"));
 	}
 
+	@Test
+	void testWithSkippedPreservesKey() throws Exception {
+		// When 'with' is falsy, the preceding key text should be preserved
+		GoTemplate template = new GoTemplate();
+		String tmpl = "key:\n  {{- with .val }}\n  {{- print . }}\n  {{- end }}\nnext:";
+		template.parse("test", tmpl);
+		Map<String, Object> data = new HashMap<>();
+		data.put("val", null);
+		StringWriter writer = new StringWriter();
+		template.execute("test", data, writer);
+		String result = writer.toString();
+		assertTrue(result.contains("key:"), "key: should be preserved when with is skipped");
+		assertTrue(result.contains("next:"), "next: should follow after skipped with");
+	}
+
 }


### PR DESCRIPTION
## Summary
- Remove `JsonInclude.Include.NON_NULL` from `YAML_MAPPER` so `toYaml` serializes null-valued map entries as `key: null` instead of omitting them
- Go's `yaml.Marshal` preserves nil entries in maps (omitempty only applies to struct fields, not map entries)
- Fixes the traefik chart's `include | fromYaml | toYaml` pipeline dropping `lifecycle: null` and `resources: null` fields
- Removes traefik lifecycle/resources comparison ignores (those fields now match Helm output)

## Test plan
- [x] Unit test `testYamlNullPreservation` in ConversionFunctionsTest
- [x] Engine integration tests for `fromYaml | toYaml` null field pipeline in EngineTest
- [x] GoTemplate test `testWithSkippedPreservesKey` verifying key text preserved when `with` is falsy
- [x] KpsComparisonTest passes for traefik (lifecycle/resources ignores removed)
- [x] Full test suite passes (391 tests, 0 failures)

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)