### PR TITLE
Normalize whole-number doubles to integer in toJson output

### DIFF
--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -10,9 +10,14 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.alexmond.jhelm.gotemplate.Function;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.json.JsonWriteFeature;
+import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.ser.std.StdSerializer;
 import tools.jackson.dataformat.toml.TomlMapper;
 import tools.jackson.dataformat.yaml.YAMLMapper;
 import tools.jackson.dataformat.yaml.YAMLWriteFeature;
@@ -47,13 +52,34 @@ public final class ConversionFunctions {
 		.compile("^[+-]?(\\d[\\d_]*(\\.[\\d_]*)?([eE][+-]?\\d+)?|\\.inf|\\.nan|0x[\\da-fA-F]+|0o[0-7]+)$");
 
 	private static final ThreadLocal<JsonMapper> JSON_MAPPER = ThreadLocal
-		.withInitial(() -> JsonMapper.builder().build());
+		.withInitial(() -> JsonMapper.builder().addModule(goNumberModule()).build());
 
-	private static final ThreadLocal<JsonMapper> RAW_JSON_MAPPER = ThreadLocal
-		.withInitial(() -> JsonMapper.builder().disable(JsonWriteFeature.ESCAPE_NON_ASCII).build());
+	private static final ThreadLocal<JsonMapper> RAW_JSON_MAPPER = ThreadLocal.withInitial(
+			() -> JsonMapper.builder().disable(JsonWriteFeature.ESCAPE_NON_ASCII).addModule(goNumberModule()).build());
 
 	private static final ThreadLocal<TomlMapper> TOML_MAPPER = ThreadLocal
 		.withInitial(() -> TomlMapper.builder().build());
+
+	/**
+	 * Go's json.Marshal normalizes whole-number float64 values to integer representation
+	 * (1.0 → 1). This module replicates that behavior.
+	 */
+	private static SimpleModule goNumberModule() {
+		SimpleModule module = new SimpleModule("GoNumberModule");
+		module.addSerializer(Double.class, new StdSerializer<>(Double.class) {
+			@Override
+			public void serialize(Double value, JsonGenerator gen, SerializationContext ctxt) throws JacksonException {
+				if (value == Math.floor(value) && !Double.isInfinite(value) && !Double.isNaN(value)
+						&& value >= Long.MIN_VALUE && value <= Long.MAX_VALUE) {
+					gen.writeNumber(value.longValue());
+				}
+				else {
+					gen.writeNumber(value);
+				}
+			}
+		});
+		return module;
+	}
 
 	public static Map<String, Function> getFunctions() {
 		Map<String, Function> functions = new HashMap<>();

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -164,6 +164,21 @@ class ConversionFunctionsTest {
 	}
 
 	@Test
+	void testToJsonWholeNumberDoubleRenderedAsInteger() {
+		Function toJson = functions().get("toJson");
+		// Go's json.Marshal normalizes float64(1.0) to 1
+		Map<String, Object> data = new java.util.LinkedHashMap<>();
+		data.put("traceSampling", 1.0);
+		data.put("rate", 100.0);
+		data.put("ratio", 0.5);
+		String json = (String) toJson.invoke(new Object[] { data });
+		assertTrue(json.contains("\"traceSampling\":1,") || json.contains("\"traceSampling\":1}"),
+				"1.0 should render as 1: " + json);
+		assertTrue(json.contains("\"rate\":100"), "100.0 should render as 100: " + json);
+		assertTrue(json.contains("\"ratio\":0.5"), "0.5 should remain as 0.5: " + json);
+	}
+
+	@Test
 	void testToRawJsonNullReturnsNullString() {
 		Function toRawJson = functions().get("toRawJson");
 		assertEquals("null", toRawJson.invoke(new Object[] {}));


### PR DESCRIPTION
## Summary
- Add `GoNumberModule` custom Jackson serializer that renders `Double(1.0)` as `1` (matching Go's `json.Marshal` behavior)
- Applies to all JSON serialization functions: `toJson`, `mustToJson`, `toRawJson`, `mustToRawJson`, `toPrettyJson`, `mustToPrettyJson`
- Add test verifying whole-number doubles render as integers while fractional values are preserved

## Test plan
- [x] Run `./mvnw test -pl jhelm-gotemplate-helm` — 100 tests pass
- [x] Full `./mvnw clean install` — all modules build successfully

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)