### PR TITLE
Enable 14 charts (129 -> 143) toward 300 parity gate

### DIFF
--- a/jhelm-core/src/test/resources/charts-skip.csv
+++ b/jhelm-core/src/test/resources/charts-skip.csv
@@ -8,6 +8,7 @@
 # that prevents `helm template` from succeeding with default values.
 argo/argocd-apps,Renders 0 documents with default values (creates CRs from empty lists)
 bitnami/common,Helm fails: library charts are not installable
+stakater/application,Helm fails with default values: "Undefined image for application container" (requires image value)
 #
 # --- Download failures (external repo issues) ---
 twuni/docker-registry,Repo DNS failure

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -127,3 +127,17 @@ grafana/grafana-agent-operator,grafana,https://grafana.github.io/helm-charts
 grafana/k6-operator,grafana,https://grafana.github.io/helm-charts
 minio/minio,minio,https://charts.min.io/
 fluxcd/flux2,fluxcd,https://fluxcd-community.github.io/helm-charts
+prometheus-community/prometheus-json-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+prometheus-community/prometheus-statsd-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+prometheus-community/prometheus-nats-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+prometheus-community/prometheus-cloudwatch-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+prometheus-community/prometheus-memcached-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+prometheus-community/prometheus-couchdb-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+prometheus-community/prometheus-rabbitmq-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+prometheus-community/prometheus-pingdom-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+argo/argo-rollouts,argo,https://argoproj.github.io/argo-helm
+jaegertracing/jaeger-operator,jaegertracing,https://jaegertracing.github.io/helm-charts
+oauth2-proxy/oauth2-proxy,oauth2-proxy,https://oauth2-proxy.github.io/manifests
+dexidp/dex,dexidp,https://charts.dexidp.io
+kubernetes-dashboard/kubernetes-dashboard,kubernetes-dashboard,https://kubernetes.github.io/dashboard/
+grafana/rollout-operator,grafana,https://grafana.github.io/helm-charts

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -11,3 +11,12 @@
 # several shared-secrets/migrations/issuer Jobs differ by content-hash suffix, the Gateway
 # object is missing a couple of listeners, and a test-hook Pod has a random name suffix.
 gitlab/gitlab,gitlab,https://charts.gitlab.io
+#
+# argo-events: Helm renders a large integer values default in scientific notation.
+# The controller-config ConfigMap interpolates
+# `{{ .Values.configs.jetstream.streamConfig.maxMsgs }}` (default 1000000) directly;
+# Helm loads values numbers as float64 so it prints `1e+06`, jhelm keeps the integer
+# and prints `1000000`. Matching Helm's large-int->scientific gotcha would require
+# treating every values.yaml integer as a double (risky, affects all direct
+# interpolations); deferred. (#27)
+argo/argo-events,argo,https://argoproj.github.io/argo-helm


### PR DESCRIPTION
Batch D toward the **300-chart 0.1.0 conformance gate**. All 14 render byte-identical to `helm template` with default values — **no engine changes needed**.

## Added (14)
- **prometheus-community exporters (8):** json, statsd, nats, cloudwatch, memcached, couchdb, rabbitmq, pingdom
- argo/argo-rollouts
- jaegertracing/jaeger-operator
- oauth2-proxy/oauth2-proxy
- dexidp/dex
- kubernetes-dashboard/kubernetes-dashboard
- grafana/rollout-operator

## Deferred
- **argo/argo-events** → `failed.csv`: Helm prints a large-integer values default in scientific notation (`maxMsgs: 1000000` → `1e+06`) because it loads values numbers as float64; jhelm keeps the integer. Matching this gotcha would require treating every values.yaml integer as a double. (#27)
- **stakater/application** → `charts-skip.csv`: `helm template` itself fails with default values (undefined image).

Chart count: **129 → 143**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)