### PR TITLE
Fix printf type coercion positional alignment for mixed format strings

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -19,6 +19,11 @@ jhelmtest:
       - resource: "MutatingWebhookConfiguration/*"
         path: "webhooks.*"
         reason: "TLS certificates are generated per render via genCA/genSignedCert"
+    "[gitea/gitea]":
+      # Subchart stringData still missing — tpl-based config_environment.sh not rendered
+      - resource: "Secret/*"
+        path: "stringData.*"
+        reason: "Subchart value propagation gap — tpl-based config scripts missing (#201)"
     "[datadog/datadog]":
       # Random UUID generated per render — always different between Helm and JHelm
       - resource: "ConfigMap/*"

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
@@ -402,9 +402,11 @@ public final class Functions {
 			format = format.replaceAll("%q", "%s"); // %(q) -> %s
 			format = format.replaceAll("%p", "%s"); // %(p) -> %s
 
-			// Extract format specifiers to coerce numeric types per-argument.
+			// Extract ALL format specifiers to coerce numeric types per-argument.
 			// Go's printf is lenient (any numeric type for %d/%g); Java is strict.
-			Matcher specMatcher = Pattern.compile("%[^%]*?([doxXbeEfgG])").matcher(format);
+			// Must track non-numeric specs (%s, %c, etc.) to maintain correct
+			// positional alignment with arguments.
+			Matcher specMatcher = Pattern.compile("%[^%]*?([a-zA-Z])").matcher(format);
 			List<Character> specTypes = new ArrayList<>();
 			while (specMatcher.find()) {
 				specTypes.add(specMatcher.group(1).charAt(0));

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
@@ -394,6 +394,9 @@ class FunctionsTest {
 		Function printf = Functions.GO_BUILTINS.get("printf");
 		assertEquals("port=9092 rate=1.500000", printf.invoke(new Object[] { "port=%d rate=%f", 9092.0, 1.5 }));
 		assertEquals("count=3 ratio=42.0000", printf.invoke(new Object[] { "count=%d ratio=%g", 3.0, 42 }));
+		// Gitea postgresql-ha.dns pattern: %s args before %g with Integer port
+		assertEquals("host.ns.svc.cluster:5432.00",
+				printf.invoke(new Object[] { "%s.%s.svc.%s:%g", "host", "ns", "cluster", 5432 }));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Printf type coercion regex only matched numeric format specifiers (`%d`, `%g`), causing positional misalignment when `%s` args preceded numeric ones. Example: `"%s.%s.%s:%g"` with 4 args — the `%g` at position 3 was tracked at index 0, so the Integer port was never coerced.

**Fix:** Match ALL format specifiers (`%[a-zA-Z]`) to maintain correct positional alignment.

This fixes rendering of `bitnami/keycloak`, `codecentric/keycloak`, and `gitea/gitea`. Also restores `gitea/gitea` stringData comparison-ignore (rendering fixed but subchart config propagation still incomplete).

## 500-chart local test results

| Metric | Before | After |
|--------|--------|-------|
| Render failures | 4 (keycloak x2, gitea, victoria-metrics) | 1 (only victoria-metrics — tpl inline parsing) |
| Diff failures | 0 | 0 |

## Test plan

- [x] `FunctionsTest#testPrintfMixedNumericFormats` — `%s.%s.%s:%g` pattern with Integer port
- [x] All existing printf tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)