### PR TITLE
Make tpl-defined templates visible to include/template

### DIFF
--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctions.java
@@ -97,22 +97,40 @@ public final class TemplateFunctions {
 			String text = String.valueOf(args[0]);
 			Object data = args[1];
 			try {
-				// Create a new template instance inheriting functions and named templates
-				GoTemplate tplTemplate = new GoTemplate(factory.getFunctions());
-				tplTemplate.getRootNodes().putAll(factory.getRootNodes());
-
-				// Parse the inline template
-				tplTemplate.parse("inline", text);
-
-				// Execute and return result
-				StringWriter writer = new StringWriter();
-				tplTemplate.execute("inline", data, writer);
-				return writer.toString();
+				return renderInline(factory, text, data);
 			}
 			catch (Exception ex) {
 				throw new FunctionExecutionException("tpl: failed to evaluate template: " + ex.getMessage(), ex);
 			}
 		};
+	}
+
+	/**
+	 * Parse and execute an inline template string against the engine's shared template
+	 * set. Named templates ({@code define} blocks) declared inside the inline text are
+	 * registered back into {@code factory} so that {@code include}/{@code template} —
+	 * which resolve against {@code factory} — can find them. This matches Helm, where a
+	 * template defined within a {@code tpl} string joins the global namespace (e.g. a
+	 * chart that declares {@code define} and {@code include} of the same name inside a
+	 * single values string).
+	 * @param factory the engine template set whose functions and named templates are
+	 * inherited
+	 * @param text the inline template source
+	 * @param data the rendering context
+	 * @return the rendered output
+	 */
+	private static String renderInline(GoTemplate factory, String text, Object data) throws Exception {
+		GoTemplate tplTemplate = new GoTemplate(factory.getFunctions());
+		tplTemplate.getRootNodes().putAll(factory.getRootNodes());
+		tplTemplate.parse("inline", text);
+		for (var entry : tplTemplate.getRootNodes().entrySet()) {
+			if (!"inline".equals(entry.getKey())) {
+				factory.getRootNodes().putIfAbsent(entry.getKey(), entry.getValue());
+			}
+		}
+		StringWriter writer = new StringWriter();
+		tplTemplate.execute("inline", data, writer);
+		return writer.toString();
 	}
 
 	/**
@@ -128,17 +146,7 @@ public final class TemplateFunctions {
 			String text = String.valueOf(args[0]);
 			Object data = args[1];
 			try {
-				// Create a new template instance inheriting functions and named templates
-				GoTemplate tplTemplate = new GoTemplate(factory.getFunctions());
-				tplTemplate.getRootNodes().putAll(factory.getRootNodes());
-
-				// Parse the inline template
-				tplTemplate.parse("inline", text);
-
-				// Execute and return result
-				StringWriter writer = new StringWriter();
-				tplTemplate.execute("inline", data, writer);
-				return writer.toString();
+				return renderInline(factory, text, data);
 			}
 			catch (Exception ex) {
 				throw new FunctionExecutionException("mustTpl: failed to evaluate template: " + ex.getMessage(), ex);

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctionsTest.java
@@ -129,6 +129,25 @@ class TemplateFunctionsTest {
 	}
 
 	@Test
+	void testTplDefineAndIncludeInSameString() throws Exception {
+		// A chart may declare a {{ define }} and {{ include }} it within one tpl'd string
+		// (e.g. openebs/mayastor's regex_or in values.yaml). The define must be visible
+		// to include, which resolves against the shared template set.
+		Function tpl = functions.get("tpl");
+		String text = "{{- define \"regex_or\" -}}{{ .a }}|{{ .b }}{{- end -}}{{ include \"regex_or\" . }}";
+		String result = (String) tpl.invoke(new Object[] { text, Map.of("a", "x", "b", "y") });
+		assertEquals("x|y", result);
+	}
+
+	@Test
+	void testMustTplDefineAndIncludeInSameString() throws Exception {
+		Function mustTpl = functions.get("mustTpl");
+		String text = "{{- define \"greet\" -}}hi {{ .who }}{{- end -}}{{ include \"greet\" . }}";
+		String result = (String) mustTpl.invoke(new Object[] { text, Map.of("who", "bob") });
+		assertEquals("hi bob", result);
+	}
+
+	@Test
 	void testTplThrowsOnSyntaxError() {
 		Function tpl = functions.get("tpl");
 		RuntimeException ex = assertThrows(RuntimeException.class,


### PR DESCRIPTION
## Problem
`tpl`/`mustTpl` parse the inline text into a *fresh* `GoTemplate`, but `include` and `template` resolve named templates against the shared engine `factory`. So a `{{ define }}` declared **inside** a `tpl`'d string was invisible to an `{{ include }}` of it in the same string, failing with `Template '<name>' not found`.

Charts hit this when a single values string both defines and includes a helper — e.g. `openebs/openebs`'s `mayastor` subchart declares `define "regex_or"` and `include "regex_or"` inside one `values.yaml` string rendered via `tpl`.

## Fix
Extract a shared `renderInline` helper used by both `tpl` and `mustTpl`, and register named templates declared inside the inline text back into the `factory` namespace — matching Helm, where `tpl`-defined templates join the global template set.

## Tests
- `testTplDefineAndIncludeInSameString` and `testMustTplDefineAndIncludeInSameString` (define + include in one `tpl` string).
- Full `jhelm-gotemplate-helm` suite passes; `validate` clean.

Found while rendering `openebs` end-to-end (after #322 and #323). See the new function-coverage doc for the broader edge-case list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)