### PR TITLE
Remove 4 stale comparison ignore rules (#220)

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -10,6 +10,10 @@ jhelmtest:
       - resource: "Secret/*"
         path: "data.*"
         reason: "Secret data contains generated passwords/certs that differ between runs"
+    "[bitnami/rabbitmq]":
+      - resource: "Service/*"
+        path: "spec.trafficDistribution"
+        reason: "trafficDistribution field rendered by JHelm but absent in Helm output"
     "[gitea/gitea]":
       # Subchart value propagation — connection strings still empty
       - resource: "Secret/*"

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -10,28 +10,11 @@ jhelmtest:
       - resource: "Secret/*"
         path: "data.*"
         reason: "Secret data contains generated passwords/certs that differ between runs"
-    "[bitnami/rabbitmq]":
-      - resource: "Service/*"
-        path: "spec.trafficDistribution"
-        reason: "trafficDistribution field rendered by JHelm but absent in Helm output"
-    "[nextcloud/nextcloud]":
-      # Hash annotation computed differently (not checksum.* pattern)
-      - resource: "Deployment/*"
-        path: "spec.template.metadata.annotations.*"
-        reason: "nextcloud-config-hash uses sha256sum with different intermediate output"
-    "[istio-official/istiod]":
-      # Go formats float64(1.0) as "1", Java Double as "1.0"
-      - resource: "Deployment/*"
-        path: "spec.template.spec.containers.*.env.*"
-        reason: "traceSampling 1.0 rendered as '1.0' instead of '1' — Go float64 formatting"
     "[gitea/gitea]":
       # Subchart value propagation — connection strings still empty
       - resource: "Secret/*"
         path: "stringData.*"
         reason: "Subchart value propagation gap — tpl-based connection strings empty (#201)"
-      - resource: "Service/*"
-        path: "spec.ports.*"
-        reason: "Service targetPort rendered as 3000 instead of null"
     "[datadog/datadog]":
       # Random UUID generated per render — always different between Helm and JHelm
       - resource: "ConfigMap/*"


### PR DESCRIPTION
## Summary
- Removed **istiod** float formatting ignore (fixed by #214 — ValuePrinter formatScalar)
- Removed **rabbitmq** trafficDistribution ignore (no longer occurs)
- Removed **nextcloud** annotation hash ignore (no longer occurs)
- Removed **gitea** Service targetPort ignore (no longer occurs)

## Remaining rules (still needed)
- Global checksum annotations — related to #215 (open)
- Global Secret data — random passwords/certs differ between runs
- gitea stringData — subchart value propagation still incomplete
- datadog install_id — random UUID per render

## Test plan
- [x] Verified each removal individually via `KpsComparisonTest#compareSingleChart`
- [x] All 4 charts pass without their removed ignore rules

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)