### PR TITLE
Fix merge not overwriting null values in destination

### DIFF
--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
@@ -208,7 +208,7 @@ public final class DictFunctions {
 				if (dstVal instanceof Map && srcVal instanceof Map) {
 					deepMerge((Map<String, Object>) dstVal, (Map<String, Object>) srcVal, overwrite);
 				}
-				else if (overwrite) {
+				else if (overwrite || dstVal == null) {
 					dst.put(key, srcVal);
 				}
 			}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
@@ -298,6 +298,26 @@ class CollectionFunctionsTest {
 	}
 
 	@Test
+	void testMergeOverwritesNullValues() throws IOException, TemplateException {
+		// In Go's sprig, merge treats nil/zero values in dst as absent
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> dst = new HashMap<>();
+		dst.put("tag", null);
+		data.put("dst", dst);
+		data.put("src", Map.of("tag", "latest"));
+		assertEquals("latest", execWithData("{{ $m := merge .dst .src }}{{ get $m \"tag\" }}", data));
+	}
+
+	@Test
+	void testMergePreservesNonNullValues() throws IOException, TemplateException {
+		// merge should NOT overwrite non-null dst values
+		Map<String, Object> data = new HashMap<>();
+		data.put("dst", new HashMap<>(Map.of("tag", "v1")));
+		data.put("src", Map.of("tag", "v2"));
+		assertEquals("v1", execWithData("{{ $m := merge .dst .src }}{{ get $m \"tag\" }}", data));
+	}
+
+	@Test
 	void testMustMergeDeepNested() throws IOException, TemplateException {
 		String template = """
 				{{ $d1 := dict "outer" (dict "a" 1 "b" 2) }}\


### PR DESCRIPTION
## Summary
- In Go's sprig, `merge` treats nil/zero values in dst as absent — source value is used
- Our `deepMerge` only checked `containsKey`, causing null dst values to block source values
- Now also overwrite when `dstVal == null`

Closes #155

## Test plan
- [x] Added `testMergeOverwritesNullValues` — merge overwrites null dst with source value
- [x] Added `testMergePreservesNonNullValues` — merge preserves non-null dst values
- [x] All existing merge tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)