### PR TITLE
Parse templates in Helm's full-path order for define resolution (#21)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -238,10 +238,18 @@ public class Engine {
 		// Also track which chart each template belongs to for proper namespacing
 		Map<String, String> allTemplates = new HashMap<>();
 		Map<String, String> templateToChartName = new HashMap<>();
-		collectAllTemplates(chart, allTemplates, templateToChartName, chart.getMetadata().getName());
+		// Full umbrella-relative path per template (e.g.
+		// "gitlab/charts/openbao/templates/
+		// x.tpl"). Helm keys templates by this path and parses in its sorted order, so
+		// when
+		// two subcharts define the same named template the last one in that order wins.
+		// Parsing in the same order makes jhelm's define resolution match Helm's.
+		Map<String, String> templateFullPath = new HashMap<>();
+		collectAllTemplates(chart, allTemplates, templateToChartName, templateFullPath, chart.getMetadata().getName());
 
-		// Second pass: try to parse each template. Templates with definitions (tpl)
-		// should be parsed first.
+		// Second pass: parse each template. Helper files (.tpl) are parsed first so their
+		// defines are present; within each group templates are parsed in Helm's full-path
+		// order so same-named defines resolve to the same winner as Helm.
 		List<String> sortedNames = allTemplates.keySet().stream().sorted((a, b) -> {
 			boolean aTpl = a.endsWith(".tpl");
 			boolean bTpl = b.endsWith(".tpl");
@@ -253,14 +261,20 @@ public class Engine {
 			}
 			// Distinct-content collision extras (synthetic "name@version/templates/..."
 			// keys; chart names never contain '@') parse before the deduped primaries so
-			// that the primary — the higher-version winner — wins any define-name
-			// conflict.
+			// that the primary — the higher-version winner — wins a same-name define
+			// conflict between versions of the same library chart (e.g. bitnami common).
 			boolean aExtra = a.indexOf('@') >= 0;
 			boolean bExtra = b.indexOf('@') >= 0;
 			if (aExtra != bExtra) {
 				return aExtra ? -1 : 1;
 			}
-			return a.compareTo(b);
+			// Within a group, parse in Helm's full-path order so that a same-name define
+			// shared by distinct subcharts (e.g. gitlab's umbrella vs openbao
+			// gitlab.gatewayApi.route.enabled) resolves to the same winner as Helm.
+			String aPath = templateFullPath.getOrDefault(a, a);
+			String bPath = templateFullPath.getOrDefault(b, b);
+			int cmp = aPath.compareTo(bPath);
+			return (cmp != 0) ? cmp : a.compareTo(b);
 		}).toList();
 
 		for (String name : sortedNames) {
@@ -328,7 +342,13 @@ public class Engine {
 	}
 
 	private void collectAllTemplates(Chart chart, Map<String, String> templates,
-			Map<String, String> templateToChartName, String rootChartName) {
+			Map<String, String> templateToChartName, Map<String, String> templateFullPath, String rootChartName) {
+		collectAllTemplates(chart, templates, templateToChartName, templateFullPath, rootChartName, rootChartName);
+	}
+
+	private void collectAllTemplates(Chart chart, Map<String, String> templates,
+			Map<String, String> templateToChartName, Map<String, String> templateFullPath, String rootChartName,
+			String pathPrefix) {
 		String chartName = chart.getMetadata().getName();
 		String chartVersion = chart.getMetadata().getVersion();
 
@@ -336,39 +356,42 @@ public class Engine {
 			// Use Helm-style path (chartName/templates/fileName) to match the names
 			// that charts use with $.Template.BasePath in include calls
 			String helmStyleKey = chartName + "/templates/" + t.getName();
+			// Full umbrella-relative path, used only to order parsing like Helm.
+			String fullPath = pathPrefix + "/templates/" + t.getName();
 			// On collision, keep the template from the higher chart version. Newer
 			// library chart versions are backward-compatible supersets of older ones,
 			// so keeping the newest avoids missing-feature failures.
 			String existingVersion = templateVersions.get(helmStyleKey);
 			if (existingVersion == null || compareVersions(chartVersion, existingVersion) > 0) {
 				// A genuinely different file is being displaced (not just an older copy
-				// of
-				// the same library helper): keep its defines so they aren't lost.
+				// of the same library helper): keep its defines so they aren't lost.
 				String displaced = templates.get(helmStyleKey);
 				if (displaced != null && !displaced.equals(t.getData())) {
-					preserveDistinctTemplate(templates, templateToChartName, templateToChartName.get(helmStyleKey),
-							existingVersion, t.getName(), displaced);
+					preserveDistinctTemplate(templates, templateToChartName, templateFullPath,
+							templateToChartName.get(helmStyleKey), templateFullPath.get(helmStyleKey), existingVersion,
+							t.getName(), displaced);
 				}
 				templates.put(helmStyleKey, t.getData());
 				templateToChartName.put(helmStyleKey, chartName);
+				templateFullPath.put(helmStyleKey, fullPath);
 				templateVersions.put(helmStyleKey, chartVersion);
 			}
 			else {
 				// Same short key, equal/older version. If the content genuinely differs,
 				// this is a distinct chart that merely shares a name (e.g. an umbrella
-				// and
-				// a subchart both named "gitlab"): keep its defines under a version-
+				// and a subchart both named "gitlab"): keep its defines under a version-
 				// qualified key instead of dropping the whole file (#18).
 				String kept = templates.get(helmStyleKey);
 				if (kept != null && !kept.equals(t.getData())) {
-					preserveDistinctTemplate(templates, templateToChartName, chartName, chartVersion, t.getName(),
-							t.getData());
+					preserveDistinctTemplate(templates, templateToChartName, templateFullPath, chartName, fullPath,
+							chartVersion, t.getName(), t.getData());
 				}
 			}
 		}
 
 		for (Chart subchart : chart.getDependencies()) {
-			collectAllTemplates(subchart, templates, templateToChartName, rootChartName);
+			collectAllTemplates(subchart, templates, templateToChartName, templateFullPath, rootChartName,
+					pathPrefix + "/charts/" + subchart.getMetadata().getName());
 		}
 	}
 
@@ -377,14 +400,19 @@ public class Engine {
 	 * with a different file (distinct content), under a version-qualified key so the
 	 * second pass still parses it and registers its named templates. The value is only
 	 * ever a helper included by {@code define} name, so the synthetic key just needs to
-	 * be unique — it is never referenced by path.
+	 * be unique — it is never referenced by path. Its real full path is recorded so it is
+	 * still ordered like Helm during parsing.
 	 */
 	private static void preserveDistinctTemplate(Map<String, String> templates, Map<String, String> templateToChartName,
-			String chartName, String version, String fileName, String content) {
+			Map<String, String> templateFullPath, String chartName, String fullPath, String version, String fileName,
+			String content) {
 		String key = chartName + "@" + ((version != null) ? version : "") + "/templates/" + fileName;
 		if (!templates.containsKey(key)) {
 			templates.put(key, content);
 			templateToChartName.put(key, chartName);
+			if (fullPath != null) {
+				templateFullPath.put(key, fullPath);
+			}
 		}
 	}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/DefineOrderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/DefineOrderTest.java
@@ -1,0 +1,46 @@
+package org.alexmond.jhelm.core;
+
+import java.io.File;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.Engine;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for #21: when the same named template is defined by distinct subcharts
+ * (here the umbrella's {@code templates/_helpers.tpl} and a {@code zzz} subchart's), Helm
+ * parses templates in full-path order — {@code .../charts/zzz/templates/...} sorts before
+ * {@code .../templates/...} — so the umbrella's definition is parsed last and wins. jhelm
+ * must resolve the same winner (verified against {@code helm template}: {@code
+ * from-umbrella}), not the one that merely sorts last by chart name.
+ */
+class DefineOrderTest {
+
+	private final ChartLoader chartLoader = new ChartLoader();
+
+	private final Engine engine = new Engine();
+
+	private final InstallAction installAction = new InstallAction(engine, null);
+
+	@Test
+	void testFullPathOrderingPicksSameDefineWinnerAsHelm() throws Exception {
+		File chartDir = new File("src/test/resources/test-charts/define-order");
+		Chart chart = chartLoader.load(chartDir);
+		assertNotNull(chart, "Chart should be loaded");
+
+		Release release = installAction.install(chart, "test-release", "default", Map.of(), 1, true);
+		assertNotNull(release, "Release should be created");
+		String manifest = release.getManifest();
+
+		assertTrue(manifest.contains("value: from-umbrella"),
+				"umbrella define must win via Helm full-path parse order; got:\n" + manifest);
+	}
+
+}

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -6,8 +6,8 @@
 # Both render under `helm template` with the comparison-values in application-test.yaml,
 # so the remaining failure is a real jhelm bug (tracked here until fixed).
 #
-# gitlab: now renders end-to-end (the name-collision #18 and printf-verb #20 crashes are
-# fixed), but still diverges from Helm — jhelm emits Ingress objects where Helm emits
-# Gateway API resources (HTTPRoute/TCPRoute/BackendTrafficPolicy), and several
-# shared-secrets/migrations Jobs differ by content-hash suffix. Separate parity work.
+# gitlab: renders end-to-end and now emits the Gateway API resources Helm does
+# (HTTPRoute/TCPRoute/BackendTrafficPolicy — the parse-order #21 fix), but still diverges:
+# several shared-secrets/migrations/issuer Jobs differ by content-hash suffix, the Gateway
+# object is missing a couple of listeners, and a test-hook Pod has a random name suffix.
 gitlab/gitlab,gitlab,https://charts.gitlab.io

--- a/jhelm-core/src/test/resources/test-charts/define-order/Chart.yaml
+++ b/jhelm-core/src/test/resources/test-charts/define-order/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: define-order
+version: 1.0.0
+description: Umbrella and a subchart define the same template name (regression for #21)

--- a/jhelm-core/src/test/resources/test-charts/define-order/charts/zzz/Chart.yaml
+++ b/jhelm-core/src/test/resources/test-charts/define-order/charts/zzz/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: zzz
+version: 1.0.0
+description: Subchart redefining shared.value

--- a/jhelm-core/src/test/resources/test-charts/define-order/charts/zzz/templates/_helpers.tpl
+++ b/jhelm-core/src/test/resources/test-charts/define-order/charts/zzz/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "shared.value" -}}
+from-zzz
+{{- end -}}

--- a/jhelm-core/src/test/resources/test-charts/define-order/templates/_helpers.tpl
+++ b/jhelm-core/src/test/resources/test-charts/define-order/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "shared.value" -}}
+from-umbrella
+{{- end -}}

