### PR TITLE
Render templates in reverse alphabetical order to match Helm 4

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -11,6 +11,7 @@ import org.alexmond.jhelm.gotemplate.internal.parse.Node;
 
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -420,7 +421,12 @@ public class Engine {
 		if ("library".equals(chart.getMetadata().getType())) {
 			return;
 		}
-		for (Chart.Template t : chart.getTemplates()) {
+		// Helm 4 executes templates in reverse alphabetical order so that
+		// zzz_*.yaml setup templates (e.g. istiod's zzz_profile.yaml which
+		// merges _internal_defaults into .Values) run before other templates.
+		List<Chart.Template> sorted = new ArrayList<>(chart.getTemplates());
+		sorted.sort(Comparator.comparing(Chart.Template::getName, Comparator.reverseOrder()));
+		for (Chart.Template t : sorted) {
 			if (!t.getName().endsWith(".yaml")) {
 				continue;
 			}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -306,12 +306,12 @@ class EngineTest {
 
 	@Test
 	void testSetDollarValuesPropagatesAcrossTemplates() {
-		// Reproduces istiod pattern: first template mutates $.Values via set,
-		// second template should see the mutation
+		// Helm 4 executes templates in reverse alphabetical order, so
+		// zzz_setup.yaml runs FIRST and aaa_consumer.yaml runs LAST
 		Chart chart = simpleChart("istiod", "1.0.0",
-				List.of(tmpl("aaa_setup.yaml",
+				List.of(tmpl("zzz_setup.yaml",
 						"{{ $_ := set $ \"Values\" (merge .Values (dict \"injected\" \"fromSetup\")) }}"),
-						tmpl("zzz_consumer.yaml", "injected: {{ .Values.injected }}")),
+						tmpl("aaa_consumer.yaml", "injected: {{ .Values.injected }}")),
 				Map.of());
 		String result = engine.render(chart, Map.of(), releaseInfo());
 		assertTrue(result.contains("injected: fromSetup"), "set $ Values mutation should propagate: " + result);
@@ -1348,6 +1348,44 @@ class EngineTest {
 		String result = engine.render(parent, Map.of(), releaseInfo());
 		assertTrue(result.contains("name: lib-value"),
 				"Library chart helpers should be available to parent: " + result);
+	}
+
+	@Test
+	void testReverseAlphabeticalExecutionOrder() {
+		// Helm 4 renders templates in reverse alphabetical order so that
+		// zzz_profile.yaml (which merges _internal_defaults) runs before
+		// deployment.yaml and others that depend on the merged values
+		String setup = """
+				{{- $defaults := $.Values._internal_defaults }}
+				{{- $_ := set $ "Values" (mustMergeOverwrite $defaults $.Values) }}""";
+		String consumer = "scope: {{ .Values.global.scope }}";
+		Map<String, Object> defaults = new HashMap<>();
+		defaults.put("global", new HashMap<>(Map.of("scope", "all")));
+		Map<String, Object> values = new HashMap<>();
+		values.put("_internal_defaults", defaults);
+		Chart chart = simpleChart("istiod", "1.0.0",
+				List.of(tmpl("deployment.yaml", consumer), tmpl("zzz_profile.yaml", setup)), values);
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("scope: all"), "zzz_profile.yaml should run first and set up .Values: " + result);
+	}
+
+	@Test
+	void testNestedOrEqConditionalRendersContent() {
+		// Reproduces the istiod pattern: or (eq ...) (eq ...)
+		String template = """
+				{{- if or (eq .Values.global.scope "all") (eq .Values.global.scope "ns") }}
+				{{- if or (not .Values.remote.enabled) .Values.global.configCluster }}
+				apiVersion: rbac.authorization.k8s.io/v1
+				kind: Role
+				metadata:
+				  name: test-role
+				{{- end }}
+				{{- end }}""";
+		Map<String, Object> values = Map.of("global", Map.of("scope", "all", "configCluster", false), "remote",
+				Map.of("enabled", false));
+		Chart chart = simpleChart("istiod-test", "1.0.0", List.of(tmpl("role.yaml", template)), values);
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("kind: Role"), "Nested or/eq conditional should render: " + result);
 	}
 
 }

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -20,10 +20,10 @@ jhelmtest:
         path: "spec.template.metadata.annotations.*"
         reason: "nextcloud-config-hash uses sha256sum with different intermediate output"
     "[istio-official/istiod]":
-      # Library chart pattern — 5 resources not rendered
-      - resource: "*"
-        path: "*"
-        reason: "Library chart rendering gap — 5 resources missing (#200)"
+      # Go formats float64(1.0) as "1", Java Double as "1.0"
+      - resource: "Deployment/*"
+        path: "spec.template.spec.containers.*.env.*"
+        reason: "traceSampling 1.0 rendered as '1.0' instead of '1' — Go float64 formatting"
     "[gitea/gitea]":
       # Subchart value propagation — connection strings still empty
       - resource: "Secret/*"


### PR DESCRIPTION
## Summary
- Helm 4 executes chart templates in **reverse alphabetical order**, so `zzz_profile.yaml` (which merges `_internal_defaults` into `.Values` via `set $ "Values"`) runs before `deployment.yaml` and other templates
- JHelm was iterating templates in unsorted filesystem order, causing istiod's 5 resources to be missing because `.Values.global` didn't exist yet when templates tried to access it
- Updated the istiod comparison ignore from a blanket wildcard to the specific remaining diff (`traceSampling: 1.0` rendered as `"1.0"` instead of `"1"`)

Fixes #200

## Root Cause
Verified empirically: Helm 4 renders templates `zzz → ccc → bbb → aaa` (reverse alphabetical). Output is then reordered by Kubernetes install order. The istiod chart relies on this: `zzz_profile.yaml` sets up `.Values` before other templates access it.

## Test plan
- [x] New test `testReverseAlphabeticalExecutionOrder` — verifies zzz_profile pattern works
- [x] Updated `testSetDollarValuesPropagatesAcrossTemplates` — fixed to use correct ordering
- [x] New test `testNestedOrEqConditionalRendersContent` — verifies istiod conditional pattern
- [x] istiod single chart comparison: 5 previously missing resources now render correctly
- [x] All 462 tests pass (including KpsComparisonTest top-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)