### PR TITLE
Apply .helmignore patterns during helm package

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/PackageAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/PackageAction.java
@@ -4,8 +4,13 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
 import lombok.RequiredArgsConstructor;
@@ -88,24 +93,31 @@ public class PackageAction {
 	}
 
 	private void createTgz(File chartDir, String chartName, File outputFile) throws IOException {
+		List<PathMatcher> ignoreMatchers = loadHelmIgnore(chartDir);
 		try (OutputStream fos = Files.newOutputStream(outputFile.toPath());
 				BufferedOutputStream bos = new BufferedOutputStream(fos);
 				GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(bos);
 				TarArchiveOutputStream taos = new TarArchiveOutputStream(gzos)) {
 			taos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
-			addDirectory(taos, chartDir, chartName);
+			addDirectory(taos, chartDir, chartName, ignoreMatchers);
 		}
 	}
 
-	private void addDirectory(TarArchiveOutputStream taos, File dir, String entryBase) throws IOException {
-		try (Stream<Path> paths = Files.walk(dir.toPath())) {
+	private void addDirectory(TarArchiveOutputStream taos, File dir, String entryBase, List<PathMatcher> ignoreMatchers)
+			throws IOException {
+		Path dirPath = dir.toPath();
+		try (Stream<Path> paths = Files.walk(dirPath)) {
 			paths.forEach((path) -> {
 				try {
 					File file = path.toFile();
-					String entryName = entryBase + "/" + dir.toPath().relativize(path);
 					if (file.isDirectory()) {
 						return;
 					}
+					Path relativePath = dirPath.relativize(path);
+					if (isIgnored(relativePath, ignoreMatchers)) {
+						return;
+					}
+					String entryName = entryBase + "/" + relativePath;
 					TarArchiveEntry entry = new TarArchiveEntry(file, entryName);
 					taos.putArchiveEntry(entry);
 					Files.copy(path, taos);
@@ -119,6 +131,48 @@ public class PackageAction {
 		catch (UncheckedIOException ex) {
 			throw ex.getCause();
 		}
+	}
+
+	static List<PathMatcher> loadHelmIgnore(File chartDir) {
+		File ignoreFile = new File(chartDir, ".helmignore");
+		if (!ignoreFile.exists()) {
+			return List.of();
+		}
+		List<PathMatcher> matchers = new ArrayList<>();
+		FileSystem fs = FileSystems.getDefault();
+		try {
+			List<String> lines = Files.readAllLines(ignoreFile.toPath());
+			for (String line : lines) {
+				String trimmed = line.trim();
+				if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+					continue;
+				}
+				// Remove trailing slashes (directory markers) for matching
+				if (trimmed.endsWith("/")) {
+					trimmed = trimmed.substring(0, trimmed.length() - 1);
+				}
+				// Convert to glob: match anywhere in the path
+				String glob = "glob:**/" + trimmed;
+				matchers.add(fs.getPathMatcher(glob));
+				// Also match at the root (no leading directory)
+				matchers.add(fs.getPathMatcher("glob:" + trimmed));
+			}
+		}
+		catch (IOException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("Failed to read .helmignore: {}", ex.getMessage());
+			}
+		}
+		return matchers;
+	}
+
+	private static boolean isIgnored(Path relativePath, List<PathMatcher> matchers) {
+		for (PathMatcher matcher : matchers) {
+			if (matcher.matches(relativePath)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private static class UncheckedIOException extends RuntimeException {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/PackageActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/PackageActionTest.java
@@ -25,6 +25,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -106,6 +113,36 @@ class PackageActionTest {
 		assertTrue(archive.exists());
 		File provFile = new File(archive.getAbsolutePath() + ".prov");
 		assertTrue(!provFile.exists());
+	}
+
+	@Test
+	void testPackageChartRespectsHelmignore() throws Exception {
+		Path chartDir = createMinimalChart("ignore-chart", "1.0.0");
+		// Add files that should be ignored
+		Files.writeString(chartDir.resolve(".git"), "gitdir");
+		Files.writeString(chartDir.resolve("notes.txt"), "dev notes");
+		Files.writeString(chartDir.resolve(".helmignore"), ".git\nnotes.txt\n");
+
+		packageAction.setDestination(tempDir.toFile());
+		File archive = packageAction.packageChart(chartDir.toString());
+
+		Set<String> entries = listTgzEntries(archive);
+		assertTrue(entries.stream().anyMatch((e) -> e.contains("Chart.yaml")), "Chart.yaml should be included");
+		assertFalse(entries.stream().anyMatch((e) -> e.contains(".git")), ".git should be excluded");
+		assertFalse(entries.stream().anyMatch((e) -> e.contains("notes.txt")), "notes.txt should be excluded");
+	}
+
+	private Set<String> listTgzEntries(File tgzFile) throws Exception {
+		Set<String> names = new HashSet<>();
+		try (var fis = Files.newInputStream(tgzFile.toPath());
+				var gis = new GzipCompressorInputStream(fis);
+				var tis = new TarArchiveInputStream(gis)) {
+			TarArchiveEntry entry;
+			while ((entry = tis.getNextEntry()) != null) {
+				names.add(entry.getName());
+			}
+		}
+		return names;
 	}
 
 	private Path createMinimalChart(String name, String version) throws Exception {


### PR DESCRIPTION
## Summary
- Parse `.helmignore` patterns before creating tgz archive
- Filter files using Java `PathMatcher` glob matching
- Supports comments (`#`), directory markers (trailing `/`), and standard patterns

## Test plan
- [x] `PackageActionTest#testPackageChartRespectsHelmignore` — ignored files excluded from archive
- [x] Existing packaging and signing tests still pass

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)