### PR TITLE
Add FunctionExecutionException for template function errors

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/FunctionExecutionException.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/FunctionExecutionException.java
@@ -1,0 +1,30 @@
+package org.alexmond.jhelm.gotemplate;
+
+/**
+ * Exception thrown when a template function fails during execution. Carries the function
+ * name for diagnostic context.
+ */
+public class FunctionExecutionException extends RuntimeException {
+
+	private final String functionName;
+
+	public FunctionExecutionException(String message) {
+		super(message);
+		this.functionName = null;
+	}
+
+	public FunctionExecutionException(String message, Throwable cause) {
+		super(message, cause);
+		this.functionName = null;
+	}
+
+	public FunctionExecutionException(String functionName, String message, Throwable cause) {
+		super(functionName + ": " + message, cause);
+		this.functionName = functionName;
+	}
+
+	public String getFunctionName() {
+		return this.functionName;
+	}
+
+}

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionExecutionExceptionTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionExecutionExceptionTest.java
@@ -1,0 +1,45 @@
+package org.alexmond.jhelm.gotemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+class FunctionExecutionExceptionTest {
+
+	@Test
+	void testMessageOnlyConstructor() {
+		FunctionExecutionException ex = new FunctionExecutionException("something failed");
+		assertEquals("something failed", ex.getMessage());
+		assertNull(ex.getCause());
+		assertNull(ex.getFunctionName());
+	}
+
+	@Test
+	void testMessageAndCauseConstructor() {
+		IllegalArgumentException cause = new IllegalArgumentException("bad arg");
+		FunctionExecutionException ex = new FunctionExecutionException("something failed", cause);
+		assertEquals("something failed", ex.getMessage());
+		assertSame(cause, ex.getCause());
+		assertNull(ex.getFunctionName());
+	}
+
+	@Test
+	void testFunctionNameConstructor() {
+		IllegalArgumentException cause = new IllegalArgumentException("bad arg");
+		FunctionExecutionException ex = new FunctionExecutionException("mustToYaml", "input is null", cause);
+		assertEquals("mustToYaml: input is null", ex.getMessage());
+		assertEquals("mustToYaml", ex.getFunctionName());
+		assertSame(cause, ex.getCause());
+	}
+
+	@Test
+	void testFunctionNameConstructorWithNullCause() {
+		FunctionExecutionException ex = new FunctionExecutionException("required", "value is required", null);
+		assertEquals("required: value is required", ex.getMessage());
+		assertEquals("required", ex.getFunctionName());
+		assertNull(ex.getCause());
+	}
+
+}


### PR DESCRIPTION
## Summary
- New `FunctionExecutionException extends RuntimeException` in `jhelm-gotemplate`
- Three constructors: message-only, message+cause, functionName+message+cause
- `getFunctionName()` getter for diagnostic context
- Foundation for #253 (include/tpl error propagation) and #254 (must* function replacement)

## Test plan
- [x] 4 unit tests covering all constructors and edge cases

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)