### PR TITLE
Enable thanos, loki-distributed, alloy, crossplane, istio base/istiod, trust-manager (70 -> 77)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -68,3 +68,10 @@ opentelemetry/opentelemetry-operator,opentelemetry,https://open-telemetry.github
 bitnami/clickhouse,bitnami,https://charts.bitnami.com/bitnami
 bitnami/valkey,bitnami,https://charts.bitnami.com/bitnami
 victoria-metrics/victoria-metrics-k8s-stack,victoria-metrics,https://victoriametrics.github.io/helm-charts
+bitnami/thanos,bitnami,https://charts.bitnami.com/bitnami
+grafana/loki-distributed,grafana,https://grafana.github.io/helm-charts
+grafana/alloy,grafana,https://grafana.github.io/helm-charts
+crossplane/crossplane,crossplane,https://charts.crossplane.io/stable
+istio/base,istio,https://istio-release.storage.googleapis.com/charts
+istio/istiod,istio,https://istio-release.storage.googleapis.com/charts
+jetstack/trust-manager,jetstack,https://charts.jetstack.io


### PR DESCRIPTION
## Summary

Seven more popular charts render identically to Helm and join the comparison suite — **no engine changes needed** (the engine is now robust across diverse chart styles):

- **bitnami/thanos** (11), **grafana/loki-distributed** (18), **grafana/alloy** (6), **crossplane/crossplane** (23), **istio/base** (17), **istio/istiod** (17), **jetstack/trust-manager** (14) — all match Helm exactly.

## Testing

**Full comparison suite: all 77 charts pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)