### PR TITLE
Implement printf %q (quote) verb instead of dropping it to %s

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
@@ -400,8 +400,9 @@ public final class Functions {
 			// Translate Go format verbs to Java equivalents
 			format = format.replaceAll("%#?v", "%s"); // %v and %#(v) -> %s
 			format = format.replaceAll("%T", "%s"); // %(T) -> %s
-			format = format.replaceAll("%q", "%s"); // %(q) -> %s
 			format = format.replaceAll("%p", "%s"); // %(p) -> %s
+			// %q is kept for now — unlike %s it double-quotes its argument (Go strconv.
+			// Quote), so the corresponding arg is quoted below before %q -> %s.
 
 			// Extract ALL format specifiers to coerce numeric types per-argument.
 			// Go's printf is lenient (any numeric type for %d/%g); Java is strict.
@@ -416,8 +417,12 @@ public final class Functions {
 			Object[] realArgs = new Object[args.length - 1];
 			for (int i = 0; i < realArgs.length; i++) {
 				Object arg = (args[i + 1] != null) ? args[i + 1] : "";
-				if (arg instanceof Number && i < specTypes.size()) {
-					char spec = specTypes.get(i);
+				char spec = (i < specTypes.size()) ? specTypes.get(i) : '\0';
+				if (spec == 'q') {
+					// Go's %q double-quotes the value with Go-syntax escaping.
+					arg = goQuote(arg);
+				}
+				else if (arg instanceof Number) {
 					if ("eEfgG".indexOf(spec) >= 0 && (arg instanceof Integer || arg instanceof Long)) {
 						arg = ((Number) arg).doubleValue();
 					}
@@ -427,6 +432,8 @@ public final class Functions {
 				}
 				realArgs[i] = arg;
 			}
+			// The %q arguments are now pre-quoted strings, so render them with %s.
+			format = format.replaceAll("%q", "%s");
 			try {
 				return String.format(format, realArgs);
 			}
@@ -440,6 +447,30 @@ public final class Functions {
 				return String.format(neutralizeInvalidFormatSpecifiers(format), realArgs);
 			}
 		};
+	}
+
+	/**
+	 * Renders a value the way Go's {@code %q} verb does: the string form wrapped in
+	 * double quotes with Go-syntax escaping of quotes, backslashes and the common control
+	 * characters. Used so {@code printf "%q" x} matches Helm/Go output.
+	 */
+	private static String goQuote(Object value) {
+		String s = String.valueOf(value);
+		StringBuilder sb = new StringBuilder(s.length() + 2);
+		sb.append('"');
+		for (int i = 0; i < s.length(); i++) {
+			char c = s.charAt(i);
+			switch (c) {
+				case '"' -> sb.append("\\\"");
+				case '\\' -> sb.append("\\\\");
+				case '\n' -> sb.append("\\n");
+				case '\t' -> sb.append("\\t");
+				case '\r' -> sb.append("\\r");
+				default -> sb.append(c);
+			}
+		}
+		sb.append('"');
+		return sb.toString();
 	}
 
 	/**

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
@@ -86,6 +86,15 @@ class FunctionsTest {
 	}
 
 	@Test
+	void testPrintfQuoteVerbDoubleQuotesStrings() {
+		// Go's %q double-quotes (with escaping); jhelm previously dropped it to %s.
+		Function printf = Functions.GO_BUILTINS.get("printf");
+		assertEquals("\"VictoriaMetrics\"", printf.invoke(new Object[] { "%q", "VictoriaMetrics" }));
+		assertEquals("{\"datasource\":\"VM\"}", printf.invoke(new Object[] { "{\"datasource\":%q}", "VM" }));
+		assertEquals("\"a\\\"b\"", printf.invoke(new Object[] { "%q", "a\"b" }), "embedded quotes are escaped");
+	}
+
+	@Test
 	void testPrintfToleratesErbStyleLiterals() {
 		// gitlab routes an ERB literal through printf; %= and %> are not Java
 		// conversions.


### PR DESCRIPTION
## Summary

Go's `%q` verb double-quotes its argument (Go-syntax escaping); jhelm's `printf` blanket-translated `%q -> %s`, emitting the value **unquoted**. This diverged from Helm wherever a chart builds quoted output via `printf` — found in **victoria-metrics-k8s-stack**, whose VMAlert `external.alert.source` is built from `` `{"datasource":%q,...}` `` and rendered `"datasource":VictoriaMetrics` instead of `"datasource":"VictoriaMetrics"`.

## Change

`printf` now keeps `%q` through specifier extraction, quotes the matching argument (`goQuote`: wrap in double quotes; escape `"`, `\`, and the common control chars), then renders it with `%s`.

## Testing

- New `FunctionsTest` cases for `%q` (plain, embedded in JSON, escaped inner quote).
- **Full comparison suite: all 63 charts pass — no regression.** gotemplate 442 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)