### PR TITLE
Add missing .Release.Revision to UpgradeAction

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -61,6 +61,7 @@ public class UpgradeAction {
 		releaseData.put("Service", "Helm");
 		releaseData.put("IsInstall", false);
 		releaseData.put("IsUpgrade", true);
+		releaseData.put("Revision", newRelease.getVersion());
 
 		String manifest = engine.render(newChart, values, releaseData);
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -107,6 +107,7 @@ class UpgradeActionTest {
 		assertEquals("default", releaseData.get("Namespace"));
 		assertEquals(false, releaseData.get("IsInstall"));
 		assertEquals(true, releaseData.get("IsUpgrade"));
+		assertEquals(2, releaseData.get("Revision"));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- `UpgradeAction` was missing `releaseData.put("Revision", ...)` — templates using `.Release.Revision` during upgrade got null
- `InstallAction` and `TemplateAction` already set it correctly

Closes #179

## Test plan
- [x] Extended `testUpgradeSuccess` to verify `Revision` is set to 2 in releaseData
- [x] All existing upgrade tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)