### PR TITLE
Evaluate dependency conditions and propagate aliases from metadata (#202)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
@@ -39,6 +39,19 @@ public class ChartLoader {
 		}
 		ChartMetadata metadata = yamlMapper.readValue(metadataFile, ChartMetadata.class);
 
+		// For apiVersion v1 charts, dependencies live in requirements.yaml rather than
+		// Chart.yaml. Load them so that condition/alias metadata is available during
+		// rendering.
+		if (metadata.getDependencies() == null || metadata.getDependencies().isEmpty()) {
+			File requirementsFile = new File(chartDir, "requirements.yaml");
+			if (requirementsFile.exists()) {
+				ChartMetadata reqMeta = yamlMapper.readValue(requirementsFile, ChartMetadata.class);
+				if (reqMeta.getDependencies() != null) {
+					metadata.setDependencies(reqMeta.getDependencies());
+				}
+			}
+		}
+
 		// Load values.yaml (supports multi-document files separated by ---)
 		File valuesFile = new File(chartDir, "values.yaml");
 		Map<String, Object> values = new LinkedHashMap<>();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -125,6 +125,11 @@ public class Engine {
 		namedTemplates.clear();
 		// Create a new template for each render to avoid accumulation
 		this.factory = new GoTemplate();
+
+		// Apply aliases from dependency metadata before collecting templates, so that
+		// subchart .Chart.Name and template registration keys use the alias consistently.
+		applyAliasesFromMetadata(chart);
+
 		// Collect all named templates (define blocks) first
 		collectNamedTemplates(chart);
 
@@ -372,10 +377,25 @@ public class Engine {
 		renderChartTemplates(chart, context, sb);
 
 		// Render subcharts
+		List<Dependency> parentDepMeta = (chart.getMetadata() != null) ? chart.getMetadata().getDependencies() : null;
 		for (Chart subchart : chart.getDependencies()) {
 			// Use alias as lookup key when set (alias takes precedence over chart name)
 			String subchartName = (subchart.getAlias() != null) ? subchart.getAlias()
 					: subchart.getMetadata().getName();
+
+			// Evaluate dependency condition from Chart.yaml/requirements.yaml (e.g.
+			// "datadog.operator.enabled"). Condition paths are checked against the
+			// PARENT chart's merged values. If the condition evaluates to false the
+			// subchart is skipped.
+			Dependency depMeta = findDependencyMetadata(parentDepMeta, subchart);
+			if (depMeta != null && depMeta.getCondition() != null && !depMeta.getCondition().isEmpty()) {
+				if (!evaluateDependencyCondition(depMeta.getCondition(), mergedValues)) {
+					if (log.isDebugEnabled()) {
+						log.debug("Subchart {} disabled by condition '{}'", subchartName, depMeta.getCondition());
+					}
+					continue;
+				}
+			}
 
 			// Subcharts are only rendered if enabled in Values
 			@SuppressWarnings("unchecked")
@@ -584,6 +604,84 @@ public class Engine {
 		}
 		String lastKey = parts[parts.length - 1];
 		current.putIfAbsent(lastKey, value);
+	}
+
+	/**
+	 * Apply aliases from dependency metadata to subchart Chart objects. In Helm, when a
+	 * dependency declares {@code alias: operator}, the subchart's {@code .Chart.Name}
+	 * becomes the alias. This must be applied before template collection so that template
+	 * keys and rendering context use the alias consistently.
+	 */
+	private void applyAliasesFromMetadata(Chart chart) {
+		List<Dependency> depMeta = (chart.getMetadata() != null) ? chart.getMetadata().getDependencies() : null;
+		if (depMeta == null) {
+			return;
+		}
+		for (Chart subchart : chart.getDependencies()) {
+			Dependency dep = findDependencyMetadata(depMeta, subchart);
+			if (dep != null && dep.getAlias() != null && !dep.getAlias().isEmpty()) {
+				subchart.setAlias(dep.getAlias());
+				subchart.getMetadata().setName(dep.getAlias());
+			}
+			// Recurse into nested subcharts
+			applyAliasesFromMetadata(subchart);
+		}
+	}
+
+	/**
+	 * Find the {@link Dependency} metadata entry that corresponds to the given subchart.
+	 */
+	private Dependency findDependencyMetadata(List<Dependency> deps, Chart subchart) {
+		if (deps == null) {
+			return null;
+		}
+		String chartName = subchart.getMetadata().getName();
+		String chartAlias = subchart.getAlias();
+		for (Dependency dep : deps) {
+			if (dep.getAlias() != null && dep.getAlias().equals(chartAlias)) {
+				return dep;
+			}
+			if (dep.getName().equals(chartName)) {
+				return dep;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Evaluate a dependency condition expression against chart values. Condition is a
+	 * comma-separated list of dot-separated value paths. The first path that resolves to
+	 * a boolean value wins. If no path resolves, the dependency is included by default.
+	 */
+	private boolean evaluateDependencyCondition(String condition, Map<String, Object> values) {
+		String[] paths = condition.split(",");
+		for (String path : paths) {
+			path = path.trim();
+			String[] parts = path.split("\\.");
+			Object current = values;
+			boolean found = true;
+			for (String part : parts) {
+				if (!(current instanceof Map<?, ?>)) {
+					found = false;
+					break;
+				}
+				current = ((Map<?, ?>) current).get(part);
+				if (current == null) {
+					found = false;
+					break;
+				}
+			}
+			if (found) {
+				if (current instanceof Boolean b) {
+					return b;
+				}
+				if (current instanceof String s) {
+					return Boolean.parseBoolean(s);
+				}
+			}
+		}
+		// No condition path resolved — include by default
+		return true;
 	}
 
 	private Map<String, Object> mergeValues(Map<String, Object> defaults, Map<String, Object> overrides) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ChartLoaderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ChartLoaderTest.java
@@ -408,4 +408,75 @@ class ChartLoaderTest {
 		assertNull(chart.getValuesSchema());
 	}
 
+	@Test
+	void testLoadV1ChartWithRequirementsYaml() throws Exception {
+		// v1 charts store dependencies in requirements.yaml, not Chart.yaml
+		Path chartDir = tempDir.resolve("v1-chart");
+		Files.createDirectories(chartDir);
+		Files.writeString(chartDir.resolve("Chart.yaml"), """
+				apiVersion: v1
+				name: v1-chart
+				version: 3.0.0
+				""");
+		Files.writeString(chartDir.resolve("values.yaml"), "{}");
+		Files.writeString(chartDir.resolve("requirements.yaml"), """
+				dependencies:
+				  - name: my-operator
+				    version: 2.0.0
+				    repository: https://example.com
+				    condition: app.operator.enabled
+				    alias: operator
+				  - name: kube-state-metrics
+				    version: 1.0.0
+				    repository: https://example.com
+				    condition: monitoring.enabled
+				""");
+		Files.createDirectories(chartDir.resolve("templates"));
+
+		Chart chart = chartLoader.load(chartDir.toFile());
+
+		assertNotNull(chart.getMetadata().getDependencies());
+		assertEquals(2, chart.getMetadata().getDependencies().size());
+
+		var op = chart.getMetadata().getDependencies().get(0);
+		assertEquals("my-operator", op.getName());
+		assertEquals("operator", op.getAlias());
+		assertEquals("app.operator.enabled", op.getCondition());
+
+		var ksm = chart.getMetadata().getDependencies().get(1);
+		assertEquals("kube-state-metrics", ksm.getName());
+		assertEquals("monitoring.enabled", ksm.getCondition());
+		assertNull(ksm.getAlias());
+	}
+
+	@Test
+	void testLoadV2ChartIgnoresRequirementsYaml() throws Exception {
+		// v2 charts with dependencies in Chart.yaml should not load requirements.yaml
+		Path chartDir = tempDir.resolve("v2-chart");
+		Files.createDirectories(chartDir);
+		Files.writeString(chartDir.resolve("Chart.yaml"), """
+				apiVersion: v2
+				name: v2-chart
+				version: 1.0.0
+				dependencies:
+				  - name: redis
+				    version: "17.0.0"
+				    repository: https://charts.bitnami.com/bitnami
+				""");
+		Files.writeString(chartDir.resolve("values.yaml"), "{}");
+		// This requirements.yaml should be ignored since Chart.yaml has dependencies
+		Files.writeString(chartDir.resolve("requirements.yaml"), """
+				dependencies:
+				  - name: stale-dep
+				    version: 0.0.1
+				    repository: https://old.example.com
+				""");
+		Files.createDirectories(chartDir.resolve("templates"));
+
+		Chart chart = chartLoader.load(chartDir.toFile());
+
+		assertEquals(1, chart.getMetadata().getDependencies().size());
+		assertEquals("redis", chart.getMetadata().getDependencies().get(0).getName());
+	}
+
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -1388,4 +1388,121 @@ class EngineTest {
 		assertTrue(result.contains("kind: Role"), "Nested or/eq conditional should render: " + result);
 	}
 
+	// --- Issue #202: dependency condition evaluation and alias propagation ---
+
+	@Test
+	void testDependencyConditionDisablesSubchart() {
+		// Subchart with condition=false should not render
+		Chart subchart = simpleChart("kube-state-metrics", "2.0.0", List.of(tmpl("svc.yaml", "kind: Service")),
+				Map.of());
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder()
+				.name("parent")
+				.version("1.0.0")
+				.dependencies(List.of(Dependency.builder()
+					.name("kube-state-metrics")
+					.condition("monitoring.kubeStateMetricsEnabled")
+					.build()))
+				.build())
+			.templates(List.of(tmpl("cm.yaml", "kind: ConfigMap")))
+			.values(new HashMap<>(Map.of("monitoring", new HashMap<>(Map.of("kubeStateMetricsEnabled", false)))))
+			.dependencies(List.of(subchart))
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		assertTrue(result.contains("kind: ConfigMap"), "Parent template should render: " + result);
+		assertFalse(result.contains("kind: Service"), "Disabled subchart should not render: " + result);
+	}
+
+	@Test
+	void testDependencyConditionEnablesSubchart() {
+		// Subchart with condition=true should render
+		Chart subchart = simpleChart("operator", "1.0.0",
+				List.of(tmpl("deploy.yaml", "kind: Deployment\nname: operator")), Map.of());
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder()
+				.name("parent")
+				.version("1.0.0")
+				.dependencies(List.of(Dependency.builder().name("operator").condition("app.operator.enabled").build()))
+				.build())
+			.templates(List.of(tmpl("cm.yaml", "kind: ConfigMap")))
+			.values(new HashMap<>(
+					Map.of("app", new HashMap<>(Map.of("operator", new HashMap<>(Map.of("enabled", true)))))))
+			.dependencies(List.of(subchart))
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		assertTrue(result.contains("kind: ConfigMap"), "Parent should render: " + result);
+		assertTrue(result.contains("kind: Deployment"), "Enabled subchart should render: " + result);
+	}
+
+	@Test
+	void testDependencyConditionCommaPathFirstTruthy() {
+		// Comma-separated condition paths: first truthy value wins
+		Chart subchart = simpleChart("crds", "1.0.0", List.of(tmpl("crd.yaml", "kind: CRD")), Map.of());
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder()
+				.name("parent")
+				.version("1.0.0")
+				.dependencies(
+						List.of(Dependency.builder().name("crds").condition("first.enabled,second.enabled").build()))
+				.build())
+			.templates(List.of(tmpl("cm.yaml", "kind: ConfigMap")))
+			.values(new HashMap<>(Map.of("second", new HashMap<>(Map.of("enabled", true)))))
+			.dependencies(List.of(subchart))
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		assertTrue(result.contains("kind: CRD"), "Second condition path should enable subchart: " + result);
+	}
+
+	@Test
+	void testDependencyAliasFromMetadataOverridesChartName() {
+		// When metadata has alias, .Chart.Name should reflect alias
+		Chart subchart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("my-operator").version("2.0.0").build())
+			.templates(List.of(tmpl("deploy.yaml", "chart: {{ .Chart.Name }}")))
+			.values(Map.of())
+			.build();
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder()
+				.name("parent")
+				.version("1.0.0")
+				.dependencies(List.of(Dependency.builder().name("my-operator").alias("operator").build()))
+				.build())
+			.templates(List.of(tmpl("cm.yaml", "kind: ConfigMap")))
+			.values(new HashMap<>())
+			.dependencies(List.of(subchart))
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		assertTrue(result.contains("chart: operator"), ".Chart.Name should be the alias 'operator': " + result);
+	}
+
+	@Test
+	void testDependencyConditionMissingPathDefaultsToEnabled() {
+		// When condition path doesn't exist in values, subchart is enabled by default
+		Chart subchart = simpleChart("extras", "1.0.0", List.of(tmpl("svc.yaml", "kind: Service")), Map.of());
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder()
+				.name("parent")
+				.version("1.0.0")
+				.dependencies(
+						List.of(Dependency.builder().name("extras").condition("nonexistent.path.enabled").build()))
+				.build())
+			.templates(List.of(tmpl("cm.yaml", "kind: ConfigMap")))
+			.values(new HashMap<>())
+			.dependencies(List.of(subchart))
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		assertTrue(result.contains("kind: Service"),
+				"Subchart with missing condition path should render by default: " + result);
+	}
+
 }

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -33,7 +33,7 @@ jhelmtest:
         path: "spec.ports.*"
         reason: "Service targetPort rendered as 3000 instead of null"
     "[datadog/datadog]":
