### PR TITLE
Enable fluent-bit, jaeger, airflow, reflector, cert-manager-csi-driver, promtail (77 -> 83)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -75,3 +75,9 @@ crossplane/crossplane,crossplane,https://charts.crossplane.io/stable
 istio/base,istio,https://istio-release.storage.googleapis.com/charts
 istio/istiod,istio,https://istio-release.storage.googleapis.com/charts
 jetstack/trust-manager,jetstack,https://charts.jetstack.io
+fluent/fluent-bit,fluent,https://fluent.github.io/helm-charts
+jaegertracing/jaeger,jaegertracing,https://jaegertracing.github.io/helm-charts
+bitnami/airflow,bitnami,https://charts.bitnami.com/bitnami
+emberstack/reflector,emberstack,https://emberstack.github.io/helm-charts
+jetstack/cert-manager-csi-driver,jetstack,https://charts.jetstack.io
+grafana/promtail,grafana,https://grafana.github.io/helm-charts


### PR DESCRIPTION
## Summary

Six more popular charts render identically to Helm and join the comparison suite — **no engine changes needed**:

- **fluent/fluent-bit** (7), **jaegertracing/jaeger** (3), **bitnami/airflow** (41), **emberstack/reflector** (4), **jetstack/cert-manager-csi-driver** (5), **grafana/promtail** (5) — all match Helm exactly.

## Testing

**Full comparison suite: all 83 charts pass.**

(grafana/oncall was evaluated but deferred — it embeds a wall-clock timestamp in a migration Job *name*, which differs between the Helm and jhelm renders and can't be matched by resource key; plus a ServiceAccount label collision. Tracked separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)