### PR TITLE
fix(sprig): title must not lowercase the rest of each word

### DIFF
--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
@@ -139,11 +139,29 @@ public final class StringFunctions {
 			if (s.isEmpty()) {
 				return s;
 			}
-			return Arrays.stream(s.split("\\s+"))
-				.map((word) -> word.isEmpty() ? word
-						: Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase(Locale.ROOT))
-				.collect(Collectors.joining(" "));
+			// Mirror Go's strings.Title (used by sprig's `title`): title-case the letter
+			// after a separator, leaving everything else untouched. So mixed-case
+			// "xtrabackupSidecar" -> "XtrabackupSidecar", not "Xtrabackupsidecar".
+			StringBuilder sb = new StringBuilder(s.length());
+			int prev = ' ';
+			int i = 0;
+			while (i < s.length()) {
+				int cp = s.codePointAt(i);
+				sb.appendCodePoint(isTitleSeparator(prev) ? Character.toTitleCase(cp) : cp);
+				prev = cp;
+				i += Character.charCount(cp);
+			}
+			return sb.toString();
 		};
+	}
+
+	// Mirrors Go's strings.isSeparator: letters, digits and '_' are part of a word; any
+	// other ASCII character separates words, and for non-ASCII only spaces separate.
+	private static boolean isTitleSeparator(int r) {
+		if (Character.isLetterOrDigit(r) || r == '_') {
+			return false;
+		}
+		return r <= 0x7F || Character.isSpaceChar(r) || Character.isWhitespace(r);
 	}
 
 	private static Function untitle() {

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctionsTest.java
@@ -34,6 +34,8 @@ class StringFunctionsTest {
 			value = { "{{ upper \"hello\" }}                          | HELLO",
 					"{{ lower \"HELLO\" }}                          | hello",
 					"{{ title \"hello world\" }}                    | Hello World",
+					"{{ title \"xtrabackupSidecar\" }}              | XtrabackupSidecar",
+					"{{ title \"hello-world\" }}                    | Hello-World",
 					"{{ repeat 3 \"ab\" }}                          | ababab",
 					"{{ substr 0 5 \"Hello World\" }}               | Hello",
 					"{{ trim \"  hello  \" }}                       | hello",


### PR DESCRIPTION
## Bug

Sprig's `title` is Go's [`strings.Title`](https://pkg.go.dev/strings#Title), which title-cases the first letter following a word separator and **leaves every other character unchanged**. jhelm's implementation split on whitespace and lower-cased the remainder of each word, so a mixed-case identifier like `xtrabackupSidecar` rendered as `Xtrabackupsidecar` instead of `XtrabackupSidecar`.

## Fix

Reimplement `title` to mirror `strings.Title`: walk code points, title-case the rune following a separator (Go's `isSeparator`: non-word ASCII separates; for non-ASCII only spaces do), pass everything else through. This also makes punctuation a word boundary (`hello-world` → `Hello-World`), matching Go.

## Surfaced by

`percona/pxc-operator` and `percona/pg-operator`, whose feature-gate helper does `{{ $key | title }}` over camelCase keys. Both now render byte-identical to `helm template`. Added regression assertions for the mixed-case and hyphen cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)