### PR TITLE
Replace chartPath with chartRef for show endpoints

### DIFF
--- a/docs/modules/ROOT/pages/rest-api.adoc
+++ b/docs/modules/ROOT/pages/rest-api.adoc
@@ -76,7 +76,7 @@ jhelm:
 | 13 release management endpoints
 
 | `ChartController`
-| `TemplateAction` present
+| `TemplateAction` + `RepoManager` present
 | 8 chart operation endpoints
 
 | `RepoController`
@@ -214,23 +214,23 @@ curl -X POST http://localhost:8080/api/v1/releases/my-release/rollback?namespace
 | Scaffold a new chart and return as .tgz download
 
 | `GET`
-| `/charts/show?chartPath=...`
+| `/charts/show?chartRef=...&version=...`
 | Show all chart info (metadata, values, README)
 
 | `GET`
-| `/charts/show/values?chartPath=...`
+| `/charts/show/values?chartRef=...&version=...`
 | Show default values.yaml
 
 | `GET`
-| `/charts/show/readme?chartPath=...`
+| `/charts/show/readme?chartRef=...&version=...`
 | Show chart README
 
 | `GET`
-| `/charts/show/chart?chartPath=...`
+| `/charts/show/chart?chartRef=...&version=...`
 | Show Chart.yaml metadata
 
 | `GET`
-| `/charts/show/crds?chartPath=...`
+| `/charts/show/crds?chartRef=...&version=...`
 | Show Custom Resource Definitions
 |===
 

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -60,10 +60,10 @@ public class JhelmRestAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnBean(TemplateAction.class)
+	@ConditionalOnBean({ TemplateAction.class, RepoManager.class })
 	public ChartController chartController(TemplateAction templateAction, LintAction lintAction,
-			CreateAction createAction, ShowAction showAction, JhelmRestProperties properties) {
-		return new ChartController(templateAction, lintAction, createAction, showAction, properties);
+			CreateAction createAction, ShowAction showAction, RepoManager repoManager, JhelmRestProperties properties) {
+		return new ChartController(templateAction, lintAction, createAction, showAction, repoManager, properties);
 	}
 
 	@Bean

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.rest.controller;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -11,6 +13,7 @@ import org.alexmond.jhelm.core.action.CreateAction;
 import org.alexmond.jhelm.core.action.LintAction;
 import org.alexmond.jhelm.core.action.ShowAction;
 import org.alexmond.jhelm.core.action.TemplateAction;
+import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
 import org.alexmond.jhelm.rest.dto.CreateRequest;
 import org.alexmond.jhelm.rest.dto.LintRequest;
