### PR TITLE
Enable 13 charts (173 -> 186) toward 300 parity gate

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -171,3 +171,16 @@ percona/pxc-operator,percona,https://percona.github.io/percona-helm-charts
 percona/pg-operator,percona,https://percona.github.io/percona-helm-charts
 cockroachdb/cockroachdb,cockroachdb,https://charts.cockroachdb.com
 prometheus-community/prometheus-windows-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+autoscaler/cluster-autoscaler,autoscaler,https://kubernetes.github.io/autoscaler
+haproxytech/kubernetes-ingress,haproxytech,https://haproxytech.github.io/helm-charts
+haproxy-ingress/haproxy-ingress,haproxy-ingress,https://haproxy-ingress.github.io/charts
+istio/gateway,istio,https://istio-release.storage.googleapis.com/charts
+istio/cni,istio,https://istio-release.storage.googleapis.com/charts
+aquasecurity/trivy-operator,aquasecurity,https://aquasecurity.github.io/helm-charts
+projectcalico/tigera-operator,projectcalico,https://docs.tigera.io/calico/charts
+fairwinds/vpa,fairwinds,https://charts.fairwinds.com/stable
+prometheus-community/prometheus-operator-crds,prometheus-community,https://prometheus-community.github.io/helm-charts
+bitnami/mlflow,bitnami,https://charts.bitnami.com/bitnami
+bitnami/scylladb,bitnami,https://charts.bitnami.com/bitnami
+bitnami/whereabouts,bitnami,https://charts.bitnami.com/bitnami
+kuberhealthy/kuberhealthy,kuberhealthy,https://kuberhealthy.github.io/kuberhealthy/helm-repos

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -32,3 +32,8 @@ kyverno/kyverno-policies,kyverno,https://kyverno.github.io/kyverno/
 # (`%!s(<nil>)`). jhelm renders a nil %s arg as empty. Matching Go's printf error
 # formatting for nil is a niche parity gap. (#29)
 linkerd/linkerd-crds,linkerd,https://helm.linkerd.io/stable
+#
+# zalando/postgres-operator: same large-int->scientific-notation gap as argo-events
+# (#27) -- the pod PriorityClass `value: 1000000` renders as `1e+06` under Helm
+# (values numbers are float64) but `1000000` under jhelm.
+zalando/postgres-operator,zalando,https://opensource.zalando.com/postgres-operator/charts/postgres-operator


### PR DESCRIPTION
Batch G toward the **300-chart 0.1.0 conformance gate**. All 13 render byte-identical to `helm template` with default values — **no engine changes**. Verified locally against helm v3.14.2.

## Added (13)
- istio/gateway, istio/cni
- projectcalico/tigera-operator
- aquasecurity/trivy-operator
- autoscaler/cluster-autoscaler
- haproxytech/kubernetes-ingress, haproxy-ingress/haproxy-ingress
- fairwinds/vpa
- prometheus-community/prometheus-operator-crds
- bitnami/mlflow, bitnami/scylladb, bitnami/whereabouts
- kuberhealthy/kuberhealthy

## Deferred to `failed.csv`
- **zalando/postgres-operator** — pod PriorityClass `value: 1000000` renders as `1e+06` under Helm (values numbers are float64) vs `1000000` under jhelm; same large-int gap as argo-events (#27).

Chart count: **173 → 186**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)