### PR TITLE
Add Repository, Hub, and Dependency REST endpoints

### DIFF
--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.rest;
 import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
 import org.alexmond.jhelm.core.action.CreateAction;
 import org.alexmond.jhelm.core.action.GetAction;
+import org.alexmond.jhelm.core.action.SearchHubAction;
 import org.alexmond.jhelm.core.action.HistoryAction;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.LintAction;
@@ -17,9 +18,14 @@ import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.action.VerifyAction;
 import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.DependencyResolver;
+import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
 import org.alexmond.jhelm.rest.controller.ChartController;
+import org.alexmond.jhelm.rest.controller.DependencyController;
+import org.alexmond.jhelm.rest.controller.HubController;
 import org.alexmond.jhelm.rest.controller.ReleaseController;
+import org.alexmond.jhelm.rest.controller.RepoController;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -60,6 +66,34 @@ public class JhelmRestAutoConfiguration {
 	public ChartController chartController(TemplateAction templateAction, LintAction lintAction,
 			CreateAction createAction, PackageAction packageAction, VerifyAction verifyAction, ShowAction showAction) {
 		return new ChartController(templateAction, lintAction, createAction, packageAction, verifyAction, showAction);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnBean(RepoManager.class)
+	public RepoController repoController(RepoManager repoManager) {
+		return new RepoController(repoManager);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnBean(SearchHubAction.class)
+	public HubController hubController(SearchHubAction searchHubAction) {
+		return new HubController(searchHubAction);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnBean(RepoManager.class)
+	public DependencyResolver dependencyResolver(RepoManager repoManager) {
+		return new DependencyResolver(repoManager);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnBean(DependencyResolver.class)
+	public DependencyController dependencyController(DependencyResolver dependencyResolver, ChartLoader chartLoader) {
+		return new DependencyController(dependencyResolver, chartLoader);
 	}
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/DependencyController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/DependencyController.java
@@ -1,0 +1,63 @@
+package org.alexmond.jhelm.rest.controller;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ChartLock;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.DependencyResolver;
+import org.alexmond.jhelm.rest.dto.DependencyResolveRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("${jhelm.rest.base-path:/api/v1}/dependencies")
+@Tag(name = "Dependencies", description = "Manage chart dependencies")
+public class DependencyController {
+
+	private final DependencyResolver dependencyResolver;
+
+	private final ChartLoader chartLoader;
+
+	public DependencyController(DependencyResolver dependencyResolver, ChartLoader chartLoader) {
+		this.dependencyResolver = dependencyResolver;
+		this.chartLoader = chartLoader;
+	}
+
+	@PostMapping("/resolve")
+	@Operation(summary = "Resolve dependencies", description = "Resolve chart dependency versions")
+	public ResponseEntity<Void> resolve(@RequestBody DependencyResolveRequest request) throws Exception {
+		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
+			throw new IllegalArgumentException("chartPath is required");
+		}
+		Chart chart = this.chartLoader.load(new File(request.getChartPath()));
+		Map<String, Object> values = (chart.getValues() != null) ? chart.getValues() : Map.of();
+		ChartLock lock = this.dependencyResolver.resolveDependencies(chart.getMetadata(), values, List.of());
+		lock.toFile(new File(request.getChartPath()));
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/download")
+	@Operation(summary = "Download dependencies", description = "Download resolved chart dependencies")
+	public ResponseEntity<Void> download(@RequestBody DependencyResolveRequest request) throws Exception {
+		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
+			throw new IllegalArgumentException("chartPath is required");
+		}
+		File chartDir = new File(request.getChartPath());
+		ChartLock lock = ChartLock.fromFile(chartDir);
+		if (lock == null) {
+			throw new IllegalArgumentException("No Chart.lock found. Run resolve first.");
+		}
+		this.dependencyResolver.downloadDependencies(chartDir, lock.getDependencies());
+		return ResponseEntity.ok().build();
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/HubController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/HubController.java
@@ -1,0 +1,35 @@
+package org.alexmond.jhelm.rest.controller;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.alexmond.jhelm.core.action.SearchHubAction;
+import org.alexmond.jhelm.rest.dto.HubSearchResultDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("${jhelm.rest.base-path:/api/v1}/hub")
+@Tag(name = "Hub", description = "Search ArtifactHub for charts")
+public class HubController {
+
+	private final SearchHubAction searchHubAction;
+
+	public HubController(SearchHubAction searchHubAction) {
+		this.searchHubAction = searchHubAction;
+	}
+
+	@GetMapping("/search")
+	@Operation(summary = "Search ArtifactHub", description = "Search for Helm charts on ArtifactHub")
+	public List<HubSearchResultDto> search(@Parameter(description = "Search keyword") @RequestParam String keyword,
+			@Parameter(description = "Maximum results (max 60)") @RequestParam(defaultValue = "20") int maxResults)
+			throws Exception {
+		return this.searchHubAction.search(keyword, maxResults).stream().map(HubSearchResultDto::from).toList();
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/RepoController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/RepoController.java
@@ -1,0 +1,95 @@
+package org.alexmond.jhelm.rest.controller;
+
+import java.util.Collections;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.alexmond.jhelm.core.model.RepositoryConfig;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.rest.dto.ChartVersionDto;
+import org.alexmond.jhelm.rest.dto.PullRequest;
+import org.alexmond.jhelm.rest.dto.RepoAddRequest;
+import org.alexmond.jhelm.rest.dto.RepoDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("${jhelm.rest.base-path:/api/v1}/repos")
+@Tag(name = "Repositories", description = "Manage chart repositories")
+public class RepoController {
+
+	private final RepoManager repoManager;
+
+	public RepoController(RepoManager repoManager) {
+		this.repoManager = repoManager;
+	}
+
+	@PostMapping
+	@Operation(summary = "Add a repository")
+	public ResponseEntity<Void> addRepo(@RequestBody RepoAddRequest request) throws Exception {
+		if (request.getName() == null || request.getName().isBlank()) {
+			throw new IllegalArgumentException("name is required");
+		}
+		if (request.getUrl() == null || request.getUrl().isBlank()) {
+			throw new IllegalArgumentException("url is required");
+		}
+		this.repoManager.addRepo(request.getName(), request.getUrl());
+		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	@GetMapping
+	@Operation(summary = "List repositories")
+	public List<RepoDto> listRepos() throws Exception {
+		RepositoryConfig config = this.repoManager.loadConfig();
+		if (config.getRepositories() == null) {
+			return Collections.emptyList();
+		}
+		return config.getRepositories().stream().map(RepoDto::from).toList();
+	}
+
+	@DeleteMapping("/{name}")
+	@Operation(summary = "Remove a repository")
+	public ResponseEntity<Void> removeRepo(@Parameter(description = "Repository name") @PathVariable String name)
+			throws Exception {
+		this.repoManager.removeRepo(name);
+		return ResponseEntity.noContent().build();
+	}
+
+	@PostMapping("/{name}/update")
+	@Operation(summary = "Update repository index")
+	public ResponseEntity<Void> updateRepo(@Parameter(description = "Repository name") @PathVariable String name)
+			throws Exception {
+		this.repoManager.updateRepo(name);
+		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/{name}/charts/{chart}/versions")
+	@Operation(summary = "List chart versions", description = "List available versions of a chart in a repository")
+	public List<ChartVersionDto> listVersions(@Parameter(description = "Repository name") @PathVariable String name,
+			@Parameter(description = "Chart name") @PathVariable String chart) throws Exception {
+		return this.repoManager.getChartVersions(name, chart).stream().map(ChartVersionDto::from).toList();
+	}
+
+	@PostMapping("/{name}/charts/{chart}/pull")
+	@Operation(summary = "Pull a chart", description = "Download a chart from a repository")
+	public ResponseEntity<Void> pullChart(@Parameter(description = "Repository name") @PathVariable String name,
+			@Parameter(description = "Chart name") @PathVariable String chart, @RequestBody PullRequest request)
+			throws Exception {
+		if (request.getDestination() == null || request.getDestination().isBlank()) {
+			throw new IllegalArgumentException("destination is required");
+		}
+		this.repoManager.pull(chart, name, request.getVersion(), request.getDestination());
+		return ResponseEntity.ok().build();
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ChartVersionDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ChartVersionDto.java
@@ -1,0 +1,35 @@
+package org.alexmond.jhelm.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import org.alexmond.jhelm.core.service.RepoManager;
+
+@Data
+@Builder
+@Schema(description = "Available chart version in a repository")
+public class ChartVersionDto {
+
+	@Schema(description = "Chart name", example = "nginx")
+	private String name;
+
+	@Schema(description = "Chart version", example = "1.0.0")
+	private String chartVersion;
+
+	@Schema(description = "Application version", example = "1.25")
+	private String appVersion;
+
+	@Schema(description = "Chart description")
+	private String description;
+
+	public static ChartVersionDto from(RepoManager.ChartVersion cv) {
+		return ChartVersionDto.builder()
+			.name(cv.getName())
+			.chartVersion(cv.getChartVersion())
+			.appVersion(cv.getAppVersion())
+			.description(cv.getDescription())
+			.build();
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/DependencyResolveRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/DependencyResolveRequest.java
@@ -1,0 +1,14 @@
+package org.alexmond.jhelm.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "Request to resolve or download chart dependencies")
+public class DependencyResolveRequest {
+
+	@Schema(description = "Path to the chart directory", example = "/tmp/my-chart",
+			requiredMode = Schema.RequiredMode.REQUIRED)
+	private String chartPath;
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/HubSearchResultDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/HubSearchResultDto.java
@@ -1,0 +1,47 @@
+package org.alexmond.jhelm.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import org.alexmond.jhelm.core.action.SearchHubAction;
+
+@Data
+@Builder
+@Schema(description = "ArtifactHub search result")
+public class HubSearchResultDto {
+
+	@Schema(description = "Chart name", example = "nginx")
+	private String name;
+
+	@Schema(description = "Chart description")
+	private String description;
+
+	@Schema(description = "Chart version", example = "1.0.0")
+	private String version;
+
+	@Schema(description = "Application version", example = "1.25")
+	private String appVersion;
+
+	@Schema(description = "Repository URL", example = "https://charts.bitnami.com/bitnami")
+	private String repoUrl;
+
+	@Schema(description = "Repository name", example = "bitnami")
+	private String repoName;
+
+	@Schema(description = "ArtifactHub URL")
+	private String url;
+
+	public static HubSearchResultDto from(SearchHubAction.HubResult result) {
+		return HubSearchResultDto.builder()
+			.name(result.getName())
+			.description(result.getDescription())
+			.version(result.getVersion())
+			.appVersion(result.getAppVersion())
+			.repoUrl(result.getRepoUrl())
+			.repoName(result.getRepoName())
+			.url(result.getUrl())
+			.build();
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/PullRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/PullRequest.java
@@ -1,0 +1,16 @@
+package org.alexmond.jhelm.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "Request to pull a chart from a repository")
+public class PullRequest {
+
+	@Schema(description = "Chart version to pull", example = "1.0.0")
+	private String version;
+
+	@Schema(description = "Destination directory", example = "/tmp/charts", requiredMode = Schema.RequiredMode.REQUIRED)
+	private String destination;
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RepoAddRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RepoAddRequest.java
@@ -1,0 +1,17 @@
+package org.alexmond.jhelm.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "Request to add a chart repository")
+public class RepoAddRequest {
+
+	@Schema(description = "Repository name", example = "bitnami", requiredMode = Schema.RequiredMode.REQUIRED)
+	private String name;
+
+	@Schema(description = "Repository URL", example = "https://charts.bitnami.com/bitnami",
+			requiredMode = Schema.RequiredMode.REQUIRED)
+	private String url;
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RepoDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RepoDto.java
@@ -1,0 +1,24 @@
+package org.alexmond.jhelm.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import org.alexmond.jhelm.core.model.RepositoryConfig;
+
+@Data
+@Builder
+@Schema(description = "Chart repository")
+public class RepoDto {
+
+	@Schema(description = "Repository name", example = "bitnami")
+	private String name;
+
+	@Schema(description = "Repository URL", example = "https://charts.bitnami.com/bitnami")
+	private String url;
+
+	public static RepoDto from(RepositoryConfig.Repository repo) {
+		return RepoDto.builder().name(repo.getName()).url(repo.getUrl()).build();
+	}
+
+}

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/DependencyControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/DependencyControllerTest.java
@@ -1,0 +1,51 @@
+package org.alexmond.jhelm.rest.controller;
+
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.DependencyResolver;
+import org.alexmond.jhelm.rest.JhelmRestExceptionHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = DependencyController.class)
+@Import(JhelmRestExceptionHandler.class)
+class DependencyControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private DependencyResolver dependencyResolver;
+
+	@MockitoBean
+	private ChartLoader chartLoader;
+
+	@Test
+	void resolveRejectsMissingChartPath() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/dependencies/resolve").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("{}"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("chartPath is required"));
+	}
+
+	@Test
+	void downloadRejectsMissingChartPath() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/dependencies/download").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("{}"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("chartPath is required"));
+	}
+
+}

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/HubControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/HubControllerTest.java
@@ -1,0 +1,57 @@
+package org.alexmond.jhelm.rest.controller;
+
+import java.util.List;
+
+import org.alexmond.jhelm.core.action.SearchHubAction;
+import org.alexmond.jhelm.rest.JhelmRestExceptionHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = HubController.class)
+@Import(JhelmRestExceptionHandler.class)
+class HubControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private SearchHubAction searchHubAction;
+
+	@Test
+	void searchReturnsResults() throws Exception {
+		SearchHubAction.HubResult result = new SearchHubAction.HubResult();
+		result.setName("nginx");
+		result.setVersion("1.0.0");
+		result.setRepoName("bitnami");
+		result.setRepoUrl("https://charts.bitnami.com/bitnami");
+		when(this.searchHubAction.search("nginx", 20)).thenReturn(List.of(result));
+
+		this.mockMvc.perform(get("/api/v1/hub/search").param("keyword", "nginx").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].name").value("nginx"))
+			.andExpect(jsonPath("$[0].version").value("1.0.0"));
+	}
+
+	@Test
+	void searchWithCustomMaxResults() throws Exception {
+		when(this.searchHubAction.search("redis", 5)).thenReturn(List.of());
+
+		this.mockMvc
+			.perform(get("/api/v1/hub/search").param("keyword", "redis")
+				.param("maxResults", "5")
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$").isArray());
+	}
+
+}

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/RepoControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/RepoControllerTest.java
@@ -1,0 +1,109 @@
+package org.alexmond.jhelm.rest.controller;
+
+import java.util.List;
+
+import org.alexmond.jhelm.core.model.RepositoryConfig;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.rest.JhelmRestExceptionHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = RepoController.class)
+@Import(JhelmRestExceptionHandler.class)
+class RepoControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private RepoManager repoManager;
+
+	@Test
+	void addRepo() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/repos").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"name": "bitnami", "url": "https://charts.bitnami.com/bitnami"}
+						"""))
+			.andExpect(status().isCreated());
+		verify(this.repoManager).addRepo("bitnami", "https://charts.bitnami.com/bitnami");
+	}
+
+	@Test
+	void addRepoRejectsMissingName() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/repos").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"url": "https://charts.bitnami.com/bitnami"}
+						"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("name is required"));
+	}
+
+	@Test
+	void listRepos() throws Exception {
+		RepositoryConfig config = new RepositoryConfig();
+		RepositoryConfig.Repository repo = new RepositoryConfig.Repository();
+		repo.setName("bitnami");
+		repo.setUrl("https://charts.bitnami.com/bitnami");
+		config.setRepositories(List.of(repo));
+		when(this.repoManager.loadConfig()).thenReturn(config);
+
+		this.mockMvc.perform(get("/api/v1/repos").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].name").value("bitnami"))
+			.andExpect(jsonPath("$[0].url").value("https://charts.bitnami.com/bitnami"));
+	}
+
+	@Test
+	void removeRepo() throws Exception {
+		this.mockMvc.perform(delete("/api/v1/repos/bitnami").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNoContent());
+		verify(this.repoManager).removeRepo("bitnami");
+	}
+
+	@Test
+	void updateRepo() throws Exception {
+		this.mockMvc.perform(post("/api/v1/repos/bitnami/update").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk());
+		verify(this.repoManager).updateRepo("bitnami");
+	}
+
+	@Test
+	void listVersions() throws Exception {
+		RepoManager.ChartVersion cv = new RepoManager.ChartVersion("nginx", "1.0.0", "1.25", null);
+		when(this.repoManager.getChartVersions("bitnami", "nginx")).thenReturn(List.of(cv));
+
+		this.mockMvc.perform(get("/api/v1/repos/bitnami/charts/nginx/versions").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].chartVersion").value("1.0.0"));
+	}
+
+	@Test
+	void pullChart() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/repos/bitnami/charts/nginx/pull").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"version": "1.0.0", "destination": "/tmp/charts"}
+						"""))
+			.andExpect(status().isOk());
+		verify(this.repoManager).pull("nginx", "bitnami", "1.0.0", "/tmp/charts");
+	}
+
+}


### PR DESCRIPTION
## Summary
- **RepoController**: 6 endpoints for repository management (add, list, remove, update, list versions, pull chart)
- **HubController**: search ArtifactHub for charts
- **DependencyController**: resolve and download chart dependencies
- DTOs with OpenAPI `@Schema` annotations
- Auto-configuration bean registrations in `JhelmRestAutoConfiguration`
- 11 new controller tests using `@WebMvcTest`

## Test plan
- [x] Run `./mvnw test -pl jhelm-rest` — 44 tests pass
- [x] Run `./mvnw validate -pl jhelm-rest` — 0 PMD/checkstyle violations

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)