### PR TITLE
Enhance REST sample app with kube dependency and Swagger redirect

### DIFF
--- a/jhelm-rest-sample/pom.xml
+++ b/jhelm-rest-sample/pom.xml
@@ -17,6 +17,10 @@
 			<artifactId>jhelm-rest</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.alexmond</groupId>
+			<artifactId>jhelm-kube</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>

--- a/jhelm-rest-sample/src/main/resources/static/index.html
+++ b/jhelm-rest-sample/src/main/resources/static/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=/swagger-ui.html">
+    <title>jhelm REST API</title>
+</head>
+<body>
+    <p>Redirecting to <a href="/swagger-ui.html">Swagger UI</a>...</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `jhelm-kube` dependency to `jhelm-rest-sample` so all controllers (including `ReleaseController`) are auto-configured
- Add `static/index.html` that redirects to Swagger UI for convenience when opening the app root

## Test plan
- [ ] `./mvnw validate -pl jhelm-rest-sample` passes
- [ ] `./mvnw spring-boot:run -pl jhelm-rest-sample` starts and `http://localhost:8080/` redirects to Swagger UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)