### PR TITLE
Fix range over map variable field chaining and template scoping

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -939,4 +939,117 @@ class EngineTest {
 				"lifecycle: null should be preserved when value is null: " + result);
 	}
 
+	// --- Issue #132: Range over map with variable field access ---
+
+	@Test
+	void testRangeSetMutatesDictInOuterScope() {
+		// Traefik service.yaml pattern: set mutates dict from inner range, used in outer
+		// scope
+		String template = """
+				{{- $ports := dict -}}
+				{{- range $name, $config := .Values.items -}}
+				  {{- $_ := set $ports $name $config -}}
+				{{- end -}}
+				{{- range $k, $v := $ports }}
+				{{ $k }}: {{ $v }}
+				{{- end }}""";
+		Map<String, Object> values = new HashMap<>();
+		Map<String, Object> items = new LinkedHashMap<>();
+		items.put("a", "alpha");
+		items.put("b", "beta");
+		values.put("items", items);
+
+		Chart chart = simpleChart("mychart", "1.0.0", List.of(tmpl("test.yaml", template)), values);
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("a: alpha"), "Ports populated by set should be visible: " + result);
+		assertTrue(result.contains("b: beta"), "Ports populated by set should be visible: " + result);
+	}
+
+	@Test
+	void testRangeOverMapVariableFieldAccess() {
+		// Traefik service-ports pattern: range over map, access fields on loop var
+		String helpers = """
+				{{- define "ports" -}}
+				{{- range $name, $config := .ports }}
+				{{- if (index (default dict $config.expose) $.serviceName) }}
+				- port: {{ default $config.port $config.exposedPort }}
+				  name: {{ $name }}
+				{{- end }}
+				{{- end }}
+				{{- end -}}""";
+		String svc = """
+				ports:
+				{{ include "ports" .Values.svcContext }}""";
+
+		Map<String, Object> web = new HashMap<>();
+		web.put("port", 8000);
+		web.put("expose", Map.of("default", true));
+		web.put("exposedPort", 80);
+		Map<String, Object> websecure = new HashMap<>();
+		websecure.put("port", 8443);
+		websecure.put("expose", Map.of("default", true));
+		websecure.put("exposedPort", 443);
+		Map<String, Object> ports = new LinkedHashMap<>();
+		ports.put("web", web);
+		ports.put("websecure", websecure);
+
+		Map<String, Object> svcContext = new HashMap<>();
+		svcContext.put("ports", ports);
+		svcContext.put("serviceName", "default");
+		Map<String, Object> values = Map.of("svcContext", svcContext);
+
+		Chart chart = simpleChart("mychart", "1.0.0", List.of(tmpl("_helpers.tpl", helpers), tmpl("svc.yaml", svc)),
+				values);
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("port: 80"), "Should render web port 80: " + result);
+		assertTrue(result.contains("port: 443"), "Should render websecure port 443: " + result);
+	}
+
+	@Test
+	void testTraefikServiceNestedRangePattern() {
+		// Full traefik service.yaml pattern: outer range over services, inner range over
+		// ports with $config.protocol field access and set to build $tcpPorts
+		String helpers = """
+				{{- define "svc-ports" -}}
+				{{- range $portName, $config := .ports }}
+				{{- if (index (default dict $config.expose) $.serviceName) }}
+				- port: {{ default $config.port $config.exposedPort }}
+				  name: {{ $portName }}
+				{{- end }}
+				{{- end }}
+				{{- end -}}""";
+		String svc = """
+				{{- $tcpPorts := dict -}}
+				{{- range $portName, $config := .Values.ports -}}
+				  {{- if $config -}}
+				    {{- if eq (toString (default "TCP" $config.protocol)) "TCP" -}}
+				      {{- $_ := set $tcpPorts $portName $config -}}
+				    {{- end -}}
+				  {{- end -}}
+				{{- end -}}
+				ports:
+				{{- template "svc-ports" (dict "ports" $tcpPorts "serviceName" "default") }}""";
+		Map<String, Object> web = new HashMap<>();
+		web.put("port", 8000);
+		web.put("expose", Map.of("default", true));
+		web.put("exposedPort", 80);
+		web.put("protocol", "TCP");
+		Map<String, Object> websecure = new HashMap<>();
+		websecure.put("port", 8443);
+		websecure.put("expose", Map.of("default", true));
+		websecure.put("exposedPort", 443);
+		websecure.put("protocol", "TCP");
+
+		Map<String, Object> ports = new LinkedHashMap<>();
+		ports.put("web", web);
+		ports.put("websecure", websecure);
+		Map<String, Object> values = Map.of("ports", ports);
+
+		Chart chart = simpleChart("mychart", "1.0.0", List.of(tmpl("_helpers.tpl", helpers), tmpl("svc.yaml", svc)),
+				values);
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("port: 80"), "Should render web port 80: " + result);
+		assertTrue(result.contains("port: 443"), "Should render websecure port 443: " + result);
+	}
+
 }

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -14,20 +14,16 @@ jhelmtest:
       - resource: "*"
         path: "spec.trafficDistribution"
         reason: "Subchart defaults merging exposes values that Helm omits"
