### PR TITLE
Keep defines from name-colliding template files (#18)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -251,6 +251,15 @@ public class Engine {
 			if (!aTpl && bTpl) {
 				return 1;
 			}
+			// Distinct-content collision extras (synthetic "name@version/templates/..."
+			// keys; chart names never contain '@') parse before the deduped primaries so
+			// that the primary — the higher-version winner — wins any define-name
+			// conflict.
+			boolean aExtra = a.indexOf('@') >= 0;
+			boolean bExtra = b.indexOf('@') >= 0;
+			if (aExtra != bExtra) {
+				return aExtra ? -1 : 1;
+			}
 			return a.compareTo(b);
 		}).toList();
 
@@ -332,14 +341,50 @@ public class Engine {
 			// so keeping the newest avoids missing-feature failures.
 			String existingVersion = templateVersions.get(helmStyleKey);
 			if (existingVersion == null || compareVersions(chartVersion, existingVersion) > 0) {
+				// A genuinely different file is being displaced (not just an older copy
+				// of
+				// the same library helper): keep its defines so they aren't lost.
+				String displaced = templates.get(helmStyleKey);
+				if (displaced != null && !displaced.equals(t.getData())) {
+					preserveDistinctTemplate(templates, templateToChartName, templateToChartName.get(helmStyleKey),
+							existingVersion, t.getName(), displaced);
+				}
 				templates.put(helmStyleKey, t.getData());
 				templateToChartName.put(helmStyleKey, chartName);
 				templateVersions.put(helmStyleKey, chartVersion);
+			}
+			else {
+				// Same short key, equal/older version. If the content genuinely differs,
+				// this is a distinct chart that merely shares a name (e.g. an umbrella
+				// and
+				// a subchart both named "gitlab"): keep its defines under a version-
+				// qualified key instead of dropping the whole file (#18).
+				String kept = templates.get(helmStyleKey);
+				if (kept != null && !kept.equals(t.getData())) {
+					preserveDistinctTemplate(templates, templateToChartName, chartName, chartVersion, t.getName(),
+							t.getData());
+				}
 			}
 		}
 
 		for (Chart subchart : chart.getDependencies()) {
 			collectAllTemplates(subchart, templates, templateToChartName, rootChartName);
+		}
+	}
+
+	/**
+	 * Registers a template file that collides on its {@code chartName/templates/file} key
+	 * with a different file (distinct content), under a version-qualified key so the
+	 * second pass still parses it and registers its named templates. The value is only
+	 * ever a helper included by {@code define} name, so the synthetic key just needs to
+	 * be unique — it is never referenced by path.
+	 */
+	private static void preserveDistinctTemplate(Map<String, String> templates, Map<String, String> templateToChartName,
+			String chartName, String version, String fileName, String content) {
+		String key = chartName + "@" + ((version != null) ? version : "") + "/templates/" + fileName;
+		if (!templates.containsKey(key)) {
+			templates.put(key, content);
+			templateToChartName.put(key, chartName);
 		}
 	}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/NameCollisionTemplateTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/NameCollisionTemplateTest.java
@@ -1,0 +1,50 @@
+package org.alexmond.jhelm.core;
+
+import java.io.File;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.Engine;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for #18: when an umbrella chart and one of its subcharts share the same
+ * name, their template files collide on the {@code <name>/templates/<file>} key. The
+ * version-based de-duplication used to drop the losing file entirely, losing its named
+ * templates — so a {@code define} that lived only in the subchart's helper file (e.g.
+ * gitlab's {@code gitlab.registry.hostname}) was reported "not found". Distinct-content
+ * collisions must keep both files' defines.
+ */
+class NameCollisionTemplateTest {
+
+	private final ChartLoader chartLoader = new ChartLoader();
+
+	private final Engine engine = new Engine();
+
+	private final InstallAction installAction = new InstallAction(engine, null);
+
+	@Test
+	void testSubchartOnlyDefineIsRegisteredDespiteNameCollision() throws Exception {
+		File chartDir = new File("src/test/resources/test-charts/name-collision");
+		Chart chart = chartLoader.load(chartDir);
+		assertNotNull(chart, "Chart should be loaded");
+
+		Release release = installAction.install(chart, "test-release", "default", Map.of(), 1, true);
+		assertNotNull(release, "Release should be created");
+		String manifest = release.getManifest();
+
+		// The umbrella's own helper resolves...
+		assertTrue(manifest.contains("parent: parent-value"),
+				"parentonly define (umbrella helper) should render; got:\n" + manifest);
+		// ...and so does the define that exists ONLY in the like-named subchart's helper.
+		assertTrue(manifest.contains("child: child-value"),
+				"childonly define (subchart helper colliding on the same key) should render; got:\n" + manifest);
+	}
+
+}

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -6,9 +6,9 @@
 # Both render under `helm template` with the comparison-values in application-test.yaml,
 # so the remaining failure is a real jhelm bug (tracked here until fixed).
 #
