### PR TITLE
Fix split/splitn to return map with underscore keys

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -1052,4 +1052,43 @@ class EngineTest {
 		assertTrue(result.contains("port: 443"), "Should render websecure port 443: " + result);
 	}
 
+	// --- split() return type and Chart.AppVersion access ---
+
+	@Test
+	void testChartAppVersionAccess() {
+		String tmpl = "version: {{ .Chart.AppVersion }}";
+		Map<String, Object> values = new HashMap<>();
+		Chart chart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").appVersion("v3.6.7").build())
+			.templates(List.of(tmpl("test.yaml", tmpl)))
+			.values(values)
+			.build();
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("version: v3.6.7"), "Chart.AppVersion should be accessible: " + result);
+	}
+
+	@Test
+	void testSplitReturnMapWithUnderscoreKeys() {
+		// Sprig split returns map with _0, _1, etc. keys — used in traefik proxyVersion
+		String helpers = """
+				{{- define "getVersion" -}}
+				{{- $t := .Values.image.tag -}}
+				{{- (split "@" (default .Chart.AppVersion $t))._0 -}}
+				{{- end -}}""";
+		String tmpl = """
+				{{- $v := include "getVersion" . -}}
+				version: {{ $v }}
+				gte34: {{ semverCompare ">=v3.4.0-0" $v }}""";
+		Map<String, Object> values = new HashMap<>();
+		values.put("image", Map.of("tag", ""));
+		Chart chart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").appVersion("v3.6.7").build())
+			.templates(List.of(tmpl("_helpers.tpl", helpers), tmpl("test.yaml", tmpl)))
+			.values(values)
+			.build();
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("version: v3.6.7"), "split._0 should extract version: " + result);
+		assertTrue(result.contains("gte34: true"), "semverCompare should work with split result: " + result);
+	}
+
 }

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -14,11 +14,6 @@ jhelmtest:
       - resource: "*"
         path: "spec.trafficDistribution"
         reason: "Subchart defaults merging exposes values that Helm omits"
-    "[traefik/traefik]":
-      # BUG: semverCompare conditions produce missing ClusterRole rules
-      - resource: "ClusterRole/*"
-        path: "rules.*"
-        reason: "BUG: semverCompare evaluates incorrectly — missing configmaps and pods rules"
     "[prometheus-community/kube-prometheus-stack]":
       # Complex multi-subchart bundle; many resources not rendered by JHelm
       - resource: "*"

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ListFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ListFunctions.java
@@ -518,11 +518,17 @@ public final class ListFunctions {
 	}
 
 	private static Function split() {
+		// Sprig split returns map[string]string with keys "_0", "_1", etc.
 		return (args) -> {
 			if (args.length < 2) {
-				return new String[0];
+				return Map.of();
 			}
-			return String.valueOf(args[1]).split(Pattern.quote(String.valueOf(args[0])));
+			String[] parts = String.valueOf(args[1]).split(Pattern.quote(String.valueOf(args[0])));
+			Map<String, String> result = new HashMap<>();
+			for (int i = 0; i < parts.length; i++) {
+				result.put("_" + i, parts[i]);
+			}
+			return result;
 		};
 	}
 
@@ -538,14 +544,19 @@ public final class ListFunctions {
 	}
 
 	private static Function splitn() {
+		// Sprig splitn returns map[string]string with keys "_0", "_1", etc.
 		return (args) -> {
 			if (args.length < 3) {
-				return Collections.emptyList();
+				return Map.of();
 			}
 			String sep = String.valueOf(args[0]);
 			int n = ((Number) args[1]).intValue();
-			String s = String.valueOf(args[2]);
-			return Arrays.asList(s.split(Pattern.quote(sep), n));
+			String[] parts = String.valueOf(args[2]).split(Pattern.quote(sep), n);
+			Map<String, String> result = new HashMap<>();
+			for (int i = 0; i < parts.length; i++) {
+				result.put("_" + i, parts[i]);
+			}
+			return result;
 		};
 	}
 

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
@@ -440,9 +440,11 @@ class CollectionFunctionsTest {
 
 	@ParameterizedTest
 	@CsvSource(delimiter = '|',
-			value = { "{{ $s := split \",\" \"a,b,c\" }}{{ index $s 1 }}        | b",
-					"{{ $s := splitList \",\" \"a,b,c\" }}{{ len $s }}        | 3",
-					"{{ $s := splitn \",\" 2 \"a,b,c\" }}{{ len $s }}         | 2" })
+			value = { "{{ $s := split \",\" \"a,b,c\" }}{{ $s._1 }}            | b",
+					"{{ $s := split \",\" \"a,b,c\" }}{{ $s._0 }}              | a",
+					"{{ $s := splitList \",\" \"a,b,c\" }}{{ len $s }}          | 3",
+					"{{ $s := splitn \",\" 2 \"a,b,c\" }}{{ $s._0 }}           | a",
+					"{{ $s := splitn \",\" 2 \"a,b,c\" }}{{ $s._1 }}           | b,c" })
 	void testSplitFunctions(String template, String expected) throws IOException, TemplateException {
 		assertEquals(expected, exec(template));
 	}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/SemverFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/SemverFunctionsTest.java
@@ -244,6 +244,24 @@ class SemverFunctionsTest {
 		assertEquals("false", writer.toString());
 	}
 
+	// --- traefik pattern: semverCompare with v-prefix in constraint ---
+
+	@Test
+	void testSemverCompareTraefikPattern() throws IOException, TemplateException {
+		// traefik clusterrole.yaml: semverCompare ">=v3.4.0-0" $version
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \">=v3.4.0-0\" \"v3.6.7\" }}", new HashMap<>(), writer);
+		assertEquals("true", writer.toString());
+	}
+
+	@Test
+	void testSemverCompareTraefikLessThanPattern() throws IOException, TemplateException {
+		// traefik: semverCompare "<v3.1.0-0" "v3.6.7" should be false
+		StringWriter writer = new StringWriter();
+		execute("test", "{{ semverCompare \"<v3.1.0-0\" \"v3.6.7\" }}", new HashMap<>(), writer);
+		assertEquals("false", writer.toString());
+	}
+
 	// --- ingress-nginx pattern: semverCompare with v-prefix ---
 
 	@Test


### PR DESCRIPTION
## Summary
- Fix `split()` to return `Map<String, String>` with `_0`, `_1`, etc. keys matching Go Sprig behavior (was returning `String[]`)
- Fix `splitn()` similarly
- Remove all traefik comparison ignores — traefik chart now matches Helm output with zero diffs
- Add Engine integration test for `split._0` + `semverCompare` pattern
- Add traefik-pattern semverCompare tests

## Test plan
- [x] Run `./mvnw test -pl jhelm-gotemplate-sprig` — split/splitn tests updated and passing
- [x] Run `./mvnw test -pl jhelm-core` — Engine tests pass including new split/semverCompare test
- [x] KpsComparisonTest with traefik — all 6 resources match Helm, zero ignores needed
- [x] No regressions in other modules

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)