### PR TITLE
Fix merge of immutable maps; enable gitlab/k8s-monitoring comparison

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -99,3 +99,52 @@ jhelmtest:
         enabled: false
       resultsCache:
         enabled: false
+    "[grafana/k8s-monitoring]":
+      cluster:
+        name: test-cluster
+      destinations:
+        loki:
+          type: loki
+          url: http://loki.example.com/loki/api/v1/push
+      clusterEvents:
+        enabled: true
+        collector: alloy-singleton
+      collectors:
+        alloy-singleton:
+          enabled: true
+    "[gitlab/gitlab]":
+      global:
+        hosts:
+          domain: example.com
+        redis:
+          host: redis.example.com
+          password:
+            enabled: false
+        psql:
+          host: postgresql.example.com
+          password:
+            secret: gitlab-postgresql-password
+            key: postgresql-password
+        appConfig:
+          object_store:
+            enabled: true
+            connection:
+              secret: gitlab-object-storage
+              key: connection
+        registry:
+          bucket: registry
+        minio:
+          enabled: false
+      certmanager-issuer:
+        email: test@example.com
+      registry:
+        storage:
+          secret: gitlab-registry-storage
+          key: config
+      gitlab:
+        toolbox:
+          backups:
+            objectStorage:
+              config:
+                secret: gitlab-backup-storage
+                key: config

--- a/jhelm-core/src/test/resources/charts-skip.csv
+++ b/jhelm-core/src/test/resources/charts-skip.csv
@@ -9,8 +9,6 @@
 argo/argocd-apps,Renders 0 documents with default values (creates CRs from empty lists)
 bitnami/common,Helm fails: library charts are not installable
 nfs-subdir-external-provisioner/nfs-subdir-external-provisioner,Helm fails: requires nfs.server
-gitlab/gitlab,Helm fails: requires mandatory values (domain)
-grafana/k8s-monitoring,Helm fails: requires cluster name
 #
 # --- Download failures (external repo issues) ---
 twuni/docker-registry,Repo DNS failure

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -3,4 +3,14 @@
 # If a chart unexpectedly passes, the test will fail — remove the entry.
 #
 # --- Code bugs ---
