### PR TITLE
Replace chartPath with chartRef for release endpoints and add upload support

### DIFF
--- a/docs/modules/ROOT/pages/rest-api.adoc
+++ b/docs/modules/ROOT/pages/rest-api.adoc
@@ -72,8 +72,8 @@ jhelm:
 | Controller | Condition | Endpoints
 
 | `ReleaseController`
-| `ListAction` + `InstallAction` present (requires `jhelm-kube`)
-| 13 release management endpoints
+| `ListAction` + `InstallAction` + `RepoManager` present (requires `jhelm-kube`)
+| 15 release management endpoints
 
 | `ChartController`
 | `TemplateAction` + `RepoManager` present
@@ -112,11 +112,19 @@ NOTE: Release endpoints require `jhelm-kube` on the classpath (Kubernetes client
 
 | `POST`
 | `/releases`
-| Install a new release
+| Install a release from a chart reference
+
+| `POST`
+| `/releases/upload`
+| Install a release from an uploaded .tgz archive (multipart)
 
 | `PUT`
 | `/releases/{name}?namespace=default`
-| Upgrade an existing release
+| Upgrade a release from a chart reference
+
+| `POST`
+| `/releases/{name}/upgrade/upload?namespace=default`
+| Upgrade a release from an uploaded .tgz archive (multipart)
 
 | `DELETE`
 | `/releases/{name}?namespace=default`
@@ -157,12 +165,15 @@ NOTE: Release endpoints require `jhelm-kube` on the classpath (Kubernetes client
 
 ==== Install a Release
 
+From a chart reference:
+
 [source,bash]
 ----
 curl -X POST http://localhost:8080/api/v1/releases \
   -H 'Content-Type: application/json' \
   -d '{
-    "chartPath": "/path/to/my-chart",
+    "chartRef": "bitnami/nginx",
+    "version": "18.3.1",
     "releaseName": "my-release",
     "namespace": "production",
     "values": {
@@ -173,17 +184,38 @@ curl -X POST http://localhost:8080/api/v1/releases \
   }'
 ----
 
+From an uploaded .tgz archive:
+
+[source,bash]
+----
+curl -X POST http://localhost:8080/api/v1/releases/upload \
+  -F 'chart=@nginx-18.3.1.tgz;type=application/gzip' \
+  -F 'request={"releaseName": "my-release", "namespace": "production"};type=application/json'
+----
+
 ==== Upgrade a Release
+
+From a chart reference:
 
 [source,bash]
 ----
 curl -X PUT http://localhost:8080/api/v1/releases/my-release?namespace=production \
   -H 'Content-Type: application/json' \
   -d '{
-    "chartPath": "/path/to/chart-v2",
+    "chartRef": "bitnami/nginx",
+    "version": "19.0.0",
     "values": {"image": {"tag": "v2.1"}},
     "dryRun": false
   }'
+----
+
+From an uploaded .tgz archive:
+
+[source,bash]
+----
+curl -X POST http://localhost:8080/api/v1/releases/my-release/upgrade/upload?namespace=production \
+  -F 'chart=@nginx-19.0.0.tgz;type=application/gzip' \
+  -F 'request={"values": {"image": {"tag": "v2.1"}}};type=application/json'
 ----
 
 ==== Rollback a Release

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -49,13 +49,13 @@ public class JhelmRestAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnBean({ ListAction.class, InstallAction.class })
+	@ConditionalOnBean({ ListAction.class, InstallAction.class, RepoManager.class })
 	public ReleaseController releaseController(ListAction listAction, StatusAction statusAction, GetAction getAction,
 			HistoryAction historyAction, InstallAction installAction, UpgradeAction upgradeAction,
 			UninstallAction uninstallAction, RollbackAction rollbackAction, TestAction testAction,
-			ChartLoader chartLoader) {
+			ChartLoader chartLoader, RepoManager repoManager, JhelmRestProperties properties) {
 		return new ReleaseController(listAction, statusAction, getAction, historyAction, installAction, upgradeAction,
-				uninstallAction, rollbackAction, testAction, chartLoader);
+				uninstallAction, rollbackAction, testAction, chartLoader, repoManager, properties);
 	}
 
 	@Bean

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
@@ -1,6 +1,5 @@
 package org.alexmond.jhelm.rest.controller;
 
