### PR TITLE
Fix global values not deep-merged with subchart globals

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -381,9 +381,15 @@ public class Engine {
 				continue;
 			}
 
-			// In Helm, global values are shared
+			// In Helm, global values are deep-merged: parent globals override subchart
+			// globals
 			if (mergedValues.containsKey("global")) {
-				subchartOverrides.put("global", mergedValues.get("global"));
+				@SuppressWarnings("unchecked")
+				Map<String, Object> parentGlobal = (Map<String, Object>) mergedValues.get("global");
+				@SuppressWarnings("unchecked")
+				Map<String, Object> subGlobal = (Map<String, Object>) subchartOverrides.getOrDefault("global",
+						new HashMap<>());
+				subchartOverrides.put("global", mergeValues(subGlobal, parentGlobal));
 			}
 
 			if (log.isDebugEnabled()) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -225,6 +225,33 @@ class EngineTest {
 		assertTrue(result.contains("env: production"));
 	}
 
+	@Test
+	void testGlobalValuesDeepMergedWithSubchartGlobals() {
+		// Subchart has its own global defaults; parent global should deep-merge, not
+		// replace
+		Chart subchart = simpleChart("postgresql-ha", "11.0.0", List.of(tmpl("cm.yaml",
+				"storageClass: {{ .Values.global.storageClass }}\nregistry: {{ .Values.global.imageRegistry }}")),
+				Map.of("global", new HashMap<>(Map.of("storageClass", "default-sc", "imageRegistry", "docker.io"))));
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder().name("gitea").version("1.0.0").build())
+			.templates(List.of(tmpl("deploy.yaml", "kind: Deployment")))
+			.values(Map.of())
+			.dependencies(List.of(subchart))
+			.build();
+
+		// Parent only overrides imageRegistry, not storageClass
+		Map<String, Object> vals = new HashMap<>();
+		vals.put("global", new HashMap<>(Map.of("imageRegistry", "gcr.io")));
+
+		String result = engine.render(parent, vals, releaseInfo());
+		// Parent override should win
+		assertTrue(result.contains("registry: gcr.io"), "parent global should override: " + result);
+		// Subchart default should be preserved (deep-merged, not replaced)
+		assertTrue(result.contains("storageClass: default-sc"),
+				"subchart global default should be preserved: " + result);
+	}
+
 	// --- Capabilities ---
 
 	@Test


### PR DESCRIPTION
## Summary
- Parent global values were replacing subchart globals entirely instead of deep-merging
- Now uses `mergeValues()` so parent globals override while subchart-specific global defaults are preserved
- Example: parent sets `global.imageRegistry=gcr.io`, subchart's `global.storageClass=default-sc` is no longer lost

Closes #163

## Test plan
- [x] Added `testGlobalValuesDeepMergedWithSubchartGlobals` — parent override wins, subchart defaults preserved
- [x] Existing `testGlobalValuesPassedToSubcharts` still passes
- [x] All engine tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)