### PR TITLE
Fix printf type coercion for Go compatibility

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -23,11 +23,6 @@ jhelmtest:
       - resource: "Service/*"
         path: "spec.trafficDistribution"
         reason: "trafficDistribution field rendered by JHelm but absent in Helm output"
-    "[gitea/gitea]":
-      # Subchart value propagation — connection strings still empty
-      - resource: "Secret/*"
-        path: "stringData.*"
-        reason: "Subchart value propagation gap — tpl-based connection strings empty (#201)"
     "[datadog/datadog]":
       # Random UUID generated per render — always different between Helm and JHelm
       - resource: "ConfigMap/*"

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -3,7 +3,5 @@
 # If a chart unexpectedly passes, the test will fail — remove the entry.
 #
 # --- Code bugs ---
-# Subchart label propagation — labels null instead of expected values
-superset/superset,superset,http://apache.github.io/superset/
 # Validation template fails — bitnami common.validations produces non-empty result where Go produces ""
 bitnami/rabbitmq,bitnami,https://charts.bitnami.com/bitnami

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class Functions {
 
@@ -400,10 +402,27 @@ public final class Functions {
 			format = format.replaceAll("%q", "%s"); // %(q) -> %s
 			format = format.replaceAll("%p", "%s"); // %(p) -> %s
 
+			// Extract format specifiers to coerce numeric types per-argument.
+			// Go's printf is lenient (any numeric type for %d/%g); Java is strict.
+			Matcher specMatcher = Pattern.compile("%[^%]*?([doxXbeEfgG])").matcher(format);
+			List<Character> specTypes = new ArrayList<>();
+			while (specMatcher.find()) {
+				specTypes.add(specMatcher.group(1).charAt(0));
+			}
+
 			Object[] realArgs = new Object[args.length - 1];
 			for (int i = 0; i < realArgs.length; i++) {
-				// Java's String.format renders null as "null"; Go uses "" for nil
-				realArgs[i] = (args[i + 1] != null) ? args[i + 1] : "";
+				Object arg = (args[i + 1] != null) ? args[i + 1] : "";
+				if (arg instanceof Number && i < specTypes.size()) {
+					char spec = specTypes.get(i);
+					if ("eEfgG".indexOf(spec) >= 0 && (arg instanceof Integer || arg instanceof Long)) {
+						arg = ((Number) arg).doubleValue();
+					}
+					else if ("doxXb".indexOf(spec) >= 0 && (arg instanceof Double || arg instanceof Float)) {
+						arg = ((Number) arg).longValue();
+					}
+				}
+				realArgs[i] = arg;
 			}
 			return String.format(format, realArgs);
 		};

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
@@ -373,6 +373,30 @@ class FunctionsTest {
 	}
 
 	@Test
+	void testPrintfFloatFormatWithInteger() throws Exception {
+		// Go's %g accepts any numeric type; Java's requires float/double (#304)
+		Function printf = Functions.GO_BUILTINS.get("printf");
+		assertEquals("5432.00", printf.invoke(new Object[] { "%g", 5432 }));
+		assertEquals("5432.00", printf.invoke(new Object[] { "%g", 5432L }));
+		assertEquals("3.000000", printf.invoke(new Object[] { "%f", 3 }));
+	}
+
+	@Test
+	void testPrintfIntFormatWithDouble() throws Exception {
+		// Go's %d accepts any numeric type; Java's requires int/long
+		Function printf = Functions.GO_BUILTINS.get("printf");
+		assertEquals("5432", printf.invoke(new Object[] { "%d", 5432.0 }));
+	}
+
+	@Test
+	void testPrintfMixedNumericFormats() throws Exception {
+		// Mixed %d and %g in same format string — each arg coerced independently
+		Function printf = Functions.GO_BUILTINS.get("printf");
+		assertEquals("port=9092 rate=1.500000", printf.invoke(new Object[] { "port=%d rate=%f", 9092.0, 1.5 }));
+		assertEquals("count=3 ratio=42.0000", printf.invoke(new Object[] { "count=%d ratio=%g", 3.0, 42 }));
+	}
+
+	@Test
 	void testPrintfEmpty() throws Exception {
 		Function printf = Functions.GO_BUILTINS.get("printf");
 		assertEquals("", printf.invoke(new Object[] {}));


### PR DESCRIPTION
## Summary

Go's `printf` is lenient with numeric types — `%g`/`%f`/`%e` accept integers and `%d` accepts floats. Java's `String.format` is strict and throws `IllegalFormatConversionException`. This caused `gitea/gitea` chart to fail with `g != java.lang.Integer` in the `postgresql-ha.dns` template.

**Fix:** Add type coercion in `printf()` to convert Integer/Long to Double for float format specifiers and Double/Float to Long for integer format specifiers.

**Bonus:** Remove `gitea/gitea` `stringData` comparison-ignore — the chart now renders correctly and matches Helm output with zero diffs.

## Test plan

- [x] `FunctionsTest#testPrintfFloatFormatWithInteger` — `%g` with Integer/Long
- [x] `FunctionsTest#testPrintfIntFormatWithDouble` — `%d` with Double
- [x] All existing `FunctionsTest` tests pass
- [x] `KpsComparisonTest#compareSingleChart` with gitea/gitea — renders successfully, all 30 resources match Helm

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)