### PR TITLE
Fix exponential node-map growth (OOM) on large umbrella charts (#311)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -228,28 +228,20 @@ public class Engine {
 			return a.compareTo(b);
 		}).toList();
 
-		// Store original rootNodes count
-		int beforeCount = factory.getRootNodes().size();
-
 		for (String name : sortedNames) {
 			try {
 				String chartName = templateToChartName.get(name);
+				// Only helper files contribute named templates that may need a
+				// chart-prefixed alias. Snapshot the keys beforehand so we can alias
+				// exactly the defines this file adds — and nothing else.
+				boolean mayDefine = name.contains("_helpers") || name.endsWith(".tpl");
+				Set<String> beforeKeys = mayDefine ? new HashSet<>(factory.getRootNodes().keySet()) : null;
 				parseWithCache(name, allTemplates.get(name));
 				if (log.isDebugEnabled()) {
 					log.debug("Parsed template: {} (from chart: {})", name, chartName);
 				}
-
-				// After parsing, check if new named templates (defines) were added
-				// If this is a _helpers.tpl from a subchart, we need to alias the
-				// templates
-				if (name.contains("_helpers") || name.endsWith(".tpl")) {
-					int afterCount = factory.getRootNodes().size();
-					if (afterCount > beforeCount) {
-						// New named templates were added
-						// We need to create aliases with chart prefix
-						createChartPrefixedAliases(chartName);
-					}
-					beforeCount = afterCount;
+				if (beforeKeys != null) {
+					createChartPrefixedAliases(chartName, beforeKeys);
 				}
 			}
 			catch (Exception ex) {
@@ -267,23 +259,28 @@ public class Engine {
 		}
 	}
 
-	private void createChartPrefixedAliases(String chartName) {
-		// Get the rootNodes map to find newly added templates
+	/**
+	 * Register chart-prefixed aliases ({@code <chartName>.<template>}) for the named
+	 * templates added by the helper file just parsed. Only the keys absent from
+	 * {@code beforeKeys} are aliased, and each gets a single prefix — re-aliasing the
+	 * whole template set on every helper file would compound prefixes across subcharts
+	 * and explode the node map (#311).
+	 * @param chartName the chart whose helper file was just parsed
+	 * @param beforeKeys the {@code rootNodes} key set captured before parsing that file
+	 */
+	private void createChartPrefixedAliases(String chartName, Set<String> beforeKeys) {
 		Map<String, Node> rootNodes = factory.getRootNodes();
-		List<String> allKeys = new ArrayList<>(rootNodes.keySet());
-
-		// Templates added between beforeCount and afterCount are the new ones
-		// We need to create aliases with chart name prefix
-		for (String templateName : allKeys) {
-			// Skip file templates (they usually have paths)
-			if (templateName.contains("/") || templateName.contains("\\")) {
-				continue;
+		List<String> newlyAdded = new ArrayList<>();
+		for (String key : rootNodes.keySet()) {
+			// Only newly added named templates (defines) — skip file-path keys.
+			if (!beforeKeys.contains(key) && !key.contains("/") && !key.contains("\\")) {
+				newlyAdded.add(key);
 			}
+		}
 
-			// If this template doesn't already have the chart prefix, create an alias
+		for (String templateName : newlyAdded) {
 			if (!templateName.startsWith(chartName + ".")) {
 				String prefixedName = chartName + "." + templateName;
-				// Add alias: (prefixedName) -> same node as templateName
 				Node node = rootNodes.get(templateName);
 				if (node != null && !rootNodes.containsKey(prefixedName)) {
 					rootNodes.put(prefixedName, node);

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -1,6 +1,7 @@
 package org.alexmond.jhelm.core.service;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -187,6 +188,36 @@ class EngineTest {
 		String result = engine.render(parent, Map.of(), releaseInfo());
 		assertTrue(result.contains("name: parent-app"));
 		assertTrue(result.contains("name: redis"));
+	}
+
+	@Test
+	void testManySubchartHelpersDoNotExplodeNodeMap() {
+		// Regression for #311: createChartPrefixedAliases used to re-alias the entire
+		// named-template set on every helper file, compounding chart prefixes across
+		// subcharts and growing the node map exponentially (millions of entries for a
+		// few hundred templates → OOM). With many helper-bearing subcharts this OOMs
+		// at the test heap on the buggy code; the fix keeps it linear.
+		int subchartCount = 30;
+		StringBuilder includes = new StringBuilder("apiVersion: v1\nkind: ConfigMap\ndata:\n");
+		List<Chart> subcharts = new ArrayList<>();
+		for (int i = 0; i < subchartCount; i++) {
+			subcharts.add(simpleChart("sub" + i, "1.0.0",
+					List.of(tmpl("_helpers.tpl", "{{ define \"tpl" + i + "\" }}val" + i + "{{ end }}")), Map.of()));
+			includes.append("  key").append(i).append(": {{ include \"tpl").append(i).append("\" . }}\n");
+		}
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder().name("parent").version("1.0.0").build())
+			.templates(List.of(tmpl("configmap.yaml", includes.toString())))
+			.values(Map.of())
+			.dependencies(subcharts)
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		// Every subchart's named template must resolve via include.
+		for (int i = 0; i < subchartCount; i++) {
+			assertTrue(result.contains("key" + i + ": val" + i), "missing rendered value for subchart " + i);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #311.

## Root cause (not what the issue hypothesized)
The OOM is **not** the combined file ASTs — it's `createChartPrefixedAliases`. For every subchart helper file, it re-aliased the **entire** named-template set with that chart's prefix, *including aliases already created for other subcharts*. Prefixes compounded across subcharts (`C.B.A.foo`…), so `rootNodes` grew **exponentially**.

Measured on openebs (~580 templates, 8 subcharts) with instrumentation:
```
[collect] parsed=100  rootNodes=4,434,823  usedMB=1073
[collect] parsed=200  rootNodes=8,861,025  usedMB=1944
```
~8.86M node-map entries after only ~200 templates → OOM at 512m/1g/**2g**.

## Fix
Alias only the named templates a helper file *actually adds* — diffed against a snapshot of the key set taken just before parsing that file — each with a **single** prefix. No compounding.

## Verification
- **Memory:** openebs now clears the collect phase at a **256MB** heap (was OOM at 2GB). >8× reduction. (It then hits a separate `tpl`-backslash parse error in the `mayastor` subchart — that's #312, not this issue.)
- **Parity:** multi-subchart charts render byte-for-byte with helm via the project comparison test — `prometheus`, `bitnami/mongodb`, `grafana` all report *"All resources match Helm output!"*.
- **Regression test:** `testManySubchartHelpersDoNotExplodeNodeMap` builds 30 helper-bearing subcharts; it OOMs the old code at the test heap and passes (linear) on the fix.
- Full `EngineTest` (97), Checkstyle/PMD `validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)