### PR TITLE
ci: split the chart-parity suite out of the default build

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
@@ -13,6 +13,7 @@ import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.RepoManager;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -204,6 +205,7 @@ class KpsComparisonTest {
 		compareChart(chartName, "release-" + chartName, repoId, repoUrl);
 	}
 
+	@Tag("comparison")
 	@ParameterizedTest
 	@CsvFileSource(resources = "/charts.csv")
 	void compareAllTopCharts(String chartName, String repoId, String repoUrl) throws Exception {
@@ -227,6 +229,7 @@ class KpsComparisonTest {
 		}
 	}
 
+	@Tag("comparison")
 	@Test
 	void compareFailedCharts() throws Exception {
 		List<String[]> charts = readFailedCsv();
@@ -886,6 +889,7 @@ class KpsComparisonTest {
 		return args.stream();
 	}
 
+	@Tag("comparison")
 	@ParameterizedTest
 	@MethodSource("topCharts")
 	void compareTopCharts(String chartName, String repoId, String repoUrl) throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,12 @@
     </developers>
 
     <properties>
+        <!-- JUnit tags excluded by default. The full chart-parity suite (`comparison`)
+             fetches and renders every chart in charts.csv against `helm template`; it is
+             slow + network-bound, so it is excluded from the normal build and runs in a
+             dedicated CI job (see .github/workflows/parity.yml). Override with
+             -Dsurefire.excludedGroups= -Dgroups=comparison to run only the parity suite. -->
+        <surefire.excludedGroups>comparison</surefire.excludedGroups>
         <kubernetes-client.version>25.0.0</kubernetes-client.version>
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>
@@ -287,6 +293,9 @@
                     <argLine>@{argLine} -Xmx512m -XX:MaxMetaspaceSize=256m</argLine>
                     <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
+                    <!-- The heavy chart-parity suite is tagged `comparison` and excluded
+                         here; it runs in the dedicated parity CI job. -->
+                    <excludedGroups>${surefire.excludedGroups}</excludedGroups>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Problem

The `KpsComparisonTest` chart-parity methods render every chart in `charts.csv` with jhelm **and** the real `helm template`, then diff the output. As we grow toward the **300-chart 0.1.0 conformance gate**, this suite pulls hundreds of charts from upstream repos on every PR/push — slow and network-flaky, far out of proportion to the engine unit tests' value on the everyday build.

## Change

- Tag the three network-heavy methods (`compareAllTopCharts`, `compareFailedCharts`, `compareTopCharts`) `@Tag("comparison")`.
- Exclude that tag from surefire by default via a new `surefire.excludedGroups` property (overridable on the command line).

The single-chart smoke test (`compareSingleChart`, 1 chart) stays untagged so the default build still exercises a real chart render.

## Companion workflow (added separately)

A dedicated `.github/workflows/parity.yml` (nightly `cron` + `workflow_dispatch`, sets up helm + kind) runs only the comparison suite:
```
./mvnw -pl jhelm-core -am test -Dsurefire.excludedGroups= -Dgroups=comparison -Dsurefire.failIfNoSpecifiedTests=false
```
It is not in this PR because the CI OAuth token lacks `workflow` scope; it will be added by a push with that scope.

## Verified

Default `./mvnw -pl jhelm-core -am verify`: `KpsComparisonTest` runs only 4 tests (was ~80+), 494 core tests total, **"All coverage checks have been met"**, BUILD SUCCESS — JaCoCo still passes without the parity suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)