@@ -43,14 +46,17 @@ public class ChartController {
 
 	private final ShowAction showAction;
 
+	private final RepoManager repoManager;
+
 	private final JhelmRestProperties properties;
 
 	public ChartController(TemplateAction templateAction, LintAction lintAction, CreateAction createAction,
-			ShowAction showAction, JhelmRestProperties properties) {
+			ShowAction showAction, RepoManager repoManager, JhelmRestProperties properties) {
 		this.templateAction = templateAction;
 		this.lintAction = lintAction;
 		this.createAction = createAction;
 		this.showAction = showAction;
+		this.repoManager = repoManager;
 		this.properties = properties;
 	}
 
@@ -98,36 +104,63 @@ public class ChartController {
 	@GetMapping("/show")
 	@Operation(summary = "Show chart info", description = "Show all chart information: metadata, values, README, CRDs")
 	public ResponseEntity<String> showAll(
-			@Parameter(description = "Path to the chart directory") @RequestParam String chartPath) throws Exception {
-		return ResponseEntity.ok(this.showAction.showAll(chartPath));
+			@Parameter(description = "Chart reference (repo/chart or oci://...)") @RequestParam String chartRef,
+			@Parameter(description = "Chart version") @RequestParam(required = false) String version) throws Exception {
+		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-show-")) {
+			String chartPath = pullChart(chartRef, version, tempDir);
+			return ResponseEntity.ok(this.showAction.showAll(chartPath));
+		}
 	}
 
 	@GetMapping("/show/values")
 	@Operation(summary = "Show chart values", description = "Show the default values.yaml")
 	public ResponseEntity<String> showValues(
-			@Parameter(description = "Path to the chart directory") @RequestParam String chartPath) throws Exception {
-		return ResponseEntity.ok(this.showAction.showValues(chartPath));
+			@Parameter(description = "Chart reference (repo/chart or oci://...)") @RequestParam String chartRef,
+			@Parameter(description = "Chart version") @RequestParam(required = false) String version) throws Exception {
+		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-show-")) {
+			String chartPath = pullChart(chartRef, version, tempDir);
+			return ResponseEntity.ok(this.showAction.showValues(chartPath));
+		}
 	}
 
 	@GetMapping("/show/readme")
 	@Operation(summary = "Show chart README")
 	public ResponseEntity<String> showReadme(
-			@Parameter(description = "Path to the chart directory") @RequestParam String chartPath) throws Exception {
-		return ResponseEntity.ok(this.showAction.showReadme(chartPath));
+			@Parameter(description = "Chart reference (repo/chart or oci://...)") @RequestParam String chartRef,
+			@Parameter(description = "Chart version") @RequestParam(required = false) String version) throws Exception {
+		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-show-")) {
+			String chartPath = pullChart(chartRef, version, tempDir);
+			return ResponseEntity.ok(this.showAction.showReadme(chartPath));
+		}
 	}
 
 	@GetMapping("/show/chart")
 	@Operation(summary = "Show chart metadata", description = "Show the Chart.yaml metadata")
 	public ResponseEntity<String> showChart(
-			@Parameter(description = "Path to the chart directory") @RequestParam String chartPath) throws Exception {
-		return ResponseEntity.ok(this.showAction.showChart(chartPath));
+			@Parameter(description = "Chart reference (repo/chart or oci://...)") @RequestParam String chartRef,
+			@Parameter(description = "Chart version") @RequestParam(required = false) String version) throws Exception {
+		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-show-")) {
+			String chartPath = pullChart(chartRef, version, tempDir);
+			return ResponseEntity.ok(this.showAction.showChart(chartPath));
+		}
 	}
 
 	@GetMapping("/show/crds")
 	@Operation(summary = "Show chart CRDs", description = "Show Custom Resource Definitions bundled with the chart")
 	public ResponseEntity<String> showCrds(
-			@Parameter(description = "Path to the chart directory") @RequestParam String chartPath) throws Exception {
-		return ResponseEntity.ok(this.showAction.showCrds(chartPath));
+			@Parameter(description = "Chart reference (repo/chart or oci://...)") @RequestParam String chartRef,
+			@Parameter(description = "Chart version") @RequestParam(required = false) String version) throws Exception {
+		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-show-")) {
+			String chartPath = pullChart(chartRef, version, tempDir);
+			return ResponseEntity.ok(this.showAction.showCrds(chartPath));
+		}
+	}
+
+	private String pullChart(String chartRef, String version, TempDir tempDir) throws IOException {
+		this.repoManager.pull(chartRef, version, tempDir.path().toString());
+		try (var stream = Files.list(tempDir.path())) {
+			return stream.filter(Files::isDirectory).findFirst().orElse(tempDir.path()).toString();
+		}
 	}
 
 }

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ChartControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ChartControllerTest.java
@@ -8,6 +8,7 @@ import org.alexmond.jhelm.core.action.CreateAction;
 import org.alexmond.jhelm.core.action.LintAction;
 import org.alexmond.jhelm.core.action.ShowAction;
 import org.alexmond.jhelm.core.action.TemplateAction;
