### PR TITLE
Fix join on null returning "null" instead of empty string

### DIFF
--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ListFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ListFunctions.java
@@ -608,12 +608,15 @@ public final class ListFunctions {
 			if (args.length < 2) {
 				return "";
 			}
-			String sep = String.valueOf(args[0]);
 			Object listObj = args[1];
+			if (listObj == null) {
+				return "";
+			}
+			String sep = String.valueOf(args[0]);
 			if (listObj instanceof Collection) {
 				return ((Collection<?>) listObj).stream().map(String::valueOf).collect(Collectors.joining(sep));
 			}
-			else if (listObj != null && listObj.getClass().isArray()) {
+			else if (listObj.getClass().isArray()) {
 				int len = Array.getLength(listObj);
 				List<String> strs = new ArrayList<>();
 				for (int i = 0; i < len; i++) {

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
@@ -494,4 +494,12 @@ class CollectionFunctionsTest {
 		assertEquals("3", execWithData("{{ $r := mustPush .items \"c\" }}{{ len $r }}", data));
 	}
 
+	@Test
+	void testJoinNull() throws IOException, TemplateException {
+		// join on null should return "" not "null"
+		Map<String, Object> data = new HashMap<>();
+		data.put("items", null);
+		assertEquals("", execWithData("{{ join \",\" .items }}", data));
+	}
+
 }


### PR DESCRIPTION
## Summary
- `join()` fell through to `String.valueOf(null)` which returns `"null"`
- Added early null check to return `""` for null list arguments, matching Go's sprig behavior

Closes #157

## Test plan
- [x] Added `testJoinNull` — `join(",", null)` returns `""` not `"null"`
- [x] All existing join tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)