-import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -22,15 +21,22 @@ import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.core.util.HookParser;
+import org.alexmond.jhelm.rest.config.JhelmRestProperties;
 import org.alexmond.jhelm.rest.dto.HelmHookDto;
 import org.alexmond.jhelm.rest.dto.InstallRequest;
+import org.alexmond.jhelm.rest.dto.InstallUploadRequest;
 import org.alexmond.jhelm.rest.dto.ReleaseDto;
 import org.alexmond.jhelm.rest.dto.ResourceStatusDto;
 import org.alexmond.jhelm.rest.dto.RollbackRequest;
 import org.alexmond.jhelm.rest.dto.TestResultDto;
 import org.alexmond.jhelm.rest.dto.UpgradeRequest;
+import org.alexmond.jhelm.rest.dto.UpgradeUploadRequest;
+import org.alexmond.jhelm.rest.util.ChartSourceResolver;
+import org.alexmond.jhelm.rest.util.TempDir;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,7 +46,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("${jhelm.rest.base-path:/api/v1}/releases")
@@ -67,10 +75,14 @@ public class ReleaseController {
 
 	private final ChartLoader chartLoader;
 
+	private final RepoManager repoManager;
+
+	private final JhelmRestProperties properties;
+
 	public ReleaseController(ListAction listAction, StatusAction statusAction, GetAction getAction,
 			HistoryAction historyAction, InstallAction installAction, UpgradeAction upgradeAction,
 			UninstallAction uninstallAction, RollbackAction rollbackAction, TestAction testAction,
-			ChartLoader chartLoader) {
+			ChartLoader chartLoader, RepoManager repoManager, JhelmRestProperties properties) {
 		this.listAction = listAction;
 		this.statusAction = statusAction;
 		this.getAction = getAction;
@@ -81,6 +93,8 @@ public class ReleaseController {
 		this.rollbackAction = rollbackAction;
 		this.testAction = testAction;
 		this.chartLoader = chartLoader;
+		this.repoManager = repoManager;
+		this.properties = properties;
 	}
 
 	@GetMapping
@@ -105,35 +119,77 @@ public class ReleaseController {
 	}
 
 	@PostMapping
-	@Operation(summary = "Install a release", description = "Install a new Helm release from a chart")
+	@Operation(summary = "Install a release",
+			description = "Install a new Helm release from a repository chart reference")
 	public ResponseEntity<ReleaseDto> install(@RequestBody InstallRequest request) throws Exception {
-		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
-			throw new IllegalArgumentException("chartPath is required");
+		if (request.getChartRef() == null || request.getChartRef().isBlank()) {
+			throw new IllegalArgumentException("chartRef is required");
 		}
 		if (request.getReleaseName() == null || request.getReleaseName().isBlank()) {
 			throw new IllegalArgumentException("releaseName is required");
 		}
-		Chart chart = this.chartLoader.load(new File(request.getChartPath()));
-		Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
-		Release release = this.installAction.install(chart, request.getReleaseName(), request.getNamespace(), values, 1,
-				request.isDryRun());
-		return ResponseEntity.status(HttpStatus.CREATED).body(ReleaseDto.from(release));
+		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-install-")) {
+			Chart chart = ChartSourceResolver.fromChartRef(request.getChartRef(), request.getVersion(),
+					this.repoManager, this.chartLoader, tempDir);
+			Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+			Release release = this.installAction.install(chart, request.getReleaseName(), request.getNamespace(),
+					values, 1, request.isDryRun());
+			return ResponseEntity.status(HttpStatus.CREATED).body(ReleaseDto.from(release));
+		}
+	}
+
+	@PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Operation(summary = "Install a release from upload",
+			description = "Install a new Helm release from an uploaded .tgz chart archive")
+	public ResponseEntity<ReleaseDto> installUpload(@RequestPart("chart") MultipartFile chart,
+			@RequestPart("request") InstallUploadRequest request) throws Exception {
+		if (request.getReleaseName() == null || request.getReleaseName().isBlank()) {
+			throw new IllegalArgumentException("releaseName is required");
+		}
+		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-install-upload-")) {
+			Chart loaded = ChartSourceResolver.fromUpload(chart, this.repoManager, this.chartLoader, tempDir);
+			Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+			Release release = this.installAction.install(loaded, request.getReleaseName(), request.getNamespace(),
+					values, 1, request.isDryRun());
+			return ResponseEntity.status(HttpStatus.CREATED).body(ReleaseDto.from(release));
+		}
 	}
 
 	@PutMapping("/{name}")
