### PR TITLE
Enable 14 charts (159 -> 173) toward 300 parity gate

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -157,3 +157,17 @@ argo/argocd-image-updater,argo,https://argoproj.github.io/argo-helm
 kedacore/keda-add-ons-http,kedacore,https://kedacore.github.io/charts
 descheduler/descheduler,descheduler,https://kubernetes-sigs.github.io/descheduler/
 elastic/eck-operator,elastic,https://helm.elastic.co
+cilium/tetragon,cilium,https://helm.cilium.io
+fairwinds/polaris,fairwinds,https://charts.fairwinds.com/stable
+fairwinds/goldilocks,fairwinds,https://charts.fairwinds.com/stable
+falcosecurity/falcosidekick,falcosecurity,https://falcosecurity.github.io/charts
+fluent/fluent-operator,fluent,https://fluent.github.io/helm-charts
+hashicorp/terraform-cloud-operator,hashicorp,https://helm.releases.hashicorp.com
+hashicorp/vault-secrets-operator,hashicorp,https://helm.releases.hashicorp.com
+influxdata/influxdb2,influxdata,https://helm.influxdata.com
+minio-operator/operator,minio-operator,https://operator.min.io
+percona/psmdb-operator,percona,https://percona.github.io/percona-helm-charts
+percona/pxc-operator,percona,https://percona.github.io/percona-helm-charts
+percona/pg-operator,percona,https://percona.github.io/percona-helm-charts
+cockroachdb/cockroachdb,cockroachdb,https://charts.cockroachdb.com
+prometheus-community/prometheus-windows-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -20,3 +20,15 @@ gitlab/gitlab,gitlab,https://charts.gitlab.io
 # treating every values.yaml integer as a double (risky, affects all direct
 # interpolations); deferred. (#27)
 argo/argo-events,argo,https://argoproj.github.io/argo-helm
+#
+# kyverno-policies: several ClusterPolicy resources carry a
+# `kyverno.io/kubernetes-version` annotation (e.g. ">=1.25.0-0") that jhelm renders
+# empty. The value comes from each policy's own annotations block; jhelm drops it.
+# Needs investigation. (#28)
+kyverno/kyverno-policies,kyverno,https://kyverno.github.io/kyverno/
+#
+# linkerd-crds: the CRDs stamp `linkerd.io/created-by: linkerd/helm %!s(<nil>)` --
+# Helm's printf hits a nil arg for %s and emits Go's bad-verb error string
+# (`%!s(<nil>)`). jhelm renders a nil %s arg as empty. Matching Go's printf error
+# formatting for nil is a niche parity gap. (#29)
+linkerd/linkerd-crds,linkerd,https://helm.linkerd.io/stable


### PR DESCRIPTION
Batch F toward the **300-chart 0.1.0 conformance gate**. Verified locally against helm v3.14.2.

## Added (14)
**No engine change (11):** cilium/tetragon, fairwinds/polaris, fairwinds/goldilocks, falcosecurity/falcosidekick, fluent/fluent-operator, hashicorp/terraform-cloud-operator, hashicorp/vault-secrets-operator, influxdata/influxdb2, minio-operator/operator, percona/psmdb-operator, prometheus-community/prometheus-windows-exporter

**Unblocked by the engine fixes just merged (3):**
- percona/pxc-operator, percona/pg-operator — `title` no longer lowercases word remainders (#365)
- cockroachdb/cockroachdb — single-arg `index` returns the value (#366)

## Deferred to `failed.csv`
- **kyverno/kyverno-policies** — `kyverno.io/kubernetes-version` annotation renders empty (#28)
- **linkerd/linkerd-crds** — Helm stamps Go's printf bad-verb error `%!s(<nil>)` for a nil `%s` arg; jhelm renders empty (#29)

Chart count: **159 → 173**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)