### PR TITLE
Add chart operations endpoints with OpenAPI annotations

### DIFF
--- a/jhelm-rest/pom.xml
+++ b/jhelm-rest/pom.xml
@@ -30,6 +30,10 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -1,17 +1,24 @@
 package org.alexmond.jhelm.rest;
 
 import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
+import org.alexmond.jhelm.core.action.CreateAction;
 import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.HistoryAction;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.LintAction;
 import org.alexmond.jhelm.core.action.ListAction;
+import org.alexmond.jhelm.core.action.PackageAction;
 import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.ShowAction;
 import org.alexmond.jhelm.core.action.StatusAction;
+import org.alexmond.jhelm.core.action.TemplateAction;
 import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.action.VerifyAction;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
+import org.alexmond.jhelm.rest.controller.ChartController;
 import org.alexmond.jhelm.rest.controller.ReleaseController;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -45,6 +52,14 @@ public class JhelmRestAutoConfiguration {
 			ChartLoader chartLoader) {
 		return new ReleaseController(listAction, statusAction, getAction, historyAction, installAction, upgradeAction,
 				uninstallAction, rollbackAction, testAction, chartLoader);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnBean(TemplateAction.class)
+	public ChartController chartController(TemplateAction templateAction, LintAction lintAction,
+			CreateAction createAction, PackageAction packageAction, VerifyAction verifyAction, ShowAction showAction) {
+		return new ChartController(templateAction, lintAction, createAction, packageAction, verifyAction, showAction);
 	}
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
@@ -1,0 +1,140 @@
+package org.alexmond.jhelm.rest.controller;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.alexmond.jhelm.core.action.CreateAction;
+import org.alexmond.jhelm.core.action.LintAction;
+import org.alexmond.jhelm.core.action.PackageAction;
+import org.alexmond.jhelm.core.action.ShowAction;
+import org.alexmond.jhelm.core.action.TemplateAction;
+import org.alexmond.jhelm.core.action.VerifyAction;
+import org.alexmond.jhelm.rest.dto.CreateRequest;
+import org.alexmond.jhelm.rest.dto.LintRequest;
+import org.alexmond.jhelm.rest.dto.LintResultDto;
+import org.alexmond.jhelm.rest.dto.PackageRequest;
+import org.alexmond.jhelm.rest.dto.PackageResultDto;
+import org.alexmond.jhelm.rest.dto.TemplateRequest;
+import org.alexmond.jhelm.rest.dto.VerifyRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("${jhelm.rest.base-path:/api/v1}/charts")
+@Tag(name = "Charts", description = "Chart operations: template, lint, create, package, verify, show")
+public class ChartController {
+
+	private final TemplateAction templateAction;
+
+	private final LintAction lintAction;
+
+	private final CreateAction createAction;
+
+	private final PackageAction packageAction;
+
+	private final VerifyAction verifyAction;
+
+	private final ShowAction showAction;
+
+	public ChartController(TemplateAction templateAction, LintAction lintAction, CreateAction createAction,
+			PackageAction packageAction, VerifyAction verifyAction, ShowAction showAction) {
+		this.templateAction = templateAction;
+		this.lintAction = lintAction;
+		this.createAction = createAction;
+		this.packageAction = packageAction;
+		this.verifyAction = verifyAction;
+		this.showAction = showAction;
+	}
+
+	@PostMapping("/template")
+	@Operation(summary = "Render templates", description = "Render chart templates with optional value overrides")
+	public ResponseEntity<String> template(@RequestBody TemplateRequest request) throws Exception {
+		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
+			throw new IllegalArgumentException("chartPath is required");
+		}
+		Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+		String manifest = this.templateAction.render(request.getChartPath(), request.getReleaseName(),
+				request.getNamespace(), values);
+		return ResponseEntity.ok(manifest);
+	}
+
+	@PostMapping("/lint")
+	@Operation(summary = "Lint a chart", description = "Validate a chart for issues and best practices")
+	public LintResultDto lint(@RequestBody LintRequest request) {
+		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
+			throw new IllegalArgumentException("chartPath is required");
+		}
+		Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+		LintAction.LintResult result = this.lintAction.lint(request.getChartPath(), values, request.isStrict());
+		return LintResultDto.from(result);
+	}
+
+	@PostMapping("/create")
+	@Operation(summary = "Create a chart", description = "Scaffold a new chart directory")
+	public ResponseEntity<Void> create(@RequestBody CreateRequest request) throws Exception {
+		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
+			throw new IllegalArgumentException("chartPath is required");
+		}
+		this.createAction.create(Path.of(request.getChartPath()));
+		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	@PostMapping("/package")
+	@Operation(summary = "Package a chart", description = "Package a chart directory into a .tgz archive")
+	public PackageResultDto packageChart(@RequestBody PackageRequest request) throws Exception {
+		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
+			throw new IllegalArgumentException("chartPath is required");
+		}
+		if (request.getDestination() != null) {
+			this.packageAction.setDestination(new File(request.getDestination()));
+		}
+		File archive = this.packageAction.packageChart(request.getChartPath());
+		return PackageResultDto.builder().archivePath(archive.getAbsolutePath()).build();
+	}
+
+	@PostMapping("/verify")
+	@Operation(summary = "Verify a chart", description = "Verify the PGP signature of a packaged chart")
+	public ResponseEntity<Void> verify(@RequestBody VerifyRequest request) throws Exception {
+		if (request.getChartTgzPath() == null || request.getChartTgzPath().isBlank()) {
+			throw new IllegalArgumentException("chartTgzPath is required");
+		}
+		if (request.getKeyringPath() == null || request.getKeyringPath().isBlank()) {
+			throw new IllegalArgumentException("keyringPath is required");
+		}
+		this.verifyAction.verify(request.getChartTgzPath(), request.getKeyringPath());
+		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/show")
+	@Operation(summary = "Show chart info", description = "Show all chart information: metadata, values, README, CRDs")
+	public ResponseEntity<String> showAll(
+			@Parameter(description = "Path to the chart directory") @RequestParam String chartPath) throws Exception {
+		return ResponseEntity.ok(this.showAction.showAll(chartPath));
+	}
+
+	@GetMapping("/show/values")
+	@Operation(summary = "Show chart values", description = "Show the default values.yaml")
+	public ResponseEntity<String> showValues(
+			@Parameter(description = "Path to the chart directory") @RequestParam String chartPath) throws Exception {
+		return ResponseEntity.ok(this.showAction.showValues(chartPath));
+	}
+
+	@GetMapping("/show/readme")
+	@Operation(summary = "Show chart README")
+	public ResponseEntity<String> showReadme(
+			@Parameter(description = "Path to the chart directory") @RequestParam String chartPath) throws Exception {
+		return ResponseEntity.ok(this.showAction.showReadme(chartPath));
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
@@ -5,6 +5,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.HistoryAction;
 import org.alexmond.jhelm.core.action.InstallAction;
@@ -39,6 +44,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("${jhelm.rest.base-path:/api/v1}/releases")
+@Tag(name = "Releases", description = "Manage Helm releases")
 public class ReleaseController {
 
 	private final ListAction listAction;
@@ -78,13 +84,20 @@ public class ReleaseController {
 	}
 
 	@GetMapping
-	public List<ReleaseDto> list(@RequestParam(defaultValue = "default") String namespace) throws Exception {
+	@Operation(summary = "List releases", description = "List all Helm releases in a namespace")
+	public List<ReleaseDto> list(
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace)
+			throws Exception {
 		return this.listAction.list(namespace).stream().map(ReleaseDto::from).toList();
 	}
 
 	@GetMapping("/{name}")
-	public ResponseEntity<ReleaseDto> status(@PathVariable String name,
-			@RequestParam(defaultValue = "default") String namespace) throws Exception {
+	@Operation(summary = "Get release status",
+			responses = { @ApiResponse(responseCode = "200", description = "Release found"),
+					@ApiResponse(responseCode = "404", description = "Release not found") })
+	public ResponseEntity<ReleaseDto> status(@Parameter(description = "Release name") @PathVariable String name,
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace)
+			throws Exception {
 		return this.statusAction.status(name, namespace)
 			.map(ReleaseDto::from)
 			.map(ResponseEntity::ok)
@@ -92,6 +105,7 @@ public class ReleaseController {
 	}
 
 	@PostMapping
+	@Operation(summary = "Install a release", description = "Install a new Helm release from a chart")
 	public ResponseEntity<ReleaseDto> install(@RequestBody InstallRequest request) throws Exception {
 		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
 			throw new IllegalArgumentException("chartPath is required");
@@ -107,7 +121,9 @@ public class ReleaseController {
 	}
 
 	@PutMapping("/{name}")
-	public ReleaseDto upgrade(@PathVariable String name, @RequestParam(defaultValue = "default") String namespace,
+	@Operation(summary = "Upgrade a release", description = "Upgrade an existing release to a new chart version")
+	public ReleaseDto upgrade(@Parameter(description = "Release name") @PathVariable String name,
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace,
 			@RequestBody UpgradeRequest request) throws Exception {
 		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
 			throw new IllegalArgumentException("chartPath is required");
@@ -121,35 +137,45 @@ public class ReleaseController {
 	}
 
 	@DeleteMapping("/{name}")
-	public ResponseEntity<Void> uninstall(@PathVariable String name,
-			@RequestParam(defaultValue = "default") String namespace) throws Exception {
+	@Operation(summary = "Uninstall a release")
+	public ResponseEntity<Void> uninstall(@Parameter(description = "Release name") @PathVariable String name,
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace)
+			throws Exception {
 		this.uninstallAction.uninstall(name, namespace);
 		return ResponseEntity.noContent().build();
 	}
 
 	@GetMapping("/{name}/history")
-	public List<ReleaseDto> history(@PathVariable String name, @RequestParam(defaultValue = "default") String namespace)
+	@Operation(summary = "Get release history", description = "List all revisions of a release")
+	public List<ReleaseDto> history(@Parameter(description = "Release name") @PathVariable String name,
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace)
 			throws Exception {
 		return this.historyAction.history(name, namespace).stream().map(ReleaseDto::from).toList();
 	}
 
 	@PostMapping("/{name}/rollback")
-	public ResponseEntity<Void> rollback(@PathVariable String name,
-			@RequestParam(defaultValue = "default") String namespace, @RequestBody RollbackRequest request)
-			throws Exception {
+	@Operation(summary = "Rollback a release", description = "Rollback a release to a previous revision")
+	public ResponseEntity<Void> rollback(@Parameter(description = "Release name") @PathVariable String name,
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace,
+			@RequestBody RollbackRequest request) throws Exception {
 		this.rollbackAction.rollback(name, namespace, request.getRevision());
 		return ResponseEntity.noContent().build();
 	}
 
 	@PostMapping("/{name}/test")
-	public List<TestResultDto> test(@PathVariable String name, @RequestParam(defaultValue = "default") String namespace,
-			@RequestParam(defaultValue = "300") int timeoutSeconds) throws Exception {
+	@Operation(summary = "Test a release", description = "Run test hooks for a release")
+	public List<TestResultDto> test(@Parameter(description = "Release name") @PathVariable String name,
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace,
+			@Parameter(description = "Timeout in seconds") @RequestParam(defaultValue = "300") int timeoutSeconds)
+			throws Exception {
 		return this.testAction.test(name, namespace, timeoutSeconds).stream().map(TestResultDto::from).toList();
 	}
 
 	@GetMapping("/{name}/values")
-	public ResponseEntity<String> getValues(@PathVariable String name,
-			@RequestParam(defaultValue = "default") String namespace, @RequestParam(defaultValue = "false") boolean all)
+	@Operation(summary = "Get release values", description = "Get the values used by a release")
+	public ResponseEntity<String> getValues(@Parameter(description = "Release name") @PathVariable String name,
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace,
+			@Parameter(description = "Include computed values") @RequestParam(defaultValue = "false") boolean all)
 			throws Exception {
 		return this.getAction.getRelease(name, namespace)
 			.map((release) -> ResponseEntity.ok(safeGetValues(release, all)))
@@ -157,24 +183,31 @@ public class ReleaseController {
 	}
 
 	@GetMapping("/{name}/manifest")
-	public ResponseEntity<String> getManifest(@PathVariable String name,
-			@RequestParam(defaultValue = "default") String namespace) throws Exception {
+	@Operation(summary = "Get release manifest", description = "Get the rendered Kubernetes manifest")
+	public ResponseEntity<String> getManifest(@Parameter(description = "Release name") @PathVariable String name,
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace)
+			throws Exception {
 		return this.getAction.getRelease(name, namespace)
 			.map((release) -> ResponseEntity.ok(this.getAction.getManifest(release)))
 			.orElse(ResponseEntity.notFound().build());
 	}
 
 	@GetMapping("/{name}/notes")
-	public ResponseEntity<String> getNotes(@PathVariable String name,
-			@RequestParam(defaultValue = "default") String namespace) throws Exception {
+	@Operation(summary = "Get release notes")
+	public ResponseEntity<String> getNotes(@Parameter(description = "Release name") @PathVariable String name,
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace)
+			throws Exception {
 		return this.getAction.getRelease(name, namespace)
 			.map((release) -> ResponseEntity.ok(this.getAction.getNotes(release)))
 			.orElse(ResponseEntity.notFound().build());
 	}
 
 	@GetMapping("/{name}/hooks")
-	public ResponseEntity<List<HelmHookDto>> getHooks(@PathVariable String name,
-			@RequestParam(defaultValue = "default") String namespace) throws Exception {
+	@Operation(summary = "Get release hooks", description = "List Helm hooks defined in the release")
+	public ResponseEntity<List<HelmHookDto>> getHooks(
+			@Parameter(description = "Release name") @PathVariable String name,
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace)
+			throws Exception {
 		return this.getAction.getRelease(name, namespace).map((release) -> {
 			List<HelmHookDto> hooks = HookParser.parseHooks(release.getManifest())
 				.stream()
@@ -185,8 +218,11 @@ public class ReleaseController {
 	}
 
 	@GetMapping("/{name}/resources")
-	public ResponseEntity<List<ResourceStatusDto>> getResources(@PathVariable String name,
-			@RequestParam(defaultValue = "default") String namespace) throws Exception {
+	@Operation(summary = "Get resource statuses", description = "List Kubernetes resources and their status")
+	public ResponseEntity<List<ResourceStatusDto>> getResources(
+			@Parameter(description = "Release name") @PathVariable String name,
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace)
+			throws Exception {
 		return this.statusAction.status(name, namespace).map((release) -> {
 			List<ResourceStatusDto> statuses = safeGetResourceStatuses(release);
 			return ResponseEntity.ok(statuses);

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/CreateRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/CreateRequest.java
@@ -1,0 +1,14 @@
+package org.alexmond.jhelm.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "Request to scaffold a new chart")
+public class CreateRequest {
+
+	@Schema(description = "Path where the chart will be created", example = "/tmp/my-chart",
+			requiredMode = Schema.RequiredMode.REQUIRED)
+	private String chartPath;
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/HelmHookDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/HelmHookDto.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.rest.dto;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,16 +10,22 @@ import org.alexmond.jhelm.core.model.HelmHook;
 
 @Data
 @Builder
+@Schema(description = "Helm hook defined in a release")
 public class HelmHookDto {
 
+	@Schema(description = "Kubernetes resource kind", example = "Job")
 	private String kind;
 
+	@Schema(description = "Hook name", example = "my-release-test")
 	private String name;
 
+	@Schema(description = "Hook execution phases", example = "[\"pre-install\", \"pre-upgrade\"]")
 	private List<String> phases;
 
+	@Schema(description = "Hook execution weight (lower runs first)", example = "0")
 	private int weight;
 
+	@Schema(description = "Hook delete policies", example = "[\"before-hook-creation\"]")
 	private List<String> deletePolicy;
 
 	public static HelmHookDto from(HelmHook hook) {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/LintRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/LintRequest.java
@@ -1,0 +1,22 @@
+package org.alexmond.jhelm.rest.dto;
+
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "Request to lint/validate a chart")
+public class LintRequest {
+
+	@Schema(description = "Path to the chart directory", example = "/tmp/nginx",
+			requiredMode = Schema.RequiredMode.REQUIRED)
+	private String chartPath;
+
+	@Schema(description = "Override values for validation")
+	private Map<String, Object> values;
+
+	@Schema(description = "Enable strict linting mode", defaultValue = "false")
+	private boolean strict;
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/LintResultDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/LintResultDto.java
@@ -1,0 +1,37 @@
+package org.alexmond.jhelm.rest.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import org.alexmond.jhelm.core.action.LintAction;
+
+@Data
+@Builder
+@Schema(description = "Result of chart linting")
+public class LintResultDto {
+
+	@Schema(description = "Path to the linted chart", example = "/tmp/nginx")
+	private String chartPath;
+
+	@Schema(description = "Whether the chart passed linting without errors")
+	private boolean ok;
+
+	@Schema(description = "List of lint errors")
+	private List<String> errors;
+
+	@Schema(description = "List of lint warnings")
+	private List<String> warnings;
+
+	public static LintResultDto from(LintAction.LintResult result) {
+		return LintResultDto.builder()
+			.chartPath(result.getChartPath())
+			.ok(result.isOk())
+			.errors(result.getErrors())
+			.warnings(result.getWarnings())
+			.build();
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/PackageRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/PackageRequest.java
@@ -1,0 +1,17 @@
+package org.alexmond.jhelm.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "Request to package a chart into a .tgz archive")
+public class PackageRequest {
+
+	@Schema(description = "Path to the chart directory", example = "/tmp/nginx",
+			requiredMode = Schema.RequiredMode.REQUIRED)
+	private String chartPath;
+
+	@Schema(description = "Destination directory for the archive", example = "/tmp/output")
+	private String destination;
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/PackageResultDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/PackageResultDto.java
@@ -1,0 +1,15 @@
+package org.alexmond.jhelm.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@Schema(description = "Result of chart packaging")
+public class PackageResultDto {
+
+	@Schema(description = "Absolute path to the created archive", example = "/tmp/output/nginx-1.0.0.tgz")
+	private String archivePath;
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ReleaseDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ReleaseDto.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.rest.dto;
 
 import java.time.OffsetDateTime;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,24 +10,34 @@ import org.alexmond.jhelm.core.model.Release;
 
 @Data
 @Builder
+@Schema(description = "Summary of a Helm release")
 public class ReleaseDto {
 
+	@Schema(description = "Release name", example = "my-release")
 	private String name;
 
+	@Schema(description = "Kubernetes namespace", example = "default")
 	private String namespace;
 
+	@Schema(description = "Release revision number", example = "1")
 	private int version;
 
+	@Schema(description = "Release status", example = "deployed")
 	private String status;
 
+	@Schema(description = "Chart name", example = "nginx")
 	private String chartName;
 
+	@Schema(description = "Chart version", example = "1.0.0")
 	private String chartVersion;
 
+	@Schema(description = "Application version", example = "1.25")
 	private String appVersion;
 
+	@Schema(description = "Status description", example = "Install complete")
 	private String description;
 
+	@Schema(description = "Timestamp of last deployment")
 	private OffsetDateTime lastDeployed;
 
 	public static ReleaseDto from(Release release) {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ResourceStatusDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ResourceStatusDto.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.rest.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,16 +8,22 @@ import org.alexmond.jhelm.core.model.ResourceStatus;
 
 @Data
 @Builder
+@Schema(description = "Status of a Kubernetes resource managed by a release")
 public class ResourceStatusDto {
 
+	@Schema(description = "Resource kind", example = "Deployment")
 	private String kind;
 
+	@Schema(description = "Resource name", example = "my-release-nginx")
 	private String name;
 
+	@Schema(description = "Kubernetes namespace", example = "default")
 	private String namespace;
 
+	@Schema(description = "Whether the resource is ready")
 	private boolean ready;
 
+	@Schema(description = "Status message")
 	private String message;
 
 	public static ResourceStatusDto from(ResourceStatus rs) {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RollbackRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RollbackRequest.java
@@ -1,10 +1,13 @@
 package org.alexmond.jhelm.rest.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
+@Schema(description = "Request to rollback a release to a previous revision")
 public class RollbackRequest {
 
+	@Schema(description = "Revision number to rollback to", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 	private int revision;
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TemplateRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TemplateRequest.java
@@ -6,23 +6,20 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
-@Schema(description = "Request to install a new Helm release")
-public class InstallRequest {
+@Schema(description = "Request to render chart templates")
+public class TemplateRequest {
 
 	@Schema(description = "Path to the chart directory", example = "/tmp/nginx",
 			requiredMode = Schema.RequiredMode.REQUIRED)
 	private String chartPath;
 
-	@Schema(description = "Name for the release", example = "my-release", requiredMode = Schema.RequiredMode.REQUIRED)
-	private String releaseName;
+	@Schema(description = "Release name for template rendering", example = "my-release", defaultValue = "RELEASE-NAME")
+	private String releaseName = "RELEASE-NAME";
 
 	@Schema(description = "Kubernetes namespace", example = "default", defaultValue = "default")
 	private String namespace = "default";
 
 	@Schema(description = "Override values for the chart")
 	private Map<String, Object> values;
-
-	@Schema(description = "Simulate an install without applying", defaultValue = "false")
-	private boolean dryRun;
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TestResultDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TestResultDto.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.rest.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,15 +8,20 @@ import org.alexmond.jhelm.core.action.TestAction;
 
 @Data
 @Builder
+@Schema(description = "Result of a Helm test execution")
 @SuppressWarnings({ "PMD.TestClassWithoutTestCases", "PMD.UnitTestShouldUseTestAnnotation" })
 public class TestResultDto {
 
+	@Schema(description = "Kubernetes resource kind", example = "Pod")
 	private String kind;
 
+	@Schema(description = "Test resource name", example = "my-release-test")
 	private String name;
 
+	@Schema(description = "Test result status", example = "PASSED")
 	private String status;
 
+	@Schema(description = "Test output message")
 	private String message;
 
 	public static TestResultDto from(TestAction.TestResult result) {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeRequest.java
@@ -2,15 +2,21 @@ package org.alexmond.jhelm.rest.dto;
 
 import java.util.Map;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
+@Schema(description = "Request to upgrade an existing Helm release")
 public class UpgradeRequest {
 
+	@Schema(description = "Path to the new chart directory", example = "/tmp/nginx-v2",
+			requiredMode = Schema.RequiredMode.REQUIRED)
 	private String chartPath;
 
+	@Schema(description = "Override values for the chart")
 	private Map<String, Object> values;
 
+	@Schema(description = "Simulate an upgrade without applying", defaultValue = "false")
 	private boolean dryRun;
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/VerifyRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/VerifyRequest.java
@@ -1,0 +1,18 @@
+package org.alexmond.jhelm.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "Request to verify a chart's PGP signature")
+public class VerifyRequest {
+
+	@Schema(description = "Path to the chart .tgz archive", example = "/tmp/nginx-1.0.0.tgz",
+			requiredMode = Schema.RequiredMode.REQUIRED)
+	private String chartTgzPath;
+
+	@Schema(description = "Path to the PGP public keyring", example = "/tmp/keyring.gpg",
+			requiredMode = Schema.RequiredMode.REQUIRED)
+	private String keyringPath;
+
+}

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ChartControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ChartControllerTest.java
@@ -1,0 +1,224 @@
+package org.alexmond.jhelm.rest.controller;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.alexmond.jhelm.core.action.CreateAction;
+import org.alexmond.jhelm.core.action.LintAction;
+import org.alexmond.jhelm.core.action.PackageAction;
+import org.alexmond.jhelm.core.action.ShowAction;
+import org.alexmond.jhelm.core.action.TemplateAction;
+import org.alexmond.jhelm.core.action.VerifyAction;
+import org.alexmond.jhelm.rest.JhelmRestExceptionHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ChartController.class)
+@Import(JhelmRestExceptionHandler.class)
+class ChartControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private TemplateAction templateAction;
+
+	@MockitoBean
+	private LintAction lintAction;
+
+	@MockitoBean
+	private CreateAction createAction;
+
+	@MockitoBean
+	private PackageAction packageAction;
+
+	@MockitoBean
+	private VerifyAction verifyAction;
+
+	@MockitoBean
+	private ShowAction showAction;
+
+	@Test
+	void templateRendersManifest() throws Exception {
+		when(this.templateAction.render(eq("/tmp/nginx"), eq("my-release"), eq("default"), anyMap()))
+			.thenReturn("apiVersion: v1\nkind: ConfigMap");
+
+		this.mockMvc
+			.perform(post("/api/v1/charts/template").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartPath": "/tmp/nginx", "releaseName": "my-release"}
+						"""))
+			.andExpect(status().isOk())
+			.andExpect(content().string("apiVersion: v1\nkind: ConfigMap"));
+	}
+
+	@Test
+	void templateRejectsMissingChartPath() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/charts/template").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"releaseName": "my-release"}
+						"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("chartPath is required"));
+	}
+
+	@Test
+	void lintReturnsResult() throws Exception {
+		LintAction.LintResult result = new LintAction.LintResult("/tmp/nginx", List.of(), List.of("missing desc"));
+		when(this.lintAction.lint(eq("/tmp/nginx"), anyMap(), eq(false))).thenReturn(result);
+
+		this.mockMvc
+			.perform(post("/api/v1/charts/lint").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartPath": "/tmp/nginx"}
+						"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.ok").value(true))
+			.andExpect(jsonPath("$.warnings[0]").value("missing desc"));
+	}
+
+	@Test
+	void lintRejectsMissingChartPath() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/charts/lint").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("{}"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("chartPath is required"));
+	}
+
+	@Test
+	void createScaffoldsChart() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/charts/create").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartPath": "/tmp/my-chart"}
+						"""))
+			.andExpect(status().isCreated());
+		verify(this.createAction).create(Path.of("/tmp/my-chart"));
+	}
+
+	@Test
+	void createRejectsMissingChartPath() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/charts/create").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("{}"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("chartPath is required"));
+	}
+
+	@Test
+	void packageChartReturnsArchivePath() throws Exception {
+		when(this.packageAction.packageChart("/tmp/nginx")).thenReturn(new File("/tmp/nginx-1.0.0.tgz"));
+
+		this.mockMvc
+			.perform(post("/api/v1/charts/package").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartPath": "/tmp/nginx"}
+						"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.archivePath").value("/tmp/nginx-1.0.0.tgz"));
+	}
+
+	@Test
+	void packageRejectsMissingChartPath() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/charts/package").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("{}"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("chartPath is required"));
+	}
+
+	@Test
+	void verifySucceeds() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/charts/verify").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartTgzPath": "/tmp/nginx-1.0.0.tgz", "keyringPath": "/tmp/keyring.gpg"}
+						"""))
+			.andExpect(status().isOk());
+		verify(this.verifyAction).verify("/tmp/nginx-1.0.0.tgz", "/tmp/keyring.gpg");
+	}
+
+	@Test
+	void verifyRejectsMissingChartTgzPath() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/charts/verify").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"keyringPath": "/tmp/keyring.gpg"}
+						"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("chartTgzPath is required"));
+	}
+
+	@Test
+	void verifyRejectsMissingKeyringPath() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/charts/verify").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartTgzPath": "/tmp/nginx-1.0.0.tgz"}
+						"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("keyringPath is required"));
+	}
+
+	@Test
+	void showAllReturnsChartInfo() throws Exception {
+		when(this.showAction.showAll("/tmp/nginx")).thenReturn("# Chart.yaml\nname: nginx");
+
+		this.mockMvc
+			.perform(get("/api/v1/charts/show").param("chartPath", "/tmp/nginx").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string("# Chart.yaml\nname: nginx"));
+	}
+
+	@Test
+	void showValuesReturnsValues() throws Exception {
+		when(this.showAction.showValues("/tmp/nginx")).thenReturn("replicas: 1");
+
+		this.mockMvc
+			.perform(get("/api/v1/charts/show/values").param("chartPath", "/tmp/nginx")
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string("replicas: 1"));
+	}
+
+	@Test
+	void showReadmeReturnsReadme() throws Exception {
+		when(this.showAction.showReadme("/tmp/nginx")).thenReturn("# Nginx Chart");
+
+		this.mockMvc
+			.perform(get("/api/v1/charts/show/readme").param("chartPath", "/tmp/nginx")
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string("# Nginx Chart"));
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <bouncycastle.version>1.83</bouncycastle.version>
         <commons-compress.version>1.26.1</commons-compress.version>
         <chicory.version>1.7.2</chicory.version>
+        <swagger-annotations.version>2.2.34</swagger-annotations.version>
         <spring-retry.version>2.0.12</spring-retry.version>
 
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
@@ -165,6 +166,11 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpg-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>${swagger-annotations.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary
- Implement `ChartController` with 8 endpoints: template, lint, create, package, verify, show-all, show-values, show-readme
- Add DTOs: `TemplateRequest`, `LintRequest`, `LintResultDto`, `CreateRequest`, `PackageRequest`, `PackageResultDto`, `VerifyRequest`
- Add OpenAPI annotations (`@Schema`, `@Operation`, `@Parameter`, `@Tag`) to all DTOs and both controllers (Release + Chart)
- Add `swagger-annotations` 2.2.34 dependency
- Register `ChartController` bean in `JhelmRestAutoConfiguration`

## Test plan
- [x] 14 MockMvc tests for ChartController (template, lint, create, package, verify, show endpoints + validation)
- [x] 16 existing ReleaseController tests still pass
- [x] PMD + Checkstyle validation passes
- [x] All 33 jhelm-rest tests pass

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)