### PR TITLE
Simplify dependency endpoints: remove download, use chartRef for resolve (#281)

### DIFF
--- a/docs/modules/ROOT/pages/rest-api.adoc
+++ b/docs/modules/ROOT/pages/rest-api.adoc
@@ -89,7 +89,7 @@ jhelm:
 
 | `DependencyController`
 | `DependencyResolver` present
-| 2 dependency management endpoints
+| 1 dependency management endpoint
 |===
 
 NOTE: Release endpoints require `jhelm-kube` on the classpath (Kubernetes client). All other endpoints work with `jhelm-core` alone.
@@ -452,11 +452,7 @@ NOTE: ArtifactHub API limits `maxResults` to 60 per request.
 
 | `POST`
 | `/dependencies/resolve`
-| Resolve dependency versions and return Chart.lock YAML
-
-| `POST`
-| `/dependencies/download`
-| Download resolved dependencies and return as .tgz download
+| Resolve dependency versions from a chart reference and return Chart.lock YAML
 |===
 
 ==== Resolve Dependencies
@@ -465,7 +461,7 @@ NOTE: ArtifactHub API limits `maxResults` to 60 per request.
 ----
 curl -X POST http://localhost:8080/api/v1/dependencies/resolve \
   -H 'Content-Type: application/json' \
-  -d '{"chartPath": "/path/to/my-chart"}'
+  -d '{"chartRef": "bitnami/nginx", "version": "18.3.1"}'
 ----
 
 Response: YAML content with `Content-Type: text/yaml`:
@@ -480,18 +476,6 @@ digest: "sha256:..."
 generated: "2026-03-08T..."
 ----
 
-==== Download Dependencies
-
-[source,bash]
-----
-curl -X POST http://localhost:8080/api/v1/dependencies/download \
-  -H 'Content-Type: application/json' \
-  -o dependencies.tgz \
-  -d '{"chartPath": "/path/to/my-chart"}'
-----
-
-Response: binary `.tgz` download with `Content-Type: application/gzip`.
-
 == Error Handling
 
 All endpoints return consistent error responses via `JhelmRestExceptionHandler`:
@@ -503,7 +487,7 @@ Error response format:
 
 [source,json]
 ----
-{"message": "chartPath is required"}
+{"message": "chartRef is required"}
 ----
 
 == Spring Boot Integration

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -95,8 +95,8 @@ public class JhelmRestAutoConfiguration {
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(DependencyResolver.class)
 	public DependencyController dependencyController(DependencyResolver dependencyResolver, ChartLoader chartLoader,
-			JhelmRestProperties properties) {
-		return new DependencyController(dependencyResolver, chartLoader, properties);
+			RepoManager repoManager, JhelmRestProperties properties) {
+		return new DependencyController(dependencyResolver, chartLoader, repoManager, properties);
 	}
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/DependencyController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/DependencyController.java
@@ -1,6 +1,8 @@
 package org.alexmond.jhelm.rest.controller;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -11,11 +13,10 @@ import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartLock;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.DependencyResolver;
+import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
 import org.alexmond.jhelm.rest.dto.DependencyResolveRequest;
-import org.alexmond.jhelm.rest.util.ChartArchiveUtil;
 import org.alexmond.jhelm.rest.util.TempDir;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,55 +29,43 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Dependencies", description = "Manage chart dependencies")
 public class DependencyController {
 
-	private static final MediaType APPLICATION_GZIP = MediaType.parseMediaType("application/gzip");
-
 	private static final MediaType TEXT_YAML = MediaType.parseMediaType("text/yaml");
 
 	private final DependencyResolver dependencyResolver;
 
 	private final ChartLoader chartLoader;
 
+	private final RepoManager repoManager;
+
 	private final JhelmRestProperties properties;
 
-	public DependencyController(DependencyResolver dependencyResolver, ChartLoader chartLoader,
+	public DependencyController(DependencyResolver dependencyResolver, ChartLoader chartLoader, RepoManager repoManager,
 			JhelmRestProperties properties) {
 		this.dependencyResolver = dependencyResolver;
 		this.chartLoader = chartLoader;
+		this.repoManager = repoManager;
 		this.properties = properties;
 	}
 
 	@PostMapping("/resolve")
 	@Operation(summary = "Resolve dependencies",
-			description = "Resolve chart dependency versions and return the Chart.lock content")
+			description = "Resolve chart dependency versions from a repository chart reference and return the Chart.lock content")
 	public ResponseEntity<String> resolve(@RequestBody DependencyResolveRequest request) throws Exception {
-		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
-			throw new IllegalArgumentException("chartPath is required");
+		if (request.getChartRef() == null || request.getChartRef().isBlank()) {
+			throw new IllegalArgumentException("chartRef is required");
 		}
-		Chart chart = this.chartLoader.load(new File(request.getChartPath()));
-		Map<String, Object> values = (chart.getValues() != null) ? chart.getValues() : Map.of();
-		ChartLock lock = this.dependencyResolver.resolveDependencies(chart.getMetadata(), values, List.of());
-		return ResponseEntity.ok().contentType(TEXT_YAML).body(lock.toYaml());
+		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-dep-resolve-")) {
+			this.repoManager.pull(request.getChartRef(), request.getVersion(), tempDir.path().toString());
+			Chart chart = this.chartLoader.load(findChartDir(tempDir.path()).toFile());
+			Map<String, Object> values = (chart.getValues() != null) ? chart.getValues() : Map.of();
+			ChartLock lock = this.dependencyResolver.resolveDependencies(chart.getMetadata(), values, List.of());
+			return ResponseEntity.ok().contentType(TEXT_YAML).body(lock.toYaml());
+		}
 	}
 
-	@PostMapping("/download")
-	@Operation(summary = "Download dependencies",
-			description = "Download resolved chart dependencies and return them as a .tgz archive")
-	public ResponseEntity<byte[]> download(@RequestBody DependencyResolveRequest request) throws Exception {
-		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
-			throw new IllegalArgumentException("chartPath is required");
-		}
-		File chartDir = new File(request.getChartPath());
-		ChartLock lock = ChartLock.fromFile(chartDir);
-		if (lock == null) {
-			throw new IllegalArgumentException("No Chart.lock found. Run resolve first.");
-		}
-		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-dep-download-")) {
-			this.dependencyResolver.downloadDependencies(tempDir.path().toFile(), lock.getDependencies());
-			byte[] tgz = ChartArchiveUtil.toTgzBytes(tempDir.path(), "dependencies");
-			return ResponseEntity.ok()
-				.contentType(APPLICATION_GZIP)
-				.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"dependencies.tgz\"")
-				.body(tgz);
+	private static Path findChartDir(Path parent) throws IOException {
+		try (var stream = Files.list(parent)) {
+			return stream.filter(Files::isDirectory).findFirst().orElse(parent);
 		}
 	}
 

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/DependencyResolveRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/DependencyResolveRequest.java
@@ -4,11 +4,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
-@Schema(description = "Request to resolve or download chart dependencies")
+@Schema(description = "Request to resolve chart dependencies")
 public class DependencyResolveRequest {
 
-	@Schema(description = "Path to the chart directory", example = "/tmp/my-chart",
+	@Schema(description = "Chart reference: repo/chart or oci://...", example = "bitnami/nginx",
 			requiredMode = Schema.RequiredMode.REQUIRED)
-	private String chartPath;
+	private String chartRef;
+
+	@Schema(description = "Chart version", example = "18.3.1")
+	private String version;
 
 }

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/DependencyControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/DependencyControllerTest.java
@@ -1,6 +1,5 @@
 package org.alexmond.jhelm.rest.controller;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -11,10 +10,10 @@ import org.alexmond.jhelm.core.model.ChartLock;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.DependencyResolver;
+import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.rest.JhelmRestExceptionHandler;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -26,6 +25,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -48,21 +49,32 @@ class DependencyControllerTest {
 	@MockitoBean
 	private ChartLoader chartLoader;
 
+	@MockitoBean
+	private RepoManager repoManager;
+
 	@Test
-	void resolveRejectsMissingChartPath() throws Exception {
+	void resolveRejectsMissingChartRef() throws Exception {
 		this.mockMvc
 			.perform(post("/api/v1/dependencies/resolve").contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
 				.content("{}"))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("chartPath is required"));
+			.andExpect(jsonPath("$.message").value("chartRef is required"));
 	}
 
 	@Test
-	void resolveReturnsYamlContent(@TempDir Path tempChart) throws Exception {
+	void resolveWithChartRefReturnsYaml() throws Exception {
+		doAnswer((invocation) -> {
+			String destDir = invocation.getArgument(2);
+			Path chartDir = Path.of(destDir).resolve("nginx");
+			Files.createDirectories(chartDir);
+			Files.writeString(chartDir.resolve("Chart.yaml"), "name: nginx\nversion: 18.3.1");
+			return null;
+		}).when(this.repoManager).pull(eq("bitnami/nginx"), eq("18.3.1"), anyString());
+
 		ChartMetadata metadata = new ChartMetadata();
-		metadata.setName("my-chart");
-		metadata.setVersion("1.0.0");
+		metadata.setName("nginx");
+		metadata.setVersion("18.3.1");
 		Chart chart = new Chart();
 		chart.setMetadata(metadata);
 		chart.setValues(Map.of());
@@ -74,53 +86,15 @@ class DependencyControllerTest {
 			.build();
 		ChartLock lock = ChartLock.builder().dependencies(List.of(dep)).digest("sha256:abc").build();
 
-		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
+		when(this.chartLoader.load(any(java.io.File.class))).thenReturn(chart);
 		when(this.dependencyResolver.resolveDependencies(any(), anyMap(), anyList())).thenReturn(lock);
 
 		this.mockMvc.perform(post("/api/v1/dependencies/resolve").contentType(MediaType.APPLICATION_JSON).content("""
-				{"chartPath": "/tmp/my-chart"}
+				{"chartRef": "bitnami/nginx", "version": "18.3.1"}
 				"""))
 			.andExpect(status().isOk())
 			.andExpect(header().string("Content-Type", "text/yaml"))
 			.andExpect(content().string(org.hamcrest.Matchers.containsString("redis")));
-	}
-
-	@Test
-	void downloadRejectsMissingChartPath() throws Exception {
-		this.mockMvc
-			.perform(post("/api/v1/dependencies/download").contentType(MediaType.APPLICATION_JSON)
-				.accept(MediaType.APPLICATION_JSON)
-				.content("{}"))
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("chartPath is required"));
-	}
-
-	@Test
-	void downloadReturnsTgzArchive(@TempDir Path tempChart) throws Exception {
-		// Write a Chart.lock so the controller can read it
-		Files.writeString(tempChart.resolve("Chart.lock"), """
-				dependencies:
-				- name: redis
-				  version: "18.0.0"
-				  repository: "https://charts.bitnami.com/bitnami"
-				digest: "sha256:abc"
-				generated: "2026-03-08T00:00:00Z"
-				""");
-
-		doAnswer((invocation) -> {
-			File destDir = invocation.getArgument(0);
-			Path chartsDir = destDir.toPath().resolve("charts");
-			Files.createDirectories(chartsDir);
-			Files.writeString(chartsDir.resolve("redis-18.0.0.tgz"), "fake-dep");
-			return null;
-		}).when(this.dependencyResolver).downloadDependencies(any(File.class), anyList());
-
-		this.mockMvc.perform(post("/api/v1/dependencies/download").contentType(MediaType.APPLICATION_JSON).content("""
-				{"chartPath": "%s"}
-				""".formatted(tempChart.toString())))
-			.andExpect(status().isOk())
-			.andExpect(header().string("Content-Type", "application/gzip"))
-			.andExpect(header().string("Content-Disposition", "attachment; filename=\"dependencies.tgz\""));
 	}
 
 }


### PR DESCRIPTION
## Summary
- Remove `POST /dependencies/download` — no practical use case for a remote REST server
- Change `POST /dependencies/resolve` from `chartPath` (local filesystem) to `chartRef` + `version` (repo reference)
- Server pulls chart internally via `RepoManager.pull()`, loads it, resolves dependencies

## API change

```bash
# Before
curl -X POST /api/v1/dependencies/resolve \
  -d '{"chartPath": "/local/path/to/chart"}'

# After
curl -X POST /api/v1/dependencies/resolve \
  -d '{"chartRef": "bitnami/nginx", "version": "18.3.1"}'
```

## Test plan
- [x] `DependencyControllerTest` — updated: `resolveRejectsMissingChartRef`, `resolveWithChartRefReturnsYaml`
- [x] All 52 REST tests pass, PMD + checkstyle clean

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)