### PR TITLE
Fix toString(nil)/required(false), enable immich + otel-collector

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -36,3 +36,18 @@ jhelmtest:
       clusterName: test-cluster
     "[rancher-stable/rancher]":
       hostname: rancher.example.com
+    "[immich/immich]":
+      immich:
+        persistence:
+          library:
+            existingClaim: test-claim
+    "[opentelemetry-helm/opentelemetry-collector]":
+      mode: deployment
+      image:
+        repository: otel/opentelemetry-collector-contrib
+      command:
+        name: otelcol-contrib
+    "[ananace-charts/matrix-synapse]":
+      serverName: matrix.example.com
+      config:
+        reportStats: false

--- a/jhelm-core/src/test/resources/charts-skip.csv
+++ b/jhelm-core/src/test/resources/charts-skip.csv
@@ -15,14 +15,12 @@ nfs-subdir-external-provisioner/nfs-subdir-external-provisioner,Helm fails: requ
 jupyterhub/jupyterhub,Helm fails: execution error
 gitlab/gitlab,Helm fails: requires mandatory values (domain)
 actions-runner-controller/actions-runner-controller,Helm fails: requires values
-immich/immich,Helm fails: requires values
 grafana/k8s-monitoring,Helm fails: requires cluster name
 prometheus-community/prometheus-blackbox-exporter,Helm fails: execution error
 prometheus-community/prometheus-postgres-exporter,Helm fails: execution error
 prometheus-community/prometheus-redis-exporter,Helm fails: execution error
 prometheus-community/prometheus-elasticsearch-exporter,Helm fails: execution error
-opentelemetry-helm/opentelemetry-collector,Helm fails: execution error
-ananace-charts/matrix-synapse,Helm fails: requires mandatory values
+ananace-charts/matrix-synapse,Renders with comparison-values but scripts ConfigMap data is empty in jhelm (follow-up)
 #
 # --- Download failures (external repo issues) ---
 twuni/docker-registry,Repo DNS failure

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -29,3 +29,5 @@ hashicorp/vault,hashicorp,https://helm.releases.hashicorp.com
 harbor/harbor,harbor,https://helm.goharbor.io
 aws/aws-load-balancer-controller,aws,https://aws.github.io/eks-charts
 rancher-stable/rancher,rancher-stable,https://releases.rancher.com/server-charts/stable