+    "[traefik/traefik]":
+      # BUG: semverCompare conditions produce missing ClusterRole rules
+      - resource: "ClusterRole/*"
+        path: "rules.*"
+        reason: "BUG: semverCompare evaluates incorrectly — missing configmaps and pods rules"
     "[prometheus-community/kube-prometheus-stack]":
       # Complex multi-subchart bundle; many resources not rendered by JHelm
       - resource: "*"
         path: "*"
         reason: "Subchart rendering gaps produce missing resources and field diffs"
-    "[traefik/traefik]":
-      # BUG: JHelm does not render service ports from traefik range-over-map template
-      - resource: "Service/*"
-        path: "spec.ports"
-        reason: "BUG: range over .Values.ports map renders empty — port iteration logic not handled"
-      # BUG: ClusterRole rules differ due to conditional template evaluation differences
-      - resource: "ClusterRole/*"
-        path: "rules.*"
-        reason: "BUG: conditional rules render differently — likely values-driven if/range evaluation gap"
     "[apache-airflow/airflow]":
       # BUG: Complex chart with many rendering gaps — worker resources, volumeMount ordering, etc.
       - resource: "*"

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
@@ -61,6 +61,9 @@ public final class Functions {
 			Object container = args[0];
 			Object key = args[1];
 			if (container instanceof Map) {
+				if (key == null) {
+					return null;
+				}
 				return ((Map<?, ?>) container).get(key);
 			}
 			if (container instanceof List) {

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/internal/exec/Executor.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/internal/exec/Executor.java
@@ -367,7 +367,17 @@ public class Executor {
 
 		Object value = executePipe(templateNode.getPipeNode(), data, beanInfo);
 		BeanInfo valueBeanInfo = (value != null) ? getBeanInfo(value) : null;
-		writeNode(writer, listNode, value, valueBeanInfo);
+		// Go resets $ and clears outer variables when entering a nested template
+		Map<String, Object> savedVariables = new HashMap<>(this.variables);
+		this.variables.clear();
+		this.variables.put("$", value);
+		try {
+			writeNode(writer, listNode, value, valueBeanInfo);
+		}
+		finally {
+			this.variables.clear();
+			this.variables.putAll(savedVariables);
+		}
 	}
 
 	private Object executePipe(PipeNode pipeNode, Object data, BeanInfo beanInfo) throws TemplateExecutionException {
@@ -481,13 +491,11 @@ public class Executor {
 		if (current == null) {
 			return null;
 		}
-
 		if (current instanceof Map<?, ?> rawMap) {
 			@SuppressWarnings("unchecked")
 			Map<String, Object> map = (Map<String, Object>) rawMap;
 			return map.get(identifier);
 		}
-
 		BeanInfo currentBeanInfo = getBeanInfo(current);
 		PropertyDescriptor[] propertyDescriptors = currentBeanInfo.getPropertyDescriptors();
 		for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
@@ -514,12 +522,10 @@ public class Executor {
 	}
 
 	private Object executeField(FieldNode fieldNode, Object data) throws TemplateExecutionException {
-		String[] identifiers = fieldNode.getIdentifiers();
 		Object current = data;
-		for (String identifier : identifiers) {
+		for (String identifier : fieldNode.getIdentifiers()) {
 			current = getFieldValue(current, identifier);
 		}
-
 		return current;
 	}
 
@@ -727,7 +733,13 @@ public class Executor {
 		if (!variables.containsKey(varName)) {
 			throw new TemplateExecutionException(String.format("undefined variable: %s", varName));
 		}
-		return variables.get(varName);
+		Object current = variables.get(varName);
+		// Chain through remaining identifiers (e.g., $config.expose.nested)
+		String[] identifiers = variableNode.getIdentifiers();
+		for (int i = 1; i < identifiers.length; i++) {
+			current = getFieldValue(current, identifiers[i]);
+		}
+		return current;
 	}
 
 	/**

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/GoTemplateTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/GoTemplateTest.java
@@ -456,4 +456,46 @@ class GoTemplateTest {
 		assertTrue(result.contains("next:"), "next: should follow after skipped with");
 	}
 
+	@Test
+	void testVariableFieldChaining() throws Exception {
+		// $var.field should resolve the field on the variable value
+		GoTemplate template = new GoTemplate();
+		String tmpl = "{{ range $k, $v := .items }}{{ $v.name }}:{{ $v.count }} {{ end }}";
+		template.parse("test", tmpl);
+
+		Map<String, Object> item1 = new HashMap<>();
+		item1.put("name", "apple");
+		item1.put("count", 3);
+		Map<String, Object> item2 = new HashMap<>();
+		item2.put("name", "banana");
+		item2.put("count", 5);
+		Map<String, Object> items = new LinkedHashMap<>();
+		items.put("a", item1);
+		items.put("b", item2);
+
+		StringWriter writer = new StringWriter();
+		template.execute("test", Map.of("items", items), writer);
+		String result = writer.toString();
+		assertTrue(result.contains("apple:3"), "Should resolve $v.name and $v.count: " + result);
+		assertTrue(result.contains("banana:5"), "Should resolve $v.name and $v.count: " + result);
+	}
+
+	@Test
+	void testVariableDeepFieldChaining() throws Exception {
+		// $var.field.nested should chain multiple field accesses
+		GoTemplate template = new GoTemplate();
+		String tmpl = "{{ range $k, $v := .items }}{{ $v.meta.label }} {{ end }}";
+		template.parse("test", tmpl);
+
+		Map<String, Object> meta = new HashMap<>();
+		meta.put("label", "important");
+		Map<String, Object> item = new HashMap<>();
+		item.put("meta", meta);
+
+		StringWriter writer = new StringWriter();
+		template.execute("test", Map.of("items", Map.of("x", item)), writer);
+		String result = writer.toString();
+		assertTrue(result.contains("important"), "Should resolve $v.meta.label: " + result);
+	}
+
 }


### PR DESCRIPTION
## Summary
- Fix `executeVariable()` to chain through remaining field identifiers (e.g. `$config.expose`, `$config.protocol`) instead of returning only the base variable
- Fix `writeTemplate()` to reset `$` and clear outer variables when entering nested templates, matching Go `text/template` behavior
- Fix `index()` function to handle null keys gracefully instead of NPE on immutable maps
- Remove traefik service ignores from comparison test (only ClusterRole/semverCompare diff remains)

## Test plan
- [x] Run `./mvnw test -pl jhelm-gotemplate` — GoTemplateTest variable field chaining tests pass
- [x] Run `./mvnw test -pl jhelm-core` — EngineTest nested range/template tests pass
- [x] Run KpsComparisonTest with traefik — service ports now render correctly
- [x] All existing tests pass with no regressions

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)