--- a/jhelm-core/src/test/resources/test-charts/define-order/templates/cm.yaml
+++ b/jhelm-core/src/test/resources/test-charts/define-order/templates/cm.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-cm
+data:
+  # shared.value is defined in both this umbrella's _helpers.tpl and the zzz subchart's.
+  # Helm parses in full-path order (charts/zzz/... before templates/...), so the
+  # umbrella's definition is parsed last and wins.
+  value: {{ include "shared.value" . }}


### PR DESCRIPTION
## Summary

Partial progress on #21. When the same named template is defined by two distinct subcharts, the winner is the one parsed **last**. Helm keys templates by their full path and parses in sorted order:

```
gitlab/charts/openbao/templates/_gateway_api_helpers.tpl   →  gitlab.gatewayApi.route.enabled = false
gitlab/templates/_gateway.tpl                              →  gitlab.gatewayApi.route.enabled = global.gatewayApi.enabled (true)
```

`charts/openbao/...` sorts before `templates/...`, so the umbrella's define is parsed last and wins → Helm emits Gateway API resources. jhelm keyed templates by chart **name** (`openbao/...` vs `gitlab/...`), giving the opposite winner — so gitlab resolved the define to `false` and emitted **Ingress** objects instead.

## Change

`collectAllTemplates` now records each template's full umbrella-relative path, and the parse pass orders by it. Crucially this is a **hybrid**:

- Distinct-content collision *extras* still parse before the de-duped primaries, so the higher-version copy of a shared library chart (e.g. bitnami `common`) still wins — keeping matrix-synapse and friends correct. (A pure full-path order regressed matrix-synapse's `app.kubernetes.io/version` labels.)
- **Full path is the tiebreaker within each group** — this is what fixes gitlab's gateway-vs-ingress branching.

## Testing

- New `DefineOrderTest`: umbrella + subchart defining the same name; the expected winner was verified against real `helm template` (`from-umbrella`).
- **Full comparison suite: all 55 charts pass — no regression** (matrix-synapse included).
- gitlab now emits HTTPRoute/TCPRoute/BackendTrafficPolicy like Helm. It **stays in `failed.csv`** for the remaining diffs (shared-secrets/migrations/issuer Job content-hash suffixes, a couple of Gateway listeners, a random-suffixed test-hook Pod) — reason updated.
- jhelm-core 552 tests + coverage gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)