### PR TITLE
Add workspace sandboxing and startup validation

### DIFF
--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/config/JhelmRestProperties.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/config/JhelmRestProperties.java
@@ -1,9 +1,13 @@
 package org.alexmond.jhelm.rest.config;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
+import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -11,6 +15,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @Getter
 @Setter
+@Slf4j
 @ConfigurationProperties(prefix = "jhelm.rest")
 public class JhelmRestProperties {
 
@@ -25,11 +30,20 @@ public class JhelmRestProperties {
 	private Path tempDir;
 
 	/**
-	 * Returns the configured temp directory, or the system default if not set.
+	 * Returns the configured temp directory, or the system default if not set. The
+	 * returned path is always absolute and normalized.
 	 * @return the temp directory path
 	 */
 	public Path getTempDir() {
-		return (this.tempDir != null) ? this.tempDir : Path.of(System.getProperty("java.io.tmpdir"));
+		Path dir = (this.tempDir != null) ? this.tempDir : Path.of(System.getProperty("java.io.tmpdir"));
+		return dir.toAbsolutePath().normalize();
+	}
+
+	@PostConstruct
+	void validateWorkspace() throws IOException {
+		Path workspace = getTempDir();
+		Files.createDirectories(workspace);
+		log.info("jhelm workspace: {}", workspace);
 	}
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
@@ -101,7 +101,7 @@ public class ChartController {
 			throw new IllegalArgumentException("name is required");
 		}
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-create-")) {
-			Path chartPath = tempDir.path().resolve(request.getName());
+			Path chartPath = tempDir.sandboxedResolve(request.getName());
 			this.createAction.create(chartPath);
 			byte[] tgz = ChartArchiveUtil.toTgzBytes(chartPath, request.getName());
 			return ResponseEntity.ok()

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/util/TempDir.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/util/TempDir.java
@@ -24,6 +24,21 @@ public class TempDir implements Closeable {
 		return this.path;
 	}
 
+	/**
+	 * Resolves a user-supplied name against this temp directory and verifies the result
+	 * stays within the sandbox. Prevents path traversal via names like {@code ../../etc}.
+	 * @param name the name to resolve (e.g. chart name)
+	 * @return the resolved path guaranteed to be within this temp directory
+	 * @throws IllegalArgumentException if the resolved path escapes the sandbox
+	 */
+	public Path sandboxedResolve(String name) {
+		Path resolved = this.path.resolve(name).normalize();
+		if (!resolved.startsWith(this.path)) {
+			throw new IllegalArgumentException("Path traversal detected: " + name);
+		}
+		return resolved;
+	}
+
 	@Override
 	public void close() throws IOException {
 		if (Files.exists(this.path)) {

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ChartControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ChartControllerTest.java
@@ -126,6 +126,17 @@ class ChartControllerTest {
 	}
 
 	@Test
+	void createRejectsPathTraversalName() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/charts/create").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"name": "../../etc/evil"}
+						"""))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
 	void showAllReturnsChartInfo() throws Exception {
 		stubPull();
 		when(this.showAction.showAll(anyString())).thenReturn("# Chart.yaml\nname: nginx");

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/util/TempDirTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/util/TempDirTest.java
@@ -1,0 +1,66 @@
+package org.alexmond.jhelm.rest.util;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TempDirTest {
+
+	@TempDir
+	Path baseDir;
+
+	@Test
+	void sandboxedResolveValidName() throws Exception {
+		try (org.alexmond.jhelm.rest.util.TempDir tempDir = new org.alexmond.jhelm.rest.util.TempDir(this.baseDir,
+				"test-")) {
+			Path resolved = tempDir.sandboxedResolve("my-chart");
+			assertTrue(resolved.startsWith(tempDir.path()));
+			assertEquals("my-chart", resolved.getFileName().toString());
+		}
+	}
+
+	@Test
+	void sandboxedResolveRejectsPathTraversal() throws Exception {
+		try (org.alexmond.jhelm.rest.util.TempDir tempDir = new org.alexmond.jhelm.rest.util.TempDir(this.baseDir,
+				"test-")) {
+			assertThrows(IllegalArgumentException.class, () -> tempDir.sandboxedResolve("../../etc/passwd"));
+		}
+	}
+
+	@Test
+	void sandboxedResolveRejectsDotDot() throws Exception {
+		try (org.alexmond.jhelm.rest.util.TempDir tempDir = new org.alexmond.jhelm.rest.util.TempDir(this.baseDir,
+				"test-")) {
+			assertThrows(IllegalArgumentException.class, () -> tempDir.sandboxedResolve(".."));
+		}
+	}
+
+	@Test
+	void sandboxedResolveAllowsSubdirectory() throws Exception {
+		try (org.alexmond.jhelm.rest.util.TempDir tempDir = new org.alexmond.jhelm.rest.util.TempDir(this.baseDir,
+				"test-")) {
+			Path resolved = tempDir.sandboxedResolve("charts/nginx");
+			assertTrue(resolved.startsWith(tempDir.path()));
+		}
+	}
+
+	@Test
+	void closeDeletesTempDirectory() throws Exception {
+		Path tempPath;
+		try (org.alexmond.jhelm.rest.util.TempDir tempDir = new org.alexmond.jhelm.rest.util.TempDir(this.baseDir,
+				"test-")) {
+			tempPath = tempDir.path();
+			Files.writeString(tempPath.resolve("test.txt"), "content");
+			assertTrue(Files.exists(tempPath));
+		}
+		assertFalse(Files.exists(tempPath));
+	}
+
+}


### PR DESCRIPTION
## Summary

- **`TempDir.sandboxedResolve(name)`** — resolves user-supplied names against the temp directory and verifies the result stays within the sandbox. Prevents path traversal via names like `../../etc/passwd`.
- **`JhelmRestProperties` startup validation** — normalizes tempDir to absolute path, creates directory if missing, logs workspace path at INFO level.
- **`ChartController.create`** — uses `sandboxedResolve` instead of raw `resolve` for the chart name.

## Test plan

- [x] `TempDirTest` (5 tests): sandboxedResolve valid name, path traversal rejection, `..` rejection, subdirectory allowed, close cleanup
- [x] `ChartControllerTest#createRejectsPathTraversalName` — verifies 400 for `../../etc/evil`
- [x] All 55 existing REST tests pass
- [x] Workspace log message visible at startup

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)