### PR TITLE
Implement .Files template object (#136)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Chart.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Chart.java
@@ -1,6 +1,7 @@
 package org.alexmond.jhelm.core.model;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +40,10 @@ public class Chart {
 
 	@Builder.Default
 	private List<Crd> crds = new ArrayList<>();
+
+	/** Non-template files from the chart archive (relative path to content). */
+	@Builder.Default
+	private Map<String, String> files = new LinkedHashMap<>();
 
 	@Data
 	@Builder

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartFiles.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartFiles.java
@@ -1,0 +1,108 @@
+package org.alexmond.jhelm.core.model;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implements Helm's .Files template object. Provides access to non-template files within
+ * a chart archive.
+ *
+ * <p>
+ * Method names use PascalCase to match Go/Helm convention (e.g. {@code .Files.Get},
+ * {@code .Files.Glob}). The template executor resolves methods by exact name via
+ * reflection.
+ *
+ * @see <a href="https://helm.sh/docs/chart_template_guide/accessing_files/">Helm File
+ * Access</a>
+ */
+@SuppressWarnings("PMD.MethodNamingConventions")
+public class ChartFiles {
+
+	private final Map<String, String> files;
+
+	public ChartFiles(Map<String, String> files) {
+		this.files = (files != null) ? files : Map.of();
+	}
+
+	/**
+	 * Returns files matching the given glob pattern as a map of path to content.
+	 * @param pattern glob pattern (e.g. "files/crds/*.yaml")
+	 * @return map of matching file paths to their content
+	 */
+	public Map<String, String> Glob(String pattern) {
+		PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pattern);
+		Map<String, String> result = new LinkedHashMap<>();
+		for (Map.Entry<String, String> entry : files.entrySet()) {
+			if (matcher.matches(Paths.get(entry.getKey()))) {
+				result.put(entry.getKey(), entry.getValue());
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Returns the content of a file as a string.
+	 * @param name the file path
+	 * @return file content or empty string if not found
+	 */
+	public String Get(String name) {
+		return files.getOrDefault(name, "");
+	}
+
+	/**
+	 * Returns the content of a file as a byte array.
+	 * @param name the file path
+	 * @return file content as bytes or empty array if not found
+	 */
+	public byte[] GetBytes(String name) {
+		String content = files.get(name);
+		return (content != null) ? content.getBytes(StandardCharsets.UTF_8) : new byte[0];
+	}
+
+	/**
+	 * Returns the content of a file split into lines.
+	 * @param name the file path
+	 * @return list of lines or empty list if not found
+	 */
+	public List<String> Lines(String name) {
+		String content = files.get(name);
+		if (content == null || content.isEmpty()) {
+			return List.of();
+		}
+		return Arrays.asList(content.split("\n", -1));
+	}
+
+	/**
+	 * Returns all files with their content base64-encoded (for use in Secret data).
+	 * @return map of file paths to base64-encoded content
+	 */
+	public Map<String, String> AsSecrets() {
+		Map<String, String> result = new LinkedHashMap<>();
+		for (Map.Entry<String, String> entry : files.entrySet()) {
+			result.put(entry.getKey(),
+					Base64.getEncoder().encodeToString(entry.getValue().getBytes(StandardCharsets.UTF_8)));
+		}
+		return result;
+	}
+
+	/**
+	 * Returns all files with their raw string content (for use in ConfigMap data).
+	 * @return map of file paths to string content
+	 */
+	public Map<String, String> AsConfig() {
+		return new LinkedHashMap<>(files);
+	}
+
+	@Override
+	public String toString() {
+		return "";
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
@@ -5,16 +5,21 @@ import org.springframework.stereotype.Component;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.MalformedInputException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.ChartLoadException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.util.ValuesLoader;
 
+@Slf4j
 @Component
 public class ChartLoader {
 
@@ -49,21 +54,7 @@ public class ChartLoader {
 		}
 
 		// Load dependencies (subcharts)
-		File chartsDir = new File(chartDir, "charts");
-		List<Chart> dependencies = new ArrayList<>();
-		if (chartsDir.exists() && chartsDir.isDirectory()) {
-			File[] subchartDirs = chartsDir.listFiles(File::isDirectory);
-			if (subchartDirs != null) {
-				for (File subchartDir : subchartDirs) {
-					Chart subchart = load(subchartDir);
-					// If the directory name differs from the chart name it is an alias
-					if (!subchartDir.getName().equals(subchart.getMetadata().getName())) {
-						subchart.setAlias(subchartDir.getName());
-					}
-					dependencies.add(subchart);
-				}
-			}
-		}
+		List<Chart> dependencies = loadDependencies(chartDir);
 
 		// Load README
 		String readme = null;
@@ -86,6 +77,10 @@ public class ChartLoader {
 			loadCrdsRecursive(crdsDir, "", crds);
 		}
 
+		// Load non-template files (for .Files object)
+		Map<String, String> chartFiles = new LinkedHashMap<>();
+		loadChartFiles(chartDir, chartFiles);
+
 		return Chart.builder()
 			.metadata(metadata)
 			.values(values)
@@ -94,7 +89,27 @@ public class ChartLoader {
 			.dependencies(dependencies)
 			.readme(readme)
 			.crds(crds)
+			.files(chartFiles)
 			.build();
+	}
+
+	private List<Chart> loadDependencies(File chartDir) throws IOException {
+		File chartsDir = new File(chartDir, "charts");
+		List<Chart> dependencies = new ArrayList<>();
+		if (!chartsDir.exists() || !chartsDir.isDirectory()) {
+			return dependencies;
+		}
+		File[] subchartDirs = chartsDir.listFiles(File::isDirectory);
+		if (subchartDirs != null) {
+			for (File subchartDir : subchartDirs) {
+				Chart subchart = load(subchartDir);
+				if (!subchartDir.getName().equals(subchart.getMetadata().getName())) {
+					subchart.setAlias(subchartDir.getName());
+				}
+				dependencies.add(subchart);
+			}
+		}
+		return dependencies;
 	}
 
 	private void loadTemplatesRecursive(File dir, String path, List<Chart.Template> templates) throws IOException {
@@ -114,6 +129,51 @@ public class ChartLoader {
 					.build();
 				templates.add(template);
 			}
+		}
+	}
+
+	private static final Set<String> EXCLUDED_DIRS = Set.of("templates", "charts", "crds");
+
+	private static final Set<String> EXCLUDED_FILES = Set.of("Chart.yaml", "Chart.lock", "values.yaml",
+			"values.schema.json", "README.md", ".helmignore");
+
+	private void loadChartFiles(File chartDir, Map<String, String> chartFiles) throws IOException {
+		File[] entries = chartDir.listFiles();
+		if (entries == null) {
+			return;
+		}
+		for (File entry : entries) {
+			if (entry.isDirectory() && !EXCLUDED_DIRS.contains(entry.getName())) {
+				loadFilesRecursive(entry, entry.getName(), chartFiles);
+			}
+			else if (entry.isFile() && !EXCLUDED_FILES.contains(entry.getName())) {
+				readTextFile(entry, entry.getName(), chartFiles);
+			}
+		}
+	}
+
+	private void loadFilesRecursive(File dir, String path, Map<String, String> chartFiles) throws IOException {
+		File[] files = dir.listFiles();
+		if (files == null) {
+			return;
+		}
+		for (File file : files) {
+			String name = path + "/" + file.getName();
+			if (file.isDirectory()) {
+				loadFilesRecursive(file, name, chartFiles);
+			}
+			else {
+				readTextFile(file, name, chartFiles);
+			}
+		}
+	}
+
+	private void readTextFile(File file, String name, Map<String, String> chartFiles) throws IOException {
+		try {
+			chartFiles.put(name, Files.readString(file.toPath()));
+		}
+		catch (MalformedInputException ex) {
+			log.debug("Skipping binary file: {}", name);
 		}
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ChartFiles;
 import org.alexmond.jhelm.core.model.VersionSet;
 
 @Slf4j
@@ -349,6 +350,7 @@ public class Engine {
 				new VersionSet(DEFAULT_API_VERSIONS)));
 		String chartBasePath = chart.getMetadata().getName() + "/templates";
 		context.put("Template", Map.of("Name", "", "BasePath", chartBasePath));
+		context.put("Files", new ChartFiles(chart.getFiles()));
 
 		StringBuilder sb = new StringBuilder();
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/model/ChartFilesTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/model/ChartFilesTest.java
@@ -1,0 +1,114 @@
+package org.alexmond.jhelm.core.model;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChartFilesTest {
+
+	@Test
+	void testGetReturnsFileContent() {
+		ChartFiles files = new ChartFiles(Map.of("config.ini", "key=value"));
+		assertEquals("key=value", files.Get("config.ini"));
+	}
+
+	@Test
+	void testGetReturnsEmptyStringForMissingFile() {
+		ChartFiles files = new ChartFiles(Map.of());
+		assertEquals("", files.Get("missing.txt"));
+	}
+
+	@Test
+	void testGetBytesReturnsContent() {
+		ChartFiles files = new ChartFiles(Map.of("data.bin", "hello"));
+		assertArrayEquals("hello".getBytes(StandardCharsets.UTF_8), files.GetBytes("data.bin"));
+	}
+
+	@Test
+	void testGetBytesReturnsEmptyForMissingFile() {
+		ChartFiles files = new ChartFiles(Map.of());
+		assertArrayEquals(new byte[0], files.GetBytes("missing.bin"));
+	}
+
+	@Test
+	void testLinesReturnsLines() {
+		ChartFiles files = new ChartFiles(Map.of("data.txt", "line1\nline2\nline3"));
+		assertEquals(List.of("line1", "line2", "line3"), files.Lines("data.txt"));
+	}
+
+	@Test
+	void testLinesReturnsEmptyForMissingFile() {
+		ChartFiles files = new ChartFiles(Map.of());
+		assertEquals(List.of(), files.Lines("missing.txt"));
+	}
+
+	@Test
+	void testLinesReturnsEmptyForEmptyContent() {
+		ChartFiles files = new ChartFiles(Map.of("empty.txt", ""));
+		assertEquals(List.of(), files.Lines("empty.txt"));
+	}
+
+	@Test
+	void testGlobMatchesFiles() {
+		Map<String, String> fileMap = new LinkedHashMap<>();
+		fileMap.put("files/config.yaml", "cfg1");
+		fileMap.put("files/secret.yaml", "sec1");
+		fileMap.put("files/readme.txt", "readme");
+		ChartFiles files = new ChartFiles(fileMap);
+
+		Map<String, String> result = files.Glob("files/*.yaml");
+		assertEquals(2, result.size());
+		assertTrue(result.containsKey("files/config.yaml"));
+		assertTrue(result.containsKey("files/secret.yaml"));
+	}
+
+	@Test
+	void testGlobReturnsEmptyForNoMatch() {
+		ChartFiles files = new ChartFiles(Map.of("data.txt", "content"));
+		assertTrue(files.Glob("*.yaml").isEmpty());
+	}
+
+	@Test
+	void testAsSecretsBase64EncodesContent() {
+		ChartFiles files = new ChartFiles(Map.of("password.txt", "s3cret"));
+		Map<String, String> secrets = files.AsSecrets();
+		String expected = Base64.getEncoder().encodeToString("s3cret".getBytes(StandardCharsets.UTF_8));
+		assertEquals(expected, secrets.get("password.txt"));
+	}
+
+	@Test
+	void testAsConfigReturnsCopy() {
+		Map<String, String> original = new LinkedHashMap<>();
+		original.put("app.conf", "port=8080");
+		ChartFiles files = new ChartFiles(original);
+		Map<String, String> config = files.AsConfig();
+		assertEquals("port=8080", config.get("app.conf"));
+		// Verify it's a copy
+		config.put("extra", "value");
+		assertEquals("", files.Get("extra"));
+	}
+
+	@Test
+	void testNullFilesMapHandled() {
+		ChartFiles files = new ChartFiles(null);
+		assertEquals("", files.Get("anything"));
+		assertTrue(files.Glob("*").isEmpty());
+		assertTrue(files.AsSecrets().isEmpty());
+		assertTrue(files.AsConfig().isEmpty());
+	}
+
+	@Test
+	void testToStringReturnsEmpty() {
+		ChartFiles files = new ChartFiles(Map.of("a", "b"));
+		assertEquals("", files.toString());
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ChartLoaderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ChartLoaderTest.java
@@ -309,6 +309,62 @@ class ChartLoaderTest {
 	}
 
 	@Test
+	void testLoadChartWithFiles() throws Exception {
+		Path chartDir = tempDir.resolve("chart-with-files");
+		Files.createDirectories(chartDir);
+		Files.writeString(chartDir.resolve("Chart.yaml"), """
+				apiVersion: v2
+				name: chart-with-files
+				version: 1.0.0
+				""");
+		Files.writeString(chartDir.resolve("values.yaml"), "{}");
+		Files.createDirectories(chartDir.resolve("templates"));
+
+		// Create non-template files
+		Path filesDir = chartDir.resolve("config");
+		Files.createDirectories(filesDir);
+		Files.writeString(filesDir.resolve("app.conf"), "port=8080");
+		Files.writeString(chartDir.resolve("extra.txt"), "extra content");
+
+		Chart chart = chartLoader.load(chartDir.toFile());
+
+		assertNotNull(chart.getFiles());
+		assertFalse(chart.getFiles().isEmpty());
+		assertEquals("port=8080", chart.getFiles().get("config/app.conf"));
+		assertEquals("extra content", chart.getFiles().get("extra.txt"));
+	}
+
+	@Test
+	void testLoadChartFilesExcludesSpecialDirsAndFiles() throws Exception {
+		Path chartDir = tempDir.resolve("chart-exclusions");
+		Files.createDirectories(chartDir);
+		Files.writeString(chartDir.resolve("Chart.yaml"), """
+				apiVersion: v2
+				name: chart-exclusions
+				version: 1.0.0
+				""");
+		Files.writeString(chartDir.resolve("values.yaml"), "{}");
+		Files.createDirectories(chartDir.resolve("templates"));
+		Files.createDirectories(chartDir.resolve("charts"));
+		Files.createDirectories(chartDir.resolve("crds"));
+
+		// Files that should be excluded
+		Files.writeString(chartDir.resolve(".helmignore"), "*.bak");
+		Files.writeString(chartDir.resolve("Chart.lock"), "lock content");
+
+		// File that should be included
+		Files.writeString(chartDir.resolve("LICENSE"), "MIT");
+
+		Chart chart = chartLoader.load(chartDir.toFile());
+
+		assertTrue(chart.getFiles().containsKey("LICENSE"));
+		assertFalse(chart.getFiles().containsKey("Chart.yaml"));
+		assertFalse(chart.getFiles().containsKey("Chart.lock"));
+		assertFalse(chart.getFiles().containsKey("values.yaml"));
+		assertFalse(chart.getFiles().containsKey(".helmignore"));
+	}
+
+	@Test
 	void testLoadChartWithValuesSchema() throws Exception {
 		Path chartDir = tempDir.resolve("chart-with-schema");
 		Files.createDirectories(chartDir);

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -32,10 +32,16 @@ class EngineTest {
 	}
 
 	private Chart simpleChart(String name, String version, List<Chart.Template> templates, Map<String, Object> values) {
+		return simpleChartWithFiles(name, version, templates, values, Map.of());
+	}
+
+	private Chart simpleChartWithFiles(String name, String version, List<Chart.Template> templates,
+			Map<String, Object> values, Map<String, String> files) {
 		return Chart.builder()
 			.metadata(ChartMetadata.builder().name(name).version(version).build())
 			.templates(templates)
 			.values(values)
+			.files(new LinkedHashMap<>(files))
 			.build();
 	}
 
@@ -1089,6 +1095,25 @@ class EngineTest {
 		String result = engine.render(chart, Map.of(), releaseInfo());
 		assertTrue(result.contains("version: v3.6.7"), "split._0 should extract version: " + result);
 		assertTrue(result.contains("gte34: true"), "semverCompare should work with split result: " + result);
+	}
+
+	// --- .Files object ---
+
+	@Test
+	void testFilesGetReturnsContent() {
+		Map<String, String> files = Map.of("config.ini", "key=value");
+		Chart chart = simpleChartWithFiles("mychart", "1.0.0",
+				List.of(tmpl("test.yaml", "data: {{ .Files.Get \"config.ini\" }}")), Map.of(), files);
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("data: key=value"), "Files.Get should return file content: " + result);
+	}
+
+	@Test
+	void testFilesGetMissingReturnsEmpty() {
+		Chart chart = simpleChartWithFiles("mychart", "1.0.0",
+				List.of(tmpl("test.yaml", "data: [{{ .Files.Get \"missing.txt\" }}]")), Map.of(), Map.of());
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("data: []"), "Files.Get for missing file should return empty: " + result);
 	}
 
 }


### PR DESCRIPTION
## Summary
- Add `ChartFiles` class implementing Helm's `.Files` API (Glob, Get, GetBytes, Lines, AsSecrets, AsConfig)
- Update `ChartLoader` to load non-template chart files, excluding standard dirs/files (templates, charts, crds, Chart.yaml, values.yaml, etc.)
- Gracefully skip binary files that can't be read as UTF-8 text
- Extract `loadDependencies()` helper from `ChartLoader.load()` to stay within method length limits
- Wire `ChartFiles` into Engine template context as `.Files`

## Test plan
- [x] Run `./mvnw test -pl jhelm-core` — 413 tests pass
- [x] `ChartFilesTest` — 13 unit tests covering Get, GetBytes, Lines, Glob, AsSecrets, AsConfig, null handling
- [x] `ChartLoaderTest` — 2 new tests for loading chart files and exclusion of special dirs/files
- [x] `EngineTest` — 2 new integration tests for `.Files.Get` in templates
- [x] `KpsComparisonTest` passes (binary file handling verified)

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)