### PR TITLE
Add failed.csv test and top-chart pagination (#229)

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
@@ -177,6 +177,53 @@ class KpsComparisonTest {
 		compareChart(chartName, "release-" + chartName, repoId, repoUrl);
 	}
 
+	private List<String[]> readFailedCsv() throws Exception {
+		try (InputStream is = getClass().getResourceAsStream("/failed.csv")) {
+			if (is == null) {
+				return List.of();
+			}
+			String content = new String(is.readAllBytes(), StandardCharsets.UTF_8).trim();
+			if (content.isEmpty()) {
+				return List.of();
+			}
+			return content.lines()
+				.filter((line) -> !line.isBlank() && !line.startsWith("#"))
+				.map((line) -> line.split(",", 3))
+				.filter((parts) -> parts.length == 3)
+				.toList();
+		}
+	}
+
+	@Test
+	void compareFailedCharts() throws Exception {
+		List<String[]> charts = readFailedCsv();
+		if (charts.isEmpty()) {
+			log.info("failed.csv is empty — no failed charts to verify");
+			return;
+		}
+		List<String> unexpectedPasses = new ArrayList<>();
+		for (String[] parts : charts) {
+			String chartName = parts[0].trim();
+			String repoId = parts[1].trim();
+			String repoUrl = parts[2].trim();
+			try {
+				compareChart(chartName, "release-" + chartName, repoId, repoUrl);
+				unexpectedPasses.add(chartName);
+				log.warn("{} - UNEXPECTEDLY PASSED — remove from failed.csv", chartName);
+			}
+			catch (AssertionError ex) {
+				log.info("{} - Expected failure confirmed: {}", chartName,
+						ex.getMessage().lines().findFirst().orElse(ex.getMessage()));
+			}
+			catch (Exception ex) {
+				log.info("{} - Expected failure (exception): {}", chartName, ex.getMessage());
+			}
+		}
+		if (!unexpectedPasses.isEmpty()) {
+			fail("Charts that unexpectedly PASSED (remove from failed.csv): " + unexpectedPasses);
+		}
+	}
+
 	private void compareChart(String chartName, String releaseName, String repoId, String repoUrl) throws Exception {
 		// No charts skipped anymore
 
@@ -249,7 +296,7 @@ class KpsComparisonTest {
 			Files.writeString(expectedFile.toPath(), helmManifest);
 
 			// Compare manifests
-			compareManifests(chartName, jhelmManifest, helmManifest);
+			compareManifests(chartName, repoId, repoUrl, jhelmManifest, helmManifest);
 
 		}
 		catch (Exception ex) {
@@ -260,7 +307,8 @@ class KpsComparisonTest {
 				return;
 			}
 			log.error("{} - JHelm rendering failed", chartName, ex);
-			fail(chartName + " - JHelm rendering failed: " + ex.getMessage());
+			fail(chartName + " - JHelm rendering failed: " + ex.getMessage() + "\n  failed.csv: " + chartName + ","
+					+ repoId + "," + repoUrl);
 		}
 	}
 
@@ -300,7 +348,8 @@ class KpsComparisonTest {
 		}
 	}
 
