### PR TITLE
Enable keda, reloader, kube-state-metrics, otel-operator, clickhouse, valkey (63 -> 69)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -61,3 +61,9 @@ datadog/datadog,datadog,https://helm.datadoghq.com
 argo/argo-workflows,argo,https://argoproj.github.io/argo-helm
 grafana/tempo,grafana,https://grafana.github.io/helm-charts
 grafana/mimir-distributed,grafana,https://grafana.github.io/helm-charts
+kedacore/keda,kedacore,https://kedacore.github.io/charts
+stakater/reloader,stakater,https://stakater.github.io/stakater-charts
+prometheus-community/kube-state-metrics,prometheus-community,https://prometheus-community.github.io/helm-charts
+opentelemetry/opentelemetry-operator,opentelemetry,https://open-telemetry.github.io/opentelemetry-helm-charts
+bitnami/clickhouse,bitnami,https://charts.bitnami.com/bitnami
+bitnami/valkey,bitnami,https://charts.bitnami.com/bitnami


### PR DESCRIPTION
## Summary

Six more popular charts render identically to Helm and join the comparison suite — **no engine changes needed**:

- **kedacore/keda** (29 docs), **stakater/reloader** (6), **prometheus-community/kube-state-metrics** (5), **opentelemetry/opentelemetry-operator** (20), **bitnami/clickhouse** (16), **bitnami/valkey** (14) — all match Helm exactly.

## Testing

**Full comparison suite: all 69 charts pass.**

(victoria-metrics-k8s-stack was also evaluated but deferred — it has 3 missing resources incl. a Helm-hook ClusterRole and a string-quoting diff; tracked separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)