### PR TITLE
Emit non-plain YAML values containing quotes as single-quoted (#327)

### DIFF
--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -640,6 +640,16 @@ public final class ConversionFunctions {
 				if (canBePlainScalar(unescaped)) {
 					sb.append(prefix).append(unescaped);
 				}
+				else if (unescaped.indexOf('"') >= 0 && canBeSingleQuoted(unescaped)) {
+					// A value that cannot be plain (e.g. starts with a flow indicator
+					// like
+					// "{{") but contains double quotes is emitted by Go's yaml.Marshal in
+					// SINGLE-quote style, not double-quote-with-backslash-escapes. The
+					// backslashes otherwise break a subsequent tpl(toYaml ...) re-parse —
+					// a
+					// common pattern is a config value of {{ include "x" . }} (#327).
+					sb.append(prefix).append('\'').append(unescaped.replace("'", "''")).append('\'');
+				}
 				else {
 					sb.append(line);
 				}
@@ -710,6 +720,21 @@ public final class ConversionFunctions {
 		// Must not look like a number (would lose string type)
 		if (NUMERIC.matcher(s).matches()) {
 			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Whether a string can be represented as a YAML single-quoted scalar. Single quotes
+	 * can hold any printable content (with {@code '} doubled), but control characters
+	 * (including newline/tab) force double-quote style, so those are rejected here.
+	 */
+	private static boolean canBeSingleQuoted(String s) {
+		for (int i = 0; i < s.length(); i++) {
+			char c = s.charAt(i);
+			if (c < 0x20 || c == 0x7f) {
+				return false;
+			}
 		}
 		return true;
 	}

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -96,8 +96,14 @@ public final class ConversionFunctions {
 		return LoadSettings.builder().setSchema(schema).build();
 	}
 
-	/** Pattern matching a YAML line with a double-quoted scalar value. */
-	private static final Pattern QUOTED_VALUE = Pattern.compile("^(\\s*\\S+:\\s+)\"((?:[^\"\\\\]|\\\\.)*)\"\\s*$");
+	/**
+	 * Pattern matching a YAML line with a double-quoted scalar value, in either a mapping
+	 * entry ({@code key: "..."}) or a sequence item ({@code - "..."}). Both forms are
+	 * over-quoted by Jackson and need plain-style normalisation to match Go's
+	 * {@code yaml.Marshal} (#312).
+	 */
+	private static final Pattern QUOTED_VALUE = Pattern
+		.compile("^(\\s*(?:\\S+:|-)\\s+)\"((?:[^\"\\\\]|\\\\.)*)\"\\s*$");
 
 	/** YAML boolean and null literals that must remain quoted. */
 	private static final Set<String> YAML_KEYWORDS = Set.of("true", "false", "yes", "no", "on", "off", "null", "~");

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -167,6 +167,25 @@ class ConversionFunctionsTest {
 				"toYaml output must be parseable by tpl: " + result);
 	}
 
+	@ParameterizedTest
+	@CsvSource({ "toYaml", "mustToYaml" })
+	void testYamlNonPlainValueWithQuotesIsSingleQuoted(String func) throws IOException, TemplateException {
+		// #327: a value that cannot be a plain scalar (starts with the flow indicator
+		// "{{") but contains double quotes was emitted double-quoted with \" escapes,
+		// breaking a subsequent tpl(toYaml ...). Go emits it single-quoted, e.g.
+		// server_address: '{{ include "loki.x" . }}'.
+		Map<String, Object> data = new HashMap<>();
+		data.put("obj", Map.of("server_address", "{{ include \"loki.indexGatewayAddress\" . }}"));
+
+		String result = execWithData("{{ " + func + " .obj }}", data);
+
+		assertTrue(result.contains("server_address: '{{ include \"loki.indexGatewayAddress\" . }}'"),
+				"non-plain value with quotes should be single-quoted, got: " + result);
+		assertFalse(result.contains("\\\""), "must not contain backslash-escaped quotes: " + result);
+		assertDoesNotThrow(() -> new GoTemplate().parse("inline", result),
+				"toYaml output must be parseable by tpl: " + result);
+	}
+
 	// --- Direct function invocation tests for edge cases ---
 
 	private Map<String, Function> functions() {

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.gotemplate.helm.functions;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -142,6 +143,28 @@ class ConversionFunctionsTest {
 		assertTrue(result.contains("replicas: 3"), "non-null integer field should be present");
 		assertTrue(result.contains("revisionHistoryLimit: null"), "null field should be rendered as null");
 		assertTrue(result.contains("dnsPolicy: null"), "null field should be rendered as null");
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "toYaml", "mustToYaml" })
+	void testYamlSequenceItemWithEmbeddedQuotesIsPlain(String func) throws IOException, TemplateException {
+		// #312: a list element containing double quotes (e.g. a shell command with a
+		// nested {{ include "x" . }}) was emitted as a double-quoted scalar with \"
+		// escapes. Go's yaml.Marshal emits it plain, and the backslashes break a
+		// subsequent tpl(toYaml ...) re-parse. Sequence items must be normalised to
+		// plain style just like mapping values are.
+		Map<String, Object> data = new HashMap<>();
+		data.put("obj", Map.of("command", List.of("sh", "-c", "until nc {{ include \"etcdUrl\" . }} 80; done")));
+
+		String result = execWithData("{{ " + func + " .obj }}", data);
+
+		assertTrue(result.contains("- until nc {{ include \"etcdUrl\" . }} 80; done"),
+				"sequence item should be a plain scalar, got: " + result);
+		assertFalse(result.contains("\\\""), "sequence item must not contain backslash-escaped quotes: " + result);
+		// The whole point: the emitted YAML must itself be re-parseable as a template
+		// (this is what tpl (toYaml ...) does).
+		assertDoesNotThrow(() -> new GoTemplate().parse("inline", result),
+				"toYaml output must be parseable by tpl: " + result);
 	}
 
 	// --- Direct function invocation tests for edge cases ---


### PR DESCRIPTION
Fixes #327. Builds on #323 (shares `removeUnnecessaryQuotes`).

## Problem
`removeUnnecessaryQuotes` normalises over-quoted scalars to plain style, but a value that **cannot** be plain — e.g. one starting with the flow indicator `{{` — was left **double-quoted with `\"` escapes** when it contained inner double quotes:

```yaml
server_address: "{{ include \"loki.indexGatewayAddress\" . }}"
```

Go's `yaml.Marshal` emits such a value **single-quoted** (confirmed via `helm template`):

```yaml
server_address: '{{ include "loki.indexGatewayAddress" . }}'
```

The backslashes break a subsequent `tpl(toYaml …)` re-parse — the pattern in `grafana/loki`'s `loki.calculatedConfig` (`tpl (mergeOverwrite (tpl .Values.loki.config . | fromYaml) … | toYaml) .`). This was the last blocker preventing **`openebs/openebs`** from rendering.

## Fix
When a quoted scalar can't be plain but its content has no control characters, emit it **single-quoted** (doubling any `'`). Numeric/keyword strings are unaffected (they don't contain `"`).

## Verification
- **`openebs/openebs` now renders end-to-end** (101 documents, same count as helm) — it previously OOM'd at 2GB.
- **22-chart comparison suite stays at full parity** ("All resources match Helm output!").
- New regression test; full `jhelm-gotemplate-helm` suite (118) + `validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)