### PR TITLE
Add helm lint command for chart validation (#176)

### DIFF
--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
@@ -5,6 +5,7 @@ import org.alexmond.jhelm.app.command.DependencyCommand;
 import org.alexmond.jhelm.app.command.GetCommand;
 import org.alexmond.jhelm.app.command.HistoryCommand;
 import org.alexmond.jhelm.app.command.InstallCommand;
+import org.alexmond.jhelm.app.command.LintCommand;
 import org.alexmond.jhelm.app.command.ListCommand;
 import org.alexmond.jhelm.app.command.PackageCommand;
 import org.alexmond.jhelm.app.command.PluginCommand;
@@ -36,8 +37,8 @@ import picocli.CommandLine;
 		subcommands = { CreateCommand.class, TemplateCommand.class, InstallCommand.class, UpgradeCommand.class,
 				UninstallCommand.class, ListCommand.class, StatusCommand.class, HistoryCommand.class,
 				RollbackCommand.class, ShowCommand.class, GetCommand.class, TestCommand.class, DependencyCommand.class,
-				PullCommand.class, PushCommand.class, PackageCommand.class, VerifyCommand.class, RepoCommand.class,
-				RegistryCommand.class, PluginCommand.class })
+				PullCommand.class, PushCommand.class, PackageCommand.class, VerifyCommand.class, LintCommand.class,
+				RepoCommand.class, RegistryCommand.class, PluginCommand.class })
 public class JHelmCommand implements Runnable {
 
 	@CommandLine.Option(names = { "--no-color" }, description = "Disable colored output",

--- a/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/LintCommand.java
+++ b/jhelm-app/src/main/java/org/alexmond/jhelm/app/command/LintCommand.java
@@ -1,0 +1,64 @@
+package org.alexmond.jhelm.app.command;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.action.LintAction;
+import org.alexmond.jhelm.core.util.ValuesOverrides;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
+
+@Component
+@CommandLine.Command(name = "lint", mixinStandardHelpOptions = true,
+		description = "Examine a chart for possible issues")
+public class LintCommand implements Runnable {
+
+	private final LintAction lintAction;
+
+	@CommandLine.Parameters(index = "0", defaultValue = ".", description = "chart path")
+	private String chartPath;
+
+	@Option(names = { "-f", "--values" }, description = "specify values YAML files")
+	private List<String> valuesFiles = new ArrayList<>();
+
+	@Option(names = { "--set" }, description = "set values on the command line (key=value)")
+	private List<String> setValues = new ArrayList<>();
+
+	@Option(names = { "--strict" }, defaultValue = "false", description = "fail on lint warnings")
+	private boolean strict;
+
+	public LintCommand(LintAction lintAction) {
+		this.lintAction = lintAction;
+	}
+
+	@Override
+	public void run() {
+		try {
+			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues);
+			LintAction.LintResult result = lintAction.lint(chartPath, overrides, strict);
+
+			CliOutput.println("==> Linting " + result.getChartPath());
+
+			for (String warning : result.getWarnings()) {
+				CliOutput.println("[WARNING] " + warning);
+			}
+			for (String error : result.getErrors()) {
+				CliOutput.errPrintln("[ERROR] " + error);
+			}
+
+			if (result.isOk() && (!strict || result.getWarnings().isEmpty())) {
+				CliOutput.println("1 chart(s) linted, 0 chart(s) failed");
+			}
+			else {
+				CliOutput.errPrintln(CliOutput.error("1 chart(s) linted, 1 chart(s) failed"));
+			}
+		}
+		catch (Exception ex) {
+			CliOutput.errPrintln(CliOutput.error("Error: " + ex.getMessage()));
+		}
+	}
+
+}

--- a/jhelm-app/src/test/java/org/alexmond/jhelm/app/command/LintCommandTest.java
+++ b/jhelm-app/src/test/java/org/alexmond/jhelm/app/command/LintCommandTest.java
@@ -1,0 +1,58 @@
+package org.alexmond.jhelm.app.command;
+
+import java.util.List;
+
+import org.alexmond.jhelm.core.action.LintAction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+class LintCommandTest {
+
+	@Mock
+	private LintAction lintAction;
+
+	private LintCommand lintCommand;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		lintCommand = new LintCommand(lintAction);
+	}
+
+	@Test
+	void testLintCommandSuccess() {
+		when(lintAction.lint(anyString(), anyMap(), anyBoolean()))
+			.thenReturn(new LintAction.LintResult("./", List.of(), List.of()));
+		CommandLine cmd = new CommandLine(lintCommand);
+		int exitCode = cmd.execute(".");
+		assertEquals(0, exitCode);
+	}
+
+	@Test
+	void testLintCommandWithWarnings() {
+		when(lintAction.lint(anyString(), anyMap(), anyBoolean()))
+			.thenReturn(new LintAction.LintResult("./", List.of(), List.of("missing description")));
+		CommandLine cmd = new CommandLine(lintCommand);
+		int exitCode = cmd.execute(".");
+		assertEquals(0, exitCode);
+	}
+
+	@Test
+	void testLintCommandWithErrors() {
+		when(lintAction.lint(anyString(), anyMap(), anyBoolean()))
+			.thenReturn(new LintAction.LintResult("./", List.of("chart name is required"), List.of()));
+		CommandLine cmd = new CommandLine(lintCommand);
+		int exitCode = cmd.execute(".");
+		assertEquals(0, exitCode);
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -16,6 +16,7 @@ import org.alexmond.jhelm.core.action.CreateAction;
 import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.HistoryAction;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.LintAction;
 import org.alexmond.jhelm.core.action.ListAction;
 import org.alexmond.jhelm.core.action.PackageAction;
 import org.alexmond.jhelm.core.action.RollbackAction;
@@ -112,6 +113,12 @@ public class JhelmCoreAutoConfiguration {
 	@ConditionalOnMissingBean
 	public ShowAction showAction(ChartLoader chartLoader) {
 		return new ShowAction(chartLoader);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public LintAction lintAction(ChartLoader chartLoader, Engine engine, SchemaValidator schemaValidator) {
+		return new LintAction(chartLoader, engine, schemaValidator);
 	}
 
 	@Bean

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/LintAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/LintAction.java
@@ -1,0 +1,135 @@
+package org.alexmond.jhelm.core.action;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.exception.SchemaValidationException;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.Engine;
+import org.alexmond.jhelm.core.service.SchemaValidator;
+
+@RequiredArgsConstructor
+@Slf4j
+public class LintAction {
+
+	private final ChartLoader chartLoader;
+
+	private final Engine engine;
+
+	private final SchemaValidator schemaValidator;
+
+	public LintResult lint(String chartPath, Map<String, Object> overrideValues, boolean strict) {
+		List<String> errors = new ArrayList<>();
+		List<String> warnings = new ArrayList<>();
+
+		File chartDir = new File(chartPath);
+		if (!chartDir.exists() || !chartDir.isDirectory()) {
+			errors.add("chart path \"" + chartPath + "\" does not exist or is not a directory");
+			return new LintResult(chartPath, errors, warnings);
+		}
+
+		Chart chart;
+		try {
+			chart = chartLoader.load(chartDir);
+		}
+		catch (Exception ex) {
+			errors.add("failed to load chart: " + ex.getMessage());
+			return new LintResult(chartPath, errors, warnings);
+		}
+
+		validateMetadata(chart.getMetadata(), errors, warnings);
+		validateValues(chart, overrideValues, errors);
+		validateTemplates(chart, overrideValues, errors);
+
+		return new LintResult(chartPath, errors, warnings);
+	}
+
+	private void validateMetadata(ChartMetadata metadata, List<String> errors, List<String> warnings) {
+		if (metadata.getName() == null || metadata.getName().isBlank()) {
+			errors.add("chart name is required in Chart.yaml");
+		}
+		if (metadata.getVersion() == null || metadata.getVersion().isBlank()) {
+			errors.add("chart version is required in Chart.yaml");
+		}
+		if (metadata.getApiVersion() == null || metadata.getApiVersion().isBlank()) {
+			errors.add("apiVersion is required in Chart.yaml");
+		}
+		else if (!"v2".equals(metadata.getApiVersion()) && !"v1".equals(metadata.getApiVersion())) {
+			warnings.add("apiVersion '" + metadata.getApiVersion() + "' is not a known Helm API version");
+		}
+		if (metadata.getDescription() == null || metadata.getDescription().isBlank()) {
+			warnings.add("chart is missing a description");
+		}
+		if (metadata.getType() != null && !"application".equals(metadata.getType())
+				&& !"library".equals(metadata.getType())) {
+			warnings.add("chart type '" + metadata.getType() + "' is not a recognized type (application or library)");
+		}
+	}
+
+	private void validateValues(Chart chart, Map<String, Object> overrideValues, List<String> errors) {
+		if (chart.getValuesSchema() == null || chart.getValuesSchema().isBlank()) {
+			return;
+		}
+		Map<String, Object> values = new HashMap<>(chart.getValues());
+		if (overrideValues != null) {
+			values.putAll(overrideValues);
+		}
+		try {
+			schemaValidator.validate(chart.getMetadata().getName(), chart.getValuesSchema(), values);
+		}
+		catch (SchemaValidationException ex) {
+			for (String error : ex.getValidationErrors()) {
+				errors.add("values schema validation: " + error);
+			}
+		}
+	}
+
+	private void validateTemplates(Chart chart, Map<String, Object> overrideValues, List<String> errors) {
+		if ("library".equals(chart.getMetadata().getType())) {
+			return;
+		}
+		Map<String, Object> values = new HashMap<>(chart.getValues());
+		if (overrideValues != null) {
+			values.putAll(overrideValues);
+		}
+
+		Map<String, Object> releaseData = new HashMap<>();
+		releaseData.put("Name", "RELEASE-NAME");
+		releaseData.put("Namespace", "default");
+		releaseData.put("Service", "Helm");
+		releaseData.put("IsInstall", true);
+		releaseData.put("IsUpgrade", false);
+		releaseData.put("Revision", 1);
+
+		try {
+			engine.render(chart, values, releaseData);
+		}
+		catch (Exception ex) {
+			errors.add("template rendering failed: " + ex.getMessage());
+		}
+	}
+
+	@lombok.Data
+	@lombok.AllArgsConstructor
+	public static class LintResult {
+
+		private String chartPath;
+
+		private List<String> errors;
+
+		private List<String> warnings;
+
+		public boolean isOk() {
+			return errors.isEmpty();
+		}
+
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/LintActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/LintActionTest.java
@@ -1,0 +1,139 @@
+package org.alexmond.jhelm.core.action;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.Engine;
+import org.alexmond.jhelm.core.service.SchemaValidator;
+
+class LintActionTest {
+
+	@TempDir
+	Path tempDir;
+
+	private LintAction lintAction;
+
+	@BeforeEach
+	void setUp() {
+		ChartLoader chartLoader = new ChartLoader();
+		Engine engine = new Engine(null, new SchemaValidator(), null);
+		SchemaValidator schemaValidator = new SchemaValidator();
+		lintAction = new LintAction(chartLoader, engine, schemaValidator);
+	}
+
+	@Test
+	void testLintValidChart() throws Exception {
+		Path chartDir = createMinimalChart("good-chart", "1.0.0", "v2");
+		LintAction.LintResult result = lintAction.lint(chartDir.toString(), null, false);
+		assertTrue(result.isOk(), "valid chart should pass lint: " + result.getErrors());
+	}
+
+	@Test
+	void testLintMissingChartYaml() {
+		Path emptyDir = tempDir.resolve("empty");
+		emptyDir.toFile().mkdirs();
+		LintAction.LintResult result = lintAction.lint(emptyDir.toString(), null, false);
+		assertFalse(result.isOk());
+		assertTrue(result.getErrors().stream().anyMatch((e) -> e.contains("failed to load chart")));
+	}
+
+	@Test
+	void testLintNonExistentPath() {
+		LintAction.LintResult result = lintAction.lint("/nonexistent/path", null, false);
+		assertFalse(result.isOk());
+		assertTrue(result.getErrors().stream().anyMatch((e) -> e.contains("does not exist")));
+	}
+
+	@Test
+	void testLintMissingName() throws Exception {
+		Path chartDir = tempDir.resolve("no-name");
+		Files.createDirectories(chartDir);
+		Files.writeString(chartDir.resolve("Chart.yaml"), """
+				apiVersion: v2
+				version: 1.0.0
+				description: missing name
+				""");
+		LintAction.LintResult result = lintAction.lint(chartDir.toString(), null, false);
+		assertFalse(result.isOk());
+		assertTrue(result.getErrors().stream().anyMatch((e) -> e.contains("chart name is required")));
+	}
+
+	@Test
+	void testLintMissingDescription() throws Exception {
+		Path chartDir = createChart("no-desc", "1.0.0", "v2", null);
+		LintAction.LintResult result = lintAction.lint(chartDir.toString(), null, false);
+		assertTrue(result.isOk());
+		assertTrue(result.getWarnings().stream().anyMatch((w) -> w.contains("missing a description")));
+	}
+
+	@Test
+	void testLintSchemaViolation() throws Exception {
+		Path chartDir = createMinimalChart("schema-chart", "1.0.0", "v2");
+		Files.writeString(chartDir.resolve("values.yaml"), "replicaCount: not-a-number\n");
+		Files.writeString(chartDir.resolve("values.schema.json"), """
+				{
+				  "type": "object",
+				  "properties": {
+				    "replicaCount": { "type": "integer" }
+				  }
+				}
+				""");
+		LintAction.LintResult result = lintAction.lint(chartDir.toString(), null, false);
+		assertFalse(result.isOk());
+		assertTrue(result.getErrors().stream().anyMatch((e) -> e.contains("schema validation")));
+	}
+
+	@Test
+	void testLintTemplateSyntaxError() throws Exception {
+		Path chartDir = createMinimalChart("bad-template", "1.0.0", "v2");
+		Files.createDirectories(chartDir.resolve("templates"));
+		Files.writeString(chartDir.resolve("templates/broken.yaml"), "{{ .Values.missing }");
+		LintAction.LintResult result = lintAction.lint(chartDir.toString(), null, false);
+		assertFalse(result.isOk());
+		assertTrue(result.getErrors().stream().anyMatch((e) -> e.contains("template rendering failed")));
+	}
+
+	@Test
+	void testLintWithOverrideValues() throws Exception {
+		Path chartDir = createMinimalChart("override-chart", "1.0.0", "v2");
+		Files.writeString(chartDir.resolve("values.yaml"), "replicaCount: 1\n");
+		Files.writeString(chartDir.resolve("values.schema.json"), """
+				{
+				  "type": "object",
+				  "properties": {
+				    "replicaCount": { "type": "integer" }
+				  }
+				}
+				""");
+		LintAction.LintResult result = lintAction.lint(chartDir.toString(), Map.of("replicaCount", 3), false);
+		assertTrue(result.isOk(), "valid override values should pass: " + result.getErrors());
+	}
+
+	private Path createMinimalChart(String name, String version, String apiVersion) throws Exception {
+		return createChart(name, version, apiVersion, "A test chart");
+	}
+
+	private Path createChart(String name, String version, String apiVersion, String description) throws Exception {
+		Path chartDir = tempDir.resolve(name);
+		Files.createDirectories(chartDir);
+		StringBuilder yaml = new StringBuilder();
+		yaml.append("apiVersion: ").append(apiVersion).append('\n');
+		yaml.append("name: ").append(name).append('\n');
+		yaml.append("version: ").append(version).append('\n');
+		if (description != null) {
+			yaml.append("description: ").append(description).append('\n');
+		}
+		Files.writeString(chartDir.resolve("Chart.yaml"), yaml.toString());
+		Files.writeString(chartDir.resolve("values.yaml"), "replicaCount: 1\n");
+		return chartDir;
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/config/JhelmCoreAutoConfigurationTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/config/JhelmCoreAutoConfigurationTest.java
@@ -16,6 +16,7 @@ import org.alexmond.jhelm.core.action.CreateAction;
 import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.HistoryAction;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.LintAction;
 import org.alexmond.jhelm.core.action.ListAction;
 import org.alexmond.jhelm.core.action.RollbackAction;
 import org.alexmond.jhelm.core.action.StatusAction;
@@ -43,6 +44,7 @@ class JhelmCoreAutoConfigurationTest {
 			assertNotNull(ctx.getBean(RegistryManager.class));
 			assertNotNull(ctx.getBean(CreateAction.class));
 			assertNotNull(ctx.getBean(TemplateAction.class));
+			assertNotNull(ctx.getBean(LintAction.class));
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Add `LintAction` in jhelm-core that validates chart metadata, values schema, and template rendering
- Add `LintCommand` (`jhelm lint`) in jhelm-app with `--values`, `--set`, and `--strict` options
- Register `LintAction` bean in auto-configuration
- Validates: required Chart.yaml fields, apiVersion, chart type, values schema, template syntax

## Test plan
- [x] `LintActionTest` — 8 tests covering valid chart, missing Chart.yaml, non-existent path, missing name, missing description, schema violation, template syntax error, override values
- [x] `LintCommandTest` — 3 tests for success, warnings, and errors
- [x] `JhelmCoreAutoConfigurationTest` — updated to verify `LintAction` bean registration
- [x] All 611 tests pass across jhelm-core (443) and jhelm-app (168)

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)