-# (none — all previously listed charts are now fixed)
+# Both render under `helm template` with the comparison-values in application-test.yaml,
+# so the remaining failure is a real jhelm bug (tracked here until fixed).
+#
+# gitlab: the umbrella chart and a subchart are both named "gitlab", so jhelm collapses
+# their template files to the same `gitlab/templates/<file>` key and version-drops one —
+# losing the subchart's _registry.tpl, so `gitlab.registry.hostname` is "not found".
+gitlab/gitlab,gitlab,https://charts.gitlab.io
+# k8s-monitoring: renders all 19 documents, but the loki destination's defaults
+# (`$.Files.Get "destinations/loki-values.yaml" | fromYaml`) come through empty, so
+# retry_on_http_429 / backoff / external_labels and the Alloy spec defaults are blank.
+grafana/k8s-monitoring,grafana,https://grafana.github.io/helm-charts

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.gotemplate.helm.functions;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -270,19 +271,19 @@ public final class ConversionFunctions {
 	private static Function fromYaml() {
 		return (args) -> {
 			if (args.length == 0 || args[0] == null) {
-				return Map.of();
+				return new LinkedHashMap<>();
 			}
 			try {
 				String yaml = String.valueOf(args[0]);
 				if (yaml.isBlank()) {
-					return Map.of();
+					return new LinkedHashMap<>();
 				}
 				Object result = loadFirstYamlDocument(yaml);
-				return (result instanceof Map<?, ?> map) ? map : Map.of();
+				return (result instanceof Map<?, ?> map) ? map : new LinkedHashMap<>();
 			}
 			catch (Exception ex) {
 				log.debug("fromYaml failed: {}", ex.getMessage());
-				return Map.of();
+				return new LinkedHashMap<>();
 			}
 		};
 	}

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
@@ -174,7 +174,7 @@ public final class DictFunctions {
 			if (args.length == 0) {
 				return new LinkedHashMap<>();
 			}
-			Map<String, Object> dst = (args[0] instanceof Map) ? (Map<String, Object>) args[0] : new LinkedHashMap<>();
+			Map<String, Object> dst = ensureMutableMap(args[0]);
 			for (int i = 1; i < args.length; i++) {
 				if (args[i] instanceof Map) {
 					deepMerge(dst, (Map<String, Object>) args[i], false);
@@ -190,7 +190,7 @@ public final class DictFunctions {
 			if (args.length == 0) {
 				return new LinkedHashMap<>();
 			}
-			Map<String, Object> dst = (args[0] instanceof Map) ? (Map<String, Object>) args[0] : new LinkedHashMap<>();
+			Map<String, Object> dst = ensureMutableMap(args[0]);
 			for (int i = 1; i < args.length; i++) {
 				if (args[i] instanceof Map) {
 					deepMerge(dst, (Map<String, Object>) args[i], true);
@@ -198,6 +198,25 @@ public final class DictFunctions {
 			}
 			return dst;
 		};
+	}
+
+	/**
+	 * Returns a mutable map for use as a merge destination. {@code fromYaml} and friends
+	 * can hand back immutable maps (e.g. {@code Map.of()} for empty/blank input), which
+	 * would throw {@link UnsupportedOperationException} when merged into. Already-mutable
+	 * maps are returned as-is so Helm's "modifies the destination in place" semantics are
+	 * preserved; anything else is shallow-copied into a {@link LinkedHashMap} (nested
+	 * maps are made mutable on demand during the recursive merge).
+	 */
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> ensureMutableMap(Object value) {
+		if (value instanceof LinkedHashMap || value instanceof HashMap) {
+			return (Map<String, Object>) value;
+		}
+		if (value instanceof Map) {
+			return new LinkedHashMap<>((Map<String, Object>) value);
+		}
+		return new LinkedHashMap<>();
 	}
 
 	@SuppressWarnings("unchecked")
@@ -208,7 +227,18 @@ public final class DictFunctions {
 			if (dst.containsKey(key)) {
 				Object dstVal = dst.get(key);
 				if (dstVal instanceof Map && srcVal instanceof Map) {
-					deepMerge((Map<String, Object>) dstVal, (Map<String, Object>) srcVal, overwrite);
+					// The nested destination may be immutable (e.g. from fromYaml). Make
+					// it
+					// mutable — writing the copy back into the parent — before merging.
+					Map<String, Object> dstChild;
+					if (dstVal instanceof LinkedHashMap || dstVal instanceof HashMap) {
+						dstChild = (Map<String, Object>) dstVal;
+					}
+					else {
+						dstChild = new LinkedHashMap<>((Map<String, Object>) dstVal);
+						dst.put(key, dstChild);
+					}
+					deepMerge(dstChild, (Map<String, Object>) srcVal, overwrite);
 				}
 				else if (overwrite || isEmptyValue(dstVal)) {
 					dst.put(key, srcVal);

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.alexmond.jhelm.gotemplate.Function;
 import org.alexmond.jhelm.gotemplate.GoTemplate;
 import org.alexmond.jhelm.gotemplate.TemplateException;
 import org.junit.jupiter.api.Test;
@@ -295,6 +296,36 @@ class CollectionFunctionsTest {
 				{{ $m := mergeOverwrite $d1 $d2 $d3 }}\
 				{{ get $m "a" }},{{ get $m "b" }},{{ get $m "c" }}""";
 		assertEquals("3,30,300", exec(template));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testMergeOverwriteToleratesImmutableMaps() {
+		// Regression: fromYaml (and similar) can yield immutable maps, both at the top
+		// level and nested. mergeOverwrite must not throw UnsupportedOperationException
+		// when merging into them — this is the grafana/k8s-monitoring failure mode where
+		// `mergeOverwrite ($.Files.Get ... | fromYaml) ...` blew up.
+		Function fn = DictFunctions.getFunctions().get("mergeOverwrite");
+		Map<String, Object> dst = Map.of("outer", Map.of("a", 1));
+		Map<String, Object> src = Map.of("outer", Map.of("a", 99, "b", 2));
+		Map<String, Object> result = (Map<String, Object>) fn.invoke(dst, src);
+		Map<String, Object> outer = (Map<String, Object>) result.get("outer");
+		assertEquals(99, outer.get("a"));
+		assertEquals(2, outer.get("b"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testMergeToleratesImmutableNestedDestination() {
+		// merge (non-overwrite) must also tolerate an immutable nested destination map,
+		// preserving the destination's existing value.
+		Function fn = DictFunctions.getFunctions().get("merge");
+		Map<String, Object> dst = Map.of("outer", Map.of("a", 1));
+		Map<String, Object> src = Map.of("outer", Map.of("a", 99, "b", 2));
+		Map<String, Object> result = (Map<String, Object>) fn.invoke(dst, src);
+		Map<String, Object> outer = (Map<String, Object>) result.get("outer");
+		assertEquals(1, outer.get("a"));
+		assertEquals(2, outer.get("b"));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Providing the mandatory values that `helm template` needs for **gitlab** and **grafana/k8s-monitoring** (so Helm renders them) surfaced real jhelm rendering bugs that the "helm fails: requires mandatory values" skip reason had been masking. This fixes one general engine bug and tracks the two remaining ones.

## Engine fix (general)

`mergeOverwrite`/`merge` threw `UnsupportedOperationException` when a destination map — or a nested one — was immutable. The common source is the maps `fromYaml` returns for empty/blank input, as in k8s-monitoring's `mergeOverwrite ($.Files.Get … | fromYaml) …`.

- `deepMerge` now promotes an immutable nested destination to a mutable `LinkedHashMap` (written back into its parent) before merging into it.
- `merge`/`mergeOverwrite` ensure a mutable top-level destination via `ensureMutableMap`.
- `fromYaml` now returns a mutable `LinkedHashMap` (not `Map.of()`) for empty/blank/non-map input, matching Helm's mutable-dict semantics.
- Added direct unit tests for merging into immutable maps.

## Comparison harness

- Added `comparison-values` for `grafana/k8s-monitoring` and `gitlab/gitlab` (the minimal values that make `helm template` succeed) and removed both from `charts-skip.csv`.
- With the immutability fix, **k8s-monitoring now renders all 19 documents** (was a hard failure). Two known bugs remain, tracked in `failed.csv`:
  - **gitlab**: the umbrella chart and a subchart are both named `gitlab`, so jhelm collapses their template files to one `gitlab/templates/<file>` key and version-drops the subchart's `_registry.tpl` — so `gitlab.registry.hostname` is "not found".
  - **k8s-monitoring**: the loki destination's defaults (`$.Files.Get "destinations/loki-values.yaml" | fromYaml`) come through empty, blanking `retry_on_http_429`/backoff/`external_labels` and the Alloy `spec` defaults.

## Testing

- sprig: 520 tests pass (incl. 2 new immutable-merge tests)
- helm: 120 tests pass
- `KpsComparisonTest#compareFailedCharts` confirms both charts fail as expected (regression tracking — they'll flag for promotion to `charts.csv` once fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)