### PR TITLE
Fix shallow merge bug and add multi-value-file tests

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/GetAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/GetAction.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.core.util.ValuesLoader;
 
 @RequiredArgsConstructor
 public class GetAction {
@@ -33,7 +34,7 @@ public class GetAction {
 		if (all && release.getChart() != null && release.getChart().getValues() != null) {
 			Map<String, Object> merged = new LinkedHashMap<>(release.getChart().getValues());
 			if (release.getConfig() != null && release.getConfig().getValues() != null) {
-				merged.putAll(release.getConfig().getValues());
+				ValuesLoader.deepMerge(merged, release.getConfig().getValues());
 			}
 			return toYaml(merged);
 		}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -18,6 +18,7 @@ import org.alexmond.jhelm.core.service.LifecycleListener;
 import org.alexmond.jhelm.core.service.PostRenderProcessor;
 import org.alexmond.jhelm.core.util.HookExecutor;
 import org.alexmond.jhelm.core.util.HookParser;
+import org.alexmond.jhelm.core.util.ValuesLoader;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -41,7 +42,7 @@ public class InstallAction {
 		}
 		Map<String, Object> values = new HashMap<>(chart.getValues());
 		if (overrideValues != null) {
-			values.putAll(overrideValues);
+			ValuesLoader.deepMerge(values, overrideValues);
 		}
 
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/LintAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/LintAction.java
@@ -14,6 +14,7 @@ import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.SchemaValidator;
+import org.alexmond.jhelm.core.util.ValuesLoader;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -79,7 +80,7 @@ public class LintAction {
 		}
 		Map<String, Object> values = new HashMap<>(chart.getValues());
 		if (overrideValues != null) {
-			values.putAll(overrideValues);
+			ValuesLoader.deepMerge(values, overrideValues);
 		}
 		try {
 			schemaValidator.validate(chart.getMetadata().getName(), chart.getValuesSchema(), values);
@@ -97,7 +98,7 @@ public class LintAction {
 		}
 		Map<String, Object> values = new HashMap<>(chart.getValues());
 		if (overrideValues != null) {
-			values.putAll(overrideValues);
+			ValuesLoader.deepMerge(values, overrideValues);
 		}
 
 		Map<String, Object> releaseData = new HashMap<>();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -18,6 +18,7 @@ import org.alexmond.jhelm.core.service.LifecycleListener;
 import org.alexmond.jhelm.core.service.PostRenderProcessor;
 import org.alexmond.jhelm.core.util.HookExecutor;
 import org.alexmond.jhelm.core.util.HookParser;
+import org.alexmond.jhelm.core.util.ValuesLoader;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -41,7 +42,7 @@ public class UpgradeAction {
 		}
 		Map<String, Object> values = new HashMap<>(newChart.getValues());
 		if (overrideValues != null) {
-			values.putAll(overrideValues);
+			ValuesLoader.deepMerge(values, overrideValues);
 		}
 
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesOverridesTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesOverridesTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ValuesOverridesTest {
@@ -133,6 +134,131 @@ class ValuesOverridesTest {
 	void testNullInputs() throws Exception {
 		Map<String, Object> result = ValuesOverrides.parse(null, null);
 		assertTrue(result.isEmpty());
+	}
+
+	// --- deep merge across files ---
+
+	@Test
+	void testDeepMergeAcrossFiles() throws Exception {
+		Path f1 = writeFile("base.yaml", """
+				db:
+				  host: localhost
+				  port: 5432
+				  name: mydb
+				""");
+		Path f2 = writeFile("override.yaml", """
+				db:
+				  port: 5433
+				  ssl: true
+				""");
+		Map<String, Object> result = ValuesOverrides.parse(List.of(f1.toString(), f2.toString()), null);
+		Map<?, ?> db = (Map<?, ?>) result.get("db");
+		assertEquals("localhost", db.get("host"));
+		assertEquals(5433, db.get("port"));
+		assertEquals("mydb", db.get("name"));
+		assertEquals(true, db.get("ssl"));
+	}
+
+	@Test
+	void testThreeFilesCascadeOrder() throws Exception {
+		Path f1 = writeFile("defaults.yaml", """
+				replicas: 1
+				image: nginx
+				tag: latest
+				""");
+		Path f2 = writeFile("staging.yaml", """
+				replicas: 2
+				tag: staging
+				""");
+		Path f3 = writeFile("custom.yaml", """
+				replicas: 5
+				""");
+		Map<String, Object> result = ValuesOverrides.parse(List.of(f1.toString(), f2.toString(), f3.toString()), null);
+		assertEquals(5, result.get("replicas"));
+		assertEquals("nginx", result.get("image"));
+		assertEquals("staging", result.get("tag"));
+	}
+
+	@Test
+	void testSetOverridesAllFiles() throws Exception {
+		Path f1 = writeFile("base.yaml", """
+				replicas: 1
+				image: nginx
+				""");
+		Path f2 = writeFile("prod.yaml", """
+				replicas: 3
+				""");
+		Map<String, Object> result = ValuesOverrides.parse(List.of(f1.toString(), f2.toString()),
+				List.of("replicas=10"));
+		assertEquals("10", result.get("replicas"));
+		assertEquals("nginx", result.get("image"));
+	}
+
+	@Test
+	void testEmptyFileDoesNotClearValues() throws Exception {
+		Path f1 = writeFile("base.yaml", """
+				replicas: 3
+				image: nginx
+				""");
+		Path f2 = writeFile("empty.yaml", "");
+		Map<String, Object> result = ValuesOverrides.parse(List.of(f1.toString(), f2.toString()), null);
+		assertEquals(3, result.get("replicas"));
+		assertEquals("nginx", result.get("image"));
+	}
+
+	@Test
+	void testNullValueRemovesKey() throws Exception {
+		Path f1 = writeFile("base.yaml", """
+				key1: value1
+				key2: value2
+				""");
+		Path f2 = writeFile("nullify.yaml", """
+				key1: null
+				""");
+		Map<String, Object> result = ValuesOverrides.parse(List.of(f1.toString(), f2.toString()), null);
+		assertNull(result.get("key1"));
+		assertEquals("value2", result.get("key2"));
+	}
+
+	@Test
+	void testSetOverridesNestedFileValues() throws Exception {
+		Path f1 = writeFile("base.yaml", """
+				db:
+				  host: localhost
+				  port: 5432
+				""");
+		Map<String, Object> result = ValuesOverrides.parse(List.of(f1.toString()), List.of("db.host=remotehost"));
+		Map<?, ?> db = (Map<?, ?>) result.get("db");
+		assertEquals("remotehost", db.get("host"));
+		assertEquals(5432, db.get("port"));
+	}
+
+	@Test
+	void testConflictingTypesMapVsScalar() throws Exception {
+		Path f1 = writeFile("base.yaml", """
+				config:
+				  key1: value1
+				  key2: value2
+				""");
+		Path f2 = writeFile("override.yaml", """
+				config: simple-string
+				""");
+		Map<String, Object> result = ValuesOverrides.parse(List.of(f1.toString(), f2.toString()), null);
+		assertEquals("simple-string", result.get("config"));
+	}
+
+	@Test
+	void testScalarToMapConversion() throws Exception {
+		Path f1 = writeFile("base.yaml", """
+				config: simple-string
+				""");
+		Path f2 = writeFile("override.yaml", """
+				config:
+				  key1: value1
+				""");
+		Map<String, Object> result = ValuesOverrides.parse(List.of(f1.toString(), f2.toString()), null);
+		Map<?, ?> config = (Map<?, ?>) result.get("config");
+		assertEquals("value1", config.get("key1"));
 	}
 
 	// --- helpers ---


### PR DESCRIPTION
## Summary
- **Bug fix**: `InstallAction`, `UpgradeAction`, `LintAction`, and `GetAction` used `putAll()` (shallow merge) instead of `deepMerge()` — nested override values were being replaced instead of properly merged
- **Tests**: 8 new test cases covering multi-file cascade ordering, deep merge across files, empty files, null values, conflicting types (map vs scalar), and `--set` override priority

## Test plan
- [x] Run `./mvnw test -pl jhelm-core` — 499 tests pass
- [x] Run `./mvnw validate -pl jhelm-core` — 0 PMD/checkstyle violations

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)