### PR TITLE
Pass the piped value to method calls; fix .Files.Get in pipelines (#19)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -53,3 +53,4 @@ metallb/metallb,metallb,https://metallb.github.io/metallb
 apache-airflow/airflow,apache-airflow,https://airflow.apache.org/
 nextcloud/nextcloud,nextcloud,https://nextcloud.github.io/helm/
 grafana/loki,grafana,https://grafana.github.io/helm-charts
+grafana/k8s-monitoring,grafana,https://grafana.github.io/helm-charts

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -10,7 +10,3 @@
 # (#18); rendering now reaches a separate bug — `gitlab.appConfig.duo.configuration` fails
 # with "Conversion = '='" (a printf/format-verb gap in that template).
 gitlab/gitlab,gitlab,https://charts.gitlab.io
-# k8s-monitoring: renders all 19 documents, but the loki destination's defaults
-# (`$.Files.Get "destinations/loki-values.yaml" | fromYaml`) come through empty, so
-# retry_on_http_429 / backoff / external_labels and the Alloy spec defaults are blank.
-grafana/k8s-monitoring,grafana,https://grafana.github.io/helm-charts

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
@@ -388,7 +388,12 @@ public final class DictFunctions {
 		if (obj == null) {
 			return null;
 		}
-		if (obj instanceof Map) {
+		// Only the standard mutable map types are deep-copied. Special map subtypes that
+		// carry behaviour — notably the engine's Files object (`.Files.Get`/`.Glob`) —
+		// must be passed through unchanged; copying them into a plain LinkedHashMap would
+		// strip their methods and break `(deepCopy $).Files.Get` (Helm preserves the
+		// concrete type here).
+		if (obj instanceof LinkedHashMap || obj instanceof HashMap) {
 			Map<String, Object> copy = new LinkedHashMap<>();
 			for (Map.Entry<String, Object> entry : ((Map<String, Object>) obj).entrySet()) {
 				copy.put(entry.getKey(), recursiveDeepCopy(entry.getValue()));
@@ -402,7 +407,8 @@ public final class DictFunctions {
 			}
 			return copy;
 		}
-		// Primitives (String, Number, Boolean) are immutable — no copy needed
+		// Primitives (String, Number, Boolean), behavioural maps, and other opaque types
+		// are immutable or method-bearing — no copy needed.
 		return obj;
 	}
 

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/CollectionFunctionsTest.java
@@ -2,6 +2,8 @@ package org.alexmond.jhelm.gotemplate.sprig.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -312,6 +314,22 @@ class CollectionFunctionsTest {
 		Map<String, Object> outer = (Map<String, Object>) result.get("outer");
 		assertEquals(99, outer.get("a"));
 		assertEquals(2, outer.get("b"));
+	}
+
+	@Test
+	void testDeepCopyPreservesBehaviouralMaps() {
+		// deepCopy deep-copies plain mutable maps but must pass non-standard map types
+		// through unchanged — otherwise the engine's Files object loses its `.Get` method
+		// after `deepCopy $`, which is how grafana/k8s-monitoring reads destination
+		// defaults via `($.Files.Get ... | fromYaml)`.
+		Function fn = DictFunctions.getFunctions().get("deepCopy");
+		Map<String, Object> plain = new HashMap<>();
+		plain.put("a", 1);
+		Object plainCopy = fn.invoke(plain);
+		assertNotSame(plain, plainCopy);
+		assertEquals(plain, plainCopy);
+		Map<String, Object> behavioural = Map.of("x", 1);
+		assertSame(behavioural, fn.invoke(behavioural));
 	}
 
 	@Test

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/exec/Executor.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/exec/Executor.java
@@ -421,10 +421,15 @@ public class Executor {
 			throw new TemplateExecutionException("empty command");
 		}
 		Node firstArgument = command.getFirstArgument();
+		// A method call on the receiver applies when there are explicit arguments
+		// (.obj.Method arg) or when an upstream pipeline value is threaded in as the
+		// final argument (arg | .obj.Method).
+		boolean methodCallPossible = command.getArgumentCount() > 1 || currentPipelineValue != null;
 		if (firstArgument instanceof FieldNode fieldNode) {
 			// Go templates: .obj.Method arg → call Method(arg) on obj
-			if (command.getArgumentCount() > 1) {
-				Object result = tryFieldMethodCall(fieldNode, command.getArguments(), data, beanInfo);
+			if (methodCallPossible) {
+				Object result = tryFieldMethodCall(fieldNode, command.getArguments(), data, beanInfo,
+						currentPipelineValue);
 				if (result != INVOKE_NOT_FOUND) {
 					return result;
 				}
@@ -437,16 +442,27 @@ public class Executor {
 		}
 		if (firstArgument instanceof ChainNode chainNode) {
 			// Go templates: (.pipe).Method arg or .X.Y.Method arg → method call
-			if (command.getArgumentCount() > 1) {
-				Object result = tryChainMethodCall(chainNode, command.getArguments(), data, beanInfo);
+			if (methodCallPossible) {
+				Object result = tryChainMethodCall(chainNode, command.getArguments(), data, beanInfo,
+						currentPipelineValue);
 				if (result != INVOKE_NOT_FOUND) {
 					return result;
 				}
 			}
 			return executeChain(chainNode, data, beanInfo);
 		}
-		if (firstArgument instanceof VariableNode) {
-			return executeVariable((VariableNode) firstArgument);
+		if (firstArgument instanceof VariableNode variableNode) {
+			// Go templates: $var.Field.Method arg → call Method(arg) on $var.Field
+			// (e.g. $.Files.Get "path" or arg | $.Files.Get). Without this, the method
+			// name resolves as a missing field and the argument is dropped.
+			if (methodCallPossible && variableNode.getIdentifiers().length > 1) {
+				Object result = tryVariableMethodCall(variableNode, command.getArguments(), data, beanInfo,
+						currentPipelineValue);
+				if (result != INVOKE_NOT_FOUND) {
+					return result;
+				}
+			}
+			return executeVariable(variableNode);
 		}
 
 		if (firstArgument instanceof DotNode) {
@@ -573,8 +589,8 @@ public class Executor {
 	 * {@code Method(arg1, arg2)} on the result of {@code .Obj}.
 	 * @return the method result, or {@link #INVOKE_NOT_FOUND} if no method matched
 	 */
-	private Object tryFieldMethodCall(FieldNode fieldNode, List<Node> cmdArgNodes, Object data, BeanInfo beanInfo)
-			throws TemplateExecutionException {
+	private Object tryFieldMethodCall(FieldNode fieldNode, List<Node> cmdArgNodes, Object data, BeanInfo beanInfo,
+			Object pipelineValue) throws TemplateExecutionException {
 		String[] identifiers = fieldNode.getIdentifiers();
 		if (identifiers.length == 0) {
 			return INVOKE_NOT_FOUND;
@@ -587,7 +603,7 @@ public class Executor {
 		}
 
 		String methodName = identifiers[identifiers.length - 1];
-		return tryMethodInvoke(receiver, methodName, cmdArgNodes, data, beanInfo);
+		return tryMethodInvoke(receiver, methodName, cmdArgNodes, data, beanInfo, pipelineValue);
 	}
 
 	/**
@@ -596,8 +612,8 @@ public class Executor {
 	 * {@code ChainNode(FieldNode("X"), ["Y", "Method"])}.
 	 * @return the method result, or {@link #INVOKE_NOT_FOUND} if no method matched
 	 */
-	private Object tryChainMethodCall(ChainNode chainNode, List<Node> cmdArgNodes, Object data, BeanInfo beanInfo)
-			throws TemplateExecutionException {
+	private Object tryChainMethodCall(ChainNode chainNode, List<Node> cmdArgNodes, Object data, BeanInfo beanInfo,
+			Object pipelineValue) throws TemplateExecutionException {
 		List<String> fields = chainNode.getFields();
 		if (fields.isEmpty()) {
 			return INVOKE_NOT_FOUND;
@@ -610,22 +626,51 @@ public class Executor {
 		}
 
 		String methodName = fields.get(fields.size() - 1);
-		return tryMethodInvoke(receiver, methodName, cmdArgNodes, data, beanInfo);
+		return tryMethodInvoke(receiver, methodName, cmdArgNodes, data, beanInfo, pipelineValue);
+	}
+
+	/**
+	 * Try to invoke the last identifier of a variable reference as a method call:
+	 * {@code $var.Field.Method arg} calls {@code Method(arg)} on the result of
+	 * {@code $var.Field}. Mirrors {@link #tryFieldMethodCall} for variable-rooted chains
+	 * such as {@code $.Files.Get "path"}.
+	 * @return the method result, or {@link #INVOKE_NOT_FOUND} if no method matched
+	 */
+	private Object tryVariableMethodCall(VariableNode variableNode, List<Node> cmdArgNodes, Object data,
+			BeanInfo beanInfo, Object pipelineValue) throws TemplateExecutionException {
+		String varName = variableNode.getIdentifier(0);
+		if (!variables.containsKey(varName)) {
+			return INVOKE_NOT_FOUND;
+		}
+		Object receiver = variables.get(varName);
+		String[] identifiers = variableNode.getIdentifiers();
+		// Resolve all identifiers except the last to get the receiver object
+		for (int i = 1; i < identifiers.length - 1; i++) {
+			receiver = getFieldValue(receiver, identifiers[i]);
+		}
+		String methodName = identifiers[identifiers.length - 1];
+		return tryMethodInvoke(receiver, methodName, cmdArgNodes, data, beanInfo, pipelineValue);
 	}
 
 	/**
 	 * Core method invocation logic shared by field and chain method calls.
 	 */
 	private Object tryMethodInvoke(Object receiver, String methodName, List<Node> cmdArgNodes, Object data,
-			BeanInfo beanInfo) throws TemplateExecutionException {
+			BeanInfo beanInfo, Object pipelineValue) throws TemplateExecutionException {
 		if (receiver == null) {
 			return INVOKE_NOT_FOUND;
 		}
 
-		// Evaluate the method arguments (skip the first arg which is the node itself)
+		// Evaluate the method arguments (skip the first arg which is the node itself).
+		// In a chained pipeline the upstream value is passed as the method's final
+		// argument (Go: "arg | .Method x" calls Method(x, arg)).
 		List<Node> argNodes = cmdArgNodes.subList(1, cmdArgNodes.size());
-		Object[] args = new Object[argNodes.size()];
+		int extra = (pipelineValue != null) ? 1 : 0;
+		Object[] args = new Object[argNodes.size() + extra];
 		executeArguments(data, beanInfo, argNodes, args);
+		if (extra == 1) {
+			args[args.length - 1] = pipelineValue;
+		}
 
 		// Try to find a matching method via reflection
 		for (Method m : receiver.getClass().getMethods()) {

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/PipelineMethodCallTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/PipelineMethodCallTest.java
@@ -1,0 +1,64 @@
+package org.alexmond.jhelm.gotemplate;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests that a method call on a value receives the upstream pipeline value as its final
+ * argument — Go's {@code arg | .obj.Method} calls {@code Method(arg)}. This is the
+ * pattern Helm's {@code .Files.Get} relies on (e.g. {@code $path | $.Files.Get}); without
+ * it the argument is dropped and the call returns empty.
+ */
+class PipelineMethodCallTest {
+
+	private String render(String body, Object data) throws IOException, TemplateException {
+		GoTemplate template = new GoTemplate();
+		template.parse("t", body);
+		StringWriter writer = new StringWriter();
+		template.execute("t", data, writer);
+		return writer.toString();
+	}
+
+	private Map<String, Object> data() {
+		return Map.of("files", new FileBag(Map.of("a.txt", "content-a")));
+	}
+
+	@Test
+	void testDirectMethodCallWithArgument() throws IOException, TemplateException {
+		assertEquals("content-a", render("{{ .files.Get \"a.txt\" }}", data()));
+	}
+
+	@Test
+	void testPipedMethodCallOnField() throws IOException, TemplateException {
+		assertEquals("content-a", render("{{ \"a.txt\" | .files.Get }}", data()));
+	}
+
+	@Test
+	void testPipedMethodCallOnRootVariable() throws IOException, TemplateException {
+		// The exact shape used by grafana/k8s-monitoring: `$path | $.Files.Get`.
+		assertEquals("content-a", render("{{ \"a.txt\" | $.files.Get }}", data()));
+	}
+
+	/**
+	 * Minimal stand-in for Helm's {@code .Files} object: a behavioural map-like accessor.
+	 */
+	public static class FileBag {
+
+		private final Map<String, String> files;
+
+		FileBag(Map<String, String> files) {
+			this.files = files;
+		}
+
+		public String Get(String name) {
+			return files.getOrDefault(name, "");
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes task #19. grafana/k8s-monitoring read its loki destination defaults via `($path | $.Files.Get | fromYaml)` and got an **empty map**, blanking `retry_on_http_429`/backoff/`external_labels` and the Alloy `spec` defaults. Two independent bugs combined to drop the value:

### 1. Pipeline method calls dropped the piped value (`Executor`)
A method call only received the command's explicit arguments — the upstream pipeline value was never threaded in. So `arg | .obj.Method` (Go: `Method(arg)`) invoked the method with **zero** args, and a `$var.Field.Method` receiver took no method path at all (the method name resolved as a missing field, returning empty).

- `tryMethodInvoke` now appends the pipeline value as the method's final argument (Go's `arg | .obj.Method x` → `Method(x, arg)`).
- The method-call dispatch fires when a pipeline value is present, not only when explicit args exist.
- Variable-rooted chains (`$.Files.Get`) now get the same method handling as field/chain chains (new `tryVariableMethodCall`).

### 2. `deepCopy` stripped the `.Files` object's methods (`DictFunctions`)
`recursiveDeepCopy` converted every `Map` — including the engine's `ChartFiles` — into a plain `LinkedHashMap`, removing `.Get`. So even once the call reached the method, `(deepCopy $).Files` no longer had one. `deepCopy` now passes behavioural (non-standard) maps through unchanged, matching Helm's type-preserving copy.

## Result

- **k8s-monitoring now renders identically to Helm** — promoted from `failed.csv` to `charts.csv`.
- New `PipelineMethodCallTest` (direct call / piped-on-field / piped-on-`$var`) and a `deepCopy`-preserves-behavioural-maps test.
- **Full comparison suite: all 55 charts pass — no regression.** jhelm-core 550 tests + coverage gate green; gotemplate (incl. 3 new tests) and sprig suites green; full reactor compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)