### PR TITLE
Implement .Subcharts context object in template rendering

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -352,6 +352,14 @@ public class Engine {
 		context.put("Template", Map.of("Name", "", "BasePath", chartBasePath));
 		context.put("Files", new ChartFiles(chart.getFiles()));
 
+		// Build .Subcharts map: subchart name/alias → { Chart: metadata }
+		Map<String, Object> subcharts = new HashMap<>();
+		for (Chart dep : chart.getDependencies()) {
+			String depKey = (dep.getAlias() != null) ? dep.getAlias() : dep.getMetadata().getName();
+			subcharts.put(depKey, Map.of("Chart", dep.getMetadata()));
+		}
+		context.put("Subcharts", subcharts);
+
 		StringBuilder sb = new StringBuilder();
 
 		// Render current chart templates

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -204,6 +204,45 @@ class EngineTest {
 		assertFalse(result.contains("name: redis-svc"));
 	}
 
+	// --- .Subcharts context ---
+
+	@Test
+	void testSubchartsContextAvailable() {
+		Chart subchart = simpleChart("prometheus-node-exporter", "4.0.0", List.of(tmpl("svc.yaml", "kind: Service")),
+				Map.of());
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder().name("kube-prometheus-stack").version("1.0.0").build())
+			.templates(List
+				.of(tmpl("test.yaml", "name: {{ (index .Subcharts \"prometheus-node-exporter\").Chart.Name }}")))
+			.values(Map.of())
+			.dependencies(List.of(subchart))
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		assertTrue(result.contains("name: prometheus-node-exporter"));
+	}
+
+	@Test
+	void testSubchartsContextWithAlias() {
+		Chart subchart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("redis").version("17.0.0").build())
+			.templates(List.of(tmpl("svc.yaml", "kind: Service")))
+			.values(Map.of())
+			.alias("cache")
+			.build();
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder().name("parent").version("1.0.0").build())
+			.templates(List.of(tmpl("test.yaml", "version: {{ .Subcharts.cache.Chart.Version }}")))
+			.values(Map.of())
+			.dependencies(List.of(subchart))
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		assertTrue(result.contains("version: 17.0.0"));
+	}
+
 	// --- Global values ---
 
 	@Test


### PR DESCRIPTION
## Summary
- Build a `Subcharts` map during rendering: subchart name/alias → `{ Chart: metadata }`
- Charts like kube-prometheus-stack use `.Subcharts` to access subchart metadata (e.g., `index .Subcharts "prometheus-node-exporter"`)
- Respects chart aliases when building the map

Closes #161

## Test plan
- [x] Added `testSubchartsContextAvailable` — access subchart Chart.Name via index
- [x] Added `testSubchartsContextWithAlias` — alias key used instead of chart name
- [x] All existing engine tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)