### PR TITLE
Replace bare RuntimeException with FunctionExecutionException

### DIFF
--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -34,6 +34,7 @@ import tools.jackson.databind.ser.std.StdSerializer;
 import tools.jackson.dataformat.toml.TomlMapper;
 import tools.jackson.dataformat.yaml.YAMLMapper;
 import tools.jackson.dataformat.yaml.YAMLWriteFeature;
+import org.alexmond.jhelm.gotemplate.FunctionExecutionException;
 
 /**
  * Helm conversion functions for YAML/JSON operations Includes Helm 4 new functions:
@@ -204,7 +205,7 @@ public final class ConversionFunctions {
 	private static Function mustToYaml() {
 		return (args) -> {
 			if (args.length == 0 || args[0] == null) {
-				throw new RuntimeException("mustToYaml: no value provided");
+				throw new FunctionExecutionException("mustToYaml: no value provided");
 			}
 			try {
 				String yaml = YAML_MAPPER.get().writeValueAsString(args[0]);
@@ -215,7 +216,7 @@ public final class ConversionFunctions {
 				return removeUnnecessaryQuotes(yaml.trim());
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustToYaml: failed to convert to YAML: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustToYaml: failed to convert to YAML: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -250,24 +251,24 @@ public final class ConversionFunctions {
 	private static Function mustFromYaml() {
 		return (args) -> {
 			if (args.length == 0 || args[0] == null) {
-				throw new RuntimeException("mustFromYaml: no YAML string provided");
+				throw new FunctionExecutionException("mustFromYaml: no YAML string provided");
 			}
 			try {
 				String yaml = String.valueOf(args[0]);
 				if (yaml.isBlank()) {
-					throw new RuntimeException("mustFromYaml: empty YAML string");
+					throw new FunctionExecutionException("mustFromYaml: empty YAML string");
 				}
 				Object result = loadFirstYamlDocument(yaml);
 				if (result instanceof Map<?, ?>) {
 					return result;
 				}
-				throw new RuntimeException("mustFromYaml: expected map but got " + result);
+				throw new FunctionExecutionException("mustFromYaml: expected map but got " + result);
 			}
 			catch (RuntimeException ex) {
 				throw ex;
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustFromYaml: failed to parse YAML: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustFromYaml: failed to parse YAML: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -301,24 +302,25 @@ public final class ConversionFunctions {
 	private static Function mustFromYamlArray() {
 		return (args) -> {
 			if (args.length == 0 || args[0] == null) {
-				throw new RuntimeException("mustFromYamlArray: no YAML string provided");
+				throw new FunctionExecutionException("mustFromYamlArray: no YAML string provided");
 			}
 			try {
 				String yaml = String.valueOf(args[0]);
 				if (yaml.isBlank()) {
-					throw new RuntimeException("mustFromYamlArray: empty YAML string");
+					throw new FunctionExecutionException("mustFromYamlArray: empty YAML string");
 				}
 				Object result = loadFirstYamlDocument(yaml);
 				if (result instanceof List<?>) {
 					return result;
 				}
-				throw new RuntimeException("mustFromYamlArray: expected list but got " + result);
+				throw new FunctionExecutionException("mustFromYamlArray: expected list but got " + result);
 			}
 			catch (RuntimeException ex) {
 				throw ex;
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustFromYamlArray: failed to parse YAML array: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException(
+						"mustFromYamlArray: failed to parse YAML array: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -364,13 +366,13 @@ public final class ConversionFunctions {
 	private static Function mustToJson() {
 		return (args) -> {
 			if (args.length == 0 || args[0] == null) {
-				throw new RuntimeException("mustToJson: no value provided");
+				throw new FunctionExecutionException("mustToJson: no value provided");
 			}
 			try {
 				return JSON_MAPPER.get().writeValueAsString(args[0]);
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustToJson: failed to convert to JSON: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustToJson: failed to convert to JSON: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -401,13 +403,14 @@ public final class ConversionFunctions {
 	private static Function mustToPrettyJson() {
 		return (args) -> {
 			if (args.length == 0 || args[0] == null) {
-				throw new RuntimeException("mustToPrettyJson: no value provided");
+				throw new FunctionExecutionException("mustToPrettyJson: no value provided");
 			}
 			try {
 				return JSON_MAPPER.get().writerWithDefaultPrettyPrinter().writeValueAsString(args[0]);
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustToPrettyJson: failed to convert to JSON: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustToPrettyJson: failed to convert to JSON: " + ex.getMessage(),
+						ex);
 			}
 		};
 	}
@@ -438,13 +441,14 @@ public final class ConversionFunctions {
 	private static Function mustToRawJson() {
 		return (args) -> {
 			if (args.length == 0 || args[0] == null) {
-				throw new RuntimeException("mustToRawJson: no value provided");
+				throw new FunctionExecutionException("mustToRawJson: no value provided");
 			}
 			try {
 				return RAW_JSON_MAPPER.get().writeValueAsString(args[0]);
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustToRawJson: failed to convert to JSON: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustToRawJson: failed to convert to JSON: " + ex.getMessage(),
+						ex);
 			}
 		};
 	}
@@ -478,20 +482,20 @@ public final class ConversionFunctions {
 	private static Function mustFromJson() {
 		return (args) -> {
 			if (args.length == 0 || args[0] == null) {
-				throw new RuntimeException("mustFromJson: no JSON string provided");
+				throw new FunctionExecutionException("mustFromJson: no JSON string provided");
 			}
 			try {
 				String json = String.valueOf(args[0]);
 				if (json.isBlank()) {
-					throw new RuntimeException("mustFromJson: empty JSON string");
+					throw new FunctionExecutionException("mustFromJson: empty JSON string");
 				}
 				if ("null".equals(json)) {
-					throw new RuntimeException("mustFromJson: cannot parse null");
+					throw new FunctionExecutionException("mustFromJson: cannot parse null");
 				}
 				return JSON_MAPPER.get().readValue(json, Map.class);
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustFromJson: failed to parse JSON: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustFromJson: failed to parse JSON: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -524,20 +528,21 @@ public final class ConversionFunctions {
 	private static Function mustFromJsonArray() {
 		return (args) -> {
 			if (args.length == 0 || args[0] == null) {
-				throw new RuntimeException("mustFromJsonArray: no JSON string provided");
+				throw new FunctionExecutionException("mustFromJsonArray: no JSON string provided");
 			}
 			try {
 				String json = String.valueOf(args[0]);
 				if (json.isBlank()) {
-					throw new RuntimeException("mustFromJsonArray: empty JSON string");
+					throw new FunctionExecutionException("mustFromJsonArray: empty JSON string");
 				}
 				if ("null".equals(json)) {
-					throw new RuntimeException("mustFromJsonArray: cannot parse null");
+					throw new FunctionExecutionException("mustFromJsonArray: cannot parse null");
 				}
 				return JSON_MAPPER.get().readValue(json, List.class);
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustFromJsonArray: failed to parse JSON array: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException(
+						"mustFromJsonArray: failed to parse JSON array: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -562,13 +567,13 @@ public final class ConversionFunctions {
 	private static Function mustToToml() {
 		return (args) -> {
 			if (args.length == 0 || args[0] == null) {
-				throw new RuntimeException("mustToToml: no value provided");
+				throw new FunctionExecutionException("mustToToml: no value provided");
 			}
 			try {
 				return TOML_MAPPER.get().writeValueAsString(args[0]);
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustToToml: failed to convert to TOML: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustToToml: failed to convert to TOML: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -595,17 +600,17 @@ public final class ConversionFunctions {
 	private static Function mustFromToml() {
 		return (args) -> {
 			if (args.length == 0 || args[0] == null) {
-				throw new RuntimeException("mustFromToml: no TOML string provided");
+				throw new FunctionExecutionException("mustFromToml: no TOML string provided");
 			}
 			try {
 				String toml = String.valueOf(args[0]);
 				if (toml.isBlank()) {
-					throw new RuntimeException("mustFromToml: empty TOML string");
+					throw new FunctionExecutionException("mustFromToml: empty TOML string");
 				}
 				return TOML_MAPPER.get().readValue(toml, Map.class);
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustFromToml: failed to parse TOML: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustFromToml: failed to parse TOML: " + ex.getMessage(), ex);
 			}
 		};
 	}

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/KubernetesFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/KubernetesFunctions.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.alexmond.jhelm.gotemplate.Function;
+import org.alexmond.jhelm.gotemplate.FunctionExecutionException;
 
 /**
  * Helm Kubernetes-specific functions Based on: <a href=
@@ -63,7 +64,7 @@ public final class KubernetesFunctions {
 			}
 
 			if (args.length < 4) {
-				throw new RuntimeException("lookup requires 4 arguments: apiVersion, kind, namespace, name");
+				throw new FunctionExecutionException("lookup requires 4 arguments: apiVersion, kind, namespace, name");
 			}
 
 			String apiVersion = String.valueOf(args[0]);

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctions.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.alexmond.jhelm.gotemplate.Function;
 import org.alexmond.jhelm.gotemplate.GoTemplate;
+import org.alexmond.jhelm.gotemplate.FunctionExecutionException;
 
 /**
  * Helm template-specific functions for template inclusion and evaluation Based on:
@@ -69,7 +70,8 @@ public final class TemplateFunctions {
 	private static Function mustInclude(GoTemplate factory) {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustInclude: insufficient arguments (requires template name and context)");
+				throw new FunctionExecutionException(
+						"mustInclude: insufficient arguments (requires template name and context)");
 			}
 			String name = String.valueOf(args[0]);
 			Object data = args[1];
@@ -79,8 +81,8 @@ public final class TemplateFunctions {
 				return writer.toString();
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustInclude: failed to execute template '" + name + "': " + ex.getMessage(),
-						ex);
+				throw new FunctionExecutionException(
+						"mustInclude: failed to execute template '" + name + "': " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -124,7 +126,8 @@ public final class TemplateFunctions {
 	private static Function mustTpl(GoTemplate factory) {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustTpl: insufficient arguments (requires template string and context)");
+				throw new FunctionExecutionException(
+						"mustTpl: insufficient arguments (requires template string and context)");
 			}
 			String text = String.valueOf(args[0]);
 			Object data = args[1];
@@ -142,7 +145,7 @@ public final class TemplateFunctions {
 				return writer.toString();
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustTpl: failed to evaluate template: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustTpl: failed to evaluate template: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -154,7 +157,7 @@ public final class TemplateFunctions {
 	private static Function required() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("required: insufficient arguments");
+				throw new FunctionExecutionException("required: insufficient arguments");
 			}
 			String message = String.valueOf(args[0]);
 			Object value = args[1];
@@ -163,7 +166,7 @@ public final class TemplateFunctions {
 			if (value == null || (value instanceof String && ((String) value).isEmpty()) || (value.equals(false))
 					|| (value instanceof Collection && ((Collection<?>) value).isEmpty())
 					|| (value instanceof Map && ((Map<?, ?>) value).isEmpty())) {
-				throw new RuntimeException(message);
+				throw new FunctionExecutionException(message);
 			}
 
 			return value;

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DateFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DateFunctions.java
@@ -13,6 +13,7 @@ import java.util.TimeZone;
 import lombok.extern.slf4j.Slf4j;
 
 import org.alexmond.jhelm.gotemplate.Function;
+import org.alexmond.jhelm.gotemplate.FunctionExecutionException;
 
 /**
  * Date and time manipulation functions from Sprig library. Includes date formatting,
@@ -202,7 +203,7 @@ public final class DateFunctions {
 	private static Function mustToDate() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustToDate: insufficient arguments");
+				throw new FunctionExecutionException("mustToDate: insufficient arguments");
 			}
 			String layout = String.valueOf(args[0]);
 			String dateStr = String.valueOf(args[1]);
@@ -213,7 +214,7 @@ public final class DateFunctions {
 				return sdf.parse(dateStr);
 			}
 			catch (ParseException ex) {
-				throw new RuntimeException("mustToDate: failed to parse date: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustToDate: failed to parse date: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -251,19 +252,19 @@ public final class DateFunctions {
 	private static Function mustDateModify() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustDateModify: insufficient arguments");
+				throw new FunctionExecutionException("mustDateModify: insufficient arguments");
 			}
 			String modification = String.valueOf(args[0]);
 			Date date = convertToDate(args[1]);
 			if (date == null) {
-				throw new RuntimeException("mustDateModify: invalid date");
+				throw new FunctionExecutionException("mustDateModify: invalid date");
 			}
 			try {
 				long millisToAdd = parseDurationToMillis(modification);
 				return new Date(date.getTime() + millisToAdd);
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustDateModify: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustDateModify: " + ex.getMessage(), ex);
 			}
 		};
 	}

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.alexmond.jhelm.gotemplate.Function;
+import org.alexmond.jhelm.gotemplate.FunctionExecutionException;
 
 /**
  * Sprig Dict (map) manipulation functions. Based on:
@@ -116,11 +117,11 @@ public final class DictFunctions {
 	private static Function mustHasKey() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustHasKey: insufficient arguments");
+				throw new FunctionExecutionException("mustHasKey: insufficient arguments");
 			}
 			boolean result = (boolean) hasKey().invoke(args);
 			if (!result) {
-				throw new RuntimeException("mustHasKey: key not found");
+				throw new FunctionExecutionException("mustHasKey: key not found");
 			}
 			return result;
 		};
@@ -250,7 +251,7 @@ public final class DictFunctions {
 	private static Function mustMerge() {
 		return (args) -> {
 			if (args.length == 0) {
-				throw new RuntimeException("mustMerge: no arguments provided");
+				throw new FunctionExecutionException("mustMerge: no arguments provided");
 			}
 			return merge().invoke(args);
 		};
@@ -259,7 +260,7 @@ public final class DictFunctions {
 	private static Function mustMergeOverwrite() {
 		return (args) -> {
 			if (args.length == 0) {
-				throw new RuntimeException("mustMergeOverwrite: no arguments provided");
+				throw new FunctionExecutionException("mustMergeOverwrite: no arguments provided");
 			}
 			return mergeOverwrite().invoke(args);
 		};
@@ -273,7 +274,7 @@ public final class DictFunctions {
 	private static Function mustKeys() {
 		return (args) -> {
 			if (args.length == 0 || !(args[0] instanceof Map)) {
-				throw new RuntimeException("mustKeys: argument is not a map");
+				throw new FunctionExecutionException("mustKeys: argument is not a map");
 			}
 			return new ArrayList<>(((Map<?, ?>) args[0]).keySet());
 		};
@@ -300,7 +301,7 @@ public final class DictFunctions {
 	private static Function mustPick() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustPick: insufficient arguments");
+				throw new FunctionExecutionException("mustPick: insufficient arguments");
 			}
 			return pick().invoke(args);
 		};
@@ -323,7 +324,7 @@ public final class DictFunctions {
 	private static Function mustOmit() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustOmit: insufficient arguments");
+				throw new FunctionExecutionException("mustOmit: insufficient arguments");
 			}
 			return omit().invoke(args);
 		};
@@ -337,7 +338,7 @@ public final class DictFunctions {
 	private static Function mustValues() {
 		return (args) -> {
 			if (args.length == 0 || !(args[0] instanceof Map)) {
-				throw new RuntimeException("mustValues: argument is not a map");
+				throw new FunctionExecutionException("mustValues: argument is not a map");
 			}
 			return new ArrayList<>(((Map<?, ?>) args[0]).values());
 		};
@@ -378,7 +379,7 @@ public final class DictFunctions {
 	private static Function mustDeepCopy() {
 		return (args) -> {
 			if (args.length == 0) {
-				throw new RuntimeException("mustDeepCopy: no arguments provided");
+				throw new FunctionExecutionException("mustDeepCopy: no arguments provided");
 			}
 			return deepCopy().invoke(args);
 		};

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ListFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ListFunctions.java
@@ -14,6 +14,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.alexmond.jhelm.gotemplate.Function;
+import org.alexmond.jhelm.gotemplate.FunctionExecutionException;
 
 /**
  * Sprig List/Slice manipulation functions. Based on:
@@ -107,7 +108,7 @@ public final class ListFunctions {
 		return (args) -> {
 			Object result = first().invoke(args);
 			if (result == null) {
-				throw new RuntimeException("mustFirst: list is empty");
+				throw new FunctionExecutionException("mustFirst: list is empty");
 			}
 			return result;
 		};
@@ -135,7 +136,7 @@ public final class ListFunctions {
 		return (args) -> {
 			Object result = rest().invoke(args);
 			if (result == null) {
-				throw new RuntimeException("mustRest: operation failed");
+				throw new FunctionExecutionException("mustRest: operation failed");
 			}
 			return result;
 		};
@@ -167,7 +168,7 @@ public final class ListFunctions {
 		return (args) -> {
 			Object result = last().invoke(args);
 			if (result == null) {
-				throw new RuntimeException("mustLast: list is empty");
+				throw new FunctionExecutionException("mustLast: list is empty");
 			}
 			return result;
 		};
@@ -195,7 +196,7 @@ public final class ListFunctions {
 		return (args) -> {
 			Object result = initial().invoke(args);
 			if (result == null) {
-				throw new RuntimeException("mustInitial: operation failed");
+				throw new FunctionExecutionException("mustInitial: operation failed");
 			}
 			return result;
 		};
@@ -215,7 +216,7 @@ public final class ListFunctions {
 	private static Function mustAppend() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustAppend: insufficient arguments");
+				throw new FunctionExecutionException("mustAppend: insufficient arguments");
 			}
 			return append().invoke(args);
 		};
@@ -235,7 +236,7 @@ public final class ListFunctions {
 	private static Function mustPrepend() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustPrepend: insufficient arguments");
+				throw new FunctionExecutionException("mustPrepend: insufficient arguments");
 			}
 			return prepend().invoke(args);
 		};
@@ -288,7 +289,7 @@ public final class ListFunctions {
 	private static Function mustReverse() {
 		return (args) -> {
 			if (args.length == 0) {
-				throw new RuntimeException("mustReverse: no arguments provided");
+				throw new FunctionExecutionException("mustReverse: no arguments provided");
 			}
 			return reverse().invoke(args);
 		};
@@ -318,7 +319,7 @@ public final class ListFunctions {
 	private static Function mustUniq() {
 		return (args) -> {
 			if (args.length == 0) {
-				throw new RuntimeException("mustUniq: no arguments provided");
+				throw new FunctionExecutionException("mustUniq: no arguments provided");
 			}
 			return uniq().invoke(args);
 		};
@@ -340,7 +341,7 @@ public final class ListFunctions {
 	private static Function mustWithout() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustWithout: insufficient arguments");
+				throw new FunctionExecutionException("mustWithout: insufficient arguments");
 			}
 			return without().invoke(args);
 		};
@@ -363,11 +364,11 @@ public final class ListFunctions {
 	private static Function mustHas() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustHas: insufficient arguments");
+				throw new FunctionExecutionException("mustHas: insufficient arguments");
 			}
 			boolean result = (boolean) has().invoke(args);
 			if (!result) {
-				throw new RuntimeException("mustHas: element not found");
+				throw new FunctionExecutionException("mustHas: element not found");
 			}
 			return result;
 		};
@@ -395,7 +396,7 @@ public final class ListFunctions {
 	private static Function mustSlice() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustSlice: insufficient arguments");
+				throw new FunctionExecutionException("mustSlice: insufficient arguments");
 			}
 			return slice().invoke(args);
 		};
@@ -492,7 +493,7 @@ public final class ListFunctions {
 	private static Function mustCompact() {
 		return (args) -> {
 			if (args.length == 0) {
-				throw new RuntimeException("mustCompact: no arguments provided");
+				throw new FunctionExecutionException("mustCompact: no arguments provided");
 			}
 			return compact().invoke(args);
 		};
@@ -597,7 +598,7 @@ public final class ListFunctions {
 	private static Function mustChunk() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustChunk: insufficient arguments");
+				throw new FunctionExecutionException("mustChunk: insufficient arguments");
 			}
 			return chunk().invoke(args);
 		};

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/LogicFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/LogicFunctions.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.alexmond.jhelm.gotemplate.Function;
+import org.alexmond.jhelm.gotemplate.FunctionExecutionException;
 
 /**
  * Sprig logic and control flow functions Based on: <a href=
@@ -66,7 +67,7 @@ public final class LogicFunctions {
 
 	private static Function fail() {
 		return (args) -> {
-			throw new RuntimeException((args.length > 0) ? String.valueOf(args[0]) : "fail");
+			throw new FunctionExecutionException((args.length > 0) ? String.valueOf(args[0]) : "fail");
 		};
 	}
 

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 import org.alexmond.jhelm.gotemplate.Function;
+import org.alexmond.jhelm.gotemplate.FunctionExecutionException;
 
 /**
  * Sprig String manipulation functions Based on: <a href=
@@ -509,13 +510,13 @@ public final class StringFunctions {
 	private static Function mustRegexMatch() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustRegexMatch: insufficient arguments");
+				throw new FunctionExecutionException("mustRegexMatch: insufficient arguments");
 			}
 			try {
 				return Pattern.compile(String.valueOf(args[0])).matcher(String.valueOf(args[1])).find();
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustRegexMatch: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustRegexMatch: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -539,17 +540,17 @@ public final class StringFunctions {
 	private static Function mustRegexFind() {
 		return (args) -> {
 			if (args.length < 2) {
-				throw new RuntimeException("mustRegexFind: insufficient arguments");
+				throw new FunctionExecutionException("mustRegexFind: insufficient arguments");
 			}
 			try {
 				Matcher m = Pattern.compile(String.valueOf(args[0])).matcher(String.valueOf(args[1]));
 				if (!m.find()) {
-					throw new RuntimeException("mustRegexFind: no match found");
+					throw new FunctionExecutionException("mustRegexFind: no match found");
 				}
 				return m.group();
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustRegexFind: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustRegexFind: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -583,7 +584,7 @@ public final class StringFunctions {
 	private static Function mustRegexFindAll() {
 		return (args) -> {
 			if (args.length < 3) {
-				throw new RuntimeException("mustRegexFindAll: insufficient arguments");
+				throw new FunctionExecutionException("mustRegexFindAll: insufficient arguments");
 			}
 			try {
 				String regex = String.valueOf(args[0]);
@@ -598,7 +599,7 @@ public final class StringFunctions {
 				return results;
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustRegexFindAll: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustRegexFindAll: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -636,7 +637,7 @@ public final class StringFunctions {
 	private static Function mustRegexReplaceAll() {
 		return (args) -> {
 			if (args.length < 3) {
-				throw new RuntimeException("mustRegexReplaceAll: insufficient arguments");
+				throw new FunctionExecutionException("mustRegexReplaceAll: insufficient arguments");
 			}
 			try {
 				// Sprig signature: mustRegexReplaceAll pattern text replacement
@@ -646,7 +647,7 @@ public final class StringFunctions {
 				return text.replaceAll(pattern, replacement);
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustRegexReplaceAll: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustRegexReplaceAll: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -720,7 +721,7 @@ public final class StringFunctions {
 	private static Function mustRegexReplaceAllLiteral() {
 		return (args) -> {
 			if (args.length < 3) {
-				throw new RuntimeException("mustRegexReplaceAllLiteral: insufficient arguments");
+				throw new FunctionExecutionException("mustRegexReplaceAllLiteral: insufficient arguments");
 			}
 			try {
 				// Sprig signature: mustRegexReplaceAllLiteral pattern replacement text
@@ -730,7 +731,7 @@ public final class StringFunctions {
 				return text.replaceAll(pattern, replacement);
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustRegexReplaceAllLiteral: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustRegexReplaceAllLiteral: " + ex.getMessage(), ex);
 			}
 		};
 	}
@@ -757,7 +758,7 @@ public final class StringFunctions {
 	private static Function mustRegexSplit() {
 		return (args) -> {
 			if (args.length < 3) {
-				throw new RuntimeException("mustRegexSplit: insufficient arguments");
+				throw new FunctionExecutionException("mustRegexSplit: insufficient arguments");
 			}
 			try {
 				String regex = String.valueOf(args[0]);
@@ -767,7 +768,7 @@ public final class StringFunctions {
 				return Arrays.asList(parts);
 			}
 			catch (Exception ex) {
-				throw new RuntimeException("mustRegexSplit: " + ex.getMessage(), ex);
+				throw new FunctionExecutionException("mustRegexSplit: " + ex.getMessage(), ex);
 			}
 		};
 	}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
@@ -281,7 +281,7 @@ public final class Functions {
 				return null;
 			}
 			if (!(args[0] instanceof Function fn)) {
-				throw new RuntimeException("call: first argument must be a function");
+				throw new FunctionExecutionException("call: first argument must be a function");
 			}
 			Object[] fnArgs = new Object[args.length - 1];
 			System.arraycopy(args, 1, fnArgs, 0, args.length - 1);


### PR DESCRIPTION
## Summary
- Replace all 79 `throw new RuntimeException(...)` sites with `FunctionExecutionException` across:
  - Go builtins (`Functions.java`) — 1 replacement
  - Sprig functions (DictFunctions, ListFunctions, StringFunctions, DateFunctions, LogicFunctions) — 42 replacements
  - Helm functions (ConversionFunctions, KubernetesFunctions, TemplateFunctions) — 36 replacements
- Zero `throw new RuntimeException` remaining in any template function code

## Test plan
- [x] Full test suite passes (all existing must* function tests still work)
- [x] `grep` confirms zero remaining `RuntimeException` throws in function files

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)