### PR TITLE
Wire HTTP repository authentication for Basic Auth and TLS (#175)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
@@ -1,0 +1,177 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactoryBuilder;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+
+import org.alexmond.jhelm.core.model.RepositoryConfig;
+
+/**
+ * Builds HTTP clients with TLS and Basic Auth for authenticated Helm repositories.
+ */
+final class RepoHttpClientFactory {
+
+	private final CloseableHttpClient defaultClient;
+
+	private final boolean globalInsecureSkipTls;
+
+	RepoHttpClientFactory(CloseableHttpClient defaultClient, boolean globalInsecureSkipTls) {
+		this.defaultClient = defaultClient;
+		this.globalInsecureSkipTls = globalInsecureSkipTls;
+	}
+
+	void configureAuth(HttpGet request, RepositoryConfig.Repository repo) {
+		if (repo == null) {
+			return;
+		}
+		if (repo.getUsername() != null && !repo.getUsername().isEmpty()) {
+			String password = (repo.getPassword() != null) ? repo.getPassword() : "";
+			String credentials = repo.getUsername() + ":" + password;
+			String encoded = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+			request.setHeader("Authorization", "Basic " + encoded);
+		}
+	}
+
+	<T> T executeGet(HttpGet request, RepositoryConfig.Repository repo, HttpClientResponseHandler<T> handler)
+			throws IOException {
+		configureAuth(request, repo);
+		if (needsCustomTls(repo)) {
+			try (CloseableHttpClient client = buildTlsClient(repo)) {
+				return client.execute(request, handler);
+			}
+		}
+		return defaultClient.execute(request, handler);
+	}
+
+	private boolean needsCustomTls(RepositoryConfig.Repository repo) {
+		if (repo == null) {
+			return false;
+		}
+		boolean hasTls = (repo.getCertFile() != null && !repo.getCertFile().isEmpty())
+				|| (repo.getCaFile() != null && !repo.getCaFile().isEmpty());
+		boolean skipVerify = repo.isInsecure_skip_tls_verify() || globalInsecureSkipTls;
+		return hasTls || skipVerify;
+	}
+
+	private CloseableHttpClient buildTlsClient(RepositoryConfig.Repository repo) throws IOException {
+		try {
+			boolean skipVerify = repo.isInsecure_skip_tls_verify() || globalInsecureSkipTls;
+			SSLContext sslContext = buildSslContext(repo, skipVerify);
+			var socketFactoryBuilder = SSLConnectionSocketFactoryBuilder.create().setSslContext(sslContext);
+			if (skipVerify) {
+				socketFactoryBuilder.setHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+			}
+			HttpClientConnectionManager connManager = PoolingHttpClientConnectionManagerBuilder.create()
+				.setSSLSocketFactory(socketFactoryBuilder.build())
+				.build();
+			return HttpClients.custom().setConnectionManager(connManager).build();
+		}
+		catch (Exception ex) {
+			throw new IOException("Failed to build TLS-configured HTTP client", ex);
+		}
+	}
+
+	private SSLContext buildSslContext(RepositoryConfig.Repository repo, boolean skipVerify) throws Exception {
+		KeyManagerFactory kmf = null;
+		TrustManagerFactory tmf = null;
+
+		if (repo.getCertFile() != null && !repo.getCertFile().isEmpty() && repo.getKeyFile() != null
+				&& !repo.getKeyFile().isEmpty()) {
+			KeyStore keyStore = KeyStore.getInstance("PKCS12");
+			keyStore.load(null, null);
+			CertificateFactory cf = CertificateFactory.getInstance("X.509");
+			Certificate cert;
+			try (InputStream certIn = new FileInputStream(repo.getCertFile())) {
+				cert = cf.generateCertificate(certIn);
+			}
+			PrivateKey key = loadPrivateKey(repo.getKeyFile());
+			keyStore.setKeyEntry("client", key, new char[0], new Certificate[] { cert });
+			kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+			kmf.init(keyStore, new char[0]);
+		}
+
+		if (repo.getCaFile() != null && !repo.getCaFile().isEmpty()) {
+			KeyStore trustStore = KeyStore.getInstance("PKCS12");
+			trustStore.load(null, null);
+			CertificateFactory cf = CertificateFactory.getInstance("X.509");
+			try (InputStream caIn = new FileInputStream(repo.getCaFile())) {
+				int idx = 0;
+				for (Certificate c : cf.generateCertificates(caIn)) {
+					trustStore.setCertificateEntry("ca-" + idx++, c);
+				}
+			}
+			tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+			tmf.init(trustStore);
+		}
+
+		SSLContext sslContext = SSLContext.getInstance("TLS");
+		TrustManager[] trustManagers = null;
+		if (skipVerify) {
+			trustManagers = new TrustManager[] { new InsecureTrustManager() };
+		}
+		else if (tmf != null) {
+			trustManagers = tmf.getTrustManagers();
+		}
+		sslContext.init((kmf != null) ? kmf.getKeyManagers() : null, trustManagers, null);
+		return sslContext;
+	}
+
+	private PrivateKey loadPrivateKey(String keyFilePath) throws Exception {
+		String pem = Files.readString(Paths.get(keyFilePath));
+		String base64 = pem.replace("-----BEGIN PRIVATE KEY-----", "")
+			.replace("-----END PRIVATE KEY-----", "")
+			.replace("-----BEGIN RSA PRIVATE KEY-----", "")
+			.replace("-----END RSA PRIVATE KEY-----", "")
+			.replaceAll("\\s", "");
+		byte[] decoded = Base64.getDecoder().decode(base64);
+		PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(decoded);
+		KeyFactory kf = KeyFactory.getInstance("RSA");
+		return kf.generatePrivate(spec);
+	}
+
+	private static final class InsecureTrustManager implements X509TrustManager {
+
+		@Override
+		public void checkClientTrusted(X509Certificate[] chain, String authType) {
+			// intentionally empty — skip verification
+		}
+
+		@Override
+		public void checkServerTrusted(X509Certificate[] chain, String authType) {
+			// intentionally empty — skip verification
+		}
+
+		@Override
+		public X509Certificate[] getAcceptedIssuers() {
+			return new X509Certificate[0];
+		}
+
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -48,6 +48,8 @@ public class RepoManager {
 
 	private CloseableHttpClient httpClient;
 
+	private RepoHttpClientFactory httpClientFactory;
+
 	private OciRegistryClient ociClient;
 
 	@Setter
@@ -74,6 +76,7 @@ public class RepoManager {
 
 	void setHttpClientForTest(CloseableHttpClient client) {
 		this.httpClient = client;
+		this.httpClientFactory = new RepoHttpClientFactory(client, insecureSkipTlsVerify);
 		this.ociClient = new OciRegistryClient(client);
 	}
 
@@ -99,7 +102,13 @@ public class RepoManager {
 			}
 			httpClient = HttpClients.createDefault();
 		}
+		httpClientFactory = new RepoHttpClientFactory(httpClient, insecureSkipTlsVerify);
 		ociClient = new OciRegistryClient(httpClient);
+	}
+
+	RepositoryConfig.Repository getRepository(String name) throws IOException {
+		RepositoryConfig config = loadConfig();
+		return config.getRepositories().stream().filter((r) -> r.getName().equals(name)).findFirst().orElse(null);
 	}
 
 	public RepositoryConfig loadConfig() throws IOException {
@@ -241,7 +250,8 @@ public class RepoManager {
 	}
 
 	public void updateRepo(String name) throws IOException {
-		String repoUrl = getRepoUrl(name);
+		RepositoryConfig.Repository repo = getRepository(name);
+		String repoUrl = (repo != null) ? repo.getUrl() : null;
 		if (repoUrl == null) {
 			throw new IOException("Repository not found: " + name);
 		}
@@ -253,7 +263,7 @@ public class RepoManager {
 		HttpGet httpGet = new HttpGet(indexUrl);
 		httpGet.setHeader("User-Agent", "jhelm");
 
-		httpClient.execute(httpGet, (response) -> {
+		httpClientFactory.executeGet(httpGet, repo, (response) -> {
 			int statusCode = response.getCode();
 			if (statusCode != 200) {
 				throw new IOException("Failed to download index from " + indexUrl + ": " + statusCode + " "
@@ -294,7 +304,8 @@ public class RepoManager {
 			indexIn = new FileInputStream(indexFile);
 		}
 		else {
-			String repoUrl = getRepoUrl(repoName);
+			RepositoryConfig.Repository repo = getRepository(repoName);
+			String repoUrl = (repo != null) ? repo.getUrl() : null;
 			if (repoUrl == null) {
 				throw new IOException("Repository name is required to get chart versions. Found: " + repoName);
 			}
@@ -306,7 +317,7 @@ public class RepoManager {
 			HttpGet httpGet = new HttpGet(indexUrl);
 			httpGet.setHeader("User-Agent", "jhelm");
 
-			byte[] indexData = httpClient.execute(httpGet, (response) -> {
+			byte[] indexData = httpClientFactory.executeGet(httpGet, repo, (response) -> {
 				int statusCode = response.getCode();
 				if (statusCode != 200) {
 					throw new IOException("Failed to download index from " + indexUrl + ": " + statusCode);
@@ -432,7 +443,7 @@ public class RepoManager {
 		}
 
 		String tgzFileName = finalChartName + "-" + version + ".tgz";
-		pullFromUrl(chartUrl, destDir, tgzFileName);
+		pullFromUrl(chartUrl, destDir, tgzFileName, repo);
 
 		File downloaded = new File(destDir, tgzFileName);
 		if (downloaded.exists()) {
@@ -483,6 +494,11 @@ public class RepoManager {
 	}
 
 	public void pullFromUrl(String chartUrl, String destDir, String fileName) throws IOException {
+		pullFromUrl(chartUrl, destDir, fileName, null);
+	}
+
+	void pullFromUrl(String chartUrl, String destDir, String fileName, RepositoryConfig.Repository repo)
+			throws IOException {
 		if (chartUrl.startsWith("oci://")) {
 			pullOci(chartUrl, destDir, fileName);
 			return;
@@ -497,7 +513,7 @@ public class RepoManager {
 		HttpGet httpGet = new HttpGet(chartUrl);
 		httpGet.setHeader("User-Agent", "jhelm");
 
-		httpClient.execute(httpGet, (response) -> {
+		httpClientFactory.executeGet(httpGet, repo, (response) -> {
 			int statusCode = response.getCode();
 			if (statusCode != 200) {
 				throw new IOException("Failed to download chart from " + chartUrl + ": " + statusCode);

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoHttpClientFactoryTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoHttpClientFactoryTest.java
@@ -1,0 +1,73 @@
+package org.alexmond.jhelm.core.service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import org.alexmond.jhelm.core.model.RepositoryConfig;
+
+class RepoHttpClientFactoryTest {
+
+	@Test
+	void testConfigureAuthSetsBasicHeader() {
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		RepoHttpClientFactory factory = new RepoHttpClientFactory(mockClient, false);
+		RepositoryConfig.Repository repo = RepositoryConfig.Repository.builder()
+			.name("test")
+			.url("https://example.com")
+			.username("myuser")
+			.password("mypass")
+			.build();
+		HttpGet request = new HttpGet("https://example.com/index.yaml");
+		factory.configureAuth(request, repo);
+		String expected = "Basic "
+				+ Base64.getEncoder().encodeToString("myuser:mypass".getBytes(StandardCharsets.UTF_8));
+		assertEquals(expected, request.getFirstHeader("Authorization").getValue());
+	}
+
+	@Test
+	void testConfigureAuthSkipsWhenNoCredentials() {
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		RepoHttpClientFactory factory = new RepoHttpClientFactory(mockClient, false);
+		RepositoryConfig.Repository repo = RepositoryConfig.Repository.builder()
+			.name("test")
+			.url("https://example.com")
+			.build();
+		HttpGet request = new HttpGet("https://example.com/index.yaml");
+		factory.configureAuth(request, repo);
+		assertNull(request.getFirstHeader("Authorization"));
+	}
+
+	@Test
+	void testConfigureAuthSkipsNullRepo() {
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		RepoHttpClientFactory factory = new RepoHttpClientFactory(mockClient, false);
+		HttpGet request = new HttpGet("https://example.com/index.yaml");
+		factory.configureAuth(request, null);
+		assertNull(request.getFirstHeader("Authorization"));
+	}
+
+	@Test
+	void testConfigureAuthHandlesNullPassword() {
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		RepoHttpClientFactory factory = new RepoHttpClientFactory(mockClient, false);
+		RepositoryConfig.Repository repo = RepositoryConfig.Repository.builder()
+			.name("test")
+			.url("https://example.com")
+			.username("tokenuser")
+			.build();
+		HttpGet request = new HttpGet("https://example.com/index.yaml");
+		factory.configureAuth(request, repo);
+		String expected = "Basic " + Base64.getEncoder().encodeToString("tokenuser:".getBytes(StandardCharsets.UTF_8));
+		assertNotNull(request.getFirstHeader("Authorization"));
+		assertEquals(expected, request.getFirstHeader("Authorization").getValue());
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
@@ -40,9 +40,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.mockito.ArgumentCaptor;
+
 import org.alexmond.jhelm.core.model.RepositoryConfig;
+
 import java.net.URL;
+import java.util.Base64;
 
 @SuppressWarnings("unchecked")
 class RepoManagerTest {
@@ -364,6 +369,76 @@ class RepoManagerTest {
 		when(mockClient.execute(isA(HttpPut.class), any(HttpClientResponseHandler.class)))
 			.thenAnswer(httpAnswer(201, null));
 		rm.pushOci(chartFile.getAbsolutePath(), "oci://test.registry.io/myorg/mychart:1.0.0");
+	}
+
+	@Test
+	void testUpdateRepoSendsBasicAuth() throws IOException {
+		RepoManager rm = new RepoManager(tempDir.resolve("repos.yaml").toString());
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		rm.setHttpClientForTest(mockClient);
+		rm.saveConfig(RepositoryConfig.builder()
+			.repositories(new ArrayList<>(List.of(RepositoryConfig.Repository.builder()
+				.name("authrepo")
+				.url("https://private.example.com")
+				.username("admin")
+				.password("secret")
+				.build())))
+			.build());
+		byte[] indexContent = "apiVersion: v1\nentries: {}\n".getBytes(StandardCharsets.UTF_8);
+		when(mockClient.execute(isA(HttpGet.class), any(HttpClientResponseHandler.class)))
+			.thenAnswer(httpAnswer(200, indexContent));
+		rm.updateRepo("authrepo");
+		var captor = ArgumentCaptor.forClass(HttpGet.class);
+		verify(mockClient).execute(captor.capture(), any(HttpClientResponseHandler.class));
+		String authHeader = captor.getValue().getFirstHeader("Authorization").getValue();
+		String expected = "Basic "
+				+ Base64.getEncoder().encodeToString("admin:secret".getBytes(StandardCharsets.UTF_8));
+		assertEquals(expected, authHeader);
+	}
+
+	@Test
+	void testPullFromUrlWithAuthSendsHeader() throws Exception {
+		RepoManager rm = new RepoManager(tempDir.resolve("repos.yaml").toString());
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		rm.setHttpClientForTest(mockClient);
+		rm.saveConfig(RepositoryConfig.builder()
+			.repositories(new ArrayList<>(List.of(RepositoryConfig.Repository.builder()
+				.name("authrepo")
+				.url("https://private.example.com")
+				.username("user")
+				.password("pass")
+				.build())))
+			.build());
+		byte[] tgz = createMinimalTgz();
+		when(mockClient.execute(isA(HttpGet.class), any(HttpClientResponseHandler.class)))
+			.thenAnswer(httpAnswer(200, tgz));
+		RepositoryConfig.Repository repo = rm.getRepository("authrepo");
+		rm.pullFromUrl("https://private.example.com/mychart-1.0.0.tgz", tempDir.toString(), "mychart-1.0.0.tgz", repo);
+		var captor = ArgumentCaptor.forClass(HttpGet.class);
+		verify(mockClient).execute(captor.capture(), any(HttpClientResponseHandler.class));
+		assertNotNull(captor.getValue().getFirstHeader("Authorization"));
+	}
+
+	@Test
+	void testGetRepositoryFound() throws IOException {
+		RepoManager rm = new RepoManager(tempDir.resolve("repos.yaml").toString());
+		rm.saveConfig(RepositoryConfig.builder()
+			.repositories(new ArrayList<>(List.of(RepositoryConfig.Repository.builder()
+				.name("myrepo")
+				.url("https://charts.example.com")
+				.username("user1")
+				.build())))
+			.build());
+		RepositoryConfig.Repository repo = rm.getRepository("myrepo");
+		assertNotNull(repo);
+		assertEquals("user1", repo.getUsername());
+	}
+
+	@Test
+	void testGetRepositoryNotFound() throws IOException {
+		RepoManager rm = new RepoManager(tempDir.resolve("repos.yaml").toString());
+		rm.saveConfig(RepositoryConfig.builder().repositories(new ArrayList<>()).build());
+		assertNull(rm.getRepository("missing"));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Wire `username`/`password` from `RepositoryConfig.Repository` as Basic Auth headers on HTTP requests
- Build custom TLS HTTP clients when `certFile`/`keyFile`/`caFile` are configured on a repository
- Support per-repo `insecure_skip_tls_verify` flag
- Extract TLS client building into `RepoHttpClientFactory` to keep `RepoManager` under file size limits
- Use `executeGet()` pattern with try-with-resources for proper lifecycle of per-repo TLS clients

## Test plan
- [x] Run `./mvnw test -pl jhelm-core` — 435 tests pass
- [x] Verify Basic Auth header is sent when repo has credentials (`testUpdateRepoSendsBasicAuth`)
- [x] Verify auth header on pull with credentials (`testPullFromUrlWithAuthSendsHeader`)
- [x] Verify `configureAuth` skips null repo, no-credential repos, and handles null password
- [x] Verify `getRepository` lookup works and returns null for missing repos
- [x] Existing tests (updateRepo, pullFromUrl, pullOci, pushOci) still pass with factory delegation

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)