+immich/immich,immich,https://immich-app.github.io/immich-charts
+opentelemetry-helm/opentelemetry-collector,opentelemetry-helm,https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctions.java
@@ -1,7 +1,6 @@
 package org.alexmond.jhelm.gotemplate.helm.functions;
 
 import java.io.StringWriter;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -166,10 +165,11 @@ public final class TemplateFunctions {
 			String message = String.valueOf(args[0]);
 			Object value = args[1];
 
-			// Check if value is "empty" (null, empty string, false, empty collection)
-			if (value == null || (value instanceof String && ((String) value).isEmpty()) || (value.equals(false))
-					|| (value instanceof Collection && ((Collection<?>) value).isEmpty())
-					|| (value instanceof Map && ((Map<?, ?>) value).isEmpty())) {
+			// Helm's `required` rejects only nil and the empty string — a boolean false,
+			// an empty list, or an empty map are all valid values and must pass through
+			// (e.g. matrix-synapse's `required "..." .Values.config.reportStats` with
+			// reportStats: false).
+			if (value == null || (value instanceof String && ((String) value).isEmpty())) {
 				throw new FunctionExecutionException(message);
 			}
 

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctionsTest.java
@@ -206,27 +206,24 @@ class TemplateFunctionsTest {
 	}
 
 	@Test
-	void testRequiredThrowsOnFalse() {
+	void testRequiredPassesFalse() {
+		// Helm only rejects nil and the empty string — a boolean false is a valid value
+		// (e.g. matrix-synapse's `required "..." .Values.config.reportStats`).
 		Function required = functions.get("required");
-		RuntimeException ex = assertThrows(RuntimeException.class,
-				() -> required.invoke(new Object[] { "must be truthy", false }));
-		assertEquals("must be truthy", ex.getMessage());
+		assertEquals(false, required.invoke(new Object[] { "must be set", false }));
 	}
 
 	@Test
-	void testRequiredThrowsOnEmptyCollection() {
+	void testRequiredPassesEmptyCollection() {
 		Function required = functions.get("required");
-		RuntimeException ex = assertThrows(RuntimeException.class,
-				() -> required.invoke(new Object[] { "list required", Collections.emptyList() }));
-		assertEquals("list required", ex.getMessage());
+		assertEquals(Collections.emptyList(),
+				required.invoke(new Object[] { "list required", Collections.emptyList() }));
 	}
 
 	@Test
-	void testRequiredThrowsOnEmptyMap() {
+	void testRequiredPassesEmptyMap() {
 		Function required = functions.get("required");
-		RuntimeException ex = assertThrows(RuntimeException.class,
-				() -> required.invoke(new Object[] { "map required", Collections.emptyMap() }));
-		assertEquals("map required", ex.getMessage());
+		assertEquals(Collections.emptyMap(), required.invoke(new Object[] { "map required", Collections.emptyMap() }));
 	}
 
 	@Test

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctions.java
@@ -129,7 +129,16 @@ public final class MathFunctions {
 	}
 
 	private static Function toStringFunc() {
-		return (args) -> (args.length == 0) ? "" : String.valueOf(args[0]);
+		return (args) -> {
+			if (args.length == 0) {
+				return "";
+			}
+			// Match Go's fmt.Sprint(nil): a nil value stringifies to "<nil>", not Java's
+			// "null". Charts rely on this, e.g. `eq (toString .x) "<nil>"` to test
+			// whether
+			// a value is unset (opentelemetry-collector.serviceEnabled).
+			return (args[0] == null) ? "<nil>" : String.valueOf(args[0]);
+		};
 	}
 
 	private static Function atoi() {

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctionsTest.java
@@ -90,6 +90,16 @@ class MathFunctionsTest {
 		assertEquals(List.of(), fn.invoke(new Object[] { null }));
 	}
 
+	@Test
+	void testToStringNilMatchesGo() {
+		// Go's fmt.Sprint(nil) is "<nil>"; charts test unset values via
+		// `eq (toString .x) "<nil>"` (e.g. opentelemetry-collector.serviceEnabled).
+		Function fn = MathFunctions.getFunctions().get("toString");
+		assertEquals("<nil>", fn.invoke(new Object[] { (Object) null }));
+		assertEquals("42", fn.invoke(new Object[] { 42 }));
+		assertEquals("true", fn.invoke(new Object[] { true }));
+	}
+
 	@ParameterizedTest
 	@CsvSource(delimiter = '|', value = { "0777 | 511", "0644 | 420", "0755 | 493" })
 	void testToDecimal(String input, long expected) {


### PR DESCRIPTION
Stacked on #331 (uses the comparison-values mechanism).

Working through charts excluded only because `helm template` needs mandatory values surfaced **two real engine bugs**, both fixed here to match Go/Helm:

### `toString(nil)` → `"<nil>"` (was Java `"null"`)
Go's `fmt.Sprint(nil)` is `"<nil>"`. Charts test unset values via `eq (toString .x) "<nil>"` — e.g. `opentelemetry-collector.serviceEnabled`. jhelm was silently **dropping the Service**.

### `required` only rejects nil / empty string (was also rejecting false, empty list, empty map)
Helm's `required` passes `false`, `[]`, `{}` through. jhelm rejected them, so `required "..." .Values.config.reportStats` with `reportStats: false` (matrix-synapse) failed.

### Charts enabled
| Chart | Docs | Result |
|---|---|---|
| immich/immich | 6/6 | ✅ match |
| opentelemetry-helm/opentelemetry-collector | 4/4 | ✅ match (Service now renders via the toString fix) |

matrix-synapse now renders too but its scripts `ConfigMap` data is still empty in jhelm — left skipped with a follow-up note; values kept in `comparison-values` for later.

### Verification
- Full comparison suite **32 charts, all passing**.
- sprig + helm module tests (120) + `validate` (Checkstyle/PMD) clean.
- New unit tests for `toString(nil)` and `required(false/[]/{})`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)