### PR TITLE
Redirect moved kubernetes-dashboard repo URL in comparison tests (#315)

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
@@ -65,6 +65,16 @@ class KpsComparisonTest {
 
 	private static final YAMLMapper YAML_MAPPER = YAMLMapper.builder().build();
 
+	/**
+	 * Repository URL overrides for charts whose upstream repo has moved but whose
+	 * ArtifactHub metadata still advertises the old (now 404) location. Keyed by the
+	 * stale URL, mapped to the working replacement.
+	 */
+	private static final Map<String, String> REPO_URL_OVERRIDES = Map.of(
+			// kubernetes-dashboard: repo renamed to kubernetes-retired; the old
+			// kubernetes.github.io/dashboard GitHub Pages site now returns 404 (#315)
+			"https://kubernetes.github.io/dashboard", "https://kubernetes-retired.github.io/dashboard");
+
 	@Autowired
 	private JhelmTestProperties testProperties;
 
@@ -253,12 +263,16 @@ class KpsComparisonTest {
 			assumeTrue(false, chartName + " is in charts-skip.csv");
 		}
 
+		// Redirect charts whose upstream repo has moved but whose ArtifactHub metadata
+		// still points at the old (now 404) location.
+		String effectiveRepoUrl = REPO_URL_OVERRIDES.getOrDefault(repoUrl.replaceAll("/+$", ""), repoUrl);
+
 		File chartDir = findChartDir(chartName);
 
 		if (chartDir == null) {
-			log.info("Chart {} not found locally, fetching from repository {}...", chartName, repoUrl);
+			log.info("Chart {} not found locally, fetching from repository {}...", chartName, effectiveRepoUrl);
 			try {
-				addHelmRepo(repoId, repoUrl);
+				addHelmRepo(repoId, effectiveRepoUrl);
 				fetchFromHelmRepo(chartName);
 				chartDir = findChartDir(chartName);
 			}

--- a/jhelm-core/src/test/resources/charts-skip.csv
+++ b/jhelm-core/src/test/resources/charts-skip.csv
@@ -28,7 +28,6 @@ opentelemetry-helm/opentelemetry-collector,Helm fails: execution error
 ananace-charts/matrix-synapse,Helm fails: requires mandatory values
 #
 # --- Download failures (external repo issues) ---
-k8s-dashboard/kubernetes-dashboard,Repo 404 — dashboard moved to OCI
 twuni/docker-registry,Repo DNS failure
 prometheus-community/prometheus-adapter,Chart download 404
 deliveryhero/node-problem-detector,Repo intermittently unavailable


### PR DESCRIPTION
Fixes #315.

## TL;DR
Not an OCI/TLS regression. `pullOci()` / the HttpClient5 migration are **not involved**. The kubernetes-dashboard repo was **renamed to `kubernetes-retired`**, so the old GitHub Pages index 404s. jhelm renders the chart with full helm parity once pointed at the working URL.

## Investigation
- `https://kubernetes.github.io/dashboard/index.yaml` → **404**. `helm repo add` against it fails too (so it's not jhelm-specific).
- The chart `.tgz` 301-redirects to `kubernetes-retired/dashboard`; `https://kubernetes-retired.github.io/dashboard/index.yaml` → **200**, `helm repo add` succeeds.
- ArtifactHub still advertises the stale `https://kubernetes.github.io/dashboard`, so `topCharts()` keeps fetching the dead location → the chart had been parked in `charts-skip.csv` with an inaccurate reason ("moved to OCI").
- It is **not OCI-only** — ArtifactHub's `content_url` is a GitHub release tgz, and plain HTTP works at the new Pages URL.

## Fix
- Add `REPO_URL_OVERRIDES` in `compareChart()` that rewrites known-relocated repos (stale → working URL), with trailing-slash normalization. Covers `single.csv`, `charts.csv`, and the dynamic `topCharts()` path.
- Remove the stale `charts-skip.csv` entry so the chart is tested again.

## Verification
Ran the project's own `KpsComparisonTest#compareSingleChart` with the **stale** URL (exactly what ArtifactHub serves) — the override redirected it and:

```
k8s-dashboard/kubernetes-dashboard - All resources match Helm output!
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

jhelm pulls (plain HTTP) and renders kubernetes-dashboard 7.x (cert-manager, ingress-nginx, kong, metrics-server subcharts) byte-for-byte with helm. `spring-javaformat` + `validate` (Checkstyle/PMD) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)