### PR TITLE
Add release management REST endpoints

### DIFF
--- a/jhelm-rest/pom.xml
+++ b/jhelm-rest/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -1,8 +1,20 @@
 package org.alexmond.jhelm.rest;
 
 import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
+import org.alexmond.jhelm.core.action.GetAction;
+import org.alexmond.jhelm.core.action.HistoryAction;
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.ListAction;
+import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.StatusAction;
+import org.alexmond.jhelm.core.action.TestAction;
+import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
+import org.alexmond.jhelm.rest.controller.ReleaseController;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -22,6 +34,17 @@ public class JhelmRestAutoConfiguration {
 	@ConditionalOnMissingBean
 	public JhelmRestExceptionHandler jhelmRestExceptionHandler() {
 		return new JhelmRestExceptionHandler();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnBean({ ListAction.class, InstallAction.class })
+	public ReleaseController releaseController(ListAction listAction, StatusAction statusAction, GetAction getAction,
+			HistoryAction historyAction, InstallAction installAction, UpgradeAction upgradeAction,
+			UninstallAction uninstallAction, RollbackAction rollbackAction, TestAction testAction,
+			ChartLoader chartLoader) {
+		return new ReleaseController(listAction, statusAction, getAction, historyAction, installAction, upgradeAction,
+				uninstallAction, rollbackAction, testAction, chartLoader);
 	}
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
@@ -1,0 +1,214 @@
+package org.alexmond.jhelm.rest.controller;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.action.GetAction;
+import org.alexmond.jhelm.core.action.HistoryAction;
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.ListAction;
+import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.StatusAction;
+import org.alexmond.jhelm.core.action.TestAction;
+import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.util.HookParser;
+import org.alexmond.jhelm.rest.dto.HelmHookDto;
+import org.alexmond.jhelm.rest.dto.InstallRequest;
+import org.alexmond.jhelm.rest.dto.ReleaseDto;
+import org.alexmond.jhelm.rest.dto.ResourceStatusDto;
+import org.alexmond.jhelm.rest.dto.RollbackRequest;
+import org.alexmond.jhelm.rest.dto.TestResultDto;
+import org.alexmond.jhelm.rest.dto.UpgradeRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("${jhelm.rest.base-path:/api/v1}/releases")
+public class ReleaseController {
+
+	private final ListAction listAction;
+
+	private final StatusAction statusAction;
+
+	private final GetAction getAction;
+
+	private final HistoryAction historyAction;
+
+	private final InstallAction installAction;
+
+	private final UpgradeAction upgradeAction;
+
+	private final UninstallAction uninstallAction;
+
+	private final RollbackAction rollbackAction;
+
+	private final TestAction testAction;
+
+	private final ChartLoader chartLoader;
+
+	public ReleaseController(ListAction listAction, StatusAction statusAction, GetAction getAction,
+			HistoryAction historyAction, InstallAction installAction, UpgradeAction upgradeAction,
+			UninstallAction uninstallAction, RollbackAction rollbackAction, TestAction testAction,
+			ChartLoader chartLoader) {
+		this.listAction = listAction;
+		this.statusAction = statusAction;
+		this.getAction = getAction;
+		this.historyAction = historyAction;
+		this.installAction = installAction;
+		this.upgradeAction = upgradeAction;
+		this.uninstallAction = uninstallAction;
+		this.rollbackAction = rollbackAction;
+		this.testAction = testAction;
+		this.chartLoader = chartLoader;
+	}
+
+	@GetMapping
+	public List<ReleaseDto> list(@RequestParam(defaultValue = "default") String namespace) throws Exception {
+		return this.listAction.list(namespace).stream().map(ReleaseDto::from).toList();
+	}
+
+	@GetMapping("/{name}")
+	public ResponseEntity<ReleaseDto> status(@PathVariable String name,
+			@RequestParam(defaultValue = "default") String namespace) throws Exception {
+		return this.statusAction.status(name, namespace)
+			.map(ReleaseDto::from)
+			.map(ResponseEntity::ok)
+			.orElse(ResponseEntity.notFound().build());
+	}
+
+	@PostMapping
+	public ResponseEntity<ReleaseDto> install(@RequestBody InstallRequest request) throws Exception {
+		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
+			throw new IllegalArgumentException("chartPath is required");
+		}
+		if (request.getReleaseName() == null || request.getReleaseName().isBlank()) {
+			throw new IllegalArgumentException("releaseName is required");
+		}
+		Chart chart = this.chartLoader.load(new File(request.getChartPath()));
+		Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+		Release release = this.installAction.install(chart, request.getReleaseName(), request.getNamespace(), values, 1,
+				request.isDryRun());
+		return ResponseEntity.status(HttpStatus.CREATED).body(ReleaseDto.from(release));
+	}
+
+	@PutMapping("/{name}")
+	public ReleaseDto upgrade(@PathVariable String name, @RequestParam(defaultValue = "default") String namespace,
+			@RequestBody UpgradeRequest request) throws Exception {
+		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
+			throw new IllegalArgumentException("chartPath is required");
+		}
+		Release current = this.getAction.getRelease(name, namespace)
+			.orElseThrow(() -> new IllegalArgumentException("Release '" + name + "' not found"));
+		Chart chart = this.chartLoader.load(new File(request.getChartPath()));
+		Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+		Release upgraded = this.upgradeAction.upgrade(current, chart, values, request.isDryRun());
+		return ReleaseDto.from(upgraded);
+	}
+
+	@DeleteMapping("/{name}")
+	public ResponseEntity<Void> uninstall(@PathVariable String name,
+			@RequestParam(defaultValue = "default") String namespace) throws Exception {
+		this.uninstallAction.uninstall(name, namespace);
+		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/{name}/history")
+	public List<ReleaseDto> history(@PathVariable String name, @RequestParam(defaultValue = "default") String namespace)
+			throws Exception {
+		return this.historyAction.history(name, namespace).stream().map(ReleaseDto::from).toList();
+	}
+
+	@PostMapping("/{name}/rollback")
+	public ResponseEntity<Void> rollback(@PathVariable String name,
+			@RequestParam(defaultValue = "default") String namespace, @RequestBody RollbackRequest request)
+			throws Exception {
+		this.rollbackAction.rollback(name, namespace, request.getRevision());
+		return ResponseEntity.noContent().build();
+	}
+
+	@PostMapping("/{name}/test")
+	public List<TestResultDto> test(@PathVariable String name, @RequestParam(defaultValue = "default") String namespace,
+			@RequestParam(defaultValue = "300") int timeoutSeconds) throws Exception {
+		return this.testAction.test(name, namespace, timeoutSeconds).stream().map(TestResultDto::from).toList();
+	}
+
+	@GetMapping("/{name}/values")
+	public ResponseEntity<String> getValues(@PathVariable String name,
+			@RequestParam(defaultValue = "default") String namespace, @RequestParam(defaultValue = "false") boolean all)
+			throws Exception {
+		return this.getAction.getRelease(name, namespace)
+			.map((release) -> ResponseEntity.ok(safeGetValues(release, all)))
+			.orElse(ResponseEntity.notFound().build());
+	}
+
+	@GetMapping("/{name}/manifest")
+	public ResponseEntity<String> getManifest(@PathVariable String name,
+			@RequestParam(defaultValue = "default") String namespace) throws Exception {
+		return this.getAction.getRelease(name, namespace)
+			.map((release) -> ResponseEntity.ok(this.getAction.getManifest(release)))
+			.orElse(ResponseEntity.notFound().build());
+	}
+
+	@GetMapping("/{name}/notes")
+	public ResponseEntity<String> getNotes(@PathVariable String name,
+			@RequestParam(defaultValue = "default") String namespace) throws Exception {
+		return this.getAction.getRelease(name, namespace)
+			.map((release) -> ResponseEntity.ok(this.getAction.getNotes(release)))
+			.orElse(ResponseEntity.notFound().build());
+	}
+
+	@GetMapping("/{name}/hooks")
+	public ResponseEntity<List<HelmHookDto>> getHooks(@PathVariable String name,
+			@RequestParam(defaultValue = "default") String namespace) throws Exception {
+		return this.getAction.getRelease(name, namespace).map((release) -> {
+			List<HelmHookDto> hooks = HookParser.parseHooks(release.getManifest())
+				.stream()
+				.map(HelmHookDto::from)
+				.toList();
+			return ResponseEntity.ok(hooks);
+		}).orElse(ResponseEntity.notFound().build());
+	}
+
+	@GetMapping("/{name}/resources")
+	public ResponseEntity<List<ResourceStatusDto>> getResources(@PathVariable String name,
+			@RequestParam(defaultValue = "default") String namespace) throws Exception {
+		return this.statusAction.status(name, namespace).map((release) -> {
+			List<ResourceStatusDto> statuses = safeGetResourceStatuses(release);
+			return ResponseEntity.ok(statuses);
+		}).orElse(ResponseEntity.notFound().build());
+	}
+
+	private String safeGetValues(Release release, boolean all) {
+		try {
+			return this.getAction.getValues(release, all);
+		}
+		catch (Exception ex) {
+			return "";
+		}
+	}
+
+	private List<ResourceStatusDto> safeGetResourceStatuses(Release release) {
+		try {
+			return this.statusAction.getResourceStatuses(release).stream().map(ResourceStatusDto::from).toList();
+		}
+		catch (Exception ex) {
+			return Collections.emptyList();
+		}
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/HelmHookDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/HelmHookDto.java
@@ -1,0 +1,34 @@
+package org.alexmond.jhelm.rest.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+
+import org.alexmond.jhelm.core.model.HelmHook;
+
+@Data
+@Builder
+public class HelmHookDto {
+
+	private String kind;
+
+	private String name;
+
+	private List<String> phases;
+
+	private int weight;
+
+	private List<String> deletePolicy;
+
+	public static HelmHookDto from(HelmHook hook) {
+		return HelmHookDto.builder()
+			.kind(hook.getKind())
+			.name(hook.getName())
+			.phases(hook.getPhases())
+			.weight(hook.getWeight())
+			.deletePolicy(hook.getDeletePolicy())
+			.build();
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallRequest.java
@@ -1,0 +1,20 @@
+package org.alexmond.jhelm.rest.dto;
+
+import java.util.Map;
+
+import lombok.Data;
+
+@Data
+public class InstallRequest {
+
+	private String chartPath;
+
+	private String releaseName;
+
+	private String namespace = "default";
+
+	private Map<String, Object> values;
+
+	private boolean dryRun;
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ReleaseDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ReleaseDto.java
@@ -1,0 +1,50 @@
+package org.alexmond.jhelm.rest.dto;
+
+import java.time.OffsetDateTime;
+
+import lombok.Builder;
+import lombok.Data;
+
+import org.alexmond.jhelm.core.model.Release;
+
+@Data
+@Builder
+public class ReleaseDto {
+
+	private String name;
+
+	private String namespace;
+
+	private int version;
+
+	private String status;
+
+	private String chartName;
+
+	private String chartVersion;
+
+	private String appVersion;
+
+	private String description;
+
+	private OffsetDateTime lastDeployed;
+
+	public static ReleaseDto from(Release release) {
+		ReleaseDto.ReleaseDtoBuilder builder = ReleaseDto.builder()
+			.name(release.getName())
+			.namespace(release.getNamespace())
+			.version(release.getVersion());
+		if (release.getChart() != null && release.getChart().getMetadata() != null) {
+			builder.chartName(release.getChart().getMetadata().getName())
+				.chartVersion(release.getChart().getMetadata().getVersion())
+				.appVersion(release.getChart().getMetadata().getAppVersion());
+		}
+		if (release.getInfo() != null) {
+			builder.status(release.getInfo().getStatus())
+				.description(release.getInfo().getDescription())
+				.lastDeployed(release.getInfo().getLastDeployed());
+		}
+		return builder.build();
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ResourceStatusDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ResourceStatusDto.java
@@ -1,0 +1,32 @@
+package org.alexmond.jhelm.rest.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import org.alexmond.jhelm.core.model.ResourceStatus;
+
+@Data
+@Builder
+public class ResourceStatusDto {
+
+	private String kind;
+
+	private String name;
+
+	private String namespace;
+
+	private boolean ready;
+
+	private String message;
+
+	public static ResourceStatusDto from(ResourceStatus rs) {
+		return ResourceStatusDto.builder()
+			.kind(rs.getKind())
+			.name(rs.getName())
+			.namespace(rs.getNamespace())
+			.ready(rs.isReady())
+			.message(rs.getMessage())
+			.build();
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RollbackRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RollbackRequest.java
@@ -1,0 +1,10 @@
+package org.alexmond.jhelm.rest.dto;
+
+import lombok.Data;
+
+@Data
+public class RollbackRequest {
+
+	private int revision;
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TestResultDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TestResultDto.java
@@ -1,0 +1,30 @@
+package org.alexmond.jhelm.rest.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import org.alexmond.jhelm.core.action.TestAction;
+
+@Data
+@Builder
+@SuppressWarnings({ "PMD.TestClassWithoutTestCases", "PMD.UnitTestShouldUseTestAnnotation" })
+public class TestResultDto {
+
+	private String kind;
+
+	private String name;
+
+	private String status;
+
+	private String message;
+
+	public static TestResultDto from(TestAction.TestResult result) {
+		return TestResultDto.builder()
+			.kind(result.getKind())
+			.name(result.getName())
+			.status(result.getStatus().name())
+			.message(result.getMessage())
+			.build();
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeRequest.java
@@ -1,0 +1,16 @@
+package org.alexmond.jhelm.rest.dto;
+
+import java.util.Map;
+
+import lombok.Data;
+
+@Data
+public class UpgradeRequest {
+
+	private String chartPath;
+
+	private Map<String, Object> values;
+
+	private boolean dryRun;
+
+}

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
@@ -1,0 +1,262 @@
+package org.alexmond.jhelm.rest.controller;
+
+import java.io.File;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.alexmond.jhelm.core.action.GetAction;
+import org.alexmond.jhelm.core.action.HistoryAction;
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.ListAction;
+import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.StatusAction;
+import org.alexmond.jhelm.core.action.TestAction;
+import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.rest.JhelmRestExceptionHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ReleaseController.class)
+@Import(JhelmRestExceptionHandler.class)
+class ReleaseControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private ListAction listAction;
+
+	@MockitoBean
+	private StatusAction statusAction;
+
+	@MockitoBean
+	private GetAction getAction;
+
+	@MockitoBean
+	private HistoryAction historyAction;
+
+	@MockitoBean
+	private InstallAction installAction;
+
+	@MockitoBean
+	private UpgradeAction upgradeAction;
+
+	@MockitoBean
+	private UninstallAction uninstallAction;
+
+	@MockitoBean
+	private RollbackAction rollbackAction;
+
+	@MockitoBean
+	private TestAction testAction;
+
+	@MockitoBean
+	private ChartLoader chartLoader;
+
+	private static Release sampleRelease() {
+		return Release.builder()
+			.name("my-release")
+			.namespace("default")
+			.version(1)
+			.chart(Chart.builder()
+				.metadata(ChartMetadata.builder().name("nginx").version("1.0.0").appVersion("1.25").build())
+				.build())
+			.info(Release.ReleaseInfo.builder()
+				.status("deployed")
+				.description("Install complete")
+				.lastDeployed(OffsetDateTime.now())
+				.build())
+			.manifest("apiVersion: v1\nkind: ConfigMap")
+			.build();
+	}
+
+	@Test
+	void listReleases() throws Exception {
+		when(this.listAction.list("default")).thenReturn(List.of(sampleRelease()));
+		this.mockMvc.perform(get("/api/v1/releases").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].name").value("my-release"))
+			.andExpect(jsonPath("$[0].chartName").value("nginx"));
+	}
+
+	@Test
+	void statusReturnsRelease() throws Exception {
+		when(this.statusAction.status("my-release", "default")).thenReturn(Optional.of(sampleRelease()));
+		this.mockMvc.perform(get("/api/v1/releases/my-release").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.name").value("my-release"))
+			.andExpect(jsonPath("$.status").value("deployed"));
+	}
+
+	@Test
+	void statusReturnsNotFound() throws Exception {
+		when(this.statusAction.status("missing", "default")).thenReturn(Optional.empty());
+		this.mockMvc.perform(get("/api/v1/releases/missing").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void installCreatesRelease() throws Exception {
+		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("1.0.0").build()).build();
+		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
+		when(this.installAction.install(any(), eq("my-release"), eq("default"), anyMap(), anyInt(), anyBoolean()))
+			.thenReturn(sampleRelease());
+
+		this.mockMvc
+			.perform(post("/api/v1/releases").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartPath": "/tmp/nginx", "releaseName": "my-release"}
+						"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.name").value("my-release"));
+	}
+
+	@Test
+	void installRejectsMissingChartPath() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/releases").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"releaseName": "my-release"}
+						"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("chartPath is required"));
+	}
+
+	@Test
+	void upgradeRelease() throws Exception {
+		Release current = sampleRelease();
+		when(this.getAction.getRelease("my-release", "default")).thenReturn(Optional.of(current));
+		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("2.0.0").build()).build();
+		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
+		Release upgraded = sampleRelease();
+		upgraded.setVersion(2);
+		when(this.upgradeAction.upgrade(any(), any(), anyMap(), anyBoolean())).thenReturn(upgraded);
+
+		this.mockMvc
+			.perform(put("/api/v1/releases/my-release").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartPath": "/tmp/nginx-v2"}
+						"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.version").value(2));
+	}
+
+	@Test
+	void uninstallRelease() throws Exception {
+		this.mockMvc.perform(delete("/api/v1/releases/my-release")).andExpect(status().isNoContent());
+		verify(this.uninstallAction).uninstall("my-release", "default");
+	}
+
+	@Test
+	void history() throws Exception {
+		when(this.historyAction.history("my-release", "default")).thenReturn(List.of(sampleRelease()));
+		this.mockMvc.perform(get("/api/v1/releases/my-release/history").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].version").value(1));
+	}
+
+	@Test
+	void rollback() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/releases/my-release/rollback").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"revision": 1}
+						"""))
+			.andExpect(status().isNoContent());
+		verify(this.rollbackAction).rollback("my-release", "default", 1);
+	}
+
+	@Test
+	void testEndpoint() throws Exception {
+		TestAction.TestResult result = new TestAction.TestResult();
+		result.setName("test-pod");
+		result.setKind("Pod");
+		result.setStatus(TestAction.TestStatus.PASSED);
+		when(this.testAction.test("my-release", "default", 300)).thenReturn(List.of(result));
+
+		this.mockMvc.perform(post("/api/v1/releases/my-release/test").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].status").value("PASSED"));
+	}
+
+	@Test
+	void getValues() throws Exception {
+		when(this.getAction.getRelease("my-release", "default")).thenReturn(Optional.of(sampleRelease()));
+		when(this.getAction.getValues(any(), anyBoolean())).thenReturn("replicas: 2");
+
+		this.mockMvc.perform(get("/api/v1/releases/my-release/values").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	void getManifest() throws Exception {
+		when(this.getAction.getRelease("my-release", "default")).thenReturn(Optional.of(sampleRelease()));
+		when(this.getAction.getManifest(any())).thenReturn("apiVersion: v1\nkind: ConfigMap");
+
+		this.mockMvc.perform(get("/api/v1/releases/my-release/manifest").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	void getNotes() throws Exception {
+		when(this.getAction.getRelease("my-release", "default")).thenReturn(Optional.of(sampleRelease()));
+		when(this.getAction.getNotes(any())).thenReturn("Thank you for installing nginx!");
+
+		this.mockMvc.perform(get("/api/v1/releases/my-release/notes").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	void getHooks() throws Exception {
+		when(this.getAction.getRelease("my-release", "default")).thenReturn(Optional.of(sampleRelease()));
+		this.mockMvc.perform(get("/api/v1/releases/my-release/hooks").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$").isArray());
+	}
+
+	@Test
+	void getResources() throws Exception {
+		when(this.statusAction.status("my-release", "default")).thenReturn(Optional.of(sampleRelease()));
+		when(this.statusAction.getResourceStatuses(any())).thenReturn(List.of());
+		this.mockMvc.perform(get("/api/v1/releases/my-release/resources").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$").isArray());
+	}
+
+	@Test
+	void getResourcesNotFound() throws Exception {
+		when(this.statusAction.status("missing", "default")).thenReturn(Optional.empty());
+		this.mockMvc.perform(get("/api/v1/releases/missing/resources").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNotFound());
+	}
+
+}

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/TestApplication.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/TestApplication.java
@@ -1,0 +1,8 @@
+package org.alexmond.jhelm.rest.controller;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+class TestApplication {
+
+}


### PR DESCRIPTION
## Summary
- Implement `ReleaseController` with 13 endpoints: install, list, status, upgrade, uninstall, history, rollback, test, values, manifest, notes, hooks, and resources
- Add DTOs: `ReleaseDto`, `InstallRequest`, `UpgradeRequest`, `RollbackRequest`, `ResourceStatusDto`, `HelmHookDto`, `TestResultDto`
- Register `ReleaseController` bean in `JhelmRestAutoConfiguration`
- Add `spring-boot-webmvc-test` dependency for Spring Boot 4 MockMvc testing

## Test plan
- [x] 16 MockMvc tests covering all endpoints (list, status, status-not-found, install, install-bad-request, upgrade, uninstall, history, rollback, test, values, manifest, notes, hooks, resources, resources-not-found)
- [x] PMD + Checkstyle validation passes
- [x] All 19 jhelm-rest tests pass

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)