### PR TITLE
Enable kube-prometheus-stack in the comparison suite

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -17,7 +17,7 @@ bitnami/ghost,bitnami,https://charts.bitnami.com/bitnami
 bitnami/moodle,bitnami,https://charts.bitnami.com/bitnami
 bitnami/magento,bitnami,https://charts.bitnami.com/bitnami
 bitnami/redmine,bitnami,https://charts.bitnami.com/bitnami
-#prometheus-community/kube-prometheus-stack,prometheus-community,https://prometheus-community.github.io/helm-charts
+prometheus-community/kube-prometheus-stack,prometheus-community,https://prometheus-community.github.io/helm-charts
 argo/argo-cd,argo,https://argoproj.github.io/argo-helm
 jetstack/cert-manager,jetstack,https://charts.jetstack.io
 karpenter/karpenter,karpenter,https://charts.karpenter.sh


### PR DESCRIPTION
## Summary

**kube-prometheus-stack** — one of the most widely deployed Helm charts (Prometheus / Alertmanager / Grafana + node/kube-state exporters; CRD- and subchart-heavy) — was commented out in `charts.csv`. It now renders **identically to Helm (121/121 documents match)** with no code changes, thanks to this session's engine fixes:

- recursive subchart value coalescing (#348)
- toYaml byte-parity — key sorting, whole-floats, single-quote style (#346/#347)
- Helm `DefaultVersionSet` capability alignment (#349)
- full-path template parse order (#345)

Just uncomment it.

## Testing

**Full comparison suite: all 59 charts pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)