### PR TITLE
Enable 13 charts (186 -> 199) toward 300 parity gate

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -184,3 +184,16 @@ bitnami/mlflow,bitnami,https://charts.bitnami.com/bitnami
 bitnami/scylladb,bitnami,https://charts.bitnami.com/bitnami
 bitnami/whereabouts,bitnami,https://charts.bitnami.com/bitnami
 kuberhealthy/kuberhealthy,kuberhealthy,https://kuberhealthy.github.io/kuberhealthy/helm-repos
+bitnami/harbor,bitnami,https://charts.bitnami.com/bitnami
+bitnami/grafana-tempo,bitnami,https://charts.bitnami.com/bitnami
+bitnami/opensearch,bitnami,https://charts.bitnami.com/bitnami
+bitnami/cert-manager,bitnami,https://charts.bitnami.com/bitnami
+bitnami/argo-workflows,bitnami,https://charts.bitnami.com/bitnami
+bitnami/prometheus,bitnami,https://charts.bitnami.com/bitnami
+bitnami/multus-cni,bitnami,https://charts.bitnami.com/bitnami
+bitnami/aspnet-core,bitnami,https://charts.bitnami.com/bitnami
+apisix/apisix,apisix,https://charts.apiseven.com
+kubereboot/kured,kubereboot,https://kubereboot.github.io/charts
+emqx/emqx,emqx,https://repos.emqx.io/charts
+nats/nats,nats,https://nats-io.github.io/k8s/helm/charts
+localstack/localstack,localstack,https://localstack.github.io/helm-charts

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -37,3 +37,9 @@ linkerd/linkerd-crds,linkerd,https://helm.linkerd.io/stable
 # (#27) -- the pod PriorityClass `value: 1000000` renders as `1e+06` under Helm
 # (values numbers are float64) but `1000000` under jhelm.
 zalando/postgres-operator,zalando,https://opensource.zalando.com/postgres-operator/charts/postgres-operator
+#
+# bitnami grafana-loki / grafana-mimir: jhelm omits the bundled memcached
+# subcomponents (memcachedfrontend/chunks/index StatefulSet/Service/SA/PDB/NetworkPolicy)
+# and the matching ConfigMap cache stanzas that Helm renders by default. (#30)
+bitnami/grafana-loki,bitnami,https://charts.bitnami.com/bitnami
+bitnami/grafana-mimir,bitnami,https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Batch H toward the **300-chart 0.1.0 conformance gate**. Verified locally against helm v3.14.2.

## Added (13)
**No engine change (12):** bitnami/grafana-tempo, bitnami/opensearch, bitnami/cert-manager, bitnami/argo-workflows, bitnami/prometheus, bitnami/multus-cni, bitnami/aspnet-core, apisix/apisix, kubereboot/kured, emqx/emqx, nats/nats, localstack/localstack

**Unblocked by the printf surplus-verb fix just merged (1):**
- **bitnami/harbor** — `harbor.noProxy` feeds 7 args to an 11× `%s` printf; now renders Helm's `%!s(MISSING)` markers instead of aborting (#370)

## Deferred to `failed.csv`
- **bitnami/grafana-loki**, **bitnami/grafana-mimir** — bundled memcached subcomponents (StatefulSet/Service/SA/PDB/NetworkPolicy + ConfigMap cache stanzas) not rendered (#30)

Chart count: **186 → 199**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)