### PR TITLE
Add per-chart values overrides to comparison harness

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
@@ -298,9 +298,13 @@ class KpsComparisonTest {
 
 		String sanitizedName = chartName.replace("/", "_");
 
+		// Value overrides for charts that require mandatory values (passed to both Helm
+		// and jhelm so any divergence is a real jhelm bug).
+		Map<String, Object> overrideValues = testProperties.getComparisonValues().getOrDefault(chartName, Map.of());
+
 		// STEP 1: Run Helm template FIRST and save output
 		log.info("{} - Running Helm template first...", chartName);
-		String helmManifest = runHelmInstallDryRun(chartDir, sanitizedReleaseName, "default");
+		String helmManifest = runHelmInstallDryRun(chartDir, sanitizedReleaseName, "default", overrideValues);
 
 		if (helmManifest == null) {
 			// Helm itself failed — skip this chart (requires mandatory values, etc.)
@@ -322,7 +326,7 @@ class KpsComparisonTest {
 		try {
 			log.info("{} - Running JHelm rendering...", chartName);
 			// JHelm dry-run
-			Release release = installAction.install(chart, sanitizedReleaseName, "default", Map.of(), 1, true);
+			Release release = installAction.install(chart, sanitizedReleaseName, "default", overrideValues, 1, true);
 			assertNotNull(release);
 
 			String jhelmManifest = release.getManifest();
@@ -354,10 +358,19 @@ class KpsComparisonTest {
 		}
 	}
 
-	private String runHelmInstallDryRun(File chartDir, String releaseName, String namespace) {
+	private String runHelmInstallDryRun(File chartDir, String releaseName, String namespace,
+			Map<String, Object> values) {
 		try {
-			ProcessBuilder pb = new ProcessBuilder("helm", "template", releaseName, chartDir.getAbsolutePath(),
-					"--namespace", namespace);
+			List<String> command = new ArrayList<>(
+					List.of("helm", "template", releaseName, chartDir.getAbsolutePath(), "--namespace", namespace));
+			if (values != null && !values.isEmpty()) {
+				File valuesFile = File.createTempFile("jhelm-values-", ".yaml");
+				valuesFile.deleteOnExit();
+				YAML_MAPPER.writeValue(valuesFile, values);
+				command.add("--values");
+				command.add(valuesFile.getAbsolutePath());
+			}
+			ProcessBuilder pb = new ProcessBuilder(command);
 			Process process = pb.start();
 
 			String output;

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/config/JhelmTestProperties.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/config/JhelmTestProperties.java
@@ -29,6 +29,14 @@ public class JhelmTestProperties {
 	private Map<String, List<IgnoreRule>> comparisonIgnores = Map.of();
 
 	/**
+	 * Value overrides applied to both Helm and jhelm rendering, keyed by chart name.
+	 * Supplies the mandatory values some charts require so they can be compared (e.g. a
+	 * cluster name or hostname). The same overrides go to {@code helm template -f} and to
+	 * the jhelm install, so any divergence is a real jhelm bug.
+	 */
+	private Map<String, Map<String, Object>> comparisonValues = Map.of();
+
+	/**
 	 * A single comparison-ignore rule describing a resource/path pattern to skip during
 	 * manifest diff.
 	 */

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -29,3 +29,10 @@ jhelmtest:
       - resource: "ConfigMap/*"
         path: "data.install_id"
         reason: "install_id is a random UUID generated per render"
+  # Value overrides for charts that Helm cannot render with default values. The same
+  # overrides are applied to both Helm and jhelm, so any divergence is a real jhelm bug.
+  comparison-values:
+    "[aws/aws-load-balancer-controller]":
+      clusterName: test-cluster
+    "[rancher-stable/rancher]":
+      hostname: rancher.example.com

--- a/jhelm-core/src/test/resources/charts-skip.csv
+++ b/jhelm-core/src/test/resources/charts-skip.csv
@@ -8,10 +8,8 @@
 # that prevents `helm template` from succeeding with default values.
 grafana/loki,Helm fails: execution error (requires storage config)
 argo/argocd-apps,Helm fails: library chart or requires values
-aws/aws-load-balancer-controller,Helm fails: execution error (requires clusterName)
 bitnami/common,Helm fails: library charts are not installable
 drone/drone,Helm fails: values schema validation error
-rancher-stable/rancher,Helm fails: requires mandatory values (hostname)
 sonarqube/sonarqube,Helm fails: requires mandatory values
 nfs-subdir-external-provisioner/nfs-subdir-external-provisioner,Helm fails: requires nfs.server
 jupyterhub/jupyterhub,Helm fails: execution error

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -22,3 +22,8 @@ argo/argo-cd,argo,https://argoproj.github.io/argo-helm
 jetstack/cert-manager,jetstack,https://charts.jetstack.io
 karpenter/karpenter,karpenter,https://charts.karpenter.sh
 openebs/openebs,openebs,https://openebs.github.io/openebs
+ingress-nginx/ingress-nginx,ingress-nginx,https://kubernetes.github.io/ingress-nginx
+traefik/traefik,traefik,https://traefik.github.io/charts
+metrics-server/metrics-server,metrics-server,https://kubernetes-sigs.github.io/metrics-server/
+hashicorp/vault,hashicorp,https://helm.releases.hashicorp.com
+harbor/harbor,harbor,https://helm.goharbor.io

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -27,3 +27,5 @@ traefik/traefik,traefik,https://traefik.github.io/charts
 metrics-server/metrics-server,metrics-server,https://kubernetes-sigs.github.io/metrics-server/
 hashicorp/vault,hashicorp,https://helm.releases.hashicorp.com
 harbor/harbor,harbor,https://helm.goharbor.io
+aws/aws-load-balancer-controller,aws,https://aws.github.io/eks-charts
+rancher-stable/rancher,rancher-stable,https://releases.rancher.com/server-charts/stable


### PR DESCRIPTION
Implements the values-override mechanism so charts that `helm template` can't render with default values can still be compared.

## What
- New `jhelmtest.comparison-values` config (keyed by chart name, bracket notation for slashes — mirrors the existing `comparison-ignores`).
- The overrides are passed to **both** `helm template --values <tmp>` and the jhelm `install(...)`, so the comparison stays apples-to-apples and any difference is a genuine jhelm bug.

## Charts unlocked
Two popular charts previously skipped as "requires mandatory values":

| Chart | Override | Docs | Result |
|---|---|---|---|
| aws/aws-load-balancer-controller | `clusterName` | 11/11 | ✅ match |
| rancher-stable/rancher | `hostname` | 19/19 | ✅ match |

Both match Helm with only the standard global ignores. Full suite now **30 charts, all passing** at the standard 512m heap.

This is the harness groundwork to bring more mandatory-values charts (gitlab, loki, k8s-monitoring, …) under comparison over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)