### PR TITLE
Emit YAML sequence items as plain scalars in toYaml (#312)

### DIFF
--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -96,8 +96,14 @@ public final class ConversionFunctions {
 		return LoadSettings.builder().setSchema(schema).build();
 	}
 
-	/** Pattern matching a YAML line with a double-quoted scalar value. */
-	private static final Pattern QUOTED_VALUE = Pattern.compile("^(\\s*\\S+:\\s+)\"((?:[^\"\\\\]|\\\\.)*)\"\\s*$");
+	/**
+	 * Pattern matching a YAML line with a double-quoted scalar value, in either a mapping
+	 * entry ({@code key: "..."}) or a sequence item ({@code - "..."}). Both forms are
+	 * over-quoted by Jackson and need plain-style normalisation to match Go's
+	 * {@code yaml.Marshal} (#312).
+	 */
+	private static final Pattern QUOTED_VALUE = Pattern
+		.compile("^(\\s*(?:\\S+:|-)\\s+)\"((?:[^\"\\\\]|\\\\.)*)\"\\s*$");
 
 	/** YAML boolean and null literals that must remain quoted. */
 	private static final Set<String> YAML_KEYWORDS = Set.of("true", "false", "yes", "no", "on", "off", "null", "~");

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.gotemplate.helm.functions;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -142,6 +143,28 @@ class ConversionFunctionsTest {
 		assertTrue(result.contains("replicas: 3"), "non-null integer field should be present");
 		assertTrue(result.contains("revisionHistoryLimit: null"), "null field should be rendered as null");
 		assertTrue(result.contains("dnsPolicy: null"), "null field should be rendered as null");
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "toYaml", "mustToYaml" })
+	void testYamlSequenceItemWithEmbeddedQuotesIsPlain(String func) throws IOException, TemplateException {
+		// #312: a list element containing double quotes (e.g. a shell command with a
+		// nested {{ include "x" . }}) was emitted as a double-quoted scalar with \"
+		// escapes. Go's yaml.Marshal emits it plain, and the backslashes break a
+		// subsequent tpl(toYaml ...) re-parse. Sequence items must be normalised to
+		// plain style just like mapping values are.
+		Map<String, Object> data = new HashMap<>();
+		data.put("obj", Map.of("command", List.of("sh", "-c", "until nc {{ include \"etcdUrl\" . }} 80; done")));
+
+		String result = execWithData("{{ " + func + " .obj }}", data);
+
+		assertTrue(result.contains("- until nc {{ include \"etcdUrl\" . }} 80; done"),
+				"sequence item should be a plain scalar, got: " + result);
+		assertFalse(result.contains("\\\""), "sequence item must not contain backslash-escaped quotes: " + result);
+		// The whole point: the emitted YAML must itself be re-parseable as a template
+		// (this is what tpl (toYaml ...) does).
+		assertDoesNotThrow(() -> new GoTemplate().parse("inline", result),
+				"toYaml output must be parseable by tpl: " + result);
 	}
 
 	// --- Direct function invocation tests for edge cases ---


### PR DESCRIPTION
Fixes #312.

## Root cause
`toYaml` already normalises over-quoted **mapping values** (`key: "..."`) back to plain style to match Go's `yaml.Marshal`, via `removeUnnecessaryQuotes` + `QUOTED_VALUE`. But `QUOTED_VALUE` only matched mapping entries — **not sequence items** (`- "..."`). So a list element containing double quotes stayed double-quoted with `\"` escapes:

```
- "until nc {{ include \"etcdUrl\" . }} 80; done"
```

When that output is fed back through `tpl` — the common `tpl ($x | toYaml) .ctx` pattern (e.g. `mayastor` in `openebs/openebs`) — the backslash inside the `{{ … }}` action breaks the lexer with `unexpected \ in command`. Go emits the string **plain**, so helm never hits it. (The lexer is correct — Go rejects a bare `\` in an action too; the bug is `toYaml` introducing the backslashes.)

## Fix
Generalise `QUOTED_VALUE` to match both mapping entries and sequence items, so the existing `canBePlainScalar`-guarded plain normalisation applies to list elements too.

```diff
- ^(\s*\S+:\s+)"(...)"\s*$
+ ^(\s*(?:\S+:|-)\s+)"(...)"\s*$
```

## Verification
- New regression test: the sequence item is emitted plain, contains no `\"` escapes, and the emitted YAML round-trips through a template parse (the `tpl(toYaml …)` scenario).
- jhelm-gotemplate-helm suite: **114** tests pass; `validate` (Checkstyle/PMD) clean.
- **Full parity preserved:** the comparison suite (`compareAllTopCharts`, 22 charts incl. argo-cd, cert-manager, prometheus, grafana, bitnami/*) reports *"All resources match Helm output!"* for every chart — the sequence-item change is byte-for-byte safe.
- Confirmed end-to-end on the original repro: `openebs/mayastor`'s `render_init_containers` (`tpl ($containers | toYaml)`) no longer throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)