### PR TITLE
Enable 3 more charts; align version selection + APIVersions with Helm

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -28,17 +28,30 @@ import org.alexmond.jhelm.core.model.VersionSet;
 @Slf4j
 public class Engine {
 
-	// Full set of API group versions matching k8s client-go v1.31 scheme registration.
-	// Helm builds this from scheme.Scheme.PrioritizedVersionsAllGroups().
-	private static final List<String> DEFAULT_API_VERSIONS = List.of("v1", "admissionregistration.k8s.io/v1",
-			"admissionregistration.k8s.io/v1beta1", "apiextensions.k8s.io/v1", "apiregistration.k8s.io/v1", "apps/v1",
-			"authentication.k8s.io/v1", "authentication.k8s.io/v1beta1", "authorization.k8s.io/v1", "autoscaling/v2",
-			"autoscaling/v1", "batch/v1", "certificates.k8s.io/v1", "certificates.k8s.io/v1alpha1",
-			"coordination.k8s.io/v1", "coordination.k8s.io/v1alpha2", "discovery.k8s.io/v1", "events.k8s.io/v1",
-			"flowcontrol.apiserver.k8s.io/v1", "flowcontrol.apiserver.k8s.io/v1beta3",
-			"internal.apiserver.k8s.io/v1alpha1", "networking.k8s.io/v1", "networking.k8s.io/v1alpha1",
-			"node.k8s.io/v1", "policy/v1", "rbac.authorization.k8s.io/v1", "resource.k8s.io/v1alpha3",
-			"scheduling.k8s.io/v1", "storage.k8s.io/v1", "storage.k8s.io/v1alpha1", "storagemigration.k8s.io/v1alpha1");
+	// Exactly Helm's built-in chartutil.DefaultVersionSet — the .Capabilities.APIVersions
+	// that `helm template` exposes with no live cluster (dumped from helm 3.x). Matching
+	// it
+	// verbatim keeps `.Capabilities.APIVersions.Has` checks in parity with Helm; notably
+	// it
+	// excludes apiregistration.k8s.io/* and keeps legacy *beta1 groups (e.g. extensions/
+	// v1beta1, apps/v1beta1, autoscaling/v2beta1) that a newer client-go scheme drops.
+	private static final List<String> DEFAULT_API_VERSIONS = List.of("admissionregistration.k8s.io/v1",
+			"admissionregistration.k8s.io/v1alpha1", "admissionregistration.k8s.io/v1beta1", "apiextensions.k8s.io/v1",
+			"apiextensions.k8s.io/v1beta1", "apps/v1", "apps/v1beta1", "apps/v1beta2", "authentication.k8s.io/v1",
+			"authentication.k8s.io/v1alpha1", "authentication.k8s.io/v1beta1", "authorization.k8s.io/v1",
+			"authorization.k8s.io/v1beta1", "autoscaling/v1", "autoscaling/v2", "autoscaling/v2beta1",
+			"autoscaling/v2beta2", "batch/v1", "batch/v1beta1", "certificates.k8s.io/v1",
+			"certificates.k8s.io/v1alpha1", "certificates.k8s.io/v1beta1", "coordination.k8s.io/v1",
+			"coordination.k8s.io/v1alpha2", "coordination.k8s.io/v1beta1", "discovery.k8s.io/v1",
+			"discovery.k8s.io/v1beta1", "events.k8s.io/v1", "events.k8s.io/v1beta1", "extensions/v1beta1",
+			"flowcontrol.apiserver.k8s.io/v1", "flowcontrol.apiserver.k8s.io/v1beta1",
+			"flowcontrol.apiserver.k8s.io/v1beta2", "flowcontrol.apiserver.k8s.io/v1beta3",
+			"internal.apiserver.k8s.io/v1alpha1", "networking.k8s.io/v1", "networking.k8s.io/v1beta1", "node.k8s.io/v1",
+			"node.k8s.io/v1alpha1", "node.k8s.io/v1beta1", "policy/v1", "policy/v1beta1",
+			"rbac.authorization.k8s.io/v1", "rbac.authorization.k8s.io/v1alpha1", "rbac.authorization.k8s.io/v1beta1",
+			"resource.k8s.io/v1", "resource.k8s.io/v1alpha3", "resource.k8s.io/v1beta1", "resource.k8s.io/v1beta2",
+			"scheduling.k8s.io/v1", "scheduling.k8s.io/v1alpha1", "scheduling.k8s.io/v1beta1", "storage.k8s.io/v1",
+			"storage.k8s.io/v1alpha1", "storage.k8s.io/v1beta1", "storagemigration.k8s.io/v1alpha1", "v1");
 
 	private final Map<String, String> namedTemplates = new HashMap<>();
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -393,7 +393,15 @@ public class RepoManager {
 		}
 	}
 
