### PR TITLE
Enable drone + sonarqube via comparison-values (suite → 40)

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -60,3 +60,12 @@ jhelmtest:
       config:
         datasource:
           password: test
+    "[drone/drone]":
+      env:
+        DRONE_SERVER_HOST: drone.example.com
+        DRONE_SERVER_PROTO: https
+        DRONE_RPC_SECRET: testsecret
+    "[sonarqube/sonarqube]":
+      monitoringPasscode: testpass123
+      community:
+        enabled: true

--- a/jhelm-core/src/test/resources/charts-skip.csv
+++ b/jhelm-core/src/test/resources/charts-skip.csv
@@ -9,10 +9,7 @@
 grafana/loki,Helm fails: execution error (requires storage config)
 argo/argocd-apps,Renders 0 documents with default values (creates CRs from empty lists)
 bitnami/common,Helm fails: library charts are not installable
-drone/drone,Helm fails: values schema validation error
-sonarqube/sonarqube,Helm fails: requires mandatory values
 nfs-subdir-external-provisioner/nfs-subdir-external-provisioner,Helm fails: requires nfs.server
-jupyterhub/jupyterhub,Helm fails: execution error
 gitlab/gitlab,Helm fails: requires mandatory values (domain)
 grafana/k8s-monitoring,Helm fails: requires cluster name
 #
@@ -20,3 +17,4 @@ grafana/k8s-monitoring,Helm fails: requires cluster name
 twuni/docker-registry,Repo DNS failure
 prometheus-community/prometheus-adapter,Chart download 404
 deliveryhero/node-problem-detector,Repo intermittently unavailable
+jupyterhub/jupyterhub,Helm fails on fetched version (.Release.Time.Seconds removed in modern Helm)

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -37,3 +37,5 @@ prometheus-community/prometheus-redis-exporter,prometheus-community,https://prom
 prometheus-community/prometheus-elasticsearch-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
 prometheus-community/prometheus-postgres-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
 actions-runner-controller/actions-runner-controller,actions-runner-controller,https://actions-runner-controller.github.io/actions-runner-controller
+drone/drone,drone,https://charts.drone.io
+sonarqube/sonarqube,sonarqube,https://SonarSource.github.io/helm-chart-sonarqube


### PR DESCRIPTION
Continues bringing mandatory-values charts under comparison via the `comparison-values` mechanism.

| Chart | Override | Docs | Result |
|---|---|---|---|
| drone/drone | `DRONE_SERVER_HOST/PROTO`, `DRONE_RPC_SECRET` | 5/5 | ✅ match |
| sonarqube/sonarqube | `monitoringPasscode`, `community.enabled` | 8/8 | ✅ match |

Both match Helm with only the standard global ignores. Full comparison suite now **40 charts, all passing**; validate clean.

`jupyterhub/jupyterhub` stays skipped with an accurate reason — **helm itself** fails on the fetched version (`.Release.Time.Seconds`, removed in modern Helm), so there's nothing to compare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)