### PR TITLE
docs: define the 0.1.0 prerelease target (>=300-chart parity gate)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,35 @@
+= Changelog
+
+== Unreleased (targeting 0.1.0)
+
+Toward the *0.1.0 prerelease target* (see the Roadmap in the docs): a *≥ 300-chart*
+byte-parity gate against `helm template` plus an extraction-ready template engine.
+
+=== Engine — Helm byte-parity
+
+* `toYaml` now matches Helm's `sigs.k8s.io/yaml` output byte-for-byte: keys are sorted,
+  whole-number floats render as integers (`1.0` -> `1`), non-plain scalars use single-quote
+  style (reserving double quotes for empty/numeric/keyword strings), and values ending in
+  `:` are quoted so they round-trip.
+* `printf` implements the `%q` (quote) verb and tolerates Go/ERB format strings such as
+  `"<%= ... %>"` (`%=`, `%>`) instead of aborting the render.
+* `.Files.Get` (and other behavioural objects) work inside pipelines and after
+  `deepCopy $` — method calls now receive the piped value and `deepCopy` preserves the
+  object type.
+* Subchart values are coalesced recursively, so a parent sees the full nested default tree
+  at `.Values.<sub>.<nestedsub>.*` (Helm `CoalesceValues` behaviour).
+* Templates parse in Helm's full-path order, so a named template defined by multiple
+  subcharts resolves to the same winner as Helm; like-named umbrella/subchart helper files
+  no longer drop each other's `define`s.
+* `.Capabilities.APIVersions` matches Helm's built-in `DefaultVersionSet`; chart versions
+  are selected by SemVer (leading `v` and pre-releases handled).
+* YAML document splitting tolerates a `---` separator with trailing whitespace, so the
+  following resource is no longer glued onto the previous document.
+* `merge`/`mergeOverwrite`/`fromYaml` no longer throw on immutable maps.
+
+=== Build & coverage
+
+* Spring Boot 4.0.6; `spring-retry` migrated to the `spring-core` retry API.
+* Comparison-suite coverage grown from 54 to 90 charts, all rendering identically to Helm
+  (k8s-monitoring, kube-prometheus-stack, victoria-metrics-k8s-stack, istio, consul,
+  airflow, datadog, and more).

--- a/docs/modules/ROOT/pages/roadmap.adoc
+++ b/docs/modules/ROOT/pages/roadmap.adoc
@@ -2,6 +2,80 @@
 
 This document outlines the planned improvements, feature priorities, and strategic vision for jhelm.
 
+== 0.1.0 Prerelease Target
+
+The first published prerelease (`0.1.0`, on Maven Central, marked _pre-release_) is defined
+by two things being true at once: a *broad real-world conformance bar* and a *stable,
+extraction-ready engine*. The release is cut via `maven_release.yml`
+(`releaseVersion=0.1.0`, `nextVersion=0.2.0-SNAPSHOT`).
+
+=== Exit criteria (Definition of Done)
+
+[cols="1,3,1"]
+|===
+| Area | Criterion | Status
+
+| Conformance gate
+| *≥ 300 charts* render byte-identical to `helm template` in CI (the `KpsComparisonTest`
+  suite, `charts.csv`), order-independent and with only the documented comparison-ignores
+  (random/timestamp names, generated secrets/certs).
+| 90 / 300
+
+| Engine maturity
+| The Go template engine (`jhelm-gotemplate` + `-sprig` + `-helm`) is in a *very advanced,
+  extraction-ready state* — see "`gotmpl4j` readiness" below. The 300-chart suite is its
+  de-facto conformance test.
+| In progress
+
+| Supported surface
+| All modules ship as supported: `gotemplate`/`sprig`/`helm` (engine), `core` (chart
+  lifecycle: install/upgrade/rollback/uninstall/list/status/history), `kube` (apply/wait),
+  `rest`, `plugin`, `cli`, plus the Spring Boot starter.
+| —
+
+| Repo + deps
+| HTTP and OCI repositories with digest verification; Helm-faithful SemVer version
+  selection; recursive dependency value coalescing; hooks; JSON-Schema validation.
+| Mostly done
+
+| Quality gates
+| `spring-javaformat`, Checkstyle, PMD, and JaCoCo coverage all green on a full
+  `./mvnw clean verify`.
+| Green
+
+| Docs
+| Antora docs current; `CHANGELOG.adoc` `0.1.0` section; README "`Status`" reflects the
+  prerelease.
+| In progress
+|===
+
+=== `gotmpl4j` readiness (engine extraction)
+
+The Go template engine is planned to be extracted into a standalone library
+(`gotmpl4j`, with a Spring Boot starter) _after_ `0.1.0`. Splitting it later complicates
+cross-repo development, so `0.1.0` requires the engine to already be in a *very advanced
+state* so the eventual extraction is mechanical, not a redesign:
+
+* *Correctness* — no known rendering gaps; the 300-chart parity suite is the conformance
+  bar.
+* *Clean boundary* — `jhelm-gotemplate` has zero dependencies on `sprig`, `helm`, or
+  `core`; Sprig (priority 100) and Helm (priority 200) functions load only via
+  `ServiceLoader`. (Enforced by the gotemplate-module rule.)
+* *Stable API* — `GoTemplate`, `Function`, `FunctionProvider` are settled; no breaking
+  churn expected post-split.
+* *Coverage* — comprehensive unit tests for lexer/parser/executor and every function
+  category, independent of the chart suite.
+
+=== Explicit non-goals for 0.1.0
+
+* Full *gitlab* parity — blocked on a complete Helm `CoalesceValues`/`ProcessDependencies`
+  reimplementation (deep, high-risk); tracked separately.
+* The `gotmpl4j` *extraction itself* — `0.1.0` makes the engine _ready_; the split lands
+  post-`0.1.0`.
+* Charts that are inherently uncomparable to a separate `helm template` run (wall-clock
+  timestamps or random suffixes in resource _names_).
+* Server-Side Apply, WASM plugins, post-renderers, and chart signing (later phases below).
+
 == Recommended Implementation Roadmap
 
 The roadmap is divided into several phases focusing on compatibility, feature completeness, and architectural modernization.


### PR DESCRIPTION
## Summary

Records the **0.1.0 prerelease target**, following the `notify4j` convention (root `CHANGELOG.adoc` + Antora docs + `maven_release.yml`; no GitHub milestones).

### Definition of Done (in `roadmap.adoc`)
- **Conformance gate: ≥ 300 charts** render byte-identical to `helm template` in CI (currently **90**), order-independent, only documented comparison-ignores.
- **All modules supported** (engine, core lifecycle, kube, rest, plugin, cli, Spring Boot starter).
- **`gotmpl4j` readiness** — the Go template engine in a very advanced, extraction-ready state (clean boundary, stable API, full coverage) so the planned post-0.1.0 split is mechanical.
- Quality gates green; docs current.
- **Non-goals**: full gitlab parity, the `gotmpl4j` extraction itself, charts with timestamp/random resource *names*, SSA/WASM/post-renderers/signing.

### `CHANGELOG.adoc`
New root changelog with an `Unreleased` section capturing this cycle's Helm byte-parity engine work (toYaml, printf `%q`, `.Files.Get` pipelines, recursive coalescing, parse-order, capabilities, separators) and the **54 → 90** chart coverage growth.

Docs-only; no code changes. Tracking: tasks for the 300-chart gate and engine extraction-readiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)