### PR TITLE
Truncate long release names in comparison harness; enable 5 charts

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
@@ -290,6 +290,12 @@ class KpsComparisonTest {
 		if (sanitizedReleaseName.startsWith("-")) {
 			sanitizedReleaseName = "r" + sanitizedReleaseName;
 		}
+		// Helm rejects release names longer than 53 characters — truncate (charts with
+		// long repo/name combos like prometheus-community/prometheus-blackbox-exporter).
+		// Applied to both Helm and jhelm, so resource names stay consistent.
+		if (sanitizedReleaseName.length() > 53) {
+			sanitizedReleaseName = sanitizedReleaseName.substring(0, 53);
+		}
 		if (sanitizedReleaseName.endsWith("-")) {
 			sanitizedReleaseName = sanitizedReleaseName.substring(0, sanitizedReleaseName.length() - 1);
 		}

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -56,3 +56,7 @@ jhelmtest:
       serverName: matrix.example.com
       config:
         reportStats: false
+    "[prometheus-community/prometheus-postgres-exporter]":
+      config:
+        datasource:
+          password: test

--- a/jhelm-core/src/test/resources/charts-skip.csv
+++ b/jhelm-core/src/test/resources/charts-skip.csv
@@ -7,19 +7,14 @@
 # These charts require mandatory values, use library type, or have schema validation
 # that prevents `helm template` from succeeding with default values.
 grafana/loki,Helm fails: execution error (requires storage config)
-argo/argocd-apps,Helm fails: library chart or requires values
+argo/argocd-apps,Renders 0 documents with default values (creates CRs from empty lists)
 bitnami/common,Helm fails: library charts are not installable
 drone/drone,Helm fails: values schema validation error
 sonarqube/sonarqube,Helm fails: requires mandatory values
 nfs-subdir-external-provisioner/nfs-subdir-external-provisioner,Helm fails: requires nfs.server
 jupyterhub/jupyterhub,Helm fails: execution error
 gitlab/gitlab,Helm fails: requires mandatory values (domain)
-actions-runner-controller/actions-runner-controller,Helm fails: requires values
 grafana/k8s-monitoring,Helm fails: requires cluster name
-prometheus-community/prometheus-blackbox-exporter,Helm fails: execution error
-prometheus-community/prometheus-postgres-exporter,Helm fails: execution error
-prometheus-community/prometheus-redis-exporter,Helm fails: execution error
-prometheus-community/prometheus-elasticsearch-exporter,Helm fails: execution error
 #
 # --- Download failures (external repo issues) ---
 twuni/docker-registry,Repo DNS failure

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -32,3 +32,8 @@ rancher-stable/rancher,rancher-stable,https://releases.rancher.com/server-charts
 immich/immich,immich,https://immich-app.github.io/immich-charts
 opentelemetry-helm/opentelemetry-collector,opentelemetry-helm,https://open-telemetry.github.io/opentelemetry-helm-charts
 ananace-charts/matrix-synapse,ananace-charts,https://ananace.gitlab.io/charts
+prometheus-community/prometheus-blackbox-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+prometheus-community/prometheus-redis-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+prometheus-community/prometheus-elasticsearch-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+prometheus-community/prometheus-postgres-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+actions-runner-controller/actions-runner-controller,actions-runner-controller,https://actions-runner-controller.github.io/actions-runner-controller


### PR DESCRIPTION
The "fetch quirk" affecting a few skipped charts was actually a **release-name-length bug** in the harness: it built `release-<chartName>`, which for long repo/name combos exceeds Helm's **53-character** release-name limit, so `helm template` failed and the chart was mis-skipped.

## Fix
Truncate the sanitized release name to 53 chars (applied to **both** Helm and jhelm, so resource names stay consistent and the comparison is valid).

## Charts unlocked (now passing)
| Chart | Docs |
|---|---|
| prometheus-blackbox-exporter | 4/4 |
| prometheus-redis-exporter | 5/5 |
| prometheus-elasticsearch-exporter | 2/2 |
| prometheus-postgres-exporter | via `config.datasource.password` override |
| actions-runner-controller | 18/18 |

`argo/argocd-apps` stays skipped with an accurate reason — it renders **0 documents** with default values (creates CRs from empty lists), so there's nothing to compare.

## Verification
Full comparison suite now **38 charts, all passing**; validate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)