### PR TITLE
Fix path traversal in chart extraction and pluck null handling

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -752,6 +752,11 @@ public class RepoManager {
 					continue;
 				}
 				File f = new File(destDir, entry.getName());
+				String canonicalDest = destDir.getCanonicalPath() + File.separator;
+				if (!f.getCanonicalPath().startsWith(canonicalDest)
+						&& !f.getCanonicalPath().equals(destDir.getCanonicalPath())) {
+					throw new IOException("Path traversal detected in chart archive: " + entry.getName());
+				}
 				if (entry.isDirectory()) {
 					if (!f.isDirectory() && !f.mkdirs()) {
 						throw new IOException("failed to create directory " + f);

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
@@ -452,6 +452,26 @@ class RepoManagerTest {
 		assertTrue(new File(destDir, "minimal/Chart.yaml").exists());
 	}
 
+	@Test
+	void testUntarRejectsPathTraversal() throws Exception {
+		// Create a malicious tgz with a path traversal entry (GHSA-hr2v-4r36-88hr)
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		try (GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(baos);
+				TarArchiveOutputStream taos = new TarArchiveOutputStream(gzos)) {
+			byte[] content = "malicious".getBytes();
+			TarArchiveEntry entry = new TarArchiveEntry("../../../etc/evil.txt");
+			entry.setSize(content.length);
+			taos.putArchiveEntry(entry);
+			taos.write(content);
+			taos.closeArchiveEntry();
+		}
+		File tgzFile = tempDir.resolve("evil.tgz").toFile();
+		Files.write(tgzFile.toPath(), baos.toByteArray());
+		File destDir = tempDir.resolve("out").toFile();
+		destDir.mkdirs();
+		assertThrows(IOException.class, () -> new RepoManager().untar(tgzFile, destDir));
+	}
+
 	// ── Test helpers ─────────────────────────────────────────────────────────
 
 	/**

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
@@ -136,9 +136,9 @@ public final class DictFunctions {
 			List<Object> result = new ArrayList<>();
 			for (int i = 1; i < args.length; i++) {
 				if (args[i] instanceof Map) {
-					Object val = ((Map<?, ?>) args[i]).get(key);
-					if (val != null) {
-						result.add(val);
+					Map<?, ?> map = (Map<?, ?>) args[i];
+					if (map.containsKey(key)) {
+						result.add(map.get(key));
 					}
 				}
 			}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
@@ -529,6 +529,29 @@ class CollectionFunctionsTest {
 	}
 
 	@Test
+	void testPluckIncludesNullValues() throws IOException, TemplateException {
+		// pluck must include null values in the result list (Helm #31971)
+		Map<String, Object> d1 = new HashMap<>();
+		d1.put("key", null);
+		Map<String, Object> d2 = new HashMap<>();
+		d2.put("key", "value2");
+		Map<String, Object> data = new HashMap<>();
+		data.put("d1", d1);
+		data.put("d2", d2);
+		assertEquals("2", execWithData("{{ $p := pluck \"key\" .d1 .d2 }}{{ len $p }}", data));
+	}
+
+	@Test
+	void testPluckNullValueIsAccessible() throws IOException, TemplateException {
+		// The null entry should appear as "<no value>" when printed
+		Map<String, Object> d1 = new HashMap<>();
+		d1.put("key", null);
+		Map<String, Object> data = new HashMap<>();
+		data.put("d1", d1);
+		assertEquals("1", execWithData("{{ $p := pluck \"key\" .d1 }}{{ len $p }}", data));
+	}
+
+	@Test
 	void testDeepCopyList() throws IOException, TemplateException {
 		assertEquals("2", exec("{{ $l := list \"a\" \"b\" }}{{ $c := deepCopy $l }}{{ len $c }}"));
 	}


### PR DESCRIPTION
## Summary

- **Security fix (#291):** Add canonical path validation in `RepoManager.untar()` to prevent directory traversal attacks via crafted `Chart.yaml` name fields. Upstream: [GHSA-hr2v-4r36-88hr](https://github.com/helm/helm/security/advisories/GHSA-hr2v-4r36-88hr), fixed in Helm v3.20.2 / v4.1.4.
- **Bug fix (#292):** Fix `DictFunctions.pluck()` to include null values in results by using `containsKey()` instead of a null check. Upstream: [helm/helm#31971](https://github.com/helm/helm/issues/31971).
- **Closed #293** as not-a-bug — `merge()` treating null as empty matches Go mergo semantics.

## Test plan

- [x] `RepoManagerTest#testUntarRejectsPathTraversal` — verifies path traversal is rejected with IOException
- [x] `CollectionFunctionsTest#testPluckIncludesNullValues` — verifies null values are counted in pluck results
- [x] `CollectionFunctionsTest#testPluckNullValueIsAccessible` — verifies single null entry is included
- [x] All existing `RepoManagerTest` and `CollectionFunctionsTest` tests pass

Closes #291, closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)