### PR TITLE
Apply CRDs before chart resources during install

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -76,6 +76,7 @@ public class InstallAction {
 		release.setManifest(manifest);
 
 		if (kubeService != null && !dryRun) {
+			applyCrds(chart, namespace);
 			fireLifecycleEvent("pre-install", releaseName, namespace);
 			List<HelmHook> hooks = HookParser.parseHooks(manifest);
 			String regularManifest = HookParser.stripHooks(manifest);
@@ -95,6 +96,18 @@ public class InstallAction {
 		}
 
 		return release;
+	}
+
+	private void applyCrds(Chart chart, String namespace) throws Exception {
+		if (chart.getCrds() == null || chart.getCrds().isEmpty()) {
+			return;
+		}
+		for (Chart.Crd crd : chart.getCrds()) {
+			if (log.isInfoEnabled()) {
+				log.info("Installing CRD: {}", crd.getName());
+			}
+			kubeService.apply(namespace, crd.getData());
+		}
 	}
 
 	private void rollbackAppliedResources(String namespace, String manifest) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
@@ -155,6 +155,28 @@ class InstallActionTest {
 	}
 
 	@Test
+	void testInstallAppliesCrdsBeforeManifest() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		String crdYaml = "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: foos.example.com\n";
+		Chart chart = Chart.builder()
+			.metadata(metadata)
+			.values(new HashMap<>())
+			.crds(List.of(Chart.Crd.builder().name("foos.yaml").data(crdYaml).build()))
+			.build();
+
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("---\nkind: ConfigMap\n");
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		installAction.install(chart, "my-release", "default", null, 1, false);
+
+		// CRD should be applied before the regular manifest
+		org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(kubeService);
+		inOrder.verify(kubeService).apply("default", crdYaml);
+		inOrder.verify(kubeService).apply("default", "---\nkind: ConfigMap\n");
+	}
+
+	@Test
 	void testInstallRejectsLibraryChart() {
 		ChartMetadata metadata = ChartMetadata.builder().name("mylib").version("1.0.0").type("library").build();
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();


### PR DESCRIPTION
## Summary
- `InstallAction` applies CRDs from `chart.getCrds()` before hooks and regular manifest
- CRDs are NOT re-applied during `helm upgrade` (matching Helm's design)
- Uses `InOrder` Mockito verification to confirm CRD-first ordering

## Test plan
- [x] `InstallActionTest#testInstallAppliesCrdsBeforeManifest` — CRDs applied before regular resources

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)