-      # Operator subchart resources missing + random UUID
-      - resource: "*"
-        path: "*"
-        reason: "9 operator subchart resources missing + random install_id UUID (#202)"
+      # Random UUID generated per render — always different between Helm and JHelm
+      - resource: "ConfigMap/*"
+        path: "data.install_id"
+        reason: "install_id is a random UUID generated per render"


### PR DESCRIPTION
## Summary
- Evaluate `Dependency.condition` paths from Chart.yaml/requirements.yaml during subchart rendering — disabled subcharts (e.g. `datadog.kubeStateMetricsEnabled: false`) are now skipped
- Propagate `Dependency.alias` to subchart's `.Chart.Name` so fullname helpers produce correct resource names (e.g. `release-datadog-operator` instead of `release-datadog-datadog-operator`)
- Load `requirements.yaml` for apiVersion v1 charts to make dependency metadata available during rendering
- Reduces datadog chart diffs from 9 missing resources + 13 extra to only a random UUID ignore

## Test plan
- [x] Unit tests for condition evaluation (true, false, comma-separated paths, missing path defaults)
- [x] Unit test for alias propagation affecting `.Chart.Name`
- [x] Unit tests for `requirements.yaml` loading in ChartLoader
- [x] Integration test: datadog single chart comparison passes (31/31 documents match)
- [x] All 469 jhelm-core tests pass
- [x] Updated comparison-ignores for datadog (wildcard → specific install_id)

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)