### PR TITLE
Handle null values in print/printf and Sprig string functions

### DIFF
--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
@@ -82,7 +82,7 @@ public final class StringFunctions {
 	}
 
 	private static Function trim() {
-		return (args) -> (args.length == 0) ? "" : String.valueOf(args[0]).trim();
+		return (args) -> (args.length == 0 || args[0] == null) ? "" : String.valueOf(args[0]).trim();
 	}
 
 	private static Function trimAll() {
@@ -119,16 +119,16 @@ public final class StringFunctions {
 	}
 
 	private static Function upper() {
-		return (args) -> (args.length == 0) ? "" : String.valueOf(args[0]).toUpperCase(Locale.ROOT);
+		return (args) -> (args.length == 0 || args[0] == null) ? "" : String.valueOf(args[0]).toUpperCase(Locale.ROOT);
 	}
 
 	private static Function lower() {
-		return (args) -> (args.length == 0) ? "" : String.valueOf(args[0]).toLowerCase(Locale.ROOT);
+		return (args) -> (args.length == 0 || args[0] == null) ? "" : String.valueOf(args[0]).toLowerCase(Locale.ROOT);
 	}
 
 	private static Function title() {
 		return (args) -> {
-			if (args.length == 0) {
+			if (args.length == 0 || args[0] == null) {
 				return "";
 			}
 			String s = String.valueOf(args[0]);
@@ -144,7 +144,7 @@ public final class StringFunctions {
 
 	private static Function untitle() {
 		return (args) -> {
-			if (args.length == 0) {
+			if (args.length == 0 || args[0] == null) {
 				return "";
 			}
 			String s = String.valueOf(args[0]);
@@ -229,7 +229,7 @@ public final class StringFunctions {
 
 	private static Function initials() {
 		return (args) -> {
-			if (args.length == 0) {
+			if (args.length == 0 || args[0] == null) {
 				return "";
 			}
 			String s = String.valueOf(args[0]);
@@ -335,7 +335,11 @@ public final class StringFunctions {
 	}
 
 	private static Function cat() {
-		return (args) -> Arrays.stream(args).map(String::valueOf).collect(Collectors.joining(" "));
+		return (args) -> Arrays.stream(args)
+			.filter((arg) -> arg != null)
+			.map(String::valueOf)
+			.filter((s) -> !s.isEmpty())
+			.collect(Collectors.joining(" "));
 	}
 
 	private static Function indent() {
@@ -402,7 +406,7 @@ public final class StringFunctions {
 
 	private static Function snakecase() {
 		return (args) -> {
-			if (args.length == 0) {
+			if (args.length == 0 || args[0] == null) {
 				return "";
 			}
 			String s = String.valueOf(args[0]);
@@ -412,7 +416,7 @@ public final class StringFunctions {
 
 	private static Function camelcase() {
 		return (args) -> {
-			if (args.length == 0) {
+			if (args.length == 0 || args[0] == null) {
 				return "";
 			}
 			String s = String.valueOf(args[0]);
@@ -427,7 +431,7 @@ public final class StringFunctions {
 
 	private static Function kebabcase() {
 		return (args) -> {
-			if (args.length == 0) {
+			if (args.length == 0 || args[0] == null) {
 				return "";
 			}
 			String s = String.valueOf(args[0]);

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
@@ -384,7 +384,7 @@ public final class Functions {
 		// NOTE: This fixes grafana/grafana but may cause issues with charts using Bitnami
 		// common helpers
 		// that rely on specific print behavior with regexReplaceAll
-		return (args) -> Arrays.stream(args).map(String::valueOf).collect(Collectors.joining(""));
+		return (args) -> Arrays.stream(args).map(Functions::sprintValue).collect(Collectors.joining(""));
 	}
 
 	private static Function printf() {
@@ -395,34 +395,35 @@ public final class Functions {
 			String format = String.valueOf(args[0]);
 
 			// Translate Go format verbs to Java equivalents
-			// %(v) -> %s (default format)
-			// %#(v) -> %s (Go-syntax representation, simplified to string)
-			// %(T) -> %s (type, simplified to string representation)
-			// %(t) -> %b (boolean)
-			// %(b) -> %s (binary, not directly supported, use string)
-			// %(c) -> %c (character - keep as is)
-			// %d, %o, %x, %(X) -> keep as is (integer formats)
-			// %e, %E, %f, %F, %g, %(G) -> keep as is (float formats)
-			// %(s) -> %s (string - keep as is)
-			// %(q) -> %s (quoted string, simplified)
-			// %(p) -> %s (pointer, simplified)
 			format = format.replaceAll("%#?v", "%s"); // %v and %#(v) -> %s
 			format = format.replaceAll("%T", "%s"); // %(T) -> %s
 			format = format.replaceAll("%q", "%s"); // %(q) -> %s
 			format = format.replaceAll("%p", "%s"); // %(p) -> %s
 
 			Object[] realArgs = new Object[args.length - 1];
-			System.arraycopy(args, 1, realArgs, 0, args.length - 1);
+			for (int i = 0; i < realArgs.length; i++) {
+				// Java's String.format renders null as "null"; Go uses "" for nil
+				realArgs[i] = (args[i + 1] != null) ? args[i + 1] : "";
+			}
 			return String.format(format, realArgs);
 		};
 	}
 
 	private static Function println() {
-		return (args) -> Arrays.stream(args).map(String::valueOf).collect(Collectors.joining(" ")) + "\n";
+		return (args) -> Arrays.stream(args).map(Functions::sprintValue).collect(Collectors.joining(" ")) + "\n";
 	}
 
 	private static Function not() {
 		return (args) -> args.length > 0 && !isTrue(args[0]);
+	}
+
+	/**
+	 * Convert a value to its string representation for print/println. Null values produce
+	 * an empty string to match Go template behavior where nil values are omitted from
+	 * output.
+	 */
+	static String sprintValue(Object value) {
+		return (value != null) ? String.valueOf(value) : "";
 	}
 
 	public static boolean isTrue(Object arg) {

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/NullHandlingTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/NullHandlingTest.java
@@ -1,0 +1,63 @@
+package org.alexmond.jhelm.gotemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that null/nil values do not produce the string "null" when rendered in templates.
+ * In Go, nil values are omitted from template output; Java's String.valueOf(null) returns
+ * "null" which must be avoided.
+ */
+class NullHandlingTest {
+
+	@Test
+	void testNullValueOmittedFromOutput() throws Exception {
+		Map<String, Object> data = new HashMap<>();
+		data.put("name", null);
+		assertEquals("prefix-suffix", render("prefix-{{ .name }}suffix", data));
+	}
+
+	@Test
+	void testNullInPrintProducesEmpty() throws Exception {
+		Map<String, Object> data = new HashMap<>();
+		data.put("val", null);
+		assertEquals("hello", render("{{ print \"hello\" .val }}", data));
+	}
+
+	@Test
+	void testNullInPrintfProducesEmpty() throws Exception {
+		Map<String, Object> data = new HashMap<>();
+		data.put("name", null);
+		assertEquals("release-", render("{{ printf \"%s-%s\" \"release\" .name }}", data));
+	}
+
+	@Test
+	void testNullInPrintlnProducesEmpty() throws Exception {
+		Map<String, Object> data = new HashMap<>();
+		data.put("val", null);
+		assertEquals("hello \n", render("{{ println \"hello\" .val }}", data));
+	}
+
+	@Test
+	void testMissingFieldProducesEmpty() throws Exception {
+		Map<String, Object> data = new HashMap<>();
+		data.put("config", new HashMap<>());
+		// Accessing a missing key in a map returns null
+		assertEquals("value=", render("value={{ .config.name }}", data));
+	}
+
+	private String render(String template, Map<String, Object> data) throws TemplateException, IOException {
+		GoTemplate tmpl = new GoTemplate();
+		tmpl.parse("test", template);
+		StringWriter writer = new StringWriter();
+		tmpl.execute(data, writer);
+		return writer.toString();
+	}
+
+}


### PR DESCRIPTION
## Summary
- Fix Go builtin functions (`print`, `printf`, `println`) to treat null arguments as empty string instead of the literal "null"
- Add null guards to Sprig string functions (`trim`, `upper`, `lower`, `title`, `untitle`, `initials`, `snakecase`, `camelcase`, `kebabcase`, `cat`) to return "" for null input
- Java's `String.valueOf(null)` returns `"null"`, but Go templates omit nil values — this mismatch caused broken output like `"null-serviceAccount"` in charts

## Test plan
- [x] New `NullHandlingTest` covering null in direct output, print, printf, println, and missing fields
- [x] All gotemplate, sprig, helm module tests pass
- [x] jhelm-core tests pass (no regressions)
- [x] Checkstyle + PMD clean

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)