### PR TITLE
Add 13 popular charts to comparison suite (40 → 53)

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
@@ -367,8 +367,12 @@ class KpsComparisonTest {
 	private String runHelmInstallDryRun(File chartDir, String releaseName, String namespace,
 			Map<String, Object> values) {
 		try {
-			List<String> command = new ArrayList<>(
-					List.of("helm", "template", releaseName, chartDir.getAbsolutePath(), "--namespace", namespace));
+			// Pin the kube version so version-gated template logic matches jhelm's
+			// Capabilities.KubeVersion (Engine sets v1.35.0). Otherwise the helm CLI's
+			// built-in default kube version varies by helm build and charts gating on it
+			// (e.g. Service.spec.trafficDistribution, hostUsers) diverge.
+			List<String> command = new ArrayList<>(List.of("helm", "template", releaseName, chartDir.getAbsolutePath(),
+					"--namespace", namespace, "--kube-version", "v1.35.0"));
 			if (values != null && !values.isEmpty()) {
 				File valuesFile = File.createTempFile("jhelm-values-", ".yaml");
 				valuesFile.deleteOnExit();

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -34,6 +34,18 @@ jhelmtest:
       - resource: "Secret/*"
         path: "stringData.config.yaml.registration_shared_secret"
         reason: "Randomly generated per render"
+    "[elastic/elasticsearch]":
+      # The Helm test-hook Pod has a random name suffix (randAlphaNum) that differs
+      # every render, so the resource key never matches.
+      - resource: "Pod/*"
+        path: "*"
+        reason: "helm test-hook Pod has a per-render random name suffix"
+    "[nextcloud/nextcloud]":
+      # hooks-hash is a sha256 of hooked content; differs only by toYaml serialization
+      # (same class as checksum/* annotations, #237).
+      - resource: "Deployment/*"
+        path: "spec.template.metadata.annotations.hooks-hash"
+        reason: "content hash differs by toYaml serialization, not semantics (#237)"
   # Value overrides for charts that Helm cannot render with default values. The same
   # overrides are applied to both Helm and jhelm, so any divergence is a real jhelm bug.
   comparison-values:

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -39,3 +39,16 @@ prometheus-community/prometheus-postgres-exporter,prometheus-community,https://p
 actions-runner-controller/actions-runner-controller,actions-runner-controller,https://actions-runner-controller.github.io/actions-runner-controller
 drone/drone,drone,https://charts.drone.io
 sonarqube/sonarqube,sonarqube,https://SonarSource.github.io/helm-chart-sonarqube
+bitnami/keycloak,bitnami,https://charts.bitnami.com/bitnami
+longhorn/longhorn,longhorn,https://charts.longhorn.io
+bitnami/rabbitmq,bitnami,https://charts.bitnami.com/bitnami
+external-secrets-operator/external-secrets,external-secrets-operator,https://charts.external-secrets.io/
+external-dns/external-dns,external-dns,https://kubernetes-sigs.github.io/external-dns/
+elastic/elasticsearch,elastic,https://helm.elastic.co
+cilium/cilium,cilium,https://helm.cilium.io/
+kyverno/kyverno,kyverno,https://kyverno.github.io/kyverno/
+cloudnative-pg/cloudnative-pg,cloudnative-pg,https://cloudnative-pg.io/charts/
+vmware-tanzu/velero,vmware-tanzu,https://vmware-tanzu.github.io/helm-charts/
+metallb/metallb,metallb,https://metallb.github.io/metallb
+apache-airflow/airflow,apache-airflow,https://airflow.apache.org/
+nextcloud/nextcloud,nextcloud,https://nextcloud.github.io/helm/


### PR DESCRIPTION
Popularity sweep of the next tranche of uncovered top ArtifactHub charts. **11 render and match Helm with default values, no overrides:** keycloak, longhorn, rabbitmq, external-secrets, external-dns, cilium, kyverno, cloudnative-pg, velero, metallb, airflow.

Two more match with one non-determinism ignore each:
- **elastic/elasticsearch** — the Helm `test`-hook Pod has a per-render random name suffix (`randAlphaNum`), so its resource key never matches. Ignored `Pod/*`.
- **nextcloud/nextcloud** — only the Deployment `hooks-hash` annotation differs, and only by toYaml serialization (same class as the existing `checksum/*` ignore, #237).

Full comparison suite now **53 charts, all passing**; validate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)