### PR TITLE
Share context across template executions for cross-template mutations

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -419,13 +419,15 @@ public class Engine {
 				parseWithCache(helmStyleName, t.getData());
 				StringWriter writer = new StringWriter();
 
+				// Share context across all template executions within a chart so that
+				// cross-template mutations via set $ "Values" propagate (Go Helm
+				// behavior)
 				@SuppressWarnings("unchecked")
 				Map<String, Object> templateMap = new HashMap<>((Map<String, Object>) context.get("Template"));
 				templateMap.put("Name", helmStyleName);
-				Map<String, Object> currentContext = new HashMap<>(context);
-				currentContext.put("Template", templateMap);
+				context.put("Template", templateMap);
 
-				factory.execute(helmStyleName, currentContext, writer);
+				factory.execute(helmStyleName, context, writer);
 				String rendered = writer.toString();
 				if (rendered != null && !rendered.isBlank()) {
 					if (!rendered.trim().endsWith("---")) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -301,6 +301,21 @@ class EngineTest {
 		assertTrue(result.contains("kube: v1.35.0"));
 	}
 
+	// --- Cross-template context mutations ---
+
+	@Test
+	void testSetDollarValuesPropagatesAcrossTemplates() {
+		// Reproduces istiod pattern: first template mutates $.Values via set,
+		// second template should see the mutation
+		Chart chart = simpleChart("istiod", "1.0.0",
+				List.of(tmpl("aaa_setup.yaml",
+						"{{ $_ := set $ \"Values\" (merge .Values (dict \"injected\" \"fromSetup\")) }}"),
+						tmpl("zzz_consumer.yaml", "injected: {{ .Values.injected }}")),
+				Map.of());
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("injected: fromSetup"), "set $ Values mutation should propagate: " + result);
+	}
+
 	// --- Error handling ---
 
 	@Test


### PR DESCRIPTION
## Summary
- Go Helm renders all templates in a chart with a shared execution context
- When a template calls `set $ "Values" newMap`, subsequent templates see the mutation
- jhelm was creating a fresh context copy per template, losing mutations
- Now `renderChartTemplates` uses the same context map, only updating `Template.Name` per file

Closes #166

## Test plan
- [x] `testSetDollarValuesPropagatesAcrossTemplates` — first template sets Values via `set $`, second template sees it
- [x] All existing engine tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)