### PR TITLE
Configure Lombok annotationProcessorPath and add release workflow

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -1,0 +1,72 @@
+name: Maven Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release version'
+        required: true
+      nextVersion:
+        description: 'Next development version (with -SNAPSHOT suffix)'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+          server-id: central
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+      - name: Set Release Version
+        run: ./mvnw versions:set -DnewVersion=${{ github.event.inputs.releaseVersion }} --no-transfer-progress
+
+      - name: Verify Build
+        run: ./mvnw --batch-mode clean verify --no-transfer-progress
+
+      - name: Commit and Tag Release
+        run: |
+          git commit -am "Prepare release ${{ github.event.inputs.releaseVersion }}"
+          git tag -a ${{ github.event.inputs.releaseVersion }} -m "Release ${{ github.event.inputs.releaseVersion }}"
+
+      - name: Deploy to Maven Central
+        run: ./mvnw --batch-mode clean deploy -Prelease -Dgpg.passphrase="${GPG_PASSPHRASE}" --no-transfer-progress
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Set Next Development Version
+        run: |
+          ./mvnw versions:set -DnewVersion=${{ github.event.inputs.nextVersion }} --no-transfer-progress
+          git commit -am "Prepare for next development iteration: ${{ github.event.inputs.nextVersion }}"
+
+      - name: Push Changes
+        run: git push && git push --tags
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.releaseVersion }}
+          name: Release ${{ github.event.inputs.releaseVersion }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <connection>scm:git:git@github.com:alexmond/jhelm.git</connection>
         <developerConnection>scm:git:git@github.com:alexmond/jhelm.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/alexmond/jsupervisor</url>
+        <url>https://github.com/alexmond/jhelm</url>
     </scm>
     <modules>
         <module>jhelm-gotemplate</module>
@@ -280,6 +280,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,12 @@
                 <configuration>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings> <!-- Optional: also show all other warnings -->
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary
- Configure Lombok as explicit `annotationProcessorPath` with `${lombok.version}` (fixes JDK 22+ builds where classpath annotation processing is deprecated)
- Add `maven_release.yml` workflow for Maven Central releases via `workflow_dispatch`
- Fix SCM URL in root POM (was pointing to `jsupervisor` instead of `jhelm`)

## Test plan
- [ ] Verify `./mvnw validate -Prelease` passes with all modules
- [ ] Verify `./mvnw versions:set -DnewVersion=X` updates all 11 modules
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)