### PR TITLE
Add toYamlPretty function

### DIFF
--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -59,6 +59,19 @@ public final class ConversionFunctions {
 		.build());
 
 	/**
+	 * YAML mapper for {@code toYamlPretty}. Identical to {@link #YAML_MAPPER} but indents
+	 * block sequence items under their key ({@code   - x} instead of {@code - x}),
+	 * matching Helm's {@code toYamlPretty} (a yaml.v3 encoder with indent 2).
+	 */
+	private static final ThreadLocal<YAMLMapper> PRETTY_YAML_MAPPER = ThreadLocal.withInitial(() -> YAMLMapper.builder()
+		.disable(YAMLWriteFeature.WRITE_DOC_START_MARKER)
+		.disable(YAMLWriteFeature.SPLIT_LINES)
+		.enable(YAMLWriteFeature.MINIMIZE_QUOTES)
+		.enable(YAMLWriteFeature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)
+		.enable(YAMLWriteFeature.INDENT_ARRAYS_WITH_INDICATOR)
+		.build());
+
+	/**
 	 * YAML 1.1 octal pattern: bare-zero prefix followed by octal digits (e.g. 0660,
 	 * 0755). Go's yaml.v3 retains YAML 1.1 compatibility for these literals, parsing them
 	 * as integers. SnakeYAML Engine (YAML 1.2 strict) only recognises 0o prefix.
@@ -146,6 +159,7 @@ public final class ConversionFunctions {
 
 		// YAML functions
 		functions.put("toYaml", toYaml());
+		functions.put("toYamlPretty", toYamlPretty());
 		functions.put("mustToYaml", mustToYaml());
 		functions.put("fromYaml", fromYaml());
 		functions.put("mustFromYaml", mustFromYaml());
@@ -193,6 +207,29 @@ public final class ConversionFunctions {
 			}
 			catch (Exception ex) {
 				log.debug("toYaml failed: {}", ex.getMessage());
+				return "";
+			}
+		};
+	}
+
+	/**
+	 * toYamlPretty converts an object to YAML with block sequence items indented under
+	 * their key (Helm's {@code toYamlPretty}). Returns empty string on error.
+	 */
+	private static Function toYamlPretty() {
+		return (args) -> {
+			if (args.length == 0 || args[0] == null) {
+				return "";
+			}
+			try {
+				String yaml = PRETTY_YAML_MAPPER.get().writeValueAsString(args[0]);
+				if (yaml.startsWith("---\n")) {
+					yaml = yaml.substring(4);
+				}
+				return removeUnnecessaryQuotes(yaml.trim());
+			}
+			catch (Exception ex) {
+				log.debug("toYamlPretty failed: {}", ex.getMessage());
 				return "";
 			}
 		};

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -144,6 +144,31 @@ class ConversionFunctionsTest {
 		assertTrue(result.contains("dnsPolicy: null"), "null field should be rendered as null");
 	}
 
+	@Test
+	void testToYamlPrettyIndentsSequenceItems() throws IOException, TemplateException {
+		// Helm's toYamlPretty indents block sequence items under their key
+		// (" - a: 1"), unlike toYaml which aligns the dash with the key ("- a: 1").
+		Map<String, Object> obj = new LinkedHashMap<>();
+		obj.put("list", List.of(Map.of("a", 1)));
+		obj.put("map", Map.of("k", "v"));
+		Map<String, Object> data = new HashMap<>();
+		data.put("obj", obj);
+
+		String pretty = execWithData("{{ toYamlPretty .obj }}", data);
+		String plain = execWithData("{{ toYaml .obj }}", data);
+
+		assertTrue(pretty.contains("list:\n  - a: 1"), "pretty should indent sequence items: " + pretty);
+		assertTrue(plain.contains("list:\n- a: 1"), "plain toYaml aligns dash with key: " + plain);
+		assertTrue(pretty.contains("map:\n  k: v"), "mapping indentation unchanged: " + pretty);
+	}
+
+	@Test
+	void testToYamlPrettyNullAndEmpty() {
+		Function toYamlPretty = functions().get("toYamlPretty");
+		assertEquals("", toYamlPretty.invoke(new Object[] {}));
+		assertEquals("", toYamlPretty.invoke(new Object[] { null }));
+	}
+
 	// --- Direct function invocation tests for edge cases ---
 
 	private Map<String, Function> functions() {
@@ -370,10 +395,10 @@ class ConversionFunctionsTest {
 	@Test
 	void testGetFunctionsReturnsAllExpected() {
 		Map<String, Function> fns = functions();
-		List<String> expected = List.of("toYaml", "mustToYaml", "fromYaml", "mustFromYaml", "fromYamlArray",
-				"mustFromYamlArray", "toJson", "mustToJson", "toPrettyJson", "mustToPrettyJson", "toRawJson",
-				"mustToRawJson", "fromJson", "mustFromJson", "fromJsonArray", "mustFromJsonArray", "toToml",
-				"mustToToml", "fromToml", "mustFromToml");
+		List<String> expected = List.of("toYaml", "toYamlPretty", "mustToYaml", "fromYaml", "mustFromYaml",
+				"fromYamlArray", "mustFromYamlArray", "toJson", "mustToJson", "toPrettyJson", "mustToPrettyJson",
+				"toRawJson", "mustToRawJson", "fromJson", "mustFromJson", "fromJsonArray", "mustFromJsonArray",
+				"toToml", "mustToToml", "fromToml", "mustFromToml");
 		for (String name : expected) {
 			assertTrue(fns.containsKey(name), "missing function: " + name);
 		}


### PR DESCRIPTION
Closes the one genuine function-coverage gap found in the audit (#325): `toYamlPretty` was the only Helm template function jhelm did not register (verified against `helm template` — it exists in Helm and returned plain results, while jhelm had no entry).

## Behaviour
`toYamlPretty` marshals like `toYaml` but **indents block sequence items under their key**:

```yaml
# toYaml          # toYamlPretty
list:             list:
- a: 1              - a: 1
```

This matches Helm's `toYamlPretty` (yaml.v3 encoder, indent 2).

## Implementation
A dedicated `YAMLMapper` with `INDENT_ARRAYS_WITH_INDICATOR`, reusing the same quote-minimisation post-processing as `toYaml`.

## Tests
- Indented-sequence output vs `toYaml`'s flush dash
- null / empty handling
- Updated the registered-function set assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)