### PR TITLE
Fix deprecation warnings in test code

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
@@ -529,10 +529,10 @@ class KpsComparisonTest {
 			}
 		}
 		else if (!expected.equals(actual)) {
-			if (expected.isTextual() && actual.isTextual()) {
+			if (expected.isString() && actual.isString()) {
 				try {
-					JsonNode parsedExpected = YAML_MAPPER.readTree(expected.textValue());
-					JsonNode parsedActual = YAML_MAPPER.readTree(actual.textValue());
+					JsonNode parsedExpected = YAML_MAPPER.readTree(expected.stringValue());
+					JsonNode parsedActual = YAML_MAPPER.readTree(actual.stringValue());
 					if (parsedExpected != null && parsedActual != null && !parsedExpected.isValueNode()
 							&& !parsedActual.isValueNode()) {
 						diffs.addAll(computeDiffs(parsedExpected, parsedActual, path));

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/PackageActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/PackageActionTest.java
@@ -47,6 +47,8 @@ class PackageActionTest {
 	Path tempDir;
 
 	@BeforeAll
+	@SuppressWarnings("deprecation") // JcaPGPKeyPair 3-arg constructor; 4-arg version has
+										// a BouncyCastle bug
 	static void generateKeys() throws Exception {
 		if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
 			Security.addProvider(new BouncyCastleProvider());

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/VerifyActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/VerifyActionTest.java
@@ -52,6 +52,8 @@ class VerifyActionTest {
 	Path tempDir;
 
 	@BeforeAll
+	@SuppressWarnings("deprecation") // JcaPGPKeyPair 3-arg constructor; 4-arg version has
+										// a BouncyCastle bug
 	static void generateKeys() throws Exception {
 		if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
 			Security.addProvider(new BouncyCastleProvider());

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/SignatureServiceTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/SignatureServiceTest.java
@@ -259,6 +259,8 @@ class SignatureServiceTest {
 				() -> signatureService.verify(chartFile, "no signature content", publicKeys));
 	}
 
+	@SuppressWarnings("deprecation") // JcaPGPKeyPair 3-arg constructor; 4-arg version has
+										// a BouncyCastle bug
 	private static PGPKeyRingGenerator createKeyRingGenerator(String userId) throws Exception {
 		KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "BC");
 		kpg.initialize(2048);


### PR DESCRIPTION
## Summary

- `KpsComparisonTest`: `isTextual()` → `isString()`, `textValue()` → `stringValue()` (Jackson 3)
- `PackageActionTest`, `VerifyActionTest`, `SignatureServiceTest`: suppress `JcaPGPKeyPair` deprecation — the 4-arg replacement constructor has a BouncyCastle bug that misinterprets the version parameter as the algorithm

Combined with PR #300 (production code), the build now has **zero deprecation warnings** across all modules.

## Test plan

- [x] Full `./mvnw clean install` produces zero deprecation warnings
- [x] `PackageActionTest`, `VerifyActionTest`, `SignatureServiceTest` all pass
- [x] `KpsComparisonTest` comparison logic works correctly with `isString()`/`stringValue()`

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)