### PR TITLE
Promote openebs/openebs from skip list to comparison suite

### DIFF
--- a/jhelm-core/src/test/resources/charts-skip.csv
+++ b/jhelm-core/src/test/resources/charts-skip.csv
@@ -2,7 +2,6 @@
 # These charts are skipped due to known issues — re-test when the issue is fixed.
 #
 # --- OOM: chart too large for default heap (#311) ---
-openebs/openebs,OOM — 28 subcharts 760 templates exhaust heap (#311)
 #
 # --- Helm itself fails with default values (not jhelm bugs) ---
 # These charts require mandatory values, use library type, or have schema validation

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -21,3 +21,4 @@ bitnami/redmine,bitnami,https://charts.bitnami.com/bitnami
 argo/argo-cd,argo,https://argoproj.github.io/argo-helm
 jetstack/cert-manager,jetstack,https://charts.jetstack.io
 karpenter/karpenter,karpenter,https://charts.karpenter.sh
+openebs/openebs,openebs,https://openebs.github.io/openebs


### PR DESCRIPTION
`openebs/openebs` was skipped as an OOM case (#311). After the alias-explosion OOM fix (#322) and the tpl/toYaml fixes (#323, #324, #327/#328), it now renders end-to-end (**101 documents**) and matches Helm output.

## Why this is genuine parity
The comparison is order-independent (resources matched by kind+name) and applies only the **standard global ignore rules** (generated Secret data, checksum annotations, webhook TLS certs — all legitimately non-deterministic). There is **no openebs-specific ignore and no catch-all**, so "all resources match" reflects real semantic parity across all 101 resources.

## Change
- Remove `openebs/openebs` from `charts-skip.csv`
- Add it to `charts.csv` so it's covered by `compareAllTopCharts`

## Verification
Full comparison suite (**23 charts**) passes at the standard 512m test heap, openebs included:
```
openebs/openebs - JHelm documents: 101, Helm documents: 101
openebs/openebs - All resources match Helm output!
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0
```

This locks in the session's fixes with a real regression guard — openebs going forward must keep rendering and matching Helm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)