### PR TITLE
Fix Go-to-Java regex replacement syntax in regexReplaceAll (#234)

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -1665,4 +1665,31 @@ class EngineTest {
 				"pick 'data' from fromYaml should not return sha256 of '{}' (empty map): " + result);
 	}
 
+	// --- regexReplaceAll with angle bracket markers (nats chart pattern) ---
+
+	@Test
+	void testRegexReplaceAllAngleBrackets() {
+		// Mimics nats chart's nats.formatConfig: toPrettyJson then strip "<< ... >>"
+		String helpersTpl = """
+				{{- define "nats.formatConfig" -}}
+				{{- $config := toPrettyJson . -}}
+				{{- regexReplaceAll "\\\"<<\\\\s+(.*?)\\\\s+>>\\\"" $config "${1}" -}}
+				{{- end -}}
+				""";
+		String mainTmpl = """
+				{{ include "nats.formatConfig" .Values.config }}
+				""";
+		Map<String, Object> config = new LinkedHashMap<>();
+		config.put("server_name", "<< $SERVER_NAME >>");
+		config.put("port", 4222);
+		Map<String, Object> values = Map.of("config", config);
+		Chart chart = simpleChart("nats", "1.0.0",
+				List.of(tmpl("_helpers.tpl", helpersTpl), tmpl("configmap.yaml", mainTmpl)), values);
+
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.contains("$SERVER_NAME"), "Should contain unquoted $SERVER_NAME: " + result);
+		assertFalse(result.contains("<<"), "Should not contain << markers: " + result);
+		assertFalse(result.contains(">>"), "Should not contain >> markers: " + result);
+	}
+
 }

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -7,8 +7,6 @@
 goauthentik/authentik,goauthentik,https://charts.goauthentik.io/
 # String cannot be cast to Number — type coercion in template
 grafana/mimir-distributed,grafana,https://grafana.github.io/helm-charts
-# $SERVER_NAME rendered as << $SERVER_NAME >> — variable interpolation
-nats/nats,nats,https://nats-io.github.io/k8s/helm/charts/
 # Subchart label propagation — labels null instead of expected values
 superset/superset,superset,http://apache.github.io/superset/
 # ClusterRole rules ordering — 112 diffs in rule array ordering

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
@@ -616,7 +616,7 @@ public final class StringFunctions {
 				// So args are: [0]=pattern, [1]=text, [2]=replacement
 				String pattern = String.valueOf(args[0]);
 				String text = String.valueOf(args[1]);
-				String replacement = String.valueOf(args[2]);
+				String replacement = convertGoReplacementToJava(String.valueOf(args[2]));
 
 				return text.replaceAll(pattern, replacement);
 			}
@@ -635,13 +635,60 @@ public final class StringFunctions {
 				// Sprig signature: mustRegexReplaceAll pattern text replacement
 				String pattern = String.valueOf(args[0]);
 				String text = String.valueOf(args[1]);
-				String replacement = String.valueOf(args[2]);
+				String replacement = convertGoReplacementToJava(String.valueOf(args[2]));
 				return text.replaceAll(pattern, replacement);
 			}
 			catch (Exception ex) {
 				throw new RuntimeException("mustRegexReplaceAll: " + ex.getMessage(), ex);
 			}
 		};