-# gitlab: the umbrella chart and a subchart are both named "gitlab", so jhelm collapses
-# their template files to the same `gitlab/templates/<file>` key and version-drops one —
-# losing the subchart's _registry.tpl, so `gitlab.registry.hostname` is "not found".
+# gitlab: the umbrella/subchart name-collision that hid gitlab.registry.hostname is fixed
+# (#18); rendering now reaches a separate bug — `gitlab.appConfig.duo.configuration` fails
+# with "Conversion = '='" (a printf/format-verb gap in that template).
 gitlab/gitlab,gitlab,https://charts.gitlab.io
 # k8s-monitoring: renders all 19 documents, but the loki destination's defaults
 # (`$.Files.Get "destinations/loki-values.yaml" | fromYaml`) come through empty, so

--- a/jhelm-core/src/test/resources/test-charts/name-collision/Chart.yaml
+++ b/jhelm-core/src/test/resources/test-charts/name-collision/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: name-collision
+version: 1.0.0
+description: Umbrella chart that shares its name with a vendored subchart (regression for #18)

--- a/jhelm-core/src/test/resources/test-charts/name-collision/charts/name-collision/Chart.yaml
+++ b/jhelm-core/src/test/resources/test-charts/name-collision/charts/name-collision/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: name-collision
+version: 0.1.0
+description: Vendored subchart sharing the umbrella's name

--- a/jhelm-core/src/test/resources/test-charts/name-collision/charts/name-collision/templates/_helpers.tpl
+++ b/jhelm-core/src/test/resources/test-charts/name-collision/charts/name-collision/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "name-collision.childonly" -}}
+child-value
+{{- end -}}

--- a/jhelm-core/src/test/resources/test-charts/name-collision/templates/_helpers.tpl
+++ b/jhelm-core/src/test/resources/test-charts/name-collision/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "name-collision.parentonly" -}}
+parent-value
+{{- end -}}

--- a/jhelm-core/src/test/resources/test-charts/name-collision/templates/cm.yaml
+++ b/jhelm-core/src/test/resources/test-charts/name-collision/templates/cm.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-cm
+data:
+  # parentonly is defined in this umbrella's _helpers.tpl; childonly is defined only in
+  # the like-named subchart's _helpers.tpl (a distinct file colliding on the same key).
+  parent: {{ include "name-collision.parentonly" . }}
+  child: {{ include "name-collision.childonly" . }}


### PR DESCRIPTION
## Summary

Fixes the engine bug behind task #18. When an umbrella chart and one of its subcharts share the same name (e.g. gitlab's umbrella + its vendored `gitlab` subchart), their template files collide on the `<name>/templates/<file>` key. The version-based de-duplication in `collectAllTemplates` kept only the higher-version file and **silently dropped the other before parsing** — so a `define` that lived only in the dropped file was never registered, and including it (e.g. `gitlab.registry.hostname`) failed with "Template not found".

## Change

`collectAllTemplates` now detects a collision where the two files have **different content** — a distinct chart that merely shares a name, not an older copy of the same library helper — and registers the displaced file under a synthetic version-qualified key (`name@version/templates/file`) so its defines are still parsed.

- Extras parse **before** the de-duped primaries, so the primary (the higher-version winner) still wins any define-name conflict.
- **Identical-content** collisions (the same library chart pulled in by multiple subcharts) are unchanged, preserving the de-dup that guards #311.

## Testing

- New `NameCollisionTemplateTest` with a fixture where the umbrella and a vendored subchart share a name and the parent template includes a subchart-only define.
- **Full comparison suite: all 54 top charts still pass — no regression.**
- gitlab now renders *past* the `registry.hostname` error and reaches a separate, unrelated bug (`gitlab.appConfig.duo.configuration` → "Conversion = '='", a printf gap), which is updated in `failed.csv`.
- jhelm-core: **550 tests pass, coverage gate met.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)