### PR TITLE
Fix without() to remove all occurrences, fixing rabbitmq validation

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.regex.Pattern;
 
 class EngineTest {
 
@@ -1694,7 +1695,7 @@ class EngineTest {
 		assertTrue(result.contains("kind: ConfigMap"), "ConfigMap should be rendered");
 
 		// Extract the checksum/configmap annotation — must not be sha256("{}")
-		java.util.regex.Matcher m = java.util.regex.Pattern.compile("checksum/configmap:\\s+(\\S+)").matcher(result);
+		java.util.regex.Matcher m = Pattern.compile("checksum/configmap:\\s+(\\S+)").matcher(result);
 		assertTrue(m.find(), "checksum/configmap should exist in output");
 		String checksum = m.group(1);
 		assertFalse("44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a".equals(checksum),
@@ -1865,6 +1866,26 @@ class EngineTest {
 		assertTrue(result.contains("$SERVER_NAME"), "Should contain unquoted $SERVER_NAME: " + result);
 		assertFalse(result.contains("<<"), "Should not contain << markers: " + result);
 		assertFalse(result.contains(">>"), "Should not contain >> markers: " + result);
+	}
+
+	@Test
+	void testValidationPatternNoErrors() throws Exception {
+		// Mirrors rabbitmq validation.yaml pattern: include checks, without "", join,
+		// fail
+		Chart chart = chartLoader.load(new File("src/test/resources/test-charts/validation-test"));
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		// With no errors triggered, validation.yaml should produce empty/whitespace
+		// output
+		assertTrue(result.isBlank(), "Validation with no errors should produce blank output, got: " + result);
+	}
+
+	@Test
+	void testValidationPatternMultipleEmptyIncludes() throws Exception {
+		// Mirrors rabbitmq #303: without() must remove ALL empty strings, not just
+		// the first
+		Chart chart = chartLoader.load(new File("src/test/resources/test-charts/validation-test"));
+		String result = engine.render(chart, Map.of(), releaseInfo());
+		assertTrue(result.isBlank(), "Validation with multiple empty includes should not trigger fail");
 	}
 
 }

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -19,10 +19,6 @@ jhelmtest:
       - resource: "MutatingWebhookConfiguration/*"
         path: "webhooks.*"
         reason: "TLS certificates are generated per render via genCA/genSignedCert"
-    "[bitnami/rabbitmq]":
-      - resource: "Service/*"
-        path: "spec.trafficDistribution"
-        reason: "trafficDistribution field rendered by JHelm but absent in Helm output"
     "[datadog/datadog]":
       # Random UUID generated per render — always different between Helm and JHelm
       - resource: "ConfigMap/*"

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -3,5 +3,4 @@
 # If a chart unexpectedly passes, the test will fail — remove the entry.
 #
 # --- Code bugs ---
-# Validation template fails — bitnami common.validations produces non-empty result where Go produces ""
-bitnami/rabbitmq,bitnami,https://charts.bitnami.com/bitnami
+# (none — all previously listed charts are now fixed)

--- a/jhelm-core/src/test/resources/test-charts/validation-test/Chart.yaml
+++ b/jhelm-core/src/test/resources/test-charts/validation-test/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: validation-test
+version: 1.0.0
+description: Test chart for validation pattern (rabbitmq-style)

--- a/jhelm-core/src/test/resources/test-charts/validation-test/templates/_helpers.tpl
+++ b/jhelm-core/src/test/resources/test-charts/validation-test/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{- define "validate" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "check.ldap" .) -}}
+{{- $messages := append $messages (include "check.watermark" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Exact rabbitmq pattern: outer if has NO right-trim marker */}}
+{{- define "check.ldap" -}}
+{{- if .Values.ldap.enabled }}
+{{- if not .Values.ldap.server }}
+validation: ldap.server is required when ldap is enabled
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Uses eq comparison */}}
+{{- define "check.watermark" -}}
+{{- if and (not (eq .Values.watermark.type "absolute")) (not (eq .Values.watermark.type "relative")) }}
+validation: watermark.type must be "absolute" or "relative"
+{{- end -}}
+{{- end -}}

--- a/jhelm-core/src/test/resources/test-charts/validation-test/templates/validation.yaml
+++ b/jhelm-core/src/test/resources/test-charts/validation-test/templates/validation.yaml
@@ -1,0 +1,1 @@
+{{- include "validate" . }}

--- a/jhelm-core/src/test/resources/test-charts/validation-test/values.yaml
+++ b/jhelm-core/src/test/resources/test-charts/validation-test/values.yaml
@@ -1,0 +1,5 @@
+ldap:
+  enabled: false
+  server: ""
+watermark:
+  type: "relative"

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctionsTest.java
@@ -61,6 +61,24 @@ class TemplateFunctionsTest {
 		assertTrue(ex.getMessage().contains("nonexistent"));
 	}
 
