### PR TITLE
Implement toToml/fromToml template functions

### DIFF
--- a/jhelm-gotemplate-helm/pom.xml
+++ b/jhelm-gotemplate-helm/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>tools.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-toml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -13,6 +13,7 @@ import org.alexmond.jhelm.gotemplate.Function;
 import tools.jackson.core.json.JsonWriteFeature;
 import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.toml.TomlMapper;
 import tools.jackson.dataformat.yaml.YAMLMapper;
 import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 
@@ -51,6 +52,9 @@ public final class ConversionFunctions {
 	private static final ThreadLocal<JsonMapper> RAW_JSON_MAPPER = ThreadLocal
 		.withInitial(() -> JsonMapper.builder().disable(JsonWriteFeature.ESCAPE_NON_ASCII).build());
 
+	private static final ThreadLocal<TomlMapper> TOML_MAPPER = ThreadLocal
+		.withInitial(() -> TomlMapper.builder().build());
+
 	public static Map<String, Function> getFunctions() {
 		Map<String, Function> functions = new HashMap<>();
 
@@ -73,6 +77,12 @@ public final class ConversionFunctions {
 		functions.put("mustFromJson", mustFromJson());
 		functions.put("fromJsonArray", fromJsonArray());
 		functions.put("mustFromJsonArray", mustFromJsonArray());
+
+		// TOML functions
+		functions.put("toToml", toToml());
+		functions.put("mustToToml", mustToToml());
+		functions.put("fromToml", fromToml());
+		functions.put("mustFromToml", mustFromToml());
 
 		return functions;
 	}
@@ -408,6 +418,74 @@ public final class ConversionFunctions {
 			}
 		};
 	}
+
+	// ===== TOML Functions =====
+
+	private static Function toToml() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return "";
+			}
+			try {
+				return TOML_MAPPER.get().writeValueAsString(args[0]);
+			}
+			catch (Exception ex) {
+				return "";
+			}
+		};
+	}
+
+	private static Function mustToToml() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				throw new RuntimeException("mustToToml: no value provided");
+			}
+			try {
+				return TOML_MAPPER.get().writeValueAsString(args[0]);
+			}
+			catch (Exception ex) {
+				throw new RuntimeException("mustToToml: failed to convert to TOML: " + ex.getMessage(), ex);
+			}
+		};
+	}
+
+	private static Function fromToml() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return Map.of();
+			}
+			try {
+				String toml = String.valueOf(args[0]);
+				if (toml.isBlank()) {
+					return Map.of();
+				}
+				return TOML_MAPPER.get().readValue(toml, Map.class);
+			}
+			catch (Exception ex) {
+				return Map.of();
+			}
+		};
+	}
+
+	private static Function mustFromToml() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				throw new RuntimeException("mustFromToml: no TOML string provided");
+			}
+			try {
+				String toml = String.valueOf(args[0]);
+				if (toml.isBlank()) {
+					throw new RuntimeException("mustFromToml: empty TOML string");
+				}
+				return TOML_MAPPER.get().readValue(toml, Map.class);
+			}
+			catch (Exception ex) {
+				throw new RuntimeException("mustFromToml: failed to parse TOML: " + ex.getMessage(), ex);
+			}
+		};
+	}
+
+	// ===== YAML Helpers =====
 
 	/**
 	 * Removes unnecessary double-quoting from YAML scalar values.

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -278,7 +278,8 @@ class ConversionFunctionsTest {
 		Map<String, Function> fns = functions();
 		List<String> expected = List.of("toYaml", "mustToYaml", "fromYaml", "mustFromYaml", "fromYamlArray",
 				"mustFromYamlArray", "toJson", "mustToJson", "toPrettyJson", "mustToPrettyJson", "toRawJson",
-				"mustToRawJson", "fromJson", "mustFromJson", "fromJsonArray", "mustFromJsonArray");
+				"mustToRawJson", "fromJson", "mustFromJson", "fromJsonArray", "mustFromJsonArray", "toToml",
+				"mustToToml", "fromToml", "mustFromToml");
 		for (String name : expected) {
 			assertTrue(fns.containsKey(name), "missing function: " + name);
 		}
@@ -338,6 +339,70 @@ class ConversionFunctionsTest {
 		Map<String, String> data = Map.of("val", "true");
 		String result = (String) toYaml.invoke(new Object[] { data });
 		assertTrue(result.contains("\"true\""), "boolean-like strings must stay quoted");
+	}
+
+	// --- TOML functions ---
+
+	@Test
+	void testToToml() {
+		Function fn = functions().get("toToml");
+		Map<String, Object> data = new HashMap<>();
+		data.put("name", "myapp");
+		data.put("port", 8080);
+		String result = (String) fn.invoke(new Object[] { data });
+		assertTrue(result.contains("myapp"), "toToml should serialize string: " + result);
+		assertTrue(result.contains("port = 8080"), "toToml should serialize integer: " + result);
+	}
+
+	@Test
+	void testToTomlNullReturnsEmpty() {
+		Function fn = functions().get("toToml");
+		assertEquals("", fn.invoke(new Object[] { null }));
+		assertEquals("", fn.invoke(new Object[] {}));
+	}
+
+	@Test
+	void testMustToTomlThrowsOnNull() {
+		Function fn = functions().get("mustToToml");
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { null }));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testFromToml() {
+		Function fn = functions().get("fromToml");
+		String toml = "name = \"myapp\"\nport = 8080\n";
+		Map<String, Object> result = (Map<String, Object>) fn.invoke(new Object[] { toml });
+		assertEquals("myapp", result.get("name"));
+		assertEquals(8080, ((Number) result.get("port")).intValue());
+	}
+
+	@Test
+	void testFromTomlNullReturnsEmptyMap() {
+		Function fn = functions().get("fromToml");
+		assertEquals(Map.of(), fn.invoke(new Object[] { null }));
+		assertEquals(Map.of(), fn.invoke(new Object[] { "" }));
+	}
+
+	@Test
+	void testMustFromTomlThrowsOnNull() {
+		Function fn = functions().get("mustFromToml");
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { null }));
+		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { "  " }));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testTomlRoundTrip() {
+		Function toToml = functions().get("toToml");
+		Function fromToml = functions().get("fromToml");
+		Map<String, Object> original = new HashMap<>();
+		original.put("key", "value");
+		original.put("count", 42);
+		String toml = (String) toToml.invoke(new Object[] { original });
+		Map<String, Object> parsed = (Map<String, Object>) fromToml.invoke(new Object[] { toml });
+		assertEquals("value", parsed.get("key"));
+		assertEquals(42, ((Number) parsed.get("count")).intValue());
 	}
 
 }


### PR DESCRIPTION
## Summary
- Add `jackson-dataformat-toml` dependency (version managed by Spring Boot BOM)
- Implement `toToml`, `mustToToml`, `fromToml`, `mustFromToml` in `ConversionFunctions`
- Follow existing ThreadLocal mapper pattern used by YAML/JSON functions

## Test plan
- [x] `testToToml` — serializes map to TOML string
- [x] `testToTomlNullReturnsEmpty` — null/empty args return ""
- [x] `testMustToTomlThrowsOnNull` — strict variant throws on null
- [x] `testFromToml` — parses TOML string to map
- [x] `testFromTomlNullReturnsEmptyMap` — null/blank returns empty map
- [x] `testMustFromTomlThrowsOnNull` — strict variant throws on null/blank
- [x] `testTomlRoundTrip` — serialize then parse preserves data
- [x] `testGetFunctionsReturnsAllExpected` — updated to include 4 TOML functions

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)