### PR TITLE
Fix deprecation warnings in Jackson, HttpClient5, BouncyCastle

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/SearchHubAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/SearchHubAction.java
@@ -73,7 +73,7 @@ public class SearchHubAction {
 
 	private String textOrEmpty(JsonNode node, String field) {
 		JsonNode child = node.get(field);
-		return (child != null && !child.isNull()) ? child.asText() : "";
+		return (child != null && !child.isNull()) ? child.stringValue() : "";
 	}
 
 	@Data

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
@@ -26,8 +26,9 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
-import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactoryBuilder;
+import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 
 import org.alexmond.jhelm.core.model.RepositoryConfig;
@@ -83,12 +84,11 @@ final class RepoHttpClientFactory {
 		try {
 			boolean skipVerify = repo.isInsecure_skip_tls_verify() || globalInsecureSkipTls;
 			SSLContext sslContext = buildSslContext(repo, skipVerify);
-			var socketFactoryBuilder = SSLConnectionSocketFactoryBuilder.create().setSslContext(sslContext);
-			if (skipVerify) {
-				socketFactoryBuilder.setHostnameVerifier(NoopHostnameVerifier.INSTANCE);
-			}
+			TlsSocketStrategy tlsStrategy = skipVerify
+					? new DefaultClientTlsStrategy(sslContext, NoopHostnameVerifier.INSTANCE)
+					: new DefaultClientTlsStrategy(sslContext);
 			HttpClientConnectionManager connManager = PoolingHttpClientConnectionManagerBuilder.create()
-				.setSSLSocketFactory(socketFactoryBuilder.build())
+				.setTlsSocketStrategy(tlsStrategy)
 				.build();
 			return HttpClients.custom().setConnectionManager(connManager).build();
 		}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SignatureService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SignatureService.java
@@ -71,7 +71,8 @@ public class SignatureService {
 
 		PGPSignatureGenerator sigGen = new PGPSignatureGenerator(
 				new JcaPGPContentSignerBuilder(secretKey.getPublicKey().getAlgorithm(), HashAlgorithmTags.SHA256)
-					.setProvider("BC"));
+					.setProvider("BC"),
+				secretKey.getPublicKey());
 		sigGen.init(PGPSignature.CANONICAL_TEXT_DOCUMENT, privateKey);
 
 		ByteArrayOutputStream out = new ByteArrayOutputStream();


### PR DESCRIPTION
## Summary

Fix all 4 deprecation warnings found during build:

| File | Deprecated | Replacement |
|------|-----------|-------------|
| `SearchHubAction.java` | `JsonNode.asText()` | `stringValue()` (Jackson 3) |
| `RepoHttpClientFactory.java` | `SSLConnectionSocketFactoryBuilder` + `.setSSLSocketFactory()` | `DefaultClientTlsStrategy` + `.setTlsSocketStrategy()` (HttpClient5) |
| `SignatureService.java` | `PGPSignatureGenerator(signerBuilder)` | 2-arg constructor with public key (BouncyCastle) |

## Test plan

- [x] Build produces zero deprecation warnings
- [x] `SearchHubActionTest` passes
- [x] `SignatureServiceTest` passes (sign + verify roundtrip)
- [x] `RepoManagerTest` passes (uses RepoHttpClientFactory)
- [x] PMD/checkstyle clean

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)