-	private int safeCompareVersions(String v1, String v2) {
+	/**
+	 * Compares two chart versions by SemVer precedence, matching how Helm selects the
+	 * "latest" version to fetch. A leading {@code v} is ignored ({@code v0.5.0} ==
+	 * release {@code 0.5.0}), the {@code major.minor.patch} core is compared numerically,
+	 * and a release with no pre-release ranks <em>above</em> an otherwise-equal
+	 * pre-release (so {@code 5.3.0} beats {@code 5.3.0-rc1} and the stale
+	 * {@code v0.5.0}).
+	 */
+	int safeCompareVersions(String v1, String v2) {
 		if (v1 == null && v2 == null) {
 			return 0;
 		}
@@ -403,8 +411,38 @@ public class RepoManager {
 		if (v2 == null) {
 			return 1;
 		}
-		String[] p1 = v1.split("[.-]");
-		String[] p2 = v2.split("[.-]");
+		v1 = stripLeadingV(v1);
+		v2 = stripLeadingV(v2);
+		String core1 = v1;
+		String pre1 = "";
+		int dash1 = v1.indexOf('-');
+		if (dash1 >= 0) {
+			core1 = v1.substring(0, dash1);
+			pre1 = v1.substring(dash1 + 1);
+		}
+		String core2 = v2;
+		String pre2 = "";
+		int dash2 = v2.indexOf('-');
+		if (dash2 >= 0) {
+			core2 = v2.substring(0, dash2);
+			pre2 = v2.substring(dash2 + 1);
+		}
+		int coreCmp = compareCoreVersions(core1, core2);
+		if (coreCmp != 0) {
+			return coreCmp;
+		}
+		// Same major.minor.patch: per SemVer a normal version outranks a pre-release.
+		boolean hasPre1 = !pre1.isEmpty();
+		boolean hasPre2 = !pre2.isEmpty();
+		if (hasPre1 != hasPre2) {
+			return hasPre1 ? -1 : 1;
+		}
+		return pre1.compareTo(pre2);
+	}
+
+	private int compareCoreVersions(String core1, String core2) {
+		String[] p1 = core1.split("\\.");
+		String[] p2 = core2.split("\\.");
 		int n = Math.max(p1.length, p2.length);
 		for (int i = 0; i < n; i++) {
 			String a = (i < p1.length) ? p1[i] : "0";
@@ -424,6 +462,10 @@ public class RepoManager {
 			}
 		}
 		return 0;
+	}
+
+	private String stripLeadingV(String v) {
+		return (!v.isEmpty() && (v.charAt(0) == 'v' || v.charAt(0) == 'V')) ? v.substring(1) : v;
 	}
 
 	private int parseIntSafe(String s) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
@@ -88,6 +88,20 @@ class RepoManagerTest {
 	}
 
 	@Test
+	void testVersionComparisonMatchesHelmSemver() {
+		RepoManager rm = new RepoManager();
+		// A leading "v" must not rank an old version above a newer bare one — the bug
+		// that
+		// made jhelm pick the 404'ing prometheus-adapter v0.5.0 over 5.3.0.
+		assertTrue(rm.safeCompareVersions("5.3.0", "v0.5.0") > 0, "5.3.0 should outrank v0.5.0");
+		assertTrue(rm.safeCompareVersions("v1.2.0", "1.10.0") < 0, "1.10.0 should outrank v1.2.0 (numeric)");
+		// A normal release outranks an equal pre-release (Helm picks the latest stable).
+		assertTrue(rm.safeCompareVersions("1.0.0", "1.0.0-rc1") > 0, "stable should outrank its pre-release");
+		assertTrue(rm.safeCompareVersions("1.0.0-rc2", "1.0.0-rc1") > 0, "rc2 should outrank rc1");
+		assertEquals(0, rm.safeCompareVersions("2.1.0", "v2.1.0"), "v-prefix is ignored");
+	}
+
+	@Test
 	void testComputeFileSha256() throws IOException {
 		RepoManager repoManager = new RepoManager();
 		File file = tempDir.resolve("test.bin").toFile();

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -148,3 +148,7 @@ jhelmtest:
               config:
                 secret: gitlab-backup-storage
                 key: config
+    "[nfs-subdir-external-provisioner/nfs-subdir-external-provisioner]":
+      nfs:
+        server: 10.0.0.1
+        path: /exported/path

--- a/jhelm-core/src/test/resources/charts-skip.csv
+++ b/jhelm-core/src/test/resources/charts-skip.csv
@@ -8,10 +8,7 @@
 # that prevents `helm template` from succeeding with default values.
 argo/argocd-apps,Renders 0 documents with default values (creates CRs from empty lists)
 bitnami/common,Helm fails: library charts are not installable
-nfs-subdir-external-provisioner/nfs-subdir-external-provisioner,Helm fails: requires nfs.server
 #
 # --- Download failures (external repo issues) ---
 twuni/docker-registry,Repo DNS failure
-prometheus-community/prometheus-adapter,Chart download 404
-deliveryhero/node-problem-detector,Repo intermittently unavailable
 jupyterhub/jupyterhub,Helm fails on fetched version (.Release.Time.Seconds removed in modern Helm)

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -54,3 +54,6 @@ apache-airflow/airflow,apache-airflow,https://airflow.apache.org/
 nextcloud/nextcloud,nextcloud,https://nextcloud.github.io/helm/
 grafana/loki,grafana,https://grafana.github.io/helm-charts
 grafana/k8s-monitoring,grafana,https://grafana.github.io/helm-charts
+nfs-subdir-external-provisioner/nfs-subdir-external-provisioner,nfs-subdir-external-provisioner,https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
+prometheus-community/prometheus-adapter,prometheus-community,https://prometheus-community.github.io/helm-charts
+deliveryhero/node-problem-detector,deliveryhero,https://charts.deliveryhero.io/


### PR DESCRIPTION
## Summary

Enables **nfs-subdir-external-provisioner**, **prometheus-adapter**, and **node-problem-detector** (55 → **58** comparison charts). Wiring them up surfaced two real Helm-parity gaps, both fixed and verified against the live `helm` oracle.

### 1. RepoManager picked the wrong chart version
`safeCompareVersions` parsed `v0.5.0`'s leading-`v` segment as non-numeric and fell back to string comparison, ranking the stale `v0.5.0` **above** `5.3.0` — so jhelm pulled `prometheus-adapter-v0.5.0.tgz` (gone → 404). It's now a proper SemVer compare: strips a leading `v`, compares `major.minor.patch` numerically, and ranks a normal release above an equal pre-release (matching how Helm selects "latest"). Unit test added.

### 2. `.Capabilities.APIVersions` diverged from `helm template`
jhelm's set was derived from a newer client-go scheme; Helm exposes its fixed `chartutil.DefaultVersionSet`. I dumped it from helm 3.x (57 entries — **no `apiregistration.k8s.io/*`**, plus legacy `*beta1` groups like `extensions/v1beta1`, `apps/v1beta1`). prometheus-adapter keys its APIService `apiVersion` on `.Capabilities.APIVersions.Has "apiregistration.k8s.io/v1"`; jhelm had it (Helm doesn't), so jhelm emitted `v1` where Helm emits `v1beta1`. `DEFAULT_API_VERSIONS` now matches Helm's set verbatim.

## Result

- nfs-subdir gets `nfs.server`/`path` comparison-values; all three removed from `charts-skip.csv` and added to `charts.csv`.
- **Full comparison suite: all 58 charts pass — no regression on the existing 55.** jhelm-core 557 tests + coverage gate green.

Both fixes are general Helm-parity improvements (version selection + capability set) beyond these three charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)