+	}
+
+	/**
+	 * Convert Go regex replacement syntax to Java replacement syntax. Go uses
+	 * {@code ${N}} for numbered groups and {@code $$} for literal {@code $}, while Java
+	 * uses {@code $N} for numbered groups and {@code \$} for literal {@code $}.
+	 */
+	static String convertGoReplacementToJava(String replacement) {
+		if (!replacement.contains("$")) {
+			return replacement;
+		}
+		StringBuilder sb = new StringBuilder(replacement.length());
+		for (int i = 0; i < replacement.length(); i++) {
+			char c = replacement.charAt(i);
+			if (c == '$' && i + 1 < replacement.length()) {
+				char next = replacement.charAt(i + 1);
+				if (next == '$') {
+					// Go: $$ → Java: \$ (literal dollar sign)
+					sb.append("\\$");
+					i++;
+				}
+				else if (next == '{') {
+					// Check for ${digits} → $digits (numbered group reference)
+					int end = replacement.indexOf('}', i + 2);
+					if (end != -1) {
+						String content = replacement.substring(i + 2, end);
+						if (content.matches("\\d+")) {
+							sb.append('$').append(content);
+							i = end;
+						}
+						else {
+							sb.append(c);
+						}
+					}
+					else {
+						sb.append(c);
+					}
+				}
+				else {
+					sb.append(c);
+				}
+			}
+			else {
+				sb.append(c);
+			}
+		}
+		return sb.toString();
 	}
 
 	private static Function regexReplaceAllLiteral() {

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctionsTest.java
@@ -178,6 +178,50 @@ class StringFunctionsTest {
 		assertFalse(exec("{{ regexReplaceAllLiteral \"[0-9]+\" \"abc123def456\" \"X\" }}").isEmpty());
 	}
 
+	@Test
+	void testConvertGoReplacementToJava() {
+		// ${N} → $N (numbered group reference)
+		assertEquals("$1", StringFunctions.convertGoReplacementToJava("${1}"));
+		assertEquals("$12", StringFunctions.convertGoReplacementToJava("${12}"));
+		assertEquals("prefix $1 suffix", StringFunctions.convertGoReplacementToJava("prefix ${1} suffix"));
+
+		// $$ → \$ (literal dollar sign)
+		assertEquals("\\$", StringFunctions.convertGoReplacementToJava("$$"));
+		assertEquals("\\$100", StringFunctions.convertGoReplacementToJava("$$100"));
+
+		// ${name} stays as ${name} (named group)
+		assertEquals("${name}", StringFunctions.convertGoReplacementToJava("${name}"));
+
+		// No $ at all — passthrough
+		assertEquals("hello", StringFunctions.convertGoReplacementToJava("hello"));
+		assertEquals("", StringFunctions.convertGoReplacementToJava(""));
+
+		// $N stays as $N (already valid Java syntax)
+		assertEquals("$1", StringFunctions.convertGoReplacementToJava("$1"));
+	}
+
+	@Test
+	void testRegexReplaceAllWithGroupReference() throws IOException, TemplateException {
+		// Exact pattern used by nats chart: strip "<< ... >>" markers
+		String result = exec(
+				"{{ regexReplaceAll \"\\\"<<\\\\s+(.*?)\\\\s+>>\\\"\" \"\\\"<< $SERVER_NAME >>\\\"\" \"${1}\" }}");
+		assertEquals("$SERVER_NAME", result);
+	}
+
+	@Test
+	void testMustRegexReplaceAllWithGroupReference() throws IOException, TemplateException {
+		String result = exec(
+				"{{ mustRegexReplaceAll \"\\\"<<\\\\s+(.*?)\\\\s+>>\\\"\" \"\\\"<< $SERVER_NAME >>\\\"\" \"${1}\" }}");
+		assertEquals("$SERVER_NAME", result);
+	}
+
+	@Test
+	void testRegexReplaceAllWithLiteralDollar() throws IOException, TemplateException {
+		// $$ in Go replacement means literal $
+		String result = exec("{{ regexReplaceAll \"price\" \"the price is\" \"$$5\" }}");
+		assertEquals("the $5 is", result);
+	}
+
 	// --- quote/squote null handling ---
 
 	@Test


### PR DESCRIPTION
## Summary
- Fix `regexReplaceAll` to translate Go regex replacement syntax (`${1}` for numbered groups, `$$` for literal `$`) to Java syntax (`$1` and `\$`)
- Java interprets `${1}` as a named group reference which throws `IllegalArgumentException` — the catch block silently returned original text
- Remove nats/nats from failed.csv since it now passes comparison

## Test plan
- [x] Unit tests for `convertGoReplacementToJava()` (numbered groups, literal dollar, named groups, passthrough)
- [x] Template-level tests for `regexReplaceAll` and `mustRegexReplaceAll` with `${1}` group references
- [x] Engine integration test mimicking nats chart `nats.formatConfig` pipeline
- [x] `KpsComparisonTest#compareSingleChart` passes for nats/nats
- [x] Full test suite passes

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)