### PR TITLE
Fix subchart library template collisions by keeping newer version

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -41,6 +41,8 @@ public class Engine {
 
 	private final Map<String, String> namedTemplates = new HashMap<>();
 
+	private final Map<String, String> templateVersions = new HashMap<>();
+
 	private final TemplateCache templateCache;
 
 	private final SchemaValidator schemaValidator;
@@ -123,6 +125,7 @@ public class Engine {
 
 	private String doRender(Chart chart, Map<String, Object> values, Map<String, Object> releaseInfo) {
 		namedTemplates.clear();
+		templateVersions.clear();
 		// Create a new template for each render to avoid accumulation
 		this.factory = new GoTemplate();
 
@@ -295,17 +298,74 @@ public class Engine {
 	private void collectAllTemplates(Chart chart, Map<String, String> templates,
 			Map<String, String> templateToChartName, String rootChartName) {
 		String chartName = chart.getMetadata().getName();
+		String chartVersion = chart.getMetadata().getVersion();
 
 		for (Chart.Template t : chart.getTemplates()) {
 			// Use Helm-style path (chartName/templates/fileName) to match the names
 			// that charts use with $.Template.BasePath in include calls
 			String helmStyleKey = chartName + "/templates/" + t.getName();
-			templates.put(helmStyleKey, t.getData());
-			templateToChartName.put(helmStyleKey, chartName);
+			// On collision, keep the template from the higher chart version. Newer
+			// library chart versions are backward-compatible supersets of older ones,
+			// so keeping the newest avoids missing-feature failures.
+			String existingVersion = templateVersions.get(helmStyleKey);
+			if (existingVersion == null || compareVersions(chartVersion, existingVersion) > 0) {
+				templates.put(helmStyleKey, t.getData());
+				templateToChartName.put(helmStyleKey, chartName);
+				templateVersions.put(helmStyleKey, chartVersion);
+			}
 		}
 
 		for (Chart subchart : chart.getDependencies()) {
 			collectAllTemplates(subchart, templates, templateToChartName, rootChartName);
+		}
+	}
+
+	/**
+	 * Compare two version strings by splitting on "." and comparing each segment
+	 * numerically. Returns positive if v1 &gt; v2, negative if v1 &lt; v2, zero if equal.
+	 */
+	static int compareVersions(String v1, String v2) {
+		if (v1 == null && v2 == null) {
+			return 0;
+		}
+		if (v1 == null) {
+			return -1;
+		}
+		if (v2 == null) {
+			return 1;
+		}
+		String[] parts1 = v1.split("\\.");
+		String[] parts2 = v2.split("\\.");
+		int len = Math.max(parts1.length, parts2.length);
+		for (int i = 0; i < len; i++) {
+			int n1 = (i < parts1.length) ? parseSegment(parts1[i]) : 0;
+			int n2 = (i < parts2.length) ? parseSegment(parts2[i]) : 0;
+			if (n1 != n2) {
+				return Integer.compare(n1, n2);
+			}
+		}
+		return 0;
+	}
+
+	private static int parseSegment(String segment) {
+		try {
+			return Integer.parseInt(segment);
+		}
+		catch (NumberFormatException ex) {
+			// Strip non-numeric suffix (e.g. "1-beta") and parse the leading digits
+			StringBuilder digits = new StringBuilder();
+			for (char ch : segment.toCharArray()) {
+				if (Character.isDigit(ch)) {
+					digits.append(ch);
+				}
+				else {
+					break;
+				}
+			}
+			if (digits.length() > 0) {
+				return Integer.parseInt(digits.toString());
+			}
+			return 0;
 		}
 	}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -1765,6 +1766,78 @@ class EngineTest {
 		String result = engine.render(chart, Map.of(), releaseInfo());
 		assertTrue(result.contains("Creating bucket my-bucket"),
 				".txt template should be included and rendered: " + result);
+	}
+
+	// --- library chart template collision (#235) ---
+
+	@Test
+	void testLibraryChartTemplateCollisionKeepsNewerVersion() {
+		// Two subcharts bundle different versions of the same library chart "common".
+		// Older version defines a simple template; newer version defines a richer one.
+		// The engine should keep the newer version's template.
+		String olderHelpers = """
+				{{- define "common.labels.standard" -}}
+				app: {{ .Chart.Name }}
+				{{- end -}}""";
+		String newerHelpers = """
+				{{- define "common.labels.standard" -}}
+				{{- $customLabels := .customLabels | default dict -}}
+				{{- $context := .context | default . -}}
+				app: {{ $context.Chart.Name }}
+				{{- range $key, $val := $customLabels }}
+				{{ $key }}: {{ $val }}
+				{{- end -}}
+				{{- end -}}""";
+
+		Chart olderCommon = Chart.builder()
+			.metadata(ChartMetadata.builder().name("common").version("2.2.4").type("library").build())
+			.templates(List.of(tmpl("_labels.tpl", olderHelpers)))
+			.values(Map.of())
+			.build();
+		Chart newerCommon = Chart.builder()
+			.metadata(ChartMetadata.builder().name("common").version("2.14.1").type("library").build())
+			.templates(List.of(tmpl("_labels.tpl", newerHelpers)))
+			.values(Map.of())
+			.build();
+
+		// Subchart "redis" bundles older common, "postgresql" bundles newer common
+		Chart redis = Chart.builder()
+			.metadata(ChartMetadata.builder().name("redis").version("1.0.0").build())
+			.templates(List.of(tmpl("svc.yaml", "labels:\n  {{- include \"common.labels.standard\" . | nindent 2 }}")))
+			.values(Map.of())
+			.dependencies(List.of(olderCommon))
+			.build();
+		Chart postgresql = Chart.builder()
+			.metadata(ChartMetadata.builder().name("postgresql").version("1.0.0").build())
+			.templates(List.of(tmpl("svc.yaml",
+					"labels:\n  {{- include \"common.labels.standard\" (dict \"customLabels\" (dict \"tier\" \"db\") \"context\" $) | nindent 2 }}")))
+			.values(Map.of())
+			.dependencies(List.of(newerCommon))
+			.build();
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder().name("superset").version("1.0.0").build())
+			.templates(List.of(tmpl("cm.yaml", "kind: ConfigMap")))
+			.values(Map.of())
+			.dependencies(List.of(redis, postgresql))
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		// The newer template supports both calling conventions.
+		// postgresql's call with dict "customLabels"/"context" should work.
+		assertTrue(result.contains("tier: db"),
+				"Newer common template should handle dict-style calling with customLabels: " + result);
+		// redis's simple call should also work (falls through to default)
+		assertTrue(result.contains("app: redis"), "Newer common template should handle simple calling too: " + result);
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "2.14.1, 2.2.4, 1", "2.2.4, 2.14.1, -1", "1.0.0, 1.0.0, 0", "3.0.0, 2.99.99, 1", "1.2.3, 1.2, 1",
+			"1.0, 1.0.0, 0" })
+	void testCompareVersions(String v1, String v2, int expectedSign) {
+		int result = Engine.compareVersions(v1, v2);
+		assertEquals(expectedSign, Integer.signum(result),
+				"compareVersions(\"%s\", \"%s\") expected sign %d but got %d".formatted(v1, v2, expectedSign, result));
 	}
 
 	// --- regexReplaceAll with angle bracket markers (nats chart pattern) ---


### PR DESCRIPTION
## Summary
- When multiple subcharts bundle different versions of the same library chart (e.g., bitnami "common"), their template `define` blocks collide. The last version collected wins, which may be the older, less feature-rich version.
- Track chart versions per template key in `collectAllTemplates` and resolve collisions by keeping the higher version (newer libraries are backward-compatible supersets).
- Add `compareVersions` utility for numeric segment comparison of version strings.

## Test plan
- [x] `testLibraryChartTemplateCollisionKeepsNewerVersion` — verifies newer template wins and supports both calling conventions
- [x] `testCompareVersions` — parameterized test for version comparison edge cases
- [x] Verified superset chart: label `null` diffs are resolved, only checksum (#237) and seLinuxOptions diffs remain

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)