### PR TITLE
Extract duplicated findChartDir and values coalescing to core

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.MalformedInputException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -24,6 +25,18 @@ import org.alexmond.jhelm.core.util.ValuesLoader;
 public class ChartLoader {
 
 	private final YAMLMapper yamlMapper = YAMLMapper.builder().build();
+
+	/**
+	 * Finds the first subdirectory inside a parent directory. Charts extracted from .tgz
+	 * archives create a single subdirectory (e.g. {@code parent/nginx/}).
+	 * @param parent the directory to search
+	 * @return the first subdirectory, or the parent itself if none found
+	 */
+	public static Path findChartDir(Path parent) throws IOException {
+		try (var stream = Files.list(parent)) {
+			return stream.filter(Files::isDirectory).findFirst().orElse(parent);
+		}
+	}
 
 	public Chart load(File chartDir) throws IOException {
 		if (!chartDir.exists() || !chartDir.isDirectory()) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesOverrides.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesOverrides.java
@@ -20,6 +20,16 @@ public final class ValuesOverrides {
 	}
 
 	/**
+	 * Returns the given values map, or an empty map if {@code null}. Convenience method
+	 * to avoid repeated null-coalescing in controllers.
+	 * @param values the values map (may be {@code null})
+	 * @return the values map, or {@code Map.of()} if {@code null}
+	 */
+	public static Map<String, Object> safeValues(Map<String, Object> values) {
+		return (values != null) ? values : Map.of();
+	}
+
+	/**
 	 * Build a merged override map from values files and {@code --set} arguments.
 	 * @param files paths to YAML values files; {@code null} or empty means none
 	 * @param setArgs {@code key=value} strings; {@code null} or empty means none

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
@@ -2,7 +2,6 @@ package org.alexmond.jhelm.rest.controller;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -11,10 +10,11 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.alexmond.jhelm.core.action.CreateAction;
-
 import org.alexmond.jhelm.core.action.ShowAction;
 import org.alexmond.jhelm.core.action.TemplateAction;
+import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.core.util.ValuesOverrides;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
 import org.alexmond.jhelm.rest.dto.CreateRequest;
 
@@ -69,7 +69,7 @@ public class ChartController {
 		}
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-template-")) {
 			String chartPath = pullChart(request.getChartRef(), request.getVersion(), tempDir);
-			Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
 			String manifest = this.templateAction.render(chartPath, request.getReleaseName(), request.getNamespace(),
 					values);
 			return ResponseEntity.ok(manifest);
@@ -85,8 +85,8 @@ public class ChartController {
 			File tgzFile = tempDir.path().resolve("upload.tgz").toFile();
 			chart.transferTo(tgzFile);
 			this.repoManager.untar(tgzFile, tempDir.path().toFile());
-			String chartPath = findChartDir(tempDir.path());
-			Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+			String chartPath = ChartLoader.findChartDir(tempDir.path()).toString();
+			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
 			String manifest = this.templateAction.render(chartPath, request.getReleaseName(), request.getNamespace(),
 					values);
 			return ResponseEntity.ok(manifest);
@@ -168,13 +168,7 @@ public class ChartController {
 
 	private String pullChart(String chartRef, String version, TempDir tempDir) throws IOException {
 		this.repoManager.pull(chartRef, version, tempDir.path().toString());
-		return findChartDir(tempDir.path());
-	}
-
-	private static String findChartDir(Path parent) throws IOException {
-		try (var stream = Files.list(parent)) {
-			return stream.filter(Files::isDirectory).findFirst().orElse(parent).toString();
-		}
+		return ChartLoader.findChartDir(tempDir.path()).toString();
 	}
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/DependencyController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/DependencyController.java
@@ -1,8 +1,5 @@
 package org.alexmond.jhelm.rest.controller;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -23,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.alexmond.jhelm.core.util.ValuesOverrides;
 
 @RestController
 @RequestMapping("${jhelm.rest.base-path:/api/v1}/dependencies")
@@ -56,16 +54,10 @@ public class DependencyController {
 		}
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-dep-resolve-")) {
 			this.repoManager.pull(request.getChartRef(), request.getVersion(), tempDir.path().toString());
-			Chart chart = this.chartLoader.load(findChartDir(tempDir.path()).toFile());
-			Map<String, Object> values = (chart.getValues() != null) ? chart.getValues() : Map.of();
+			Chart chart = this.chartLoader.load(ChartLoader.findChartDir(tempDir.path()).toFile());
+			Map<String, Object> values = ValuesOverrides.safeValues(chart.getValues());
 			ChartLock lock = this.dependencyResolver.resolveDependencies(chart.getMetadata(), values, List.of());
 			return ResponseEntity.ok().contentType(TEXT_YAML).body(lock.toYaml());
-		}
-	}
-
-	private static Path findChartDir(Path parent) throws IOException {
-		try (var stream = Files.list(parent)) {
-			return stream.filter(Files::isDirectory).findFirst().orElse(parent);
 		}
 	}
 

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
@@ -49,6 +49,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.alexmond.jhelm.core.util.ValuesOverrides;
 
 @RestController
 @RequestMapping("${jhelm.rest.base-path:/api/v1}/releases")
@@ -131,7 +132,7 @@ public class ReleaseController {
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-install-")) {
 			Chart chart = ChartSourceResolver.fromChartRef(request.getChartRef(), request.getVersion(),
 					this.repoManager, this.chartLoader, tempDir);
-			Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
 			Release release = this.installAction.install(chart, request.getReleaseName(), request.getNamespace(),
 					values, 1, request.isDryRun());
 			return ResponseEntity.status(HttpStatus.CREATED).body(ReleaseDto.from(release));
@@ -148,7 +149,7 @@ public class ReleaseController {
 		}
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-install-upload-")) {
 			Chart loaded = ChartSourceResolver.fromUpload(chart, this.repoManager, this.chartLoader, tempDir);
-			Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
 			Release release = this.installAction.install(loaded, request.getReleaseName(), request.getNamespace(),
 					values, 1, request.isDryRun());
 			return ResponseEntity.status(HttpStatus.CREATED).body(ReleaseDto.from(release));
@@ -169,7 +170,7 @@ public class ReleaseController {
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-upgrade-")) {
 			Chart chart = ChartSourceResolver.fromChartRef(request.getChartRef(), request.getVersion(),
 					this.repoManager, this.chartLoader, tempDir);
-			Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
 			Release upgraded = this.upgradeAction.upgrade(current, chart, values, request.isDryRun());
 			return ReleaseDto.from(upgraded);
 		}
@@ -186,7 +187,7 @@ public class ReleaseController {
 			.orElseThrow(() -> new IllegalArgumentException("Release '" + name + "' not found"));
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-upgrade-upload-")) {
 			Chart loaded = ChartSourceResolver.fromUpload(chart, this.repoManager, this.chartLoader, tempDir);
-			Map<String, Object> values = (request.getValues() != null) ? request.getValues() : Map.of();
+			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
 			Release upgraded = this.upgradeAction.upgrade(current, loaded, values, request.isDryRun());
 			return ReleaseDto.from(upgraded);
 		}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/RepoController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/RepoController.java
@@ -1,7 +1,6 @@
 package org.alexmond.jhelm.rest.controller;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -33,6 +32,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.alexmond.jhelm.core.service.ChartLoader;
 
 @RestController
 @RequestMapping("${jhelm.rest.base-path:/api/v1}/repos")
@@ -121,7 +121,7 @@ public class RepoController {
 					.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + files[0].getName() + "\"")
 					.body(tgz);
 			}
-			Path chartDir = findSingleSubdir(tempDir.path());
+			Path chartDir = ChartLoader.findChartDir(tempDir.path());
 			String dirName = chartDir.getFileName().toString();
 			byte[] tgz = ChartArchiveUtil.toTgzBytes(chartDir, dirName);
 			return ResponseEntity.ok()
@@ -166,12 +166,6 @@ public class RepoController {
 		}
 		String v = (version != null) ? version : "latest";
 		return chartName + "-" + v + ".tgz";
-	}
-
-	private static Path findSingleSubdir(Path parent) throws IOException {
-		try (var stream = Files.list(parent)) {
-			return stream.filter(Files::isDirectory).findFirst().orElse(parent);
-		}
 	}
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/util/ChartSourceResolver.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/util/ChartSourceResolver.java
@@ -1,10 +1,7 @@
 package org.alexmond.jhelm.rest.util;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.stream.Stream;
 
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -32,7 +29,7 @@ public final class ChartSourceResolver {
 	public static Chart fromChartRef(String chartRef, String version, RepoManager repoManager, ChartLoader chartLoader,
 			TempDir tempDir) throws Exception {
 		repoManager.pull(chartRef, version, tempDir.path().toString());
-		Path chartDir = findChartDir(tempDir.path());
+		Path chartDir = ChartLoader.findChartDir(tempDir.path());
 		return chartLoader.load(chartDir.toFile());
 	}
 
@@ -49,14 +46,8 @@ public final class ChartSourceResolver {
 		File tgzFile = tempDir.path().resolve("upload.tgz").toFile();
 		file.transferTo(tgzFile);
 		repoManager.untar(tgzFile, tempDir.path().toFile());
-		Path chartDir = findChartDir(tempDir.path());
+		Path chartDir = ChartLoader.findChartDir(tempDir.path());
 		return chartLoader.load(chartDir.toFile());
-	}
-
-	private static Path findChartDir(Path parent) throws IOException {
-		try (Stream<Path> stream = Files.list(parent)) {
-			return stream.filter(Files::isDirectory).findFirst().orElse(parent);
-		}
 	}
 
 }


### PR DESCRIPTION
## Summary

Extract the two most-duplicated code patterns from REST controllers into shared core utilities:

- **`ChartLoader.findChartDir(Path)`** — consolidates 4 identical copies (ChartController, DependencyController, RepoController, ChartSourceResolver) into one static method in jhelm-core
- **`ValuesOverrides.safeValues(Map)`** — replaces 7 copies of `(values != null) ? values : Map.of()` null-coalescing pattern

Net result: **-5 lines** (41 added, 46 removed) while eliminating 11 duplicate code blocks.

## Test plan

- [x] All 55 REST tests pass (unchanged behavior)
- [x] PMD/checkstyle clean
- [x] No unused imports remaining

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)