### PR TITLE
Enable datadog, argo-workflows, tempo, mimir-distributed (59 -> 63 charts)

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -29,6 +29,10 @@ jhelmtest:
       - resource: "ConfigMap/*"
         path: "data.install_id"
         reason: "install_id is a random UUID generated per render"
+      # Unix timestamp of the render — the Helm and JHelm renders happen seconds apart
+      - resource: "ConfigMap/*"
+        path: "data.install_time"
+        reason: "install_time is the render Unix timestamp; differs by seconds between the two renders"
     "[ananace-charts/matrix-synapse]":
       # registration_shared_secret is generated per render (randAlphaNum)
       - resource: "Secret/*"

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -57,3 +57,7 @@ grafana/k8s-monitoring,grafana,https://grafana.github.io/helm-charts
 nfs-subdir-external-provisioner/nfs-subdir-external-provisioner,nfs-subdir-external-provisioner,https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
 prometheus-community/prometheus-adapter,prometheus-community,https://prometheus-community.github.io/helm-charts
 deliveryhero/node-problem-detector,deliveryhero,https://charts.deliveryhero.io/
+datadog/datadog,datadog,https://helm.datadoghq.com
+argo/argo-workflows,argo,https://argoproj.github.io/argo-helm
+grafana/tempo,grafana,https://grafana.github.io/helm-charts
+grafana/mimir-distributed,grafana,https://grafana.github.io/helm-charts


### PR DESCRIPTION
## Summary

Four more popular charts now render identically to Helm and join the comparison suite — **no engine changes needed** (the session's fixes already cover them):

- **argo/argo-workflows** (23 docs), **grafana/tempo** (4), **grafana/mimir-distributed** (79) — match Helm exactly.
- **datadog/datadog** (37) — matches once `data.install_time` is ignored: it's the render's Unix timestamp, which differs by seconds between the Helm and JHelm runs (same class as the existing `install_id` UUID ignore).

## Testing

**Full comparison suite: all 63 charts pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)