### PR TITLE
ci: report tests + coverage to UniTrack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,15 +33,16 @@ jobs:
       - name: Build with Maven
         run: ./mvnw clean install -B --fail-at-end
 
-      - name: Report coverage to UniTrack
+      - name: Report tests + coverage to UniTrack
         if: always()
         uses: alexmond/unitrack/action@v0
         with:
           url: ${{ vars.UNITRACK_URL }}
           token: ${{ secrets.UNITRACK_TOKEN }}
-          # Coverage only for now: the CI integration/parity suite (Kind, 173 charts) emits
-          # surefire XML larger than Cloudflare's 100MB request cap. jacoco scales with code,
-          # not test output, so it stays small. Re-add junit once the uploader gzips/shards.
+          # Coverage for all modules + unit-test results from the pure-unit gotemplate module.
+          # The Kind-based integration/parity suite (173 charts) emits surefire XML larger than
+          # Cloudflare's 100MB request cap; widen `junit` to **/ once the gzip uploader ships.
+          junit: 'jhelm-gotemplate/**/surefire-reports/TEST-*.xml'
           jacoco: './**/target/site/jacoco/jacoco.xml'
 
 #      - name: Publish Test Results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           url: ${{ vars.UNITRACK_URL }}
           token: ${{ secrets.UNITRACK_TOKEN }}
-          junit: '**/surefire-reports/TEST-*.xml'
-          jacoco: '**/target/site/jacoco/jacoco.xml'
+          junit: './**/surefire-reports/TEST-*.xml'
+          jacoco: './**/target/site/jacoco/jacoco.xml'
 
 #      - name: Publish Test Results
 #        uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,14 @@ jobs:
         with:
           url: ${{ vars.UNITRACK_URL }}
           token: ${{ secrets.UNITRACK_TOKEN }}
-          junit: '**/surefire-reports/TEST-*.xml'
+          # Full coverage + unit tests from the pure-template modules. The chart-parity tests
+          # (kube/rest/cli/core/gotemplate-sprig) embed full rendered charts in surefire's
+          # system-out — ~1-2GB of XML, >100MB even gzipped. To upload those too, set surefire
+          # <redirectTestOutputToFile>true</redirectTestOutputToFile> (keeps console out of the
+          # XML) or shard per-module with a shared run-key.
+          junit: |
+            jhelm-gotemplate/**/surefire-reports/TEST-*.xml
+            jhelm-gotemplate-helm/**/surefire-reports/TEST-*.xml
           jacoco: '**/target/site/jacoco/jacoco.xml'
 
 #      - name: Publish Test Results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,11 +39,8 @@ jobs:
         with:
           url: ${{ vars.UNITRACK_URL }}
           token: ${{ secrets.UNITRACK_TOKEN }}
-          # Coverage for all modules + unit-test results from the pure-unit gotemplate module.
-          # The Kind-based integration/parity suite (173 charts) emits surefire XML larger than
-          # Cloudflare's 100MB request cap; widen `junit` to **/ once the gzip uploader ships.
-          junit: 'jhelm-gotemplate/**/surefire-reports/TEST-*.xml'
-          jacoco: './**/target/site/jacoco/jacoco.xml'
+          junit: '**/surefire-reports/TEST-*.xml'
+          jacoco: '**/target/site/jacoco/jacoco.xml'
 
 #      - name: Publish Test Results
 #        uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,14 +39,13 @@ jobs:
         with:
           url: ${{ vars.UNITRACK_URL }}
           token: ${{ secrets.UNITRACK_TOKEN }}
-          # Full coverage + unit tests from the pure-template modules. The chart-parity tests
-          # (kube/rest/cli/core/gotemplate-sprig) embed full rendered charts in surefire's
-          # system-out — ~1-2GB of XML, >100MB even gzipped. To upload those too, set surefire
-          # <redirectTestOutputToFile>true</redirectTestOutputToFile> (keeps console out of the
-          # XML) or shard per-module with a shared run-key.
-          junit: |
-            jhelm-gotemplate/**/surefire-reports/TEST-*.xml
-            jhelm-gotemplate-helm/**/surefire-reports/TEST-*.xml
+          # soft-fail: reporting to UniTrack must never fail the build.
+          # jhelm's tests embed full rendered charts in surefire system-out — ~GBs of XML,
+          # >100MB even gzipped. Until surefire <redirectTestOutputToFile>true</...> trims that
+          # (or you shard per-module with a shared run-key), upload coverage for everything plus
+          # tests from one small module; widen `junit` to **/ afterwards.
+          soft-fail: "true"
+          junit: 'jhelm-gotemplate-helm/**/surefire-reports/TEST-*.xml'
           jacoco: '**/target/site/jacoco/jacoco.xml'
 
 #      - name: Publish Test Results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Build with Maven
         run: ./mvnw clean install -B --fail-at-end
 
+      - name: Report tests + coverage to UniTrack
+        if: always()
+        uses: alexmond/unitrack/action@v0
+        with:
+          url: ${{ vars.UNITRACK_URL }}
+          token: ${{ secrets.UNITRACK_TOKEN }}
+          junit: '**/surefire-reports/TEST-*.xml'
+          jacoco: '**/target/site/jacoco/jacoco.xml'
+
 #      - name: Publish Test Results
 #        uses: EnricoMi/publish-unit-test-result-action@v2
 #        if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,15 @@ jobs:
       - name: Build with Maven
         run: ./mvnw clean install -B --fail-at-end
 
-      - name: Report tests + coverage to UniTrack
+      - name: Report coverage to UniTrack
         if: always()
         uses: alexmond/unitrack/action@v0
         with:
           url: ${{ vars.UNITRACK_URL }}
           token: ${{ secrets.UNITRACK_TOKEN }}
-          junit: './**/surefire-reports/TEST-*.xml'
+          # Coverage only for now: the CI integration/parity suite (Kind, 173 charts) emits
+          # surefire XML larger than Cloudflare's 100MB request cap. jacoco scales with code,
+          # not test output, so it stays small. Re-add junit once the uploader gzips/shards.
           jacoco: './**/target/site/jacoco/jacoco.xml'
 
 #      - name: Publish Test Results


### PR DESCRIPTION
Adds a step to `build.yml` that publishes surefire + jacoco to the self-hosted UniTrack instance (`https://unitrack.alexmond.org`) using `alexmond/unitrack/action@v0`.

- Project auto-detected as `jhelm`; branch/commit/build-url from `GITHUB_*`.
- `if: always()` so failures are reported too.
- Auth: repo secret `UNITRACK_TOKEN` (an ingest token owned by `alexm`) + var `UNITRACK_URL`.

This PR doubles as the end-to-end test that the action works. Tracks test/coverage trends, flaky detection, and the quality gate over time.