### PR TITLE
Enable 6 charts (199 -> 205) toward 300 parity gate

### DIFF
--- a/jhelm-core/src/test/resources/charts-skip.csv
+++ b/jhelm-core/src/test/resources/charts-skip.csv
@@ -13,3 +13,4 @@ stakater/application,Helm fails with default values: "Undefined image for applic
 # --- Download failures (external repo issues) ---
 twuni/docker-registry,Repo DNS failure
 jupyterhub/jupyterhub,Helm fails on fetched version (.Release.Time.Seconds removed in modern Helm)
+robusta/robusta,Helm fails with default values: "At least one sink must be defined"

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -197,3 +197,9 @@ kubereboot/kured,kubereboot,https://kubereboot.github.io/charts
 emqx/emqx,emqx,https://repos.emqx.io/charts
 nats/nats,nats,https://nats-io.github.io/k8s/helm/charts
 localstack/localstack,localstack,https://localstack.github.io/helm-charts
+bitnami/dokuwiki,bitnami,https://charts.bitnami.com/bitnami
+bitnami/parse,bitnami,https://charts.bitnami.com/bitnami
+bitnami/kong,bitnami,https://charts.bitnami.com/bitnami
+bitnami/grafana-operator,bitnami,https://charts.bitnami.com/bitnami
+emqx/emqx-operator,emqx,https://repos.emqx.io/charts
+newrelic/nri-metadata-injection,newrelic,https://helm-charts.newrelic.com

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -43,3 +43,8 @@ zalando/postgres-operator,zalando,https://opensource.zalando.com/postgres-operat
 # and the matching ConfigMap cache stanzas that Helm renders by default. (#30)
 bitnami/grafana-loki,bitnami,https://charts.bitnami.com/bitnami
 bitnami/grafana-mimir,bitnami,https://charts.bitnami.com/bitnami
+#
+# bitnami/jasperreports: the bundled mariadb StatefulSet renders
+# `securityContext.seLinuxOptions: null` where Helm omits the key entirely
+# (bitnami-common null securityContext field handling). (#31)
+bitnami/jasperreports,bitnami,https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Batch I toward the **300-chart 0.1.0 conformance gate**. All 6 render byte-identical to `helm template` with default values — **no engine changes**. Verified locally against helm v3.14.2.

## Added (6)
bitnami/dokuwiki, bitnami/parse, bitnami/kong, bitnami/grafana-operator, emqx/emqx-operator, newrelic/nri-metadata-injection

## Deferred
- **bitnami/jasperreports** → `failed.csv`: bundled mariadb StatefulSet renders `securityContext.seLinuxOptions: null` where Helm omits the key (bitnami-common quirk, #31)
- **robusta/robusta** → `charts-skip.csv`: `helm template` itself requires a sink to be defined

Chart count: **199 → 205**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)