### PR TITLE
Match Helm toYaml: sort keys and render whole floats as ints (#237)

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -49,6 +49,10 @@
     <suppress checks="MethodLength" files="HelmChartTemplates\.java"/>
     <suppress checks="FileLength" files="HelmChartTemplates\.java"/>
 
+    <!-- ConversionFunctions is one cohesive registry of YAML/JSON/TOML conversion functions
+         plus the Go-faithful serialization post-processing — long by nature -->
+    <suppress checks="FileLength" files="ConversionFunctions\.java"/>
+
     <!-- Test files are exempt from size limits: test methods are short but files accumulate many of them -->
     <suppress checks="MethodLength" files=".*Test\.java"/>
     <suppress checks="FileLength" files=".*Test\.java"/>

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -56,7 +56,13 @@ public final class ConversionFunctions {
 		.enable(YAMLWriteFeature.MINIMIZE_QUOTES)
 		// Keep quotes on numeric-looking strings to match Go yaml.Marshal behavior
 		.enable(YAMLWriteFeature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)
-		// Go's yaml.Marshal preserves insertion order — do NOT sort keys alphabetically
+		// Helm's toYaml marshals via sigs.k8s.io/yaml (-> JSON, which sorts keys); match
+		// it
+		// so hashed toYaml (name suffixes, checksum/*) agrees. (toYamlPretty keeps
+		// order.)
+		.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+		// Render whole-number floats as ints (1.0 -> 1) like Helm's JSON-based marshal.
+		.addModule(goNumberModule())
 		.build());
 
 	/**

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -103,6 +103,49 @@ class ConversionFunctionsTest {
 		assertTrue(result.contains(expectedContains));
 	}
 
+	@Test
+	void testToYamlSortsKeysLikeHelm() throws IOException, TemplateException {
+		// Helm's toYaml marshals via sigs.k8s.io/yaml (-> JSON, which sorts map keys), so
+		// jhelm must sort too — otherwise toYaml output that gets hashed (resource-name
+		// suffixes, checksum/* annotations) diverges from Helm byte-for-byte (#237).
+		Map<String, Object> obj = new java.util.LinkedHashMap<>();
+		obj.put("zebra", 1);
+		obj.put("alpha", 2);
+		obj.put("mike", 3);
+		Map<String, Object> data = new HashMap<>();
+		data.put("obj", obj);
+		String result = execWithData("{{ toYaml .obj }}", data).trim();
+		assertEquals("alpha: 2\nmike: 3\nzebra: 1", result, "toYaml must emit keys in sorted order");
+	}
+
+	@Test
+	void testToYamlRendersWholeFloatsAsIntegers() {
+		// Helm marshals via JSON, where float64(1.0) -> "1". jhelm must match (whole
+		// floats
+		// lose the ".0") so hashed toYaml agrees; fractional floats are unchanged.
+		Function toYaml = functions().get("toYaml");
+		Map<String, Object> data = new LinkedHashMap<>();
+		data.put("whole", 1.0);
+		data.put("frac", 0.5);
+		String result = (String) toYaml.invoke(new Object[] { data });
+		assertTrue(result.contains("whole: 1\n") || result.endsWith("whole: 1"),
+				"whole-number float must render as int: " + result);
+		assertTrue(result.contains("frac: 0.5"), "fractional float must be unchanged: " + result);
+	}
+
+	@Test
+	void testToYamlSortsNestedKeys() throws IOException, TemplateException {
+		Map<String, Object> inner = new java.util.LinkedHashMap<>();
+		inner.put("bb", 1);
+		inner.put("aa", 2);
+		Map<String, Object> obj = new java.util.LinkedHashMap<>();
+		obj.put("outer", inner);
+		Map<String, Object> data = new HashMap<>();
+		data.put("obj", obj);
+		String result = execWithData("{{ toYaml .obj }}", data).trim();
+		assertEquals("outer:\n  aa: 2\n  bb: 1", result, "toYaml must sort nested map keys too");
+	}
+
 	@ParameterizedTest
 	@CsvSource({ "toYaml", "mustToYaml" })
 	void testYamlNumericStringsQuoted(String func) throws IOException, TemplateException {
@@ -463,20 +506,20 @@ class ConversionFunctionsTest {
 	}
 
 	@Test
-	void testToYamlPreservesInsertionOrder() {
-		// Go's yaml.Marshal preserves map insertion order, NOT alphabetical
+	void testToYamlSortsKeysNotInsertionOrder() {
+		// Helm's toYaml marshals via sigs.k8s.io/yaml (-> JSON), which sorts map keys —
+		// it does NOT preserve insertion order. jhelm must match so hashed toYaml agrees.
 		Function toYaml = functions().get("toYaml");
 		Map<String, Object> data = new LinkedHashMap<>();
 		data.put("zebra", "last");
 		data.put("alpha", "first");
 		data.put("middle", "mid");
 		String result = (String) toYaml.invoke(new Object[] { data });
-		// Keys must appear in insertion order: zebra, alpha, middle
 		int zebraPos = result.indexOf("zebra");
 		int alphaPos = result.indexOf("alpha");
 		int middlePos = result.indexOf("middle");
-		assertTrue(zebraPos < alphaPos, "zebra should come before alpha (insertion order): " + result);
-		assertTrue(alphaPos < middlePos, "alpha should come before middle (insertion order): " + result);
+		assertTrue(alphaPos < middlePos, "alpha should come before middle (sorted): " + result);
+		assertTrue(middlePos < zebraPos, "middle should come before zebra (sorted): " + result);
 	}
 
 	// --- toYaml with regex values (backslash handling) ---


### PR DESCRIPTION
## Summary

First concrete progress on the **toYaml byte-parity epic (#237)**. Helm's `toYaml` marshals via `sigs.k8s.io/yaml` (Go struct/map → JSON → YAML), and `encoding/json` **sorts map keys** and renders `float64(1.0)` as `1`. jhelm's `toYaml` used Jackson with insertion order preserved and `1.0` kept, so any `toYaml` output that gets **hashed** diverged from Helm byte-for-byte — e.g. gitlab's `shared-secrets`/`migrations`/`issuer` Job name suffixes (`sha256(… b64enc(toYaml(.Values)))`) and `checksum/*` annotations.

The original code deliberately disabled sorting on the assumption Helm uses Go's `yaml.Marshal` (insertion order). I verified against real `helm template` that Helm's `toYaml` **does sort** (and drops `.0`) — that assumption was wrong.

## Change

- Enable `ORDER_MAP_ENTRIES_BY_KEYS` on the `toYaml` mapper (recursively sorts keys). `toYamlPretty` is left unchanged — Helm's `toYamlPretty` uses `yaml.v3` and preserves insertion order.
- Wire the existing `goNumberModule` (already used by `toJson`) into the `toYaml` mapper so whole-number floats lose the `.0`.
- Corrected the stale `testToYamlPreservesInsertionOrder` (it asserted the opposite of Helm's real behaviour); added sorted-keys, nested-sort, and whole-float tests, each cross-checked against `helm template`.

## Why it's safe

Key sorting and `1.0→1` are **semantically invisible** to the comparison harness (it parses YAML back into structures and compares order-independently), so the byte-level change doesn't affect rendered-resource comparison — **all 55 charts still pass**. The payoff is on byte-exact *hashed* output.

## Testing

- gotemplate-helm: 70 conversion tests (incl. new sorted/nested/float cases)
- jhelm-core: 552 tests + coverage gate green
- **Full comparison suite: all 55 charts pass — no regression**

## Remaining

The last `toYaml` byte-parity gap is **quote style** — Go yaml uses single quotes where Jackson emits double — left for a follow-up. (Even full byte-parity won't flip gitlab to passing on its own: its Job *set* also differs via `global` subchart propagation, plus a random-suffixed test-hook Pod.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)