### PR TITLE
Fix missing Jaeger Deployment and pihole test Pod

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
@@ -135,7 +135,7 @@ public class ChartLoader {
 			if (file.isDirectory()) {
 				loadTemplatesRecursive(file, name, templates);
 			}
-			else if (name.endsWith(".yaml") || name.endsWith(".tpl")) {
+			else if (name.endsWith(".yaml") || name.endsWith(".yml") || name.endsWith(".tpl")) {
 				Chart.Template template = Chart.Template.builder()
 					.name(name)
 					.data(Files.readString(file.toPath()))

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -447,7 +447,7 @@ public class Engine {
 		List<Chart.Template> sorted = new ArrayList<>(chart.getTemplates());
 		sorted.sort(Comparator.comparing(Chart.Template::getName, Comparator.reverseOrder()));
 		for (Chart.Template t : sorted) {
-			if (!t.getName().endsWith(".yaml")) {
+			if (!t.getName().endsWith(".yaml") && !t.getName().endsWith(".yml")) {
 				continue;
 			}
 			try {

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
@@ -209,7 +209,7 @@ public final class DictFunctions {
 				if (dstVal instanceof Map && srcVal instanceof Map) {
 					deepMerge((Map<String, Object>) dstVal, (Map<String, Object>) srcVal, overwrite);
 				}
-				else if (overwrite || dstVal == null) {
+				else if (overwrite || isEmptyValue(dstVal)) {
 					dst.put(key, srcVal);
 				}
 			}
@@ -217,6 +217,34 @@ public final class DictFunctions {
 				dst.put(key, srcVal);
 			}
 		}
+	}
+
+	/**
+	 * Checks whether a value is considered "empty" for merge purposes, matching Go's
+	 * mergo {@code isEmptyValue} semantics. Empty values (zero-length strings, zero
+	 * numbers, {@code false} booleans, empty collections, and {@code null}) are
+	 * overwritten by the source even in non-overwrite mode.
+	 */
+	private static boolean isEmptyValue(Object value) {
+		if (value == null) {
+			return true;
+		}
+		if (value instanceof String s) {
+			return s.isEmpty();
+		}
+		if (value instanceof Number n) {
+			return n.doubleValue() == 0;
+		}
+		if (value instanceof Boolean b) {
+			return !b;
+		}
+		if (value instanceof Collection<?> c) {
+			return c.isEmpty();
+		}
+		if (value instanceof Map<?, ?> m) {
+			return m.isEmpty();
+		}
+		return false;
 	}
 
 	private static Function mustMerge() {

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
@@ -318,6 +318,59 @@ class CollectionFunctionsTest {
 	}
 
 	@Test
+	void testMergeOverwritesEmptyString() throws IOException, TemplateException {
+		// Go mergo treats empty strings as zero values: merge overwrites them
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> dst = new HashMap<>();
+		dst.put("tag", "");
+		data.put("dst", dst);
+		data.put("src", Map.of("tag", "2.15.1"));
+		assertEquals("2.15.1", execWithData("{{ $m := merge .dst .src }}{{ get $m \"tag\" }}", data));
+	}
+
+	@Test
+	void testMergeOverwritesZeroNumber() throws IOException, TemplateException {
+		// Go mergo treats zero numbers as zero values: merge overwrites them
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> dst = new HashMap<>();
+		dst.put("count", 0);
+		data.put("dst", dst);
+		data.put("src", Map.of("count", 42));
+		assertEquals("42", execWithData("{{ $m := merge .dst .src }}{{ get $m \"count\" }}", data));
+	}
+
+	@Test
+	void testMergeOverwritesFalseBoolean() throws IOException, TemplateException {
+		// Go mergo treats false as a zero value: merge overwrites it
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> dst = new HashMap<>();
+		dst.put("enabled", false);
+		data.put("dst", dst);
+		data.put("src", Map.of("enabled", true));
+		assertEquals("true", execWithData("{{ $m := merge .dst .src }}{{ get $m \"enabled\" }}", data));
+	}
+
+	@Test
+	void testMergePreservesTrueBoolean() throws IOException, TemplateException {
+		// Non-zero dst values should be preserved by merge
+		Map<String, Object> data = new HashMap<>();
+		data.put("dst", new HashMap<>(Map.of("enabled", true)));
+		data.put("src", Map.of("enabled", false));
+		assertEquals("true", execWithData("{{ $m := merge .dst .src }}{{ get $m \"enabled\" }}", data));
+	}
+
+	@Test
+	void testMergeOverwritesEmptyList() throws IOException, TemplateException {
+		// Go mergo treats empty collections as zero values
+		Map<String, Object> data = new HashMap<>();
+		Map<String, Object> dst = new HashMap<>();
+		dst.put("items", new ArrayList<>());
+		data.put("dst", dst);
+		data.put("src", Map.of("items", java.util.List.of("a", "b")));
+		assertEquals("2", execWithData("{{ $m := merge .dst .src }}{{ len (get $m \"items\") }}", data));
+	}
+
+	@Test
 	void testMustMergeDeepNested() throws IOException, TemplateException {
 		String template = """
 				{{ $d1 := dict "outer" (dict "a" 1 "b" 2) }}\


### PR DESCRIPTION
## Summary
- Fix `merge` function to overwrite empty/zero values (empty strings, zero numbers, false booleans, empty collections) matching Go's mergo `isEmptyValue` semantics — this was causing Jaeger's image tag to remain empty, producing invalid YAML
- Support `.yml` template file extension in both `ChartLoader` and `Engine` — pihole's test pod template uses `.yml` which was silently ignored

## Test plan
- [x] New merge tests: empty string, zero number, false boolean, true boolean (preserved), empty list
- [x] All sprig module tests pass
- [x] All core module tests pass
- [x] Checkstyle + PMD clean

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)