### PR TITLE
Match Go yaml single-quote style in toYaml (#237)

### DIFF
--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -684,14 +684,17 @@ public final class ConversionFunctions {
 				if (canBePlainScalar(unescaped)) {
 					sb.append(prefix).append(unescaped);
 				}
-				else if (unescaped.indexOf('"') >= 0 && canBeSingleQuoted(unescaped)) {
-					// A value that cannot be plain (e.g. starts with a flow indicator
-					// like
-					// "{{") but contains double quotes is emitted by Go's yaml.Marshal in
-					// SINGLE-quote style, not double-quote-with-backslash-escapes. The
-					// backslashes otherwise break a subsequent tpl(toYaml ...) re-parse —
-					// a
-					// common pattern is a config value of {{ include "x" . }} (#327).
+				else if (canBeSingleQuoted(unescaped) && !needsDoubleQuote(unescaped)) {
+					// Go's yaml.Marshal (Helm's toYaml, via sigs.k8s.io/yaml -> yaml.v2)
+					// emits SINGLE-quote style for non-plain scalars — e.g. values with a
+					// ": "/" #" indicator or a flow-indicator start like "{{" — reserving
+					// double quotes for empty/numeric/keyword strings (see
+					// needsDoubleQuote)
+					// and control-char content. Single quotes also keep backslashes
+					// literal,
+					// so a re-parse of tpl(toYaml ...) over {{ include "x" . }} stays
+					// intact
+					// (#327).
 					sb.append(prefix).append('\'').append(unescaped.replace("'", "''")).append('\'');
 				}
 				else {
@@ -773,6 +776,16 @@ public final class ConversionFunctions {
 	 * can hold any printable content (with {@code '} doubled), but control characters
 	 * (including newline/tab) force double-quote style, so those are rejected here.
 	 */
+	/**
+	 * Whether Go's yaml.Marshal would keep a non-plain scalar in double-quote style
+	 * rather than single. It reserves double quotes for the empty string and for strings
+	 * that look like another YAML type (numbers, booleans, null) — quoting those keeps
+	 * them strings; everything else quotable is emitted single-quoted.
+	 */
+	private static boolean needsDoubleQuote(String s) {
+		return s.isEmpty() || NUMERIC.matcher(s).matches() || YAML_KEYWORDS.contains(s.toLowerCase(Locale.ROOT));
+	}
+
 	private static boolean canBeSingleQuoted(String s) {
 		for (int i = 0; i < s.length(); i++) {
 			char c = s.charAt(i);

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -119,6 +119,29 @@ class ConversionFunctionsTest {
 	}
 
 	@Test
+	void testToYamlQuoteStyleMatchesGoYaml() {
+		// Go's yaml.Marshal (Helm's toYaml) single-quotes non-plain scalars (special
+		// chars,
+		// flow-indicator starts) but double-quotes empty/numeric/keyword strings.
+		// Verified
+		// against `helm template`.
+		Map<String, Object> data = new LinkedHashMap<>();
+		data.put("withColon", "key: value");
+		data.put("withHash", "a # b");
+		data.put("flow", "{{ x }}");
+		data.put("numStr", "123");
+		data.put("emptyStr", "");
+		data.put("tilde", "~");
+		String result = (String) functions().get("toYaml").invoke(new Object[] { data });
+		assertTrue(result.contains("withColon: 'key: value'"), "special-char string is single-quoted: " + result);
+		assertTrue(result.contains("withHash: 'a # b'"), "hash string is single-quoted: " + result);
+		assertTrue(result.contains("flow: '{{ x }}'"), "flow-indicator string is single-quoted: " + result);
+		assertTrue(result.contains("numStr: \"123\""), "numeric string stays double-quoted: " + result);
+		assertTrue(result.contains("emptyStr: \"\""), "empty string stays double-quoted: " + result);
+		assertTrue(result.contains("tilde: \"~\""), "null keyword stays double-quoted: " + result);
+	}
+
+	@Test
 	void testToYamlRendersWholeFloatsAsIntegers() {
 		// Helm marshals via JSON, where float64(1.0) -> "1". jhelm must match (whole
 		// floats
@@ -546,11 +569,12 @@ class ConversionFunctionsTest {
 
 	@Test
 	void testToYamlPreservesQuotesWhenNeeded() {
-		// Values starting with flow indicators must stay quoted
+		// Values starting with flow indicators must stay quoted. Go's yaml.Marshal uses
+		// single-quote style for these (not double), so jhelm emits '{flow}'.
 		Function toYaml = functions().get("toYaml");
 		Map<String, String> data = Map.of("val", "{flow}");
 		String result = (String) toYaml.invoke(new Object[] { data });
-		assertTrue(result.contains("\""), "values starting with { must stay quoted");
+		assertTrue(result.contains("'{flow}'"), "flow-indicator value must stay single-quoted: " + result);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Completes the common-case `toYaml` byte-parity with Helm (after key-sorting + whole-float in #346). Go's `yaml.Marshal` (Helm's `toYaml`, via `sigs.k8s.io/yaml` → `yaml.v2`) emits non-plain scalars in **single-quote** style — `'key: value'`, `'a # b'`, `'{{ x }}'` — reserving **double** quotes for the empty string and for values that look like another YAML type (numbers, booleans, null) and must stay quoted to remain strings. jhelm/Jackson emitted everything double-quoted.

## Change

`removeUnnecessaryQuotes` now single-quotes any non-plain, control-char-free scalar unless `needsDoubleQuote` (empty / numeric / keyword) applies. With this plus the earlier sorting and whole-float changes, jhelm's `toYaml` is **byte-identical to `helm template`** across a comprehensive mixed-type values set (verified by diff).

## Testing

- New `testToYamlQuoteStyleMatchesGoYaml`; corrected the stale `testToYamlPreservesQuotesWhenNeeded` (Go single-quotes a `{`-leading value, it doesn't double-quote it).
- **Full comparison suite: all 55 charts pass** — quote style is semantically invisible, so no regression.
- gotemplate-helm: 124 tests + coverage gate green.

## Note

gitlab's Job-name `sha256(toYaml(.Values))` suffixes **still differ** — its very large values tree exercises further long-tail serialization cases beyond this set (the hash moved but didn't converge). Tracked in #21; this PR stands on its own as general #237 progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)