### PR TITLE
Honor helm.sh/resource-policy: keep on uninstall

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
@@ -29,7 +29,8 @@ public class UninstallAction {
 		String regularManifest = HookParser.stripHooks(release.getManifest());
 		HookExecutor hookExecutor = new HookExecutor(kubeService);
 		hookExecutor.run(namespace, hooks, "pre-delete", 300);
-		kubeService.delete(namespace, regularManifest);
+		String deletableManifest = HookParser.stripKeptResources(regularManifest);
+		kubeService.delete(namespace, deletableManifest);
 		hookExecutor.run(namespace, hooks, "post-delete", 300);
 		kubeService.deleteReleaseHistory(releaseName, namespace);
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/HookParser.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/HookParser.java
@@ -120,4 +120,34 @@ public final class HookParser {
 		return result.toString();
 	}
 
+	/**
+	 * Strips resources annotated with {@code helm.sh/resource-policy: keep} from the
+	 * manifest. These resources should be preserved during uninstall.
+	 * @param manifest the YAML manifest (may be null or blank)
+	 * @return manifest with kept resources removed
+	 */
+	public static String stripKeptResources(String manifest) {
+		if (manifest == null) {
+			return "";
+		}
+		if (manifest.isBlank()) {
+			return manifest;
+		}
+
+		String[] docs = manifest.split("---");
+		StringBuilder result = new StringBuilder();
+
+		for (String doc : docs) {
+			if (doc.isBlank()) {
+				continue;
+			}
+			if (doc.contains("helm.sh/resource-policy") && doc.contains("keep")) {
+				continue;
+			}
+			result.append("---\n").append(doc.trim()).append('\n');
+		}
+
+		return result.toString();
+	}
+
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UninstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UninstallActionTest.java
@@ -88,6 +88,34 @@ class UninstallActionTest {
 	}
 
 	@Test
+	void testUninstallSkipsResourcesWithKeepPolicy() throws Exception {
+		String keepYaml = """
+				apiVersion: v1
+				kind: PersistentVolumeClaim
+				metadata:
+				  name: myapp-data
+				  annotations:
+				    helm.sh/resource-policy: keep
+				spec:
+				  accessModes: [ReadWriteOnce]
+				""";
+		String regularYaml = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: myapp-cfg\n";
+		String fullManifest = "---\n" + keepYaml + regularYaml;
+
+		Release release = Release.builder().name("myapp").namespace("default").manifest(fullManifest).build();
+
+		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).deleteReleaseHistory(anyString(), anyString());
+
+		uninstallAction.uninstall("myapp", "default");
+
+		// Only ConfigMap should be deleted — PVC with resource-policy: keep is preserved
+		String deletedManifest = HookParser.stripKeptResources(HookParser.stripHooks(fullManifest));
+		verify(kubeService).delete("default", deletedManifest);
+	}
+
+	@Test
 	void testUninstallThrowsWhenReleaseNotFound() throws Exception {
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/HookParserTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/HookParserTest.java
@@ -211,4 +211,36 @@ class HookParserTest {
 		assertTrue(stripped.isBlank() || stripped.equals(""));
 	}
 
+	// --- stripKeptResources ---
+
+	@Test
+	void testStripKeptResourcesRemovesAnnotated() {
+		String keptDoc = """
+				apiVersion: v1
+				kind: PersistentVolumeClaim
+				metadata:
+				  name: myapp-data
+				  annotations:
+				    helm.sh/resource-policy: keep
+				spec:
+				  accessModes: [ReadWriteOnce]
+				""";
+		String manifest = "---\n" + keptDoc + "---\n" + REGULAR_DOC;
+		String result = HookParser.stripKeptResources(manifest);
+		assertFalse(result.contains("myapp-data"), "Kept resource should be removed: " + result);
+		assertTrue(result.contains("my-config"), "Regular resource should remain: " + result);
+	}
+
+	@Test
+	void testStripKeptResourcesPreservesNonAnnotated() {
+		String manifest = "---\n" + REGULAR_DOC;
+		String result = HookParser.stripKeptResources(manifest);
+		assertTrue(result.contains("my-config"));
+	}
+
+	@Test
+	void testStripKeptResourcesReturnsEmptyForNull() {
+		assertEquals("", HookParser.stripKeptResources(null));
+	}
+
 }


### PR DESCRIPTION
## Summary
- Add `HookParser.stripKeptResources()` to filter resources with `helm.sh/resource-policy: keep`
- `UninstallAction` now strips kept resources before calling `kubeService.delete()`
- Resources like PVCs annotated with `resource-policy: keep` are preserved during uninstall

## Test plan
- [x] `HookParserTest#testStripKeptResourcesRemovesAnnotated` — annotated resources filtered out
- [x] `HookParserTest#testStripKeptResourcesPreservesNonAnnotated` — regular resources kept
- [x] `HookParserTest#testStripKeptResourcesReturnsEmptyForNull` — null safety
- [x] `UninstallActionTest#testUninstallSkipsResourcesWithKeepPolicy` — end-to-end uninstall

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)