### PR TITLE
Implement true recursive deepCopy

### DIFF
--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.alexmond.jhelm.gotemplate.Function;
@@ -131,7 +132,7 @@ public final class DictFunctions {
 				return Collections.emptyList();
 			}
 			String key = String.valueOf(args[0]);
-			java.util.List<Object> result = new ArrayList<>();
+			List<Object> result = new ArrayList<>();
 			for (int i = 1; i < args.length; i++) {
 				if (args[i] instanceof Map) {
 					Object val = ((Map<?, ?>) args[i]).get(key);
@@ -314,25 +315,36 @@ public final class DictFunctions {
 		};
 	}
 
-	@SuppressWarnings("unchecked")
 	private static Function deepCopy() {
 		return (args) -> {
 			if (args.length == 0) {
 				return null;
 			}
-			Object obj = args[0];
-			if (obj instanceof Map) {
-				Map<String, Object> copy = new LinkedHashMap<>();
-				for (Map.Entry<String, Object> entry : ((Map<String, Object>) obj).entrySet()) {
-					copy.put(entry.getKey(), entry.getValue()); // Shallow copy for now
-				}
-				return copy;
-			}
-			else if (obj instanceof Collection) {
-				return new ArrayList<>((Collection<?>) obj);
-			}
-			return obj;
+			return recursiveDeepCopy(args[0]);
 		};
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Object recursiveDeepCopy(Object obj) {
+		if (obj == null) {
+			return null;
+		}
+		if (obj instanceof Map) {
+			Map<String, Object> copy = new LinkedHashMap<>();
+			for (Map.Entry<String, Object> entry : ((Map<String, Object>) obj).entrySet()) {
+				copy.put(entry.getKey(), recursiveDeepCopy(entry.getValue()));
+			}
+			return copy;
+		}
+		if (obj instanceof Collection) {
+			List<Object> copy = new ArrayList<>();
+			for (Object item : (Collection<?>) obj) {
+				copy.add(recursiveDeepCopy(item));
+			}
+			return copy;
+		}
+		// Primitives (String, Number, Boolean) are immutable — no copy needed
+		return obj;
 	}
 
 	private static Function mustDeepCopy() {

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
@@ -480,6 +480,43 @@ class CollectionFunctionsTest {
 		assertEquals("2", exec("{{ $l := list \"a\" \"b\" }}{{ $c := deepCopy $l }}{{ len $c }}"));
 	}
 
+	@Test
+	void testDeepCopyNestedMapIsIndependent() throws IOException, TemplateException {
+		// Mutating the copy's nested map must NOT affect the original
+		String template = """
+				{{ $orig := dict "inner" (dict "key" "original") }}\
+				{{ $copy := deepCopy $orig }}\
+				{{ $_ := set (get $copy "inner") "key" "mutated" }}\
+				{{ get (get $orig "inner") "key" }}""";
+		assertEquals("original", exec(template));
+	}
+
+	@Test
+	void testDeepCopyNestedListIsIndependent() throws IOException, TemplateException {
+		// Mutating the copy's nested list must NOT affect the original
+		String template = """
+				{{ $inner := list "a" "b" }}\
+				{{ $orig := dict "items" $inner }}\
+				{{ $copy := deepCopy $orig }}\
+				{{ $_ := set $copy "items" (append (get $copy "items") "c") }}\
+				{{ len (get $orig "items") }}""";
+		assertEquals("2", exec(template));
+	}
+
+	@Test
+	void testDeepCopyContextSetDoesNotMutateOriginal() throws IOException, TemplateException {
+		// Reproduces the airflow pattern: deepCopy context, set Values, verify original
+		Map<String, Object> inner = new HashMap<>();
+		inner.put("key", "original");
+		Map<String, Object> data = new HashMap<>();
+		data.put("Values", new HashMap<>(Map.of("config", inner)));
+		String template = """
+				{{ $globals := deepCopy . }}\
+				{{ $_ := set $globals.Values "extra" "added" }}\
+				{{ hasKey .Values "extra" }}""";
+		assertEquals("false", execWithData(template, data));
+	}
+
 	// --- New functions: chunk, mustChunk, push, mustPush ---
 
 	@Test


### PR DESCRIPTION
## Summary
- `deepCopy` was only copying top-level map entries — nested maps and lists shared references with the original
- Now recursively walks maps and lists, creating new instances at each level
- Primitives (String, Number, Boolean) are immutable and don't need copying

Closes #165

## Test plan
- [x] `testDeepCopyNestedMapIsIndependent` — mutating copy's nested map does NOT affect original
- [x] `testDeepCopyNestedListIsIndependent` — mutating copy's nested list does NOT affect original
- [x] `testDeepCopyContextSetDoesNotMutateOriginal` — reproduces airflow pattern: `deepCopy .` + `set $globals.Values` leaves original `.Values` unchanged
- [x] Existing `testDeepCopyList` and `testMergeAndCopy` (deepCopy/mustDeepCopy) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)