### PR TITLE
Disable YAML line splitting to fix tpl(toYaml) with embedded templates

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -14,11 +14,6 @@ jhelmtest:
       - resource: "Service/*"
         path: "spec.trafficDistribution"
         reason: "trafficDistribution field rendered by JHelm but absent in Helm output"
-    "[apache-airflow/airflow]":
-      # Job container args rendered as null — tpl(toYaml) with embedded Go templates
-      - resource: "Job/*"
-        path: "spec.template.spec.containers.*"
-        reason: "Job container args with embedded Go templates via tpl(toYaml) evaluate to null (#203)"
     "[nextcloud/nextcloud]":
       # Hash annotation computed differently (not checksum.* pattern)
       - resource: "Deployment/*"

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -34,6 +34,9 @@ public final class ConversionFunctions {
 
 	private static final ThreadLocal<YAMLMapper> YAML_MAPPER = ThreadLocal.withInitial(() -> YAMLMapper.builder()
 		.disable(YAMLWriteFeature.WRITE_DOC_START_MARKER)
+		// Go's yaml.Marshal never wraps long lines; Jackson defaults to 80-char width
+		// which inserts \ line continuations that break tpl(toYaml ...) patterns (#203)
+		.disable(YAMLWriteFeature.SPLIT_LINES)
 		.enable(YAMLWriteFeature.MINIMIZE_QUOTES)
 		// Keep quotes on numeric-looking strings to match Go yaml.Marshal behavior
 		.enable(YAMLWriteFeature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -421,6 +421,19 @@ class ConversionFunctionsTest {
 	}
 
 	@Test
+	void testToYamlDoesNotSplitLongLines() {
+		Function toYaml = functions().get("toYaml");
+		// String longer than 80 chars containing Go template expressions
+		String longValue = "{{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.role }}"
+				+ "{{ else }}{{ .Values.createUserJob.defaultUser.role }}{{ end }}";
+		Map<String, Object> data = Map.of("arg", longValue);
+		String yaml = (String) toYaml.invoke(new Object[] { data });
+		// Must NOT contain backslash line continuation that would break tpl() parsing
+		assertFalse(yaml.contains("\\\n"), "toYaml should not split lines with \\ continuation");
+		assertTrue(yaml.contains(longValue) || yaml.contains("\"" + longValue + "\""));
+	}
+
+	@Test
 	@SuppressWarnings("unchecked")
 	void testTomlRoundTrip() {
 		Function toToml = functions().get("toToml");


### PR DESCRIPTION
## Summary
- Disable `SPLIT_LINES` on the YAML mapper to prevent Jackson from wrapping long double-quoted strings with `\` line continuation at 80 chars
- Go's `yaml.Marshal` never wraps lines — this mismatch caused `tpl(toYaml ...)` to fail when values contained Go template expressions longer than 80 chars
- Remove the airflow Job args comparison ignore (chart now renders identically to Helm)

Fixes #203

## Root Cause
Jackson YAML wraps: `"{{ if .Values.x }}{{ .Values.x.role }}{{ else }}..."` → `"{{ if .Values.x }}{{ .Values.x.role }}{{\n\ else }}..."`, breaking Go template parsing.

## Test plan
- [x] New unit test `testToYamlDoesNotSplitLongLines` verifies no `\` line continuation
- [x] Airflow single chart comparison passes with 0 diffs
- [x] All 460 existing tests pass (including KpsComparisonTest top-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)