-	@Operation(summary = "Upgrade a release", description = "Upgrade an existing release to a new chart version")
+	@Operation(summary = "Upgrade a release",
+			description = "Upgrade an existing release from a repository chart reference")
 	public ReleaseDto upgrade(@Parameter(description = "Release name") @PathVariable String name,
 			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace,
 			@RequestBody UpgradeRequest request) throws Exception {
-		if (request.getChartPath() == null || request.getChartPath().isBlank()) {
-			throw new IllegalArgumentException("chartPath is required");
+		if (request.getChartRef() == null || request.getChartRef().isBlank()) {
+			throw new IllegalArgumentException("chartRef is required");
 		}
 		Release current = this.getAction.getRelease(name, namespace)
 			.orElseThrow(() -> new IllegalArgumentException("Release '" + name + "' not found"));
-		Chart chart = this.chartLoader.load(new File(request.getChartPath()));
-		Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
-		Release upgraded = this.upgradeAction.upgrade(current, chart, values, request.isDryRun());
-		return ReleaseDto.from(upgraded);
+		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-upgrade-")) {
+			Chart chart = ChartSourceResolver.fromChartRef(request.getChartRef(), request.getVersion(),
+					this.repoManager, this.chartLoader, tempDir);
+			Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+			Release upgraded = this.upgradeAction.upgrade(current, chart, values, request.isDryRun());
+			return ReleaseDto.from(upgraded);
+		}
+	}
+
+	@PostMapping(path = "/{name}/upgrade/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Operation(summary = "Upgrade a release from upload",
+			description = "Upgrade an existing release from an uploaded .tgz chart archive")
+	public ReleaseDto upgradeUpload(@Parameter(description = "Release name") @PathVariable String name,
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace,
+			@RequestPart("chart") MultipartFile chart, @RequestPart("request") UpgradeUploadRequest request)
+			throws Exception {
+		Release current = this.getAction.getRelease(name, namespace)
+			.orElseThrow(() -> new IllegalArgumentException("Release '" + name + "' not found"));
+		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-upgrade-upload-")) {
+			Chart loaded = ChartSourceResolver.fromUpload(chart, this.repoManager, this.chartLoader, tempDir);
+			Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+			Release upgraded = this.upgradeAction.upgrade(current, loaded, values, request.isDryRun());
+			return ReleaseDto.from(upgraded);
+		}
 	}
 
 	@DeleteMapping("/{name}")

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallUploadRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallUploadRequest.java
@@ -6,15 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
-@Schema(description = "Request to install a new Helm release from a repository chart reference")
-public class InstallRequest {
-
-	@Schema(description = "Chart reference (repo/chart or oci://...)", example = "bitnami/nginx",
-			requiredMode = Schema.RequiredMode.REQUIRED)
-	private String chartRef;
-
-	@Schema(description = "Chart version", example = "18.3.1")
-	private String version;
+@Schema(description = "Metadata for installing a release from an uploaded .tgz chart archive")
+public class InstallUploadRequest {
 
 	@Schema(description = "Name for the release", example = "my-release", requiredMode = Schema.RequiredMode.REQUIRED)
 	private String releaseName;

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeRequest.java
@@ -6,12 +6,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
-@Schema(description = "Request to upgrade an existing Helm release")
+@Schema(description = "Request to upgrade an existing Helm release from a repository chart reference")
 public class UpgradeRequest {
 
-	@Schema(description = "Path to the new chart directory", example = "/tmp/nginx-v2",
+	@Schema(description = "Chart reference (repo/chart or oci://...)", example = "bitnami/nginx",
 			requiredMode = Schema.RequiredMode.REQUIRED)
-	private String chartPath;
+	private String chartRef;
+
+	@Schema(description = "Chart version", example = "18.3.1")
+	private String version;
 
 	@Schema(description = "Override values for the chart")
 	private Map<String, Object> values;

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeUploadRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeUploadRequest.java
@@ -1,0 +1,18 @@
+package org.alexmond.jhelm.rest.dto;
+
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "Metadata for upgrading a release from an uploaded .tgz chart archive")
+public class UpgradeUploadRequest {
+
+	@Schema(description = "Override values for the chart")
+	private Map<String, Object> values;
+
+	@Schema(description = "Simulate an upgrade without applying", defaultValue = "false")
+	private boolean dryRun;
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/util/ChartSourceResolver.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/util/ChartSourceResolver.java
@@ -1,0 +1,62 @@
+package org.alexmond.jhelm.rest.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * Resolves a chart source (repository reference or uploaded .tgz) to a loaded
+ * {@link Chart} inside a {@link TempDir}.
+ */
+public final class ChartSourceResolver {
+
+	private ChartSourceResolver() {
+	}
+
+	/**
+	 * Pull a chart from a repository and load it.
+	 * @param chartRef chart reference (e.g. "bitnami/nginx" or "oci://...")
+	 * @param version optional version constraint
+	 * @param repoManager repository manager for pulling
+	 * @param chartLoader loader to parse the chart directory
+	 * @param tempDir temporary directory to pull into
+	 * @return the loaded chart
+	 */
+	public static Chart fromChartRef(String chartRef, String version, RepoManager repoManager, ChartLoader chartLoader,
+			TempDir tempDir) throws Exception {
+		repoManager.pull(chartRef, version, tempDir.path().toString());
+		Path chartDir = findChartDir(tempDir.path());
+		return chartLoader.load(chartDir.toFile());
+	}
+
+	/**
+	 * Extract an uploaded .tgz chart archive and load it.
+	 * @param file the uploaded .tgz file
+	 * @param repoManager repository manager (for untar utility)
+	 * @param chartLoader loader to parse the chart directory
+	 * @param tempDir temporary directory to extract into
+	 * @return the loaded chart
+	 */
+	public static Chart fromUpload(MultipartFile file, RepoManager repoManager, ChartLoader chartLoader,
+			TempDir tempDir) throws Exception {
+		File tgzFile = tempDir.path().resolve("upload.tgz").toFile();
+		file.transferTo(tgzFile);
+		repoManager.untar(tgzFile, tempDir.path().toFile());
+		Path chartDir = findChartDir(tempDir.path());
+		return chartLoader.load(chartDir.toFile());
+	}
+
+	private static Path findChartDir(Path parent) throws IOException {
+		try (Stream<Path> stream = Files.list(parent)) {
+			return stream.filter(Files::isDirectory).findFirst().orElse(parent);
+		}
+	}
+
+}

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
@@ -1,6 +1,8 @@
 package org.alexmond.jhelm.rest.controller;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -18,12 +20,16 @@ import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.rest.JhelmRestExceptionHandler;
+import org.alexmond.jhelm.rest.config.JhelmRestProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -31,11 +37,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -43,6 +52,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = ReleaseController.class)
 @Import(JhelmRestExceptionHandler.class)
+@EnableConfigurationProperties(JhelmRestProperties.class)
 class ReleaseControllerTest {
 
 	@Autowired
@@ -77,6 +87,9 @@ class ReleaseControllerTest {
 
 	@MockitoBean
 	private ChartLoader chartLoader;
+
+	@MockitoBean
+	private RepoManager repoManager;
 
 	private static Release sampleRelease() {
 		return Release.builder()
@@ -122,6 +135,7 @@ class ReleaseControllerTest {
 
 	@Test
 	void installCreatesRelease() throws Exception {
+		stubPull();
 		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("1.0.0").build()).build();
 		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
 		when(this.installAction.install(any(), eq("my-release"), eq("default"), anyMap(), anyInt(), anyBoolean()))
@@ -131,14 +145,14 @@ class ReleaseControllerTest {
 			.perform(post("/api/v1/releases").contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
 				.content("""
-						{"chartPath": "/tmp/nginx", "releaseName": "my-release"}
+						{"chartRef": "bitnami/nginx", "version": "1.0.0", "releaseName": "my-release"}
 						"""))
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.name").value("my-release"));
 	}
 
 	@Test
-	void installRejectsMissingChartPath() throws Exception {
+	void installRejectsMissingChartRef() throws Exception {
 		this.mockMvc
 			.perform(post("/api/v1/releases").contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
@@ -146,13 +160,33 @@ class ReleaseControllerTest {
 						{"releaseName": "my-release"}
 						"""))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("chartPath is required"));
+			.andExpect(jsonPath("$.message").value("chartRef is required"));
+	}
+
+	@Test
+	void installUploadCreatesRelease() throws Exception {
+		stubUntar();
+		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("1.0.0").build()).build();
+		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
+		when(this.installAction.install(any(), eq("my-release"), eq("default"), anyMap(), anyInt(), anyBoolean()))
+			.thenReturn(sampleRelease());
+
+		MockMultipartFile chartFile = new MockMultipartFile("chart", "nginx-1.0.0.tgz", "application/gzip",
+				new byte[] { 1, 2, 3 });
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json", """
+				{"releaseName": "my-release"}
+				""".getBytes());
+
+		this.mockMvc.perform(multipart("/api/v1/releases/upload").file(chartFile).file(requestPart))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.name").value("my-release"));
 	}
 
 	@Test
 	void upgradeRelease() throws Exception {
 		Release current = sampleRelease();
 		when(this.getAction.getRelease("my-release", "default")).thenReturn(Optional.of(current));
+		stubPull();
 		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("2.0.0").build()).build();
 		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
 		Release upgraded = sampleRelease();
@@ -163,8 +197,28 @@ class ReleaseControllerTest {
 			.perform(put("/api/v1/releases/my-release").contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
 				.content("""
-						{"chartPath": "/tmp/nginx-v2"}
+						{"chartRef": "bitnami/nginx", "version": "2.0.0"}
 						"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.version").value(2));
+	}
+
+	@Test
+	void upgradeUploadRelease() throws Exception {
+		Release current = sampleRelease();
+		when(this.getAction.getRelease("my-release", "default")).thenReturn(Optional.of(current));
+		stubUntar();
+		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("2.0.0").build()).build();
+		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
+		Release upgraded = sampleRelease();
+		upgraded.setVersion(2);
+		when(this.upgradeAction.upgrade(any(), any(), anyMap(), anyBoolean())).thenReturn(upgraded);
+
+		MockMultipartFile chartFile = new MockMultipartFile("chart", "nginx-2.0.0.tgz", "application/gzip",
+				new byte[] { 1, 2, 3 });
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json", "{}".getBytes());
+
+		this.mockMvc.perform(multipart("/api/v1/releases/my-release/upgrade/upload").file(chartFile).file(requestPart))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.version").value(2));
 	}
@@ -257,6 +311,26 @@ class ReleaseControllerTest {
 		when(this.statusAction.status("missing", "default")).thenReturn(Optional.empty());
 		this.mockMvc.perform(get("/api/v1/releases/missing/resources").accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isNotFound());
+	}
+
+	private void stubPull() throws Exception {
+		doAnswer((invocation) -> {
+			String destDir = invocation.getArgument(2);
+			Path chartDir = Path.of(destDir).resolve("nginx");
+			Files.createDirectories(chartDir);
+			Files.writeString(chartDir.resolve("Chart.yaml"), "name: nginx\nversion: 1.0.0");
+			return null;
+		}).when(this.repoManager).pull(anyString(), any(), anyString());
+	}
+
+	private void stubUntar() throws Exception {
+		doAnswer((invocation) -> {
+			File destDir = invocation.getArgument(1);
+			Path chartDir = destDir.toPath().resolve("nginx");
+			Files.createDirectories(chartDir);
+			Files.writeString(chartDir.resolve("Chart.yaml"), "name: nginx\nversion: 1.0.0");
+			return null;
+		}).when(this.repoManager).untar(any(File.class), any(File.class));
 	}
 
 }


### PR DESCRIPTION
## Summary
- Replace `chartPath` (local filesystem path) with `chartRef` + `version` (repository reference) in install and upgrade request DTOs
- Add `POST /releases/upload` and `POST /releases/{name}/upgrade/upload` multipart endpoints for installing/upgrading from uploaded `.tgz` archives
- Add `ChartSourceResolver` utility for shared chart resolution logic (repo pull or upload extraction)
- Update `JhelmRestAutoConfiguration` to require `RepoManager` for `ReleaseController`
- Update documentation with new endpoint descriptions and curl examples

Closes #286

## Test plan
- [x] All 50 jhelm-rest tests pass (2 new upload tests added)
- [x] Validation passes with 0 PMD/Checkstyle violations
- [x] jhelm-rest-sample compiles successfully
- [ ] Manual test: install from chart ref
- [ ] Manual test: install from uploaded .tgz
- [ ] Manual test: upgrade from chart ref
- [ ] Manual test: upgrade from uploaded .tgz

🤖 Generated with [Claude Code](https://claude.com/claude-code)