+	@Test
+	void testIncludeOfEmptyTemplateReturnsEmptyString() throws Exception {
+		// Mirrors rabbitmq validation pattern: include a template that produces nothing
+		template.parse("check", "{{- define \"check\" -}}{{- if false -}}error{{- end -}}{{- end -}}");
+		Function include = functions.get("include");
+		String result = (String) include.invoke(new Object[] { "check", new HashMap<>() });
+		assertEquals("", result, "include of empty-producing template should return \"\"");
+	}
+
+	@Test
+	void testIncludeOfConditionallyEmptyTemplate() throws Exception {
+		// Include a template with a false condition and trim markers — should return ""
+		template.parse("helpers", "{{- define \"check1\" -}}{{- if false -}}error{{- end -}}{{- end -}}");
+		Function include = functions.get("include");
+		String result = (String) include.invoke(new Object[] { "check1", new HashMap<>() });
+		assertEquals("", result, "include of conditionally empty template should return empty string");
+	}
+
 	// --- mustInclude tests ---
 
 	@Test

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ListFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ListFunctions.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -332,7 +333,9 @@ public final class ListFunctions {
 			}
 			List<Object> result = new ArrayList<>((Collection<?>) args[0]);
 			for (int i = 1; i < args.length; i++) {
-				result.remove(args[i]);
+				// Remove ALL occurrences, matching Go's Sprig without() behavior
+				Object toRemove = args[i];
+				result.removeIf((item) -> Objects.equals(item, toRemove));
 			}
 			return result;
 		};

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import java.util.List;
 
 class CollectionFunctionsTest {
 
@@ -90,6 +91,27 @@ class CollectionFunctionsTest {
 			data.put("items", new ArrayList<>(Arrays.asList("b", "c")));
 			assertEquals("a,b,c", execWithData("{{ $l := " + func + " .items \"a\" }}{{ join \",\" $l }}", data));
 		}
+	}
+
+	@Test
+	void testWithoutRemovesSingleOccurrence() throws IOException, TemplateException {
+		Map<String, Object> data = new HashMap<>();
+		data.put("items", new ArrayList<>(Arrays.asList("a", "b", "c")));
+		assertEquals("a,c", execWithData("{{ $r := without .items \"b\" }}{{ join \",\" $r }}", data));
+	}
+
+	@Test
+	void testWithoutRemovesAllOccurrences() throws IOException, TemplateException {
+		// Go's Sprig without() removes ALL matching elements, not just the first (#303)
+		Map<String, Object> data = new HashMap<>();
+		data.put("items", new ArrayList<>(Arrays.asList("a", "", "b", "", "c", "")));
+		assertEquals("a,b,c", execWithData("{{ $r := without .items \"\" }}{{ join \",\" $r }}", data));
+	}
+
+	@Test
+	void testWithoutEmptyStringsFromIncludes() throws IOException, TemplateException {
+		// Mirrors rabbitmq validation pattern: list of empty include results
+		assertEquals("0", exec("{{ $m := list \"\" \"\" \"\" \"\" }}{{ $m = without $m \"\" }}{{ len $m }}"));
 	}
 
 	@ParameterizedTest
@@ -366,7 +388,7 @@ class CollectionFunctionsTest {
 		Map<String, Object> dst = new HashMap<>();
 		dst.put("items", new ArrayList<>());
 		data.put("dst", dst);
-		data.put("src", Map.of("items", java.util.List.of("a", "b")));
+		data.put("src", Map.of("items", List.of("a", "b")));
 		assertEquals("2", execWithData("{{ $m := merge .dst .src }}{{ len (get $m \"items\") }}", data));
 	}
 


### PR DESCRIPTION
## Summary

Sprig's `without()` should remove **all** matching elements from a list, but the Java implementation used `List.remove(Object)` which only removes the **first** occurrence. This caused `bitnami/rabbitmq`'s `validation.yaml` to fail: the list of 4 empty validation results was reduced to 3 (not 0) by `without(list, "")`, leaving residual entries that joined into `"\n\n"` and triggered `fail()`.

**Fix:** Use `removeIf()` to remove all matching elements.

**Bonus:** Remove rabbitmq comparison-ignore (`trafficDistribution`) and `failed.csv` entry — the chart now renders correctly and matches Helm output with zero diffs. The `failed.csv` is now empty (all previously listed charts are fixed).

## Test plan

- [x] `CollectionFunctionsTest#testWithoutRemovesAllOccurrences` — verifies all empty strings removed
- [x] `CollectionFunctionsTest#testWithoutEmptyStringsFromIncludes` — mirrors rabbitmq pattern (4 empty → 0)
- [x] `TemplateFunctionsTest#testIncludeOfConditionallyEmptyTemplate` — include returns ""
- [x] `EngineTest#testValidationPatternNoErrors` + `testValidationPatternMultipleEmptyIncludes` — full Engine-level validation pattern
- [x] `KpsComparisonTest#compareSingleChart` with rabbitmq — renders successfully, all resources match Helm

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)