### PR TITLE
Enable pushgateway, spark, jenkins, consul, vector, authentik, tomcat (83 -> 90)

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -44,6 +44,12 @@ jhelmtest:
       - resource: "Pod/*"
         path: "*"
         reason: "helm test-hook Pod has a per-render random name suffix"
+    "[jenkins/jenkins]":
+      # The jenkins-ui-test Helm test-hook Pod has a random name suffix that differs
+      # every render, so the resource key never matches.
+      - resource: "Pod/*"
+        path: "*"
+        reason: "helm test-hook Pod has a per-render random name suffix"
     "[nextcloud/nextcloud]":
       # hooks-hash is a sha256 of hooked content; differs only by toYaml serialization
       # (same class as checksum/* annotations, #237).

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -81,3 +81,10 @@ bitnami/airflow,bitnami,https://charts.bitnami.com/bitnami
 emberstack/reflector,emberstack,https://emberstack.github.io/helm-charts
 jetstack/cert-manager-csi-driver,jetstack,https://charts.jetstack.io
 grafana/promtail,grafana,https://grafana.github.io/helm-charts
+prometheus-community/prometheus-pushgateway,prometheus-community,https://prometheus-community.github.io/helm-charts
+bitnami/spark,bitnami,https://charts.bitnami.com/bitnami
+jenkins/jenkins,jenkins,https://charts.jenkins.io
+hashicorp/consul,hashicorp,https://helm.releases.hashicorp.com
+vector/vector,vector,https://helm.vector.dev
+authentik/authentik,authentik,https://charts.goauthentik.io
+bitnami/tomcat,bitnami,https://charts.bitnami.com/bitnami


### PR DESCRIPTION
## Summary

Seven more popular charts join the comparison suite:

- **prometheus-community/prometheus-pushgateway** (3), **bitnami/spark** (10), **hashicorp/consul** (74), **vector/vector** (5), **authentik/authentik** (9), **bitnami/tomcat** (7) — render identically to Helm, no changes needed.
- **jenkins/jenkins** (14) — matches once its `jenkins-ui-test` Helm test-hook Pod is ignored (per-render random name suffix, same class as the existing `elastic/elasticsearch` ignore).

## Testing

**Full comparison suite: all 90 charts pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)