### PR TITLE
Fix kindIs "float64" returning false for Java Integer

### DIFF
--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ReflectionFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ReflectionFunctions.java
@@ -177,6 +177,12 @@ public final class ReflectionFunctions {
 	/**
 	 * Maps a Java object to its Go-style kind name, matching Go's
 	 * {@code reflect.ValueOf(src).Kind().String()}.
+	 * <p>
+	 * Go's YAML parser unmarshals all numbers (integer or decimal) as {@code float64}.
+	 * Java's YAML parser uses {@code Integer} for whole numbers and {@code Double} for
+	 * decimals. To match Go behavior, all numeric types are mapped to {@code "float64"}
+	 * so that templates using {@code kindIs "float64"} work correctly for YAML-parsed
+	 * numbers.
 	 */
 	private static String goKindName(Object obj) {
 		Class<?> c = obj.getClass();
@@ -186,17 +192,8 @@ public final class ReflectionFunctions {
 		if (c == Boolean.class) {
 			return "bool";
 		}
-		if (c == Integer.class || c == Short.class || c == Byte.class) {
-			return "int";
-		}
-		if (c == Long.class || c == BigInteger.class) {
-			return "int64";
-		}
-		if (c == Double.class || c == BigDecimal.class) {
+		if (Number.class.isAssignableFrom(c)) {
 			return "float64";
-		}
-		if (c == Float.class) {
-			return "float32";
 		}
 		if (Map.class.isAssignableFrom(c)) {
 			return "map";

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/ReflectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/ReflectionFunctionsTest.java
@@ -104,7 +104,9 @@ class ReflectionFunctionsTest {
 
 	@Test
 	void testKindOfInt() throws IOException, TemplateException {
-		assertEquals("int", eval("{{ kindOf .value }}", Map.of("value", 123)));
+		// Go YAML unmarshals all numbers as float64; kindOf maps all numeric types to
+		// float64
+		assertEquals("float64", eval("{{ kindOf .value }}", Map.of("value", 123)));
 	}
 
 	@Test
@@ -177,7 +179,8 @@ class ReflectionFunctionsTest {
 
 	@Test
 	void testKindIsInt() throws IOException, TemplateException {
-		assertEquals("true", eval("{{ kindIs \"int\" .value }}", Map.of("value", 42)));
+		// Go YAML unmarshals all numbers as float64, so kindIs "int" returns false
+		assertEquals("false", eval("{{ kindIs \"int\" .value }}", Map.of("value", 42)));
 	}
 
 	@Test
@@ -193,6 +196,17 @@ class ReflectionFunctionsTest {
 	@Test
 	void testKindIsSlice() throws IOException, TemplateException {
 		assertEquals("true", eval("{{ kindIs \"slice\" .value }}", Map.of("value", Arrays.asList(1))));
+	}
+
+	@Test
+	void testKindIsFloat64ForInteger() throws IOException, TemplateException {
+		// Go YAML unmarshals 15 as float64 — kindIs "float64" must match Java Integer
+		assertEquals("true", eval("{{ kindIs \"float64\" .value }}", Map.of("value", 15)));
+	}
+
+	@Test
+	void testKindIsFloat64ForLong() throws IOException, TemplateException {
+		assertEquals("true", eval("{{ kindIs \"float64\" .value }}", Map.of("value", 42L)));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Go's YAML parser unmarshals all numbers as `float64`; Java uses `Integer` for whole numbers
- Map all `Number` subclasses → `"float64"` in `goKindName` so `kindIs "float64"` works for YAML-parsed integers
- Simplifies the numeric type handling in `goKindName` to a single `Number.class.isAssignableFrom(c)` check

Closes #159

## Test plan
- [x] Added `testKindIsFloat64ForInteger` — `kindIs "float64"` returns true for integer 15
- [x] Added `testKindIsFloat64ForLong` — `kindIs "float64"` returns true for long 42L
- [x] Updated `testKindOfInt` and `testKindIsInt` to reflect new float64 mapping
- [x] All existing reflection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)