### PR TITLE
Implement dependency import-values resolution (#173)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartFiles;
+import org.alexmond.jhelm.core.model.Dependency;
 import org.alexmond.jhelm.core.model.VersionSet;
 
 @Slf4j
@@ -319,8 +320,12 @@ public class Engine {
 		}
 		renderedCharts.add(chartKey);
 
+		// Process import-values to enrich chart defaults from subchart values
+		Map<String, Object> chartValues = (chart.getValues() != null) ? new HashMap<>(chart.getValues())
+				: new HashMap<>();
+		processImportValues(chart, chartValues);
+
 		// Merge chart default values with provided values
-		Map<String, Object> chartValues = (chart.getValues() != null) ? chart.getValues() : new HashMap<>();
 		Map<String, Object> mergedValues = mergeValues(chartValues, values);
 
 		// Helm makes subchart defaults available to parent templates via
@@ -479,6 +484,100 @@ public class Engine {
 				mergedValues.put(depKey, merged);
 			}
 		}
+	}
+
+	/**
+	 * Process {@code import-values} directives from chart dependency metadata. For each
+	 * dependency that declares {@code import-values}, values are extracted from the
+	 * subchart's defaults and placed into the parent chart's defaults.
+	 *
+	 * <p>
+	 * Two forms are supported:
+	 * <ul>
+	 * <li>String: imports from subchart's {@code exports.<value>} into parent root</li>
+	 * <li>Map with {@code child}/{@code parent}: imports from subchart path to parent
+	 * path</li>
+	 * </ul>
+	 */
+	@SuppressWarnings("unchecked")
+	private void processImportValues(Chart chart, Map<String, Object> chartValues) {
+		List<Dependency> depMetadata = (chart.getMetadata() != null) ? chart.getMetadata().getDependencies() : null;
+		if (depMetadata == null || depMetadata.isEmpty()) {
+			return;
+		}
+		for (Dependency dep : depMetadata) {
+			if (dep.getImportValues() == null || dep.getImportValues().isEmpty()) {
+				continue;
+			}
+			String depKey = (dep.getAlias() != null && !dep.getAlias().isEmpty()) ? dep.getAlias() : dep.getName();
+			Chart subchart = findSubchart(chart, depKey);
+			if (subchart == null) {
+				continue;
+			}
+			Map<String, Object> subValues = (subchart.getValues() != null) ? subchart.getValues() : Map.of();
+			for (Object iv : dep.getImportValues()) {
+				if (iv instanceof Map<?, ?> m) {
+					String child = String.valueOf(m.get("child"));
+					String parent = String.valueOf(m.get("parent"));
+					Object value = getNestedValue(subValues, child);
+					if (value != null) {
+						setNestedValue(chartValues, parent, value);
+					}
+				}
+				else if (iv instanceof String s) {
+					Object value = getNestedValue(subValues, "exports." + s);
+					if (value instanceof Map<?, ?> exportedMap) {
+						for (Map.Entry<?, ?> entry : exportedMap.entrySet()) {
+							chartValues.putIfAbsent(String.valueOf(entry.getKey()), entry.getValue());
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private Chart findSubchart(Chart chart, String key) {
+		for (Chart dep : chart.getDependencies()) {
+			String name = (dep.getAlias() != null) ? dep.getAlias() : dep.getMetadata().getName();
+			if (key.equals(name)) {
+				return dep;
+			}
+		}
+		return null;
+	}
+
+	private Object getNestedValue(Map<String, Object> map, String path) {
+		String[] parts = path.split("\\.");
+		Object current = map;
+		for (String part : parts) {
+			if (!(current instanceof Map<?, ?>)) {
+				return null;
+			}
+			current = ((Map<?, ?>) current).get(part);
+			if (current == null) {
+				return null;
+			}
+		}
+		return current;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void setNestedValue(Map<String, Object> map, String path, Object value) {
+		String[] parts = path.split("\\.");
+		Map<String, Object> current = map;
+		for (int i = 0; i < parts.length - 1; i++) {
+			Object next = current.get(parts[i]);
+			if (!(next instanceof Map<?, ?>)) {
+				Map<String, Object> newMap = new HashMap<>();
+				current.put(parts[i], newMap);
+				current = newMap;
+			}
+			else {
+				current = (Map<String, Object>) next;
+			}
+		}
+		String lastKey = parts[parts.length - 1];
+		current.putIfAbsent(lastKey, value);
 	}
 
 	private Map<String, Object> mergeValues(Map<String, Object> defaults, Map<String, Object> overrides) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.alexmond.jhelm.core.exception.TemplateRenderException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.model.Dependency;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -730,6 +731,127 @@ class EngineTest {
 
 		String result = engine.render(parent, Map.of(), releaseInfo());
 		assertTrue(result.contains("cache-port: 6379"));
+	}
+
+	// --- Issue #173: dependency import-values ---
+
+	@Test
+	void testImportValuesStringForm() {
+		// String form: import from subchart's exports.<value> into parent root
+		Chart subchart = simpleChart("mydb", "1.0.0", List.of(tmpl("svc.yaml", "kind: Service")),
+				Map.of("exports", Map.of("data", Map.of("dbhost", "localhost", "dbport", 5432))));
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder()
+				.name("parent")
+				.version("1.0.0")
+				.dependencies(List.of(Dependency.builder().name("mydb").importValues(List.of("data")).build()))
+				.build())
+			.templates(List.of(tmpl("cm.yaml", "host: {{ .Values.dbhost }}\nport: {{ .Values.dbport }}")))
+			.values(new HashMap<>())
+			.dependencies(List.of(subchart))
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		assertTrue(result.contains("host: localhost"), "imported dbhost: " + result);
+		assertTrue(result.contains("port: 5432"), "imported dbport: " + result);
+	}
+
+	@Test
+	void testImportValuesMapForm() {
+		// Map form: {child: "path.in.sub", parent: "path.in.parent"}
+		Chart subchart = simpleChart("mydb", "1.0.0", List.of(tmpl("svc.yaml", "kind: Service")),
+				Map.of("default", Map.of("data", Map.of("dbhost", "db.local", "dbport", 3306))));
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder()
+				.name("parent")
+				.version("1.0.0")
+				.dependencies(List.of(Dependency.builder()
+					.name("mydb")
+					.importValues(List.of(Map.of("child", "default.data", "parent", "myimports")))
+					.build()))
+				.build())
+			.templates(List
+				.of(tmpl("cm.yaml", "host: {{ .Values.myimports.dbhost }}\nport: {{ .Values.myimports.dbport }}")))
+			.values(new HashMap<>())
+			.dependencies(List.of(subchart))
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		assertTrue(result.contains("host: db.local"), "imported via map form: " + result);
+		assertTrue(result.contains("port: 3306"), "imported via map form: " + result);
+	}
+
+	@Test
+	void testImportValuesUserOverrideTakesPrecedence() {
+		// User-provided values should override imported defaults
+		Chart subchart = simpleChart("mydb", "1.0.0", List.of(tmpl("svc.yaml", "kind: Service")),
+				Map.of("exports", Map.of("data", Map.of("dbhost", "localhost", "dbport", 5432))));
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder()
+				.name("parent")
+				.version("1.0.0")
+				.dependencies(List.of(Dependency.builder().name("mydb").importValues(List.of("data")).build()))
+				.build())
+			.templates(List.of(tmpl("cm.yaml", "host: {{ .Values.dbhost }}")))
+			.values(new HashMap<>())
+			.dependencies(List.of(subchart))
+			.build();
+
+		Map<String, Object> overrides = new HashMap<>();
+		overrides.put("dbhost", "prod-db.example.com");
+
+		String result = engine.render(parent, overrides, releaseInfo());
+		assertTrue(result.contains("host: prod-db.example.com"), "user override should win: " + result);
+	}
+
+	@Test
+	void testImportValuesWithAlias() {
+		// import-values with aliased dependency
+		Chart subchart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("redis").version("17.0.0").build())
+			.templates(List.of(tmpl("svc.yaml", "kind: Service")))
+			.values(Map.of("exports", Map.of("config", Map.of("cacheHost", "redis-master", "cachePort", 6379))))
+			.alias("cache")
+			.build();
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder()
+				.name("parent")
+				.version("1.0.0")
+				.dependencies(List
+					.of(Dependency.builder().name("redis").alias("cache").importValues(List.of("config")).build()))
+				.build())
+			.templates(List.of(tmpl("cm.yaml", "cacheHost: {{ .Values.cacheHost }}")))
+			.values(new HashMap<>())
+			.dependencies(List.of(subchart))
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		assertTrue(result.contains("cacheHost: redis-master"), "import with alias: " + result);
+	}
+
+	@Test
+	void testImportValuesNoImportWhenEmpty() {
+		// No import-values directive should not affect behavior
+		Chart subchart = simpleChart("redis", "17.0.0", List.of(tmpl("svc.yaml", "kind: Service")),
+				Map.of("exports", Map.of("data", Map.of("key", "val"))));
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder()
+				.name("parent")
+				.version("1.0.0")
+				.dependencies(List.of(Dependency.builder().name("redis").build()))
+				.build())
+			.templates(List.of(tmpl("cm.yaml", "kind: ConfigMap")))
+			.values(new HashMap<>())
+			.dependencies(List.of(subchart))
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		assertFalse(result.contains("key: val"), "no import should occur without directive: " + result);
 	}
 
 	// --- Issue #137: nested parenthesized expressions ---


### PR DESCRIPTION
## Summary
- Process `import-values` directives from Chart.yaml dependencies to import subchart default values into parent scope
- String form: imports from subchart's `exports.<key>` into parent root values
- Map form: imports from subchart's `child` path to parent's `parent` path
- Imported values are defaults — user overrides take precedence

## Test plan
- [x] Run `./mvnw test -pl jhelm-core` — all 443+ tests pass
- [x] String form import-values test
- [x] Map form import-values test
- [x] User override takes precedence over imported values
- [x] Alias-based dependency import-values
- [x] No import when directive absent

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)