+import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.rest.JhelmRestExceptionHandler;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
@@ -50,6 +52,9 @@ class ChartControllerTest {
 
 	@MockitoBean
 	private ShowAction showAction;
+
+	@MockitoBean
+	private RepoManager repoManager;
 
 	@Test
 	void templateRendersManifest() throws Exception {
@@ -133,20 +138,25 @@ class ChartControllerTest {
 
 	@Test
 	void showAllReturnsChartInfo() throws Exception {
-		when(this.showAction.showAll("/tmp/nginx")).thenReturn("# Chart.yaml\nname: nginx");
+		stubPull();
+		when(this.showAction.showAll(anyString())).thenReturn("# Chart.yaml\nname: nginx");
 
 		this.mockMvc
-			.perform(get("/api/v1/charts/show").param("chartPath", "/tmp/nginx").accept(MediaType.APPLICATION_JSON))
+			.perform(get("/api/v1/charts/show").param("chartRef", "bitnami/nginx")
+				.param("version", "18.3.1")
+				.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(content().string("# Chart.yaml\nname: nginx"));
 	}
 
 	@Test
 	void showValuesReturnsValues() throws Exception {
-		when(this.showAction.showValues("/tmp/nginx")).thenReturn("replicas: 1");
+		stubPull();
+		when(this.showAction.showValues(anyString())).thenReturn("replicas: 1");
 
 		this.mockMvc
-			.perform(get("/api/v1/charts/show/values").param("chartPath", "/tmp/nginx")
+			.perform(get("/api/v1/charts/show/values").param("chartRef", "bitnami/nginx")
+				.param("version", "18.3.1")
 				.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(content().string("replicas: 1"));
@@ -154,10 +164,12 @@ class ChartControllerTest {
 
 	@Test
 	void showReadmeReturnsReadme() throws Exception {
-		when(this.showAction.showReadme("/tmp/nginx")).thenReturn("# Nginx Chart");
+		stubPull();
+		when(this.showAction.showReadme(anyString())).thenReturn("# Nginx Chart");
 
 		this.mockMvc
-			.perform(get("/api/v1/charts/show/readme").param("chartPath", "/tmp/nginx")
+			.perform(get("/api/v1/charts/show/readme").param("chartRef", "bitnami/nginx")
+				.param("version", "18.3.1")
 				.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(content().string("# Nginx Chart"));
@@ -165,10 +177,12 @@ class ChartControllerTest {
 
 	@Test
 	void showChartReturnsMetadata() throws Exception {
-		when(this.showAction.showChart("/tmp/nginx")).thenReturn("apiVersion: v2\nname: nginx");
+		stubPull();
+		when(this.showAction.showChart(anyString())).thenReturn("apiVersion: v2\nname: nginx");
 
 		this.mockMvc
-			.perform(get("/api/v1/charts/show/chart").param("chartPath", "/tmp/nginx")
+			.perform(get("/api/v1/charts/show/chart").param("chartRef", "bitnami/nginx")
+				.param("version", "18.3.1")
 				.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(content().string("apiVersion: v2\nname: nginx"));
@@ -176,13 +190,36 @@ class ChartControllerTest {
 
 	@Test
 	void showCrdsReturnsCrds() throws Exception {
-		when(this.showAction.showCrds("/tmp/nginx")).thenReturn("apiVersion: apiextensions.k8s.io/v1\nkind: CRD");
+		stubPull();
+		when(this.showAction.showCrds(anyString())).thenReturn("apiVersion: apiextensions.k8s.io/v1\nkind: CRD");
 
 		this.mockMvc
-			.perform(
-					get("/api/v1/charts/show/crds").param("chartPath", "/tmp/nginx").accept(MediaType.APPLICATION_JSON))
+			.perform(get("/api/v1/charts/show/crds").param("chartRef", "bitnami/nginx")
+				.param("version", "18.3.1")
+				.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(content().string("apiVersion: apiextensions.k8s.io/v1\nkind: CRD"));
+	}
+
+	@Test
+	void showWithoutVersionPulls() throws Exception {
+		stubPull();
+		when(this.showAction.showAll(anyString())).thenReturn("name: nginx");
+
+		this.mockMvc
+			.perform(get("/api/v1/charts/show").param("chartRef", "bitnami/nginx").accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string("name: nginx"));
+	}
+
+	private void stubPull() throws Exception {
+		doAnswer((invocation) -> {
+			String destDir = invocation.getArgument(2);
+			Path chartDir = Path.of(destDir).resolve("nginx");
+			Files.createDirectories(chartDir);
+			Files.writeString(chartDir.resolve("Chart.yaml"), "name: nginx\nversion: 18.3.1");
+			return null;
+		}).when(this.repoManager).pull(anyString(), any(), anyString());
 	}
 
 }


### PR DESCRIPTION
## Summary
- Show endpoints (`/charts/show*`) now accept `chartRef` + `version` query params instead of a local `chartPath`
- Controller pulls the chart via `RepoManager` into a server-managed temp dir, runs `ShowAction`, then cleans up
- `ChartController` now requires `RepoManager` (updated auto-configuration condition)
- Added test for version-optional show request

Closes #287

## Test plan
- [x] `./mvnw validate -pl jhelm-rest` — checkstyle/PMD pass
- [x] `./mvnw test -pl jhelm-rest` — 48 tests pass (all show tests updated for chartRef)

🤖 Generated with [Claude Code](https://claude.com/claude-code)