### PR TITLE
Enforce library chart type: skip rendering and reject install/upgrade

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -35,6 +35,10 @@ public class InstallAction {
 
 	public Release install(Chart chart, String releaseName, String namespace, Map<String, Object> overrideValues,
 			int version, boolean dryRun) throws Exception {
+		if ("library".equals(chart.getMetadata().getType())) {
+			throw new IllegalArgumentException(
+					"chart '" + chart.getMetadata().getName() + "' is a library chart and cannot be installed");
+		}
 		Map<String, Object> values = new HashMap<>(chart.getValues());
 		if (overrideValues != null) {
 			values.putAll(overrideValues);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -35,6 +35,10 @@ public class UpgradeAction {
 
 	public Release upgrade(Release currentRelease, Chart newChart, Map<String, Object> overrideValues, boolean dryRun)
 			throws Exception {
+		if ("library".equals(newChart.getMetadata().getType())) {
+			throw new IllegalArgumentException(
+					"chart '" + newChart.getMetadata().getName() + "' is a library chart and cannot be upgraded");
+		}
 		Map<String, Object> values = new HashMap<>(newChart.getValues());
 		if (overrideValues != null) {
 			values.putAll(overrideValues);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -410,6 +410,11 @@ public class Engine {
 	}
 
 	private void renderChartTemplates(Chart chart, Map<String, Object> context, StringBuilder sb) {
+		// Library charts only provide named templates via include — do not render
+		// their .yaml files as standalone resources
+		if ("library".equals(chart.getMetadata().getType())) {
+			return;
+		}
 		for (Chart.Template t : chart.getTemplates()) {
 			if (!t.getName().endsWith(".yaml")) {
 				continue;

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
@@ -154,4 +154,13 @@ class InstallActionTest {
 		verify(kubeService).delete("default", HookParser.stripHooks(manifest));
 	}
 
+	@Test
+	void testInstallRejectsLibraryChart() {
+		ChartMetadata metadata = ChartMetadata.builder().name("mylib").version("1.0.0").type("library").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		assertThrows(IllegalArgumentException.class,
+				() -> installAction.install(chart, "my-release", "default", null, 1, false));
+	}
+
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -290,4 +290,20 @@ class UpgradeActionTest {
 		verify(kubeService, times(2)).apply(eq("default"), anyString());
 	}
 
+	@Test
+	void testUpgradeRejectsLibraryChart() {
+		ChartMetadata metadata = ChartMetadata.builder().name("mylib").version("1.0.0").type("library").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		Release currentRelease = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.info(Release.ReleaseInfo.builder().status("deployed").build())
+			.build();
+
+		assertThrows(IllegalArgumentException.class, () -> upgradeAction.upgrade(currentRelease, chart, null, false));
+	}
+
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -1197,4 +1197,35 @@ class EngineTest {
 		assertTrue(result.contains("data: []"), "Files.Get for missing file should return empty: " + result);
 	}
 
+	// --- library chart ---
+
+	@Test
+	void testLibraryChartTemplatesNotRendered() {
+		Chart library = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mylib").version("1.0.0").type("library").build())
+			.templates(List.of(tmpl("configmap.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: lib-cm")))
+			.values(Map.of())
+			.build();
+		String result = engine.render(library, Map.of(), releaseInfo());
+		assertFalse(result.contains("lib-cm"), "Library chart .yaml templates should not be rendered: " + result);
+	}
+
+	@Test
+	void testLibraryChartHelpersAvailableToParent() {
+		Chart library = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mylib").version("1.0.0").type("library").build())
+			.templates(List.of(tmpl("_helpers.tpl", "{{- define \"mylib.name\" -}}lib-value{{- end -}}")))
+			.values(Map.of())
+			.build();
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder().name("myapp").version("1.0.0").build())
+			.templates(List.of(tmpl("configmap.yaml", "name: {{ include \"mylib.name\" . }}")))
+			.values(Map.of())
+			.dependencies(List.of(library))
+			.build();
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		assertTrue(result.contains("name: lib-value"),
+				"Library chart helpers should be available to parent: " + result);
+	}
+
 }


### PR DESCRIPTION
## Summary
- `Engine.renderChartTemplates` skips `.yaml` templates for `type: library` charts (helpers still parsed)
- `InstallAction` and `UpgradeAction` reject library charts with `IllegalArgumentException`
- Tests added at Engine, InstallAction, and UpgradeAction levels

## Test plan
- [x] `EngineTest#testLibraryChartTemplatesNotRendered` — library `.yaml` templates produce no output
- [x] `EngineTest#testLibraryChartHelpersAvailableToParent` — `_helpers.tpl` from library chart works via `include`
- [x] `InstallActionTest#testInstallRejectsLibraryChart` — install throws for library charts
- [x] `UpgradeActionTest#testUpgradeRejectsLibraryChart` — upgrade throws for library charts

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)