-	private void compareManifests(String chartName, String jhelm, String helm) throws Exception {
+	private void compareManifests(String chartName, String repoId, String repoUrl, String jhelm, String helm)
+			throws Exception {
 		// Parse both manifests into YAML documents
 		List<JsonNode> jhelmDocs = parseYamlDocuments(jhelm);
 		List<JsonNode> helmDocs = parseYamlDocuments(helm);
@@ -376,6 +425,13 @@ class KpsComparisonTest {
 			for (String f : failures) {
 				msg.append("  - ").append(f).append('\n');
 			}
+			msg.append("  failed.csv: ")
+				.append(chartName)
+				.append(',')
+				.append(repoId)
+				.append(',')
+				.append(repoUrl)
+				.append('\n');
 			fail(msg.toString());
 		}
 	}
@@ -714,24 +770,33 @@ class KpsComparisonTest {
 	 * controlled by the {@code jhelmtest.number-of-top-charts} property (default 30).
 	 */
 	Stream<Arguments> topCharts() throws Exception {
-		int limit = testProperties.getNumberOfTopCharts();
-		String url = "https://artifacthub.io/api/v1/packages/search?kind=0&sort=relevance&limit=" + limit;
+		int total = testProperties.getNumberOfTopCharts();
 		JsonMapper mapper = JsonMapper.builder().build();
-		JsonNode result;
-		HttpsURLConnection conn = (HttpsURLConnection) URI.create(url).toURL().openConnection();
-		setupInsecureSsl(conn);
-		try (InputStream in = conn.getInputStream()) {
-			result = mapper.readTree(in);
-		}
-		JsonNode packages = result.has("packages") ? result.get("packages") : result;
-
 		List<Arguments> args = new ArrayList<>();
-		for (JsonNode pkg : packages) {
-			String name = pkg.get("name").asString();
-			JsonNode repo = pkg.get("repository");
-			String repoId = repo.get("name").asString();
-			String repoUrl = repo.get("url").asString();
-			args.add(Arguments.of(repoId + "/" + name, repoId, repoUrl));
+
+		int offset = 0;
+		while (args.size() < total) {
+			int batchSize = Math.min(60, total - args.size());
+			String url = "https://artifacthub.io/api/v1/packages/search?kind=0&sort=relevance&limit=" + batchSize
+					+ "&offset=" + offset;
+			HttpsURLConnection conn = (HttpsURLConnection) URI.create(url).toURL().openConnection();
+			setupInsecureSsl(conn);
+			JsonNode result;
+			try (InputStream in = conn.getInputStream()) {
+				result = mapper.readTree(in);
+			}
+			JsonNode packages = result.has("packages") ? result.get("packages") : result;
+			if (packages.isEmpty()) {
+				break;
+			}
+			for (JsonNode pkg : packages) {
+				String name = pkg.get("name").asString();
+				JsonNode repo = pkg.get("repository");
+				String repoId = repo.get("name").asString();
+				String repoUrl = repo.get("url").asString();
+				args.add(Arguments.of(repoId + "/" + name, repoId, repoUrl));
+			}
+			offset += batchSize;
 		}
 		return args.stream();
 	}

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -6,10 +6,19 @@ jhelmtest:
       - resource: "Secret/*"
         path: "data.*"
         reason: "Secret data contains generated passwords/certs that differ between runs"
-      # Checksum of secret templates — hash differs because underlying secret has random passwords
+      # Checksum annotations for secrets/credentials — hash differs because underlying data has random passwords
       - resource: "*"
         path: "spec.template.metadata.annotations.checksum/secret*"
         reason: "Secret templates contain generated passwords that differ between runs"
+      - resource: "*"
+        path: "spec.template.metadata.annotations.checksum/credential*"
+        reason: "Credential secrets contain generated data that differs between runs"
+      - resource: "*"
+        path: "spec.template.metadata.annotations.checksum/jwt*"
+        reason: "JWT secrets are generated per render"
+      - resource: "*"
+        path: "spec.template.metadata.annotations.checksum/clusteragent*"
+        reason: "Cluster agent tokens are generated per render"
     "[bitnami/rabbitmq]":
       - resource: "Service/*"
         path: "spec.trafficDistribution"

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -1,0 +1,23 @@
+# Charts with known comparison failures (format: chartName,repoId,repoUrl)
+# When a chart is fixed, remove it from this file.
+# If a chart unexpectedly passes, the test will fail — remove the entry.
+#
+# --- Code bugs ---
+# Octal number literals rendered as decimal (0660 -> 432) — #217
+cilium/cilium,cilium,https://helm.cilium.io/
+# serviceAccountName rendering — template expression evaluated incorrectly
+goauthentik/authentik,goauthentik,https://charts.goauthentik.io/
+# String cannot be cast to Number — type coercion in template
+grafana/mimir-distributed,grafana,https://grafana.github.io/helm-charts
+# $SERVER_NAME rendered as << $SERVER_NAME >> — variable interpolation
+nats/nats,nats,https://nats-io.github.io/k8s/helm/charts/
+# Subchart label propagation — labels null instead of expected values
+superset/superset,superset,http://apache.github.io/superset/
+# ClusterRole rules ordering — 112 diffs in rule array ordering
+kong/kong,kong,https://charts.konghq.com
+# --- toYaml serialization diffs (configmap checksums) ---
+# toYaml produces different output than Go yaml.Marshal
+harbor/harbor,harbor,https://helm.goharbor.io
+cloudnative-pg/cloudnative-pg,cloudnative-pg,https://cloudnative-pg.io/charts/
+falcosecurity/falco,falcosecurity,https://falcosecurity.github.io/charts
+dandydev-charts/redis-ha,dandydev-charts,https://dandydeveloper.github.io/charts/


### PR DESCRIPTION
## Summary
- Add `failed.csv` with 10 charts that have known code bugs (octal rendering, type casts, label propagation, rule ordering, toYaml serialization)
- Add `compareFailedCharts` test that expects failure and flags unexpected passes
- Add pagination to `topCharts()` for fetching >60 charts from ArtifactHub (max 60 per request)
- Include `failed.csv:` line in comparison failure messages for easy copy-paste triage
- Add global ignore rules for secret/credential/JWT/cluster-agent-token checksums (random data, not code bugs)
- Created 6 bug issues from top-100 analysis: #232 #233 #234 #235 #236 #237

## Test plan
- [x] `compareFailedCharts` passes with empty CSV (no-op)
- [x] `compareFailedCharts` passes with 10 known-failing charts (all confirmed as expected failures)
- [x] 5 secret-checksum charts now pass with new ignore rules
- [x] All 480 jhelm-core tests pass
- [x] Checkstyle/PMD validation clean

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)