### PR TITLE
Upgrade Spring Boot from 4.0.3 to 4.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.alexmond</groupId>


### PR DESCRIPTION
## Summary

- Upgrade `spring-boot-starter-parent` from 4.0.3 to 4.0.5 (latest stable, released 2026-03-26)
- Patch version bump — bug fixes and security patches only

## Test plan

- [x] `./mvnw clean install` — all modules compile, all tests pass (except pre-existing KpsComparisonTest issue)
- [x] `./mvnw test -pl jhelm-app` — CLI tests pass
- [x] No API breaking changes expected in patch release

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)