### PR TITLE
Make printf tolerate Go/ERB format strings (#20)

### DIFF
--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -6,7 +6,8 @@
 # Both render under `helm template` with the comparison-values in application-test.yaml,
 # so the remaining failure is a real jhelm bug (tracked here until fixed).
 #
-# gitlab: the umbrella/subchart name-collision that hid gitlab.registry.hostname is fixed
-# (#18); rendering now reaches a separate bug — `gitlab.appConfig.duo.configuration` fails
-# with "Conversion = '='" (a printf/format-verb gap in that template).
+# gitlab: now renders end-to-end (the name-collision #18 and printf-verb #20 crashes are
+# fixed), but still diverges from Helm — jhelm emits Ingress objects where Helm emits
+# Gateway API resources (HTTPRoute/TCPRoute/BackendTrafficPolicy), and several
+# shared-secrets/migrations Jobs differ by content-hash suffix. Separate parity work.
 gitlab/gitlab,gitlab,https://charts.gitlab.io

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.IllegalFormatException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -426,8 +427,77 @@ public final class Functions {
 				}
 				realArgs[i] = arg;
 			}
-			return String.format(format, realArgs);
+			try {
+				return String.format(format, realArgs);
+			}
+			catch (IllegalFormatException ex) {
+				// Go's fmt never aborts on malformed verbs (it emits best-effort
+				// markers),
+				// but Java's Formatter throws. ERB-style literals routed through printf —
+				// e.g. gitlab's "<%= File.read('%s')... %>" where %= and %> are not Java
+				// conversions — must not crash rendering. Neutralise the unparseable '%'
+				// sequences (keeping the real verbs) and retry.
+				return String.format(neutralizeInvalidFormatSpecifiers(format), realArgs);
+			}
 		};
+	}
+
+	/**
+	 * Replaces every {@code %} that does not begin a valid Java format conversion (or
+	 * {@code %%}) with a literal {@code %%}, leaving genuine verbs (and their flags,
+	 * width and precision) intact. This lets {@link String#format} tolerate Go/ERB format
+	 * strings such as {@code "<%= ... %>"} without throwing, mirroring Go's lenient fmt.
+	 */
+	private static String neutralizeInvalidFormatSpecifiers(String format) {
+		final String flags = "-+ #0,(";
+		final String validVerbs = "bBhHsScCdoxXeEfgGaAn";
+		StringBuilder out = new StringBuilder(format.length() + 8);
+		int i = 0;
+		int n = format.length();
+		while (i < n) {
+			char c = format.charAt(i);
+			if (c != '%') {
+				out.append(c);
+				i++;
+				continue;
+			}
+			if (i + 1 < n && format.charAt(i + 1) == '%') {
+				out.append("%%");
+				i += 2;
+				continue;
+			}
+			int j = i + 1;
+			// optional argument index "k$"
+			int k = j;
+			while (k < n && Character.isDigit(format.charAt(k))) {
+				k++;
+			}
+			if (k < n && k > j && format.charAt(k) == '$') {
+				j = k + 1;
+			}
+			while (j < n && flags.indexOf(format.charAt(j)) >= 0) {
+				j++;
+			}
+			while (j < n && Character.isDigit(format.charAt(j))) {
+				j++;
+			}
+			if (j < n && format.charAt(j) == '.') {
+				j++;
+				while (j < n && Character.isDigit(format.charAt(j))) {
+					j++;
+				}
+			}
+			if (j < n && validVerbs.indexOf(format.charAt(j)) >= 0) {
+				out.append(format, i, j + 1);
+				i = j + 1;
+			}
+			else {
+				// Not a valid conversion: treat this '%' as a literal.
+				out.append("%%");
+				i++;
+			}
+		}
+		return out.toString();
 	}
 
 	private static Function println() {

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
@@ -80,6 +80,22 @@ class FunctionsTest {
 	}
 
 	@Test
+	void testPrintfStillFormatsValidVerbs() {
+		Function printf = Functions.GO_BUILTINS.get("printf");
+		assertEquals("a=1", printf.invoke(new Object[] { "%s=%d", "a", 1 }));
+	}
+
+	@Test
+	void testPrintfToleratesErbStyleLiterals() {
+		// gitlab routes an ERB literal through printf; %= and %> are not Java
+		// conversions.
+		// Go's fmt never throws — the real %s verb must still substitute.
+		Function printf = Functions.GO_BUILTINS.get("printf");
+		assertEquals("<%= File.read('/etc/x').strip.to_json() %>",
+				printf.invoke(new Object[] { "<%= File.read('%s').strip.to_json() %>", "/etc/x" }));
+	}
+
+	@Test
 	void testIndexFromMapMissingKey() throws Exception {
 		Function index = Functions.GO_BUILTINS.get("index");
 		Map<String, Object> map = Map.of("key", "value");


### PR DESCRIPTION
## Summary

Fixes task #20. gitlab's `gitlab.appConfig.duo.configuration` routes an ERB literal through `printf`:

```
printf "<%= File.read('%s').strip.to_json() %>" path
```

`%=` and `%>` are not Java format conversions, so Java's `Formatter` threw `UnknownFormatConversionException: Conversion = '='` and aborted the entire render. Go's `fmt` never fails on malformed verbs (it emits best-effort markers).

## Change

`printf` keeps `String.format` as the **primary** path — so every currently-passing chart is byte-for-byte unaffected — and **only on `IllegalFormatException`** neutralises the unparseable `%` sequences (leaving genuine verbs, flags, width and precision intact) and retries. The real `%s` still substitutes.

## Result

- New `FunctionsTest` cases: valid verbs still format; the ERB literal now substitutes its `%s` and renders without throwing.
- **gitlab now renders end-to-end** (149 documents) instead of crashing. It stays in `failed.csv` — the remaining differences are separate parity work (Helm emits Gateway API resources — HTTPRoute/TCPRoute/BackendTrafficPolicy — where jhelm emits Ingress; some shared-secrets/migrations Jobs differ by content-hash suffix). Reason updated.
- **Full comparison suite: all 55 charts still pass — no regression.** jhelm-core 551 tests + coverage green; gotemplate 441 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)