### PR TITLE
Add next 5 popular charts to comparison suite

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -22,3 +22,8 @@ argo/argo-cd,argo,https://argoproj.github.io/argo-helm
 jetstack/cert-manager,jetstack,https://charts.jetstack.io
 karpenter/karpenter,karpenter,https://charts.karpenter.sh
 openebs/openebs,openebs,https://openebs.github.io/openebs
+ingress-nginx/ingress-nginx,ingress-nginx,https://kubernetes.github.io/ingress-nginx
+traefik/traefik,traefik,https://traefik.github.io/charts
+metrics-server/metrics-server,metrics-server,https://kubernetes-sigs.github.io/metrics-server/
+hashicorp/vault,hashicorp,https://helm.releases.hashicorp.com
+harbor/harbor,harbor,https://helm.goharbor.io


### PR DESCRIPTION
Expands comparison coverage to the next 5 most-popular ArtifactHub charts not already covered: **ingress-nginx, traefik, metrics-server, hashicorp/vault, harbor**.

All render and match Helm output with only the standard global ignores (no chart-specific or catch-all ignores):

| Chart | Docs | Result |
|---|---|---|
| ingress-nginx/ingress-nginx | 18/18 | ✅ match |
| traefik/traefik | 6/6 | ✅ match |
| metrics-server/metrics-server | 9/9 | ✅ match |
| hashicorp/vault | 13/13 | ✅ match |
| harbor/harbor | 31/31 | ✅ match |

Full suite now **28 charts, all passing** at the standard 512m test heap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)