### PR TITLE
Bump Spring Boot to 4.0.6 and migrate to spring-core retry

### DIFF
--- a/jhelm-kube/pom.xml
+++ b/jhelm-kube/pom.xml
@@ -30,10 +30,6 @@
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.retry</groupId>
-            <artifactId>spring-retry</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <optional>true</optional>

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
@@ -18,12 +18,9 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.retry.backoff.ExponentialBackOffPolicy;
-import org.springframework.retry.policy.SimpleRetryPolicy;
-import org.springframework.retry.support.RetryTemplate;
-import org.springframework.retry.RetryCallback;
-import org.springframework.retry.RetryContext;
-import org.springframework.retry.RetryListener;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
+import java.time.Duration;
 
 /**
  * Auto-configuration for the jhelm Kubernetes integration module. Registers an
@@ -66,38 +63,18 @@ public class JhelmKubeAutoConfiguration {
 	}
 
 	private RetryTemplate buildRetryTemplate(JhelmKubernetesProperties.Retry config) {
-		SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy(config.getMaxAttempts());
-
-		ExponentialBackOffPolicy backOff = new ExponentialBackOffPolicy();
-		backOff.setInitialInterval(config.getInitialIntervalMs());
-		backOff.setMultiplier(config.getMultiplier());
-		backOff.setMaxInterval(config.getMaxIntervalMs());
-
-		RetryTemplate template = new RetryTemplate();
-		template.setRetryPolicy(retryPolicy);
-		template.setBackOffPolicy(backOff);
-		template.registerListener(new TransientRetryListener());
-		return template;
-	}
-
-	/**
-	 * A retry listener that only allows retries for transient errors.
-	 */
-	private static final class TransientRetryListener implements RetryListener {
-
-		@Override
-		public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
-			return true;
-		}
-
-		@Override
-		public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
-				Throwable throwable) {
-			if (!RetryableKubeService.isTransient(throwable)) {
-				context.setExhaustedOnly();
-			}
-		}
-
+		RetryPolicy policy = RetryPolicy.builder()
+			// maxRetries excludes the initial call, so subtract one to preserve the
+			// total invocation count of the old SimpleRetryPolicy(maxAttempts).
+			.maxRetries(Math.max(0, config.getMaxAttempts() - 1))
+			.delay(Duration.ofMillis(config.getInitialIntervalMs()))
+			.multiplier(config.getMultiplier())
+			.maxDelay(Duration.ofMillis(config.getMaxIntervalMs()))
+			// Only transient errors are retried; non-transient failures stop immediately
+			// (replaces the old TransientRetryListener.setExhaustedOnly logic).
+			.predicate(RetryableKubeService::isTransient)
+			.build();
+		return new RetryTemplate(policy);
 	}
 
 }

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/RetryableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/RetryableKubeService.java
@@ -9,8 +9,9 @@ import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.alexmond.jhelm.core.service.KubeService;
-import org.springframework.retry.RetryCallback;
-import org.springframework.retry.support.RetryTemplate;
+import org.springframework.core.retry.RetryException;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.core.retry.Retryable;
 import java.net.ConnectException;
 import java.net.SocketException;
 
@@ -37,7 +38,7 @@ public class RetryableKubeService implements KubeService {
 
 	@Override
 	public void storeRelease(Release release) throws Exception {
-		executeWithRetry("storeRelease", (ctx) -> {
+		executeWithRetry("storeRelease", () -> {
 			delegate.storeRelease(release);
 			return null;
 		});
@@ -45,22 +46,22 @@ public class RetryableKubeService implements KubeService {
 
 	@Override
 	public Optional<Release> getRelease(String name, String namespace) throws Exception {
-		return executeWithRetry("getRelease", (ctx) -> delegate.getRelease(name, namespace));
+		return executeWithRetry("getRelease", () -> delegate.getRelease(name, namespace));
 	}
 
 	@Override
 	public List<Release> listReleases(String namespace) throws Exception {
-		return executeWithRetry("listReleases", (ctx) -> delegate.listReleases(namespace));
+		return executeWithRetry("listReleases", () -> delegate.listReleases(namespace));
 	}
 
 	@Override
 	public List<Release> getReleaseHistory(String name, String namespace) throws Exception {
-		return executeWithRetry("getReleaseHistory", (ctx) -> delegate.getReleaseHistory(name, namespace));
+		return executeWithRetry("getReleaseHistory", () -> delegate.getReleaseHistory(name, namespace));
 	}
 
 	@Override
 	public void deleteReleaseHistory(String name, String namespace) throws Exception {
-		executeWithRetry("deleteReleaseHistory", (ctx) -> {
+		executeWithRetry("deleteReleaseHistory", () -> {
 			delegate.deleteReleaseHistory(name, namespace);
 			return null;
 		});
@@ -68,7 +69,7 @@ public class RetryableKubeService implements KubeService {
 
 	@Override
 	public void apply(String namespace, String yamlContent) throws Exception {
-		executeWithRetry("apply", (ctx) -> {
+		executeWithRetry("apply", () -> {
 			delegate.apply(namespace, yamlContent);
 			return null;
 		});
@@ -76,7 +77,7 @@ public class RetryableKubeService implements KubeService {
 
 	@Override
 	public void delete(String namespace, String yamlContent) throws Exception {
-		executeWithRetry("delete", (ctx) -> {
+		executeWithRetry("delete", () -> {
 			delegate.delete(namespace, yamlContent);
 			return null;
 		});
@@ -84,7 +85,7 @@ public class RetryableKubeService implements KubeService {
 
 	@Override
 	public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) throws Exception {
-		return executeWithRetry("getResourceStatuses", (ctx) -> delegate.getResourceStatuses(namespace, manifest));
+		return executeWithRetry("getResourceStatuses", () -> delegate.getResourceStatuses(namespace, manifest));
 	}
 
 	@Override
@@ -93,17 +94,23 @@ public class RetryableKubeService implements KubeService {
 		delegate.waitForReady(namespace, manifest, timeoutSeconds);
 	}
 
-	private <T> T executeWithRetry(String operation, RetryCallback<T, Exception> callback) throws Exception {
-		return retryTemplate.execute(callback, (ctx) -> {
-			Throwable last = ctx.getLastThrowable();
+	private <T> T executeWithRetry(String operation, Retryable<T> callback) throws Exception {
+		try {
+			return retryTemplate.execute(callback);
+		}
+		catch (RetryException ex) {
+			// Thrown when the policy stops retrying — either a non-transient failure (the
+			// predicate rejected it) or all retries exhausted. The cause is the last
+			// underlying failure; rethrow it as-is so callers see the original exception.
+			Throwable last = ex.getCause();
 			if (log.isErrorEnabled()) {
 				log.error("All retry attempts exhausted for {}", operation, last);
 			}
-			if (last instanceof Exception ex) {
-				throw ex;
+			if (last instanceof Exception cause) {
+				throw cause;
 			}
 			throw new KubernetesOperationException("Retry exhausted for " + operation, last);
-		});
+		}
 	}
 
 	/**

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/RetryableKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/RetryableKubeServiceTest.java
@@ -9,13 +9,14 @@ import io.kubernetes.client.openapi.ApiException;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.KubeService;
+import java.time.Duration;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.retry.backoff.FixedBackOffPolicy;
-import org.springframework.retry.policy.SimpleRetryPolicy;
-import org.springframework.retry.support.RetryTemplate;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -37,13 +38,9 @@ class RetryableKubeServiceTest {
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
 
-		// Simple retry: up to 3 attempts with no backoff for fast tests
-		RetryTemplate template = new RetryTemplate();
-		SimpleRetryPolicy policy = new SimpleRetryPolicy(3);
-		FixedBackOffPolicy backOff = new FixedBackOffPolicy();
-		backOff.setBackOffPeriod(0);
-		template.setRetryPolicy(policy);
-		template.setBackOffPolicy(backOff);
+		// Up to 3 attempts (2 retries) with no backoff for fast tests
+		RetryPolicy policy = RetryPolicy.builder().maxRetries(2).delay(Duration.ZERO).build();
+		RetryTemplate template = new RetryTemplate(policy);
 
 		retryableService = new RetryableKubeService(delegate, template);
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.alexmond</groupId>
@@ -44,7 +44,6 @@
         <chicory.version>1.7.2</chicory.version>
         <swagger-annotations.version>2.2.34</swagger-annotations.version>
         <springdoc-openapi.version>3.0.2</springdoc-openapi.version>
-        <spring-retry.version>2.0.12</spring-retry.version>
 
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
@@ -148,11 +147,6 @@
                 <groupId>com.dylibso.chicory</groupId>
                 <artifactId>wasi</artifactId>
                 <version>${chicory.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.retry</groupId>
-                <artifactId>spring-retry</artifactId>
-                <version>${spring-retry.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Summary

Bumps Spring Boot to 4.0.6 and migrates jhelm-kube off the standalone `spring-retry` library. In Spring Boot 4 / Framework 7, retry support is absorbed into spring-core (`org.springframework.core.retry`) and `spring-retry` is no longer in the managed BOM.

## Changes

- **Root `pom.xml`**: parent `4.0.5 → 4.0.6`; removed the `spring-retry` version property and its `dependencyManagement` entry.
- **`jhelm-kube/pom.xml`**: dropped the `spring-retry` dependency (retry classes now come transitively via spring-core).
- **`RetryableKubeService`**: moved to `org.springframework.core.retry` (`RetryTemplate`/`Retryable`/`RetryException`). The new `execute()` throws `RetryException` whose cause is the last failure; `executeWithRetry` unwraps and rethrows it to preserve the original-exception contract for both the non-transient-first-failure and exhaustion paths. The 8 callbacks became `Retryable<T>`. `isTransient` is unchanged.
- **`JhelmKubeAutoConfiguration`**: `buildRetryTemplate` now uses `RetryPolicy.builder()` with `maxRetries = maxAttempts - 1` (maxRetries excludes the initial call, preserving the total invocation count), exponential delay/multiplier/maxDelay, and `predicate(RetryableKubeService::isTransient)` — replacing the deleted `TransientRetryListener.setExhaustedOnly` logic.
- **`RetryableKubeServiceTest`**: updated to the core retry API.

## Behavior preservation

- Total invocation count unchanged (`maxRetries = maxAttempts - 1`).
- Transient-only retry preserved via the policy predicate instead of the listener.
- Callers still see the original underlying exception, not a `RetryException` wrapper.

## Testing

All 191 jhelm-kube tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)