### PR TITLE
Fix "--- " separator splitting and trailing-colon toYaml; enable victoria-metrics

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -221,8 +221,11 @@ public class Engine {
 		// Split by YAML document separator patterns:
 		// 1. \n---\n (standard separator with blank line)
 		// 2. \n--- followed by newline with content (template-generated separator)
-		// Use lookbehind to keep the newline before --- but not the --- itself
-		String[] docs = normalized.split("\\n---(?=\\n)");
+		// Trailing whitespace after the --- is allowed (YAML treats "--- " as a
+		// separator;
+		// some charts emit it literally), otherwise the following resource is glued onto
+		// the previous document and disappears from the resource set.
+		String[] docs = normalized.split("\\n---[ \\t]*(?=\\n)");
 		StringBuilder cleaned = new StringBuilder();
 
 		for (String doc : docs) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/YamlDocumentSeparatorTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/YamlDocumentSeparatorTest.java
@@ -26,6 +26,22 @@ class YamlDocumentSeparatorTest {
 	}
 
 	@Test
+	void testSeparatorWithTrailingWhitespace() throws Exception {
+		// A "---" with trailing whitespace (some charts emit it literally) must still
+		// split
+		// the documents, otherwise the second resource is glued onto the first and
+		// vanishes
+		// from the resource set (victoria-metrics-k8s-stack's aggregated ClusterRoles).
+		String input = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test1\n--- \n"
+				+ "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test2\n";
+		String result = cleanManifest(input);
+		assertTrue(result.contains("name: test1"), "first doc kept: " + result);
+		assertTrue(result.contains("name: test2"), "second doc must not be glued/dropped: " + result);
+		long docs = result.lines().filter((line) -> line.equals("kind: ConfigMap")).count();
+		assertEquals(2, docs, "both documents must be present: " + result);
+	}
+
+	@Test
 	void testBasicSeparator() throws Exception {
 		String input = """
 				apiVersion: v1

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -67,3 +67,4 @@ prometheus-community/kube-state-metrics,prometheus-community,https://prometheus-
 opentelemetry/opentelemetry-operator,opentelemetry,https://open-telemetry.github.io/opentelemetry-helm-charts
 bitnami/clickhouse,bitnami,https://charts.bitnami.com/bitnami
 bitnami/valkey,bitnami,https://charts.bitnami.com/bitnami
+victoria-metrics/victoria-metrics-k8s-stack,victoria-metrics,https://victoriametrics.github.io/helm-charts

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -756,8 +756,11 @@ public final class ConversionFunctions {
 		if ((first == '-' || first == '?') && s.length() > 1 && s.charAt(1) == ' ') {
 			return false;
 		}
-		// Must not contain ": " (mapping indicator) or " #" (comment indicator)
-		if (s.contains(": ") || s.contains(" #")) {
+		// Must not contain ": " (mapping indicator) or " #" (comment indicator), nor end
+		// with ":" — a trailing colon (e.g. a Prometheus recording-rule name like
+		// "node_namespace_pod:kube_pod_info:") is read as a mapping key and corrupts the
+		// document, so Go's yaml.Marshal quotes it.
+		if (s.contains(": ") || s.contains(" #") || s.endsWith(":")) {
 			return false;
 		}
 		// Must not be a YAML boolean/null keyword

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -142,6 +142,25 @@ class ConversionFunctionsTest {
 	}
 
 	@Test
+	void testToYamlQuotesTrailingColonStrings() {
+		// A value ending in ':' (e.g. a Prometheus recording-rule name) would otherwise
+		// be
+		// read back as a mapping key and corrupt the document — Go's yaml.Marshal quotes
+		// it.
+		Map<String, Object> data = new LinkedHashMap<>();
+		data.put("record", "node_namespace_pod:kube_pod_info:");
+		String result = (String) functions().get("toYaml").invoke(new Object[] { data });
+		assertTrue(
+				result.contains("'node_namespace_pod:kube_pod_info:'")
+						|| result.contains("\"node_namespace_pod:kube_pod_info:\""),
+				"trailing-colon value must be quoted: " + result);
+		// Sanity: the result must round-trip as valid YAML.
+		Object back = functions().get("fromYaml").invoke(new Object[] { result });
+		assertInstanceOf(Map.class, back);
+		assertEquals("node_namespace_pod:kube_pod_info:", ((Map<?, ?>) back).get("record"));
+	}
+
+	@Test
 	void testToYamlRendersWholeFloatsAsIntegers() {
 		// Helm marshals via JSON, where float64(1.0) -> "1". jhelm must match (whole
 		// floats


### PR DESCRIPTION
## Summary

Enabling **victoria-metrics-k8s-stack** (Helm 111 docs) surfaced two real, **general** engine bugs, both fixed:

### 1. Document separators with trailing whitespace
`Engine.cleanManifest` split on `\n---(?=\n)` — the separator had to be *immediately* followed by a newline. A `--- ` with a trailing space (valid YAML, emitted literally by the operator's `role.yaml`) wasn't recognised, so the **following resource was glued onto the previous document and vanished** from the resource set (the aggregated `victoriametrics-admin` ClusterRole + `cleanup-hook`). The split now tolerates trailing whitespace.

### 2. toYaml didn't quote trailing-colon values
`canBePlainScalar` left a value ending in `:` unquoted — e.g. a Prometheus recording-rule name `node_namespace_pod:kube_pod_info:`. YAML reads the trailing colon as a mapping key, so the **whole VMRule document failed to parse and disappeared**. Such values are now quoted, matching Go's `yaml.Marshal`.

## Result

- **victoria-metrics-k8s-stack renders identically to Helm (111/111)** — added to `charts.csv` (69 → **70**).
- New tests: trailing-whitespace separator; trailing-colon quoting (with round-trip parse).
- **Full comparison suite: all 70 charts pass.** jhelm-core 570 tests + coverage gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)