### PR TITLE
Coalesce subchart values recursively (Helm CoalesceValues) (#21)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -670,12 +670,41 @@ public class Engine {
 	private void mergeSubchartDefaults(Chart chart, Map<String, Object> mergedValues) {
 		for (Chart dep : chart.getDependencies()) {
 			String depKey = (dep.getAlias() != null) ? dep.getAlias() : dep.getMetadata().getName();
-			if (dep.getValues() != null && !dep.getValues().isEmpty()) {
+			// Coalesce the subchart's full default tree — its own values.yaml plus its
+			// nested subcharts' defaults, recursively — so parent templates that read
+			// .Values.<sub>.<nestedsub>.* (e.g. gitlab's .Values.gitlab.webservice) see
+			// the
+			// same tree Helm builds. Anything already set on the parent for this key
+			// wins.
+			Map<String, Object> depDefaults = coalesceChartValues(dep);
+			if (!depDefaults.isEmpty()) {
 				Map<String, Object> existing = (Map<String, Object>) mergedValues.getOrDefault(depKey, new HashMap<>());
-				Map<String, Object> merged = mergeValues(dep.getValues(), existing);
-				mergedValues.put(depKey, merged);
+				mergedValues.put(depKey, mergeValues(depDefaults, existing));
 			}
 		}
+	}
+
+	/**
+	 * Recursively coalesce a chart's default values: its own {@code values.yaml} with
+	 * each subchart's coalesced defaults placed under the subchart's name/alias key. The
+	 * chart's own values for a subchart key win over that subchart's defaults (Helm
+	 * precedence).
+	 */
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> coalesceChartValues(Chart chart) {
+		Map<String, Object> base = (chart.getValues() != null) ? new HashMap<>(chart.getValues()) : new HashMap<>();
+		for (Chart dep : chart.getDependencies()) {
+			String depKey = (dep.getAlias() != null) ? dep.getAlias() : dep.getMetadata().getName();
+			Map<String, Object> depDefaults = coalesceChartValues(dep);
+			if (depDefaults.isEmpty()) {
+				continue;
+			}
+			Object existing = base.get(depKey);
+			Map<String, Object> overrides = (existing instanceof Map) ? (Map<String, Object>) existing
+					: new HashMap<>();
+			base.put(depKey, mergeValues(depDefaults, overrides));
+		}
+		return base;
 	}
 
 	/**

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/NestedSubchartValuesTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/NestedSubchartValuesTest.java
@@ -1,0 +1,45 @@
+package org.alexmond.jhelm.core;
+
+import java.io.File;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.Engine;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for #21: a default declared by a sub-subchart must be visible to the
+ * umbrella at {@code .Values.<mid>.<leaf>.*}. Helm coalesces subchart values recursively
+ * (its {@code chartutil.CoalesceValues}), so the umbrella sees the whole nested default
+ * tree — e.g. gitlab reading {@code .Values.gitlab.gitlab-shell.enabled}. Verified
+ * against {@code helm template} ({@code leafColor: blue}).
+ */
+class NestedSubchartValuesTest {
+
+	private final ChartLoader chartLoader = new ChartLoader();
+
+	private final Engine engine = new Engine();
+
+	private final InstallAction installAction = new InstallAction(engine, null);
+
+	@Test
+	void testTwoLevelDeepSubchartDefaultIsVisibleToUmbrella() throws Exception {
+		File chartDir = new File("src/test/resources/test-charts/nested-values");
+		Chart chart = chartLoader.load(chartDir);
+		assertNotNull(chart, "Chart should be loaded");
+
+		Release release = installAction.install(chart, "test-release", "default", Map.of(), 1, true);
+		assertNotNull(release, "Release should be created");
+		String manifest = release.getManifest();
+
+		assertTrue(manifest.contains("leafColor: blue"),
+				"umbrella must see the leaf sub-subchart default via recursive coalescing; got:\n" + manifest);
+	}
+
+}

--- a/jhelm-core/src/test/resources/test-charts/nested-values/Chart.yaml
+++ b/jhelm-core/src/test/resources/test-charts/nested-values/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: nested-values
+version: 1.0.0
+description: Umbrella reading a 2-levels-deep subchart default (regression for #21)

--- a/jhelm-core/src/test/resources/test-charts/nested-values/charts/mid/Chart.yaml
+++ b/jhelm-core/src/test/resources/test-charts/nested-values/charts/mid/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: mid
+version: 1.0.0

--- a/jhelm-core/src/test/resources/test-charts/nested-values/charts/mid/charts/leaf/Chart.yaml
+++ b/jhelm-core/src/test/resources/test-charts/nested-values/charts/mid/charts/leaf/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: leaf
+version: 1.0.0

--- a/jhelm-core/src/test/resources/test-charts/nested-values/charts/mid/charts/leaf/values.yaml
+++ b/jhelm-core/src/test/resources/test-charts/nested-values/charts/mid/charts/leaf/values.yaml
@@ -1,0 +1,1 @@
+color: blue

--- a/jhelm-core/src/test/resources/test-charts/nested-values/templates/cm.yaml
+++ b/jhelm-core/src/test/resources/test-charts/nested-values/templates/cm.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-cm
+data:
+  # leaf.color is a default of the leaf sub-subchart; the umbrella must see it at
+  # .Values.mid.leaf.color via recursive subchart value coalescing (Helm behaviour).
+  leafColor: {{ .Values.mid.leaf.color }}


### PR DESCRIPTION
## Summary

`mergeSubchartDefaults` merged each *direct* subchart's own `values.yaml` only **one level deep**, so a nested sub-subchart's defaults never reached the umbrella's `.Values.<sub>.<nestedsub>.*`. Helm coalesces **recursively** (`chartutil.CoalesceValues`), so its `.Values` tree is far larger.

Diagnosed by rendering a probe ConfigMap that emits `toYaml(.Values)` from **both** jhelm and `helm template` on the same gitlab chart + values, then diffing: jhelm's tree was 3,410 lines vs Helm's 13,029, dominated by **`.Values.gitlab` = 44 lines (jhelm) vs 7,429 (Helm)** — the `gitlab` subchart is itself an umbrella over webservice/sidekiq/gitaly/kas/gitlab-shell/… So parent templates reading `.Values.gitlab["gitlab-shell"].enabled` or `.Values.global.kas.enabled` saw nothing.

## Change

`coalesceChartValues(chart)` builds a chart's own `values.yaml` deep-merged with each subchart's **recursively coalesced** defaults under the subchart key (the chart's own values win — Helm precedence). `mergeSubchartDefaults` uses it so the umbrella sees the full nested default tree.

## Result

- **gitlab: the Gateway now renders the `kas-web` and `gitlab-ssh` listeners** it was missing (the `Gateway` 8-diff is resolved — one fewer comparison failure). It stays in `failed.csv` for the remaining items (Job-name `toYaml`-hash suffixes from residual `.Values` diffs, and a random-suffixed test-hook Pod).
- New `NestedSubchartValuesTest` (umbrella reading a 2-levels-deep leaf default), expected value **verified against `helm template`**.
- **Full comparison suite: all 55 charts pass — no regression.** jhelm-core 553 tests + coverage gate green.

This is a general value-propagation correctness fix — it benefits any deeply-nested chart, not just gitlab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)