### PR TITLE
Add --atomic flag for auto-rollback on install/upgrade failure

### DIFF
--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -24,6 +25,8 @@ import picocli.CommandLine.Option;
 public class InstallCommand implements Runnable {
 
 	private final InstallAction installAction;
+
+	private final UninstallAction uninstallAction;
 
 	private final KubeService kubeService;
 
@@ -53,11 +56,16 @@ public class InstallCommand implements Runnable {
 	@Option(names = { "--timeout" }, defaultValue = "300", description = "timeout in seconds for --wait (default 300)")
 	private int timeout;
 
+	@Option(names = { "--atomic" }, description = "uninstall on failure (implies --wait)")
+	private boolean atomic;
+
 	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
 
-	public InstallCommand(InstallAction installAction, KubeService kubeService, ChartLoader chartLoader) {
+	public InstallCommand(InstallAction installAction, UninstallAction uninstallAction, KubeService kubeService,
+			ChartLoader chartLoader) {
 		this.installAction = installAction;
+		this.uninstallAction = uninstallAction;
 		this.kubeService = kubeService;
 		this.chartLoader = chartLoader;
 	}
@@ -81,13 +89,26 @@ public class InstallCommand implements Runnable {
 			}
 			else {
 				CliOutput.println(CliOutput.success("Release \"" + name + "\" has been installed."));
-				if (wait) {
+				if (wait || atomic) {
 					kubeService.waitForReady(namespace, release.getManifest(), timeout);
 				}
 			}
 		}
 		catch (Exception ex) {
-			CliOutput.errPrintln(CliOutput.error("Error installing chart: " + ex.getMessage()));
+			if (atomic) {
+				CliOutput
+					.errPrintln(CliOutput.error("Install failed, performing atomic uninstall: " + ex.getMessage()));
+				try {
+					uninstallAction.uninstall(name, namespace);
+					CliOutput.println("Atomic uninstall of \"" + name + "\" complete.");
+				}
+				catch (Exception rollbackEx) {
+					CliOutput.errPrintln(CliOutput.error("Atomic uninstall failed: " + rollbackEx.getMessage()));
+				}
+			}
+			else {
+				CliOutput.errPrintln(CliOutput.error("Error installing chart: " + ex.getMessage()));
+			}
 			if (log.isDebugEnabled()) {
 				log.debug("Install error details", ex);
 			}

--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
@@ -29,7 +31,11 @@ public class UpgradeCommand implements Runnable {
 
 	private final InstallAction installAction;
 
+	private final UninstallAction uninstallAction;
+
 	private final UpgradeAction upgradeAction;
+
+	private final RollbackAction rollbackAction;
 
 	private final ChartLoader chartLoader;
 
@@ -60,19 +66,26 @@ public class UpgradeCommand implements Runnable {
 	@Option(names = { "--timeout" }, defaultValue = "300", description = "timeout in seconds for --wait (default 300)")
 	private int timeout;
 
+	@Option(names = { "--atomic" }, description = "rollback on failure (implies --wait)")
+	private boolean atomic;
+
 	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
 
-	public UpgradeCommand(KubeService kubeService, InstallAction installAction, UpgradeAction upgradeAction,
-			ChartLoader chartLoader) {
+	public UpgradeCommand(KubeService kubeService, InstallAction installAction, UninstallAction uninstallAction,
+			UpgradeAction upgradeAction, RollbackAction rollbackAction, ChartLoader chartLoader) {
 		this.kubeService = kubeService;
 		this.installAction = installAction;
+		this.uninstallAction = uninstallAction;
 		this.upgradeAction = upgradeAction;
+		this.rollbackAction = rollbackAction;
 		this.chartLoader = chartLoader;
 	}
 
 	@Override
 	public void run() {
+		int previousVersion = -1;
+		boolean wasInstall = false;
 		try {
 			Optional<Release> currentReleaseOpt = kubeService.getRelease(name, namespace);
 			Chart chart = chartLoader.load(new File(chartPath));
@@ -80,6 +93,7 @@ public class UpgradeCommand implements Runnable {
 
 			if (currentReleaseOpt.isEmpty()) {
 				if (install) {
+					wasInstall = true;
 					Release release = installAction.install(chart, name, namespace, overrides, 1, dryRun);
 					applyCliPostRenderers(release);
 					if (dryRun) {
@@ -88,7 +102,7 @@ public class UpgradeCommand implements Runnable {
 					else {
 						CliOutput
 							.println(CliOutput.success("Release \"" + name + "\" does not exist. Installing it now."));
-						if (wait) {
+						if (wait || atomic) {
 							kubeService.waitForReady(namespace, release.getManifest(), timeout);
 						}
 					}
@@ -99,6 +113,7 @@ public class UpgradeCommand implements Runnable {
 				return;
 			}
 
+			previousVersion = currentReleaseOpt.get().getVersion();
 			Release upgradedRelease = upgradeAction.upgrade(currentReleaseOpt.get(), chart, overrides, dryRun);
 			applyCliPostRenderers(upgradedRelease);
 
@@ -107,13 +122,31 @@ public class UpgradeCommand implements Runnable {
 			}
 			else {
 				CliOutput.println(CliOutput.success("Release \"" + name + "\" has been upgraded. Happy Helming!"));
-				if (wait) {
+				if (wait || atomic) {
 					kubeService.waitForReady(namespace, upgradedRelease.getManifest(), timeout);
 				}
 			}
 		}
 		catch (Exception ex) {
-			CliOutput.errPrintln(CliOutput.error("Error upgrading release: " + ex.getMessage()));
+			if (atomic) {
+				CliOutput.errPrintln(CliOutput.error("Upgrade failed, performing atomic rollback: " + ex.getMessage()));
+				try {
+					if (wasInstall || previousVersion < 0) {
+						uninstallAction.uninstall(name, namespace);
+						CliOutput.println("Atomic uninstall of \"" + name + "\" complete.");
+					}
+					else {
+						rollbackAction.rollback(name, namespace, previousVersion);
+						CliOutput.println("Atomic rollback of \"" + name + "\" complete.");
+					}
+				}
+				catch (Exception rollbackEx) {
+					CliOutput.errPrintln(CliOutput.error("Atomic rollback failed: " + rollbackEx.getMessage()));
+				}
+			}
+			else {
+				CliOutput.errPrintln(CliOutput.error("Error upgrading release: " + ex.getMessage()));
+			}
 			if (log.isDebugEnabled()) {
 				log.debug("Upgrade error details", ex);
 			}

--- a/jhelm-app/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-app/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -6,6 +6,7 @@ import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.UninstallAction;
 
 import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +35,9 @@ class InstallCommandTest {
 	private InstallAction installAction;
 
 	@Mock
+	private UninstallAction uninstallAction;
+
+	@Mock
 	private KubeService kubeService;
 
 	@Mock
@@ -52,7 +56,7 @@ class InstallCommandTest {
 			.values(new HashMap<>())
 			.build();
 		when(chartLoader.load(any(File.class))).thenReturn(defaultChart);
-		installCommand = new InstallCommand(installAction, kubeService, chartLoader);
+		installCommand = new InstallCommand(installAction, uninstallAction, kubeService, chartLoader);
 	}
 
 	@Test
@@ -117,6 +121,19 @@ class InstallCommandTest {
 
 		// waitForReady should NOT be called when --dry-run is active
 		verify(kubeService, Mockito.never()).waitForReady(anyString(), anyString(), anyInt());
+	}
+
+	@Test
+	void testInstallCommandAtomicUninstallsOnFailure() throws Exception {
+		File chartDir = createMockChart();
+
+		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean()))
+			.thenThrow(new RuntimeException("deploy failed"));
+
+		CommandLine cmd = new CommandLine(installCommand);
+		cmd.execute("my-release", chartDir.getAbsolutePath(), "--atomic");
+
+		verify(uninstallAction).uninstall("my-release", "default");
 	}
 
 	private File createMockChart() throws Exception {

--- a/jhelm-app/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-app/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -6,6 +6,8 @@ import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 
 import java.util.HashMap;
@@ -38,7 +40,13 @@ class UpgradeCommandTest {
 	private InstallAction installAction;
 
 	@Mock
+	private UninstallAction uninstallAction;
+
+	@Mock
 	private UpgradeAction upgradeAction;
+
+	@Mock
+	private RollbackAction rollbackAction;
 
 	@Mock
 	private ChartLoader chartLoader;
@@ -56,7 +64,8 @@ class UpgradeCommandTest {
 			.values(new HashMap<>())
 			.build();
 		when(chartLoader.load(any(File.class))).thenReturn(defaultChart);
-		upgradeCommand = new UpgradeCommand(kubeService, installAction, upgradeAction, chartLoader);
+		upgradeCommand = new UpgradeCommand(kubeService, installAction, uninstallAction, upgradeAction, rollbackAction,
+				chartLoader);
 	}
 
 	@Test
@@ -179,6 +188,21 @@ class UpgradeCommandTest {
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "--install", "--dry-run");
 
 		verify(installAction).install(any(Chart.class), eq("my-release"), eq("default"), anyMap(), eq(1), eq(true));
+	}
+
+	@Test
+	void testUpgradeCommandAtomicRollsBackOnFailure() throws Exception {
+		File chartDir = createMockChart();
+		Release existingRelease = createMockRelease("my-release", 3);
+
+		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
+		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), anyBoolean()))
+			.thenThrow(new RuntimeException("upgrade failed"));
+
+		CommandLine cmd = new CommandLine(upgradeCommand);
+		cmd.execute("my-release", chartDir.getAbsolutePath(), "--atomic");
+
+		verify(rollbackAction).rollback("my-release", "default", 3);
 	}
 
 	private Release createMockRelease(String name, int version) {


### PR DESCRIPTION
## Summary
- Add `--atomic` flag to `InstallCommand` and `UpgradeCommand` (implies `--wait`)
- Install: auto-uninstall on failure
- Upgrade: auto-rollback to previous version on failure; auto-uninstall if it was a fresh `--install`

## Test plan
- [x] `InstallCommandTest#testInstallCommandAtomicUninstallsOnFailure`
- [x] `UpgradeCommandTest#testUpgradeCommandAtomicRollsBackOnFailure`
- [x] Existing wait/dry-run tests still pass

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)