### PR TITLE
Fix regexReplaceAllLiteral/mustRegexReplaceAllLiteral argument order

### DIFF
--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
@@ -705,15 +705,15 @@ public final class StringFunctions {
 				return "";
 			}
 			try {
-				// Sprig signature: regexReplaceAllLiteral pattern replacement text
+				// Sprig signature: regexReplaceAllLiteral pattern text replacement
 				String pattern = String.valueOf(args[0]);
-				String replacement = Matcher.quoteReplacement(String.valueOf(args[1]));
-				String text = String.valueOf(args[2]);
+				String text = String.valueOf(args[1]);
+				String replacement = Matcher.quoteReplacement(String.valueOf(args[2]));
 				return text.replaceAll(pattern, replacement);
 			}
 			catch (Exception ex) {
 				log.debug("regexReplaceAllLiteral failed: {}", ex.getMessage());
-				return String.valueOf(args[2]); // Return original text on error
+				return String.valueOf(args[1]); // Return original text on error
 			}
 		};
 	}
@@ -724,10 +724,10 @@ public final class StringFunctions {
 				throw new FunctionExecutionException("mustRegexReplaceAllLiteral: insufficient arguments");
 			}
 			try {
-				// Sprig signature: mustRegexReplaceAllLiteral pattern replacement text
+				// Sprig signature: mustRegexReplaceAllLiteral pattern text replacement
 				String pattern = String.valueOf(args[0]);
-				String replacement = Matcher.quoteReplacement(String.valueOf(args[1]));
-				String text = String.valueOf(args[2]);
+				String text = String.valueOf(args[1]);
+				String replacement = Matcher.quoteReplacement(String.valueOf(args[2]));
 				return text.replaceAll(pattern, replacement);
 			}
 			catch (Exception ex) {

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/SprigFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/SprigFunctionsTest.java
@@ -47,7 +47,8 @@ class SprigFunctionsTest {
 		StringWriter writer = new StringWriter();
 		Map<String, Object> data = new HashMap<>();
 		data.put("text", "hello world");
-		execute("test", "{{ mustRegexReplaceAllLiteral \"world\" \"universe\" .text }}", data, writer);
+		// Sprig signature: mustRegexReplaceAllLiteral REGEX STRING REPL
+		execute("test", "{{ mustRegexReplaceAllLiteral \"world\" .text \"universe\" }}", data, writer);
 
 		assertEquals("hello universe", writer.toString());
 	}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctionsTest.java
@@ -173,9 +173,15 @@ class StringFunctionsTest {
 		assertEquals(expected, exec(template));
 	}
 
-	@Test
-	void testRegexReplaceAllLiteral() throws IOException, TemplateException {
-		assertFalse(exec("{{ regexReplaceAllLiteral \"[0-9]+\" \"abc123def456\" \"X\" }}").isEmpty());
+	// Sprig signature: regexReplaceAllLiteral REGEX STRING REPL. Expected values
+	// verified against `helm template` (Go text/template + Masterminds/sprig).
+	@ParameterizedTest
+	@CsvSource(delimiter = '|',
+			value = { "{{ regexReplaceAllLiteral \"[0-9]+\" \"abc123def456\" \"X\" }}      | abcXdefX",
+					"{{ regexReplaceAllLiteral \"\\\\W\" \"a@b\" \"_\" }}                   | a_b",
+					"{{ regexReplaceAllLiteral \"o\" \"foo\" \"$1\" }}                      | f$1$1" })
+	void testRegexReplaceAllLiteral(String template, String expected) throws IOException, TemplateException {
+		assertEquals(expected, exec(template));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

`regexReplaceAllLiteral` and `mustRegexReplaceAllLiteral` swapped the **text** and **replacement** arguments. Sprig's signature is `regexReplaceAllLiteral REGEX STRING REPL` (same order as the non-literal `regexReplaceAll` right above it), but jhelm read `args[1]` as the replacement and `args[2]` as the text — producing wrong output.

```
regexReplaceAllLiteral "\W" "a@b" "_"
  helm  -> a_b
  jhelm -> _        (ran "_".replaceAll("\W", "a@b") -> no match)
```

This is on a code path real charts use (e.g. bitnami common `_secrets.tpl`: `regexReplaceAllLiteral "\\W" $password "@"`).

## Changes
- `StringFunctions.java` — fix arg order in both functions (`args[1]`=text, `args[2]`=replacement) and correct the misleading comments.
- `SprigFunctionsTest.java` — the existing `testMustRegexReplaceAllLiteral` **encoded the bug** (passed args in swapped order); corrected to the real Sprig order.
- `StringFunctionsTest.java` — replaced the weak `assertFalse(...isEmpty())` assertion with three parameterized cases whose expected values were **verified against `helm template`** (`abcXdefX`, `a_b`, `f$1$1`).

## Verification
- sprig **517** + helm **112** tests pass, 0 failures.
- `spring-javaformat:apply` + `validate` (Checkstyle/PMD) clean.
- Expected values cross-checked against the real `helm` binary (Go text/template + Masterminds/sprig).

## Note on #312
Found while investigating #312. **#312's lexer diagnosis does not reproduce** — jhelm's backslash handling matches Go exactly (both reject a bare `\` in an action with the identical `unexpected \ in command` error). This PR fixes an adjacent, genuine bug; #312 needs separate resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)