### PR TITLE
Add jhelm-rest-sample module with Swagger UI

### DIFF
--- a/jhelm-rest-sample/pom.xml
+++ b/jhelm-rest-sample/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.alexmond</groupId>
+		<artifactId>jhelm-parent</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+	<artifactId>jhelm-rest-sample</artifactId>
+	<name>jhelm-rest-sample</name>
+	<description>Sample Spring Boot application with jhelm REST API and Swagger UI</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.alexmond</groupId>
+			<artifactId>jhelm-rest</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/jhelm-rest-sample/src/main/java/org/alexmond/jhelm/rest/sample/JhelmRestSampleApplication.java
+++ b/jhelm-rest-sample/src/main/java/org/alexmond/jhelm/rest/sample/JhelmRestSampleApplication.java
@@ -1,0 +1,14 @@
+package org.alexmond.jhelm.rest.sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+@SuppressWarnings("PMD.UseUtilityClass")
+public class JhelmRestSampleApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(JhelmRestSampleApplication.class, args);
+	}
+
+}

--- a/jhelm-rest-sample/src/main/resources/application.yaml
+++ b/jhelm-rest-sample/src/main/resources/application.yaml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name: jhelm-rest-sample
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  api-docs:
+    path: /v3/api-docs
+
+jhelm:
+  rest:
+    base-path: /api/v1

--- a/jhelm-rest-sample/src/test/java/org/alexmond/jhelm/rest/sample/JhelmRestSampleApplicationTest.java
+++ b/jhelm-rest-sample/src/test/java/org/alexmond/jhelm/rest/sample/JhelmRestSampleApplicationTest.java
@@ -1,0 +1,21 @@
+package org.alexmond.jhelm.rest.sample;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+class JhelmRestSampleApplicationTest {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Test
+	void contextLoads() {
+		assertNotNull(context);
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <commons-compress.version>1.26.1</commons-compress.version>
         <chicory.version>1.7.2</chicory.version>
         <swagger-annotations.version>2.2.34</swagger-annotations.version>
+        <springdoc-openapi.version>3.0.2</springdoc-openapi.version>
         <spring-retry.version>2.0.12</spring-retry.version>
 
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
@@ -74,6 +75,7 @@
         <module>jhelm-plugin</module>
         <module>jhelm-app</module>
         <module>jhelm-sample</module>
+        <module>jhelm-rest-sample</module>
     </modules>
 
     <dependencyManagement>
@@ -171,6 +173,11 @@
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-annotations</artifactId>
                 <version>${swagger-annotations.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springdoc</groupId>
+                <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                <version>${springdoc-openapi.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary
- New `jhelm-rest-sample` Maven module demonstrating the jhelm REST API starter
- Includes `springdoc-openapi-starter-webmvc-ui` 3.0.2 for Swagger UI
- Swagger UI available at `/swagger-ui.html` with all jhelm REST endpoints
- Smoke test verifies Spring context loads correctly
- Root pom updated with `springdoc-openapi` dependency management

## Test plan
- [x] Run `./mvnw test -pl jhelm-rest-sample` — context loads test passes
- [x] Run `./mvnw validate -pl jhelm-rest-sample` — 0 violations

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)