### PR TITLE
fix(gotemplate): index with no keys must return the value itself

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
@@ -58,9 +58,10 @@ public final class Functions {
 
 	private static Function index() {
 		return (args) -> {
-			if (args.length < 2) {
+			if (args.length == 0) {
 				return null;
 			}
+			// Go's `index x` with no keys returns x itself; only indexing keys descend.
 			Object result = args[0];
 			for (int i = 1; i < args.length; i++) {
 				Object key = args[i];

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
@@ -112,6 +112,14 @@ class FunctionsTest {
 	}
 
 	@Test
+	void testIndexWithNoKeysReturnsValueItself() throws Exception {
+		// Go's `index x` with no indexing keys returns x unchanged.
+		Function index = Functions.GO_BUILTINS.get("index");
+		assertEquals(8080, index.invoke(new Object[] { 8080 }));
+		assertEquals("value", index.invoke(new Object[] { "value" }));
+	}
+
+	@Test
 	void testIndexFromList() throws Exception {
 		Function index = Functions.GO_BUILTINS.get("index");
 		List<String> list = List.of("a", "b", "c");
@@ -132,9 +140,16 @@ class FunctionsTest {
 	}
 
 	@Test
-	void testIndexInsufficientArgs() throws Exception {
+	void testIndexWithoutKeysReturnsCollectionItself() throws Exception {
+		// Go's `index x` with no indexing keys returns x unchanged, even for a map.
 		Function index = Functions.GO_BUILTINS.get("index");
-		assertNull(index.invoke(new Object[] { Map.of("a", 1) }));
+		assertEquals(Map.of("a", 1), index.invoke(new Object[] { Map.of("a", 1) }));
+	}
+
+	@Test
+	void testIndexNoArgsReturnsNull() throws Exception {
+		Function index = Functions.GO_BUILTINS.get("index");
+		assertNull(index.invoke(new Object[] {}));
 	}
 
 	@Test


### PR DESCRIPTION
## Bug

Go's [`index`](https://pkg.go.dev/text/template#hdr-Functions) builtin returns its first argument unchanged when given no indexing keys — `index x` == `x`; only trailing keys descend into maps/slices/arrays. jhelm returned `null` whenever `index` was called with fewer than two arguments.

Charts use single-arg `index` as a defensive no-op, e.g. cockroachdb:
```
--http-port={{ index .Values.service.ports.http.port | int64 }}
```
jhelm collapsed that to `null`, so `int64(null)` rendered `0` instead of `8080`.

## Fix

Return `args[0]` for a single argument; only a zero-arg call yields `null`. Updates the unit test that pinned the previous (incorrect) single-arg behaviour and adds coverage for the no-key and no-arg cases.

## Surfaced by

`cockroachdb/cockroachdb`, which now renders byte-identical to `helm template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)