### PR TITLE
Enable 9 charts (205 -> 214) toward 300 parity gate

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -203,3 +203,12 @@ bitnami/kong,bitnami,https://charts.bitnami.com/bitnami
 bitnami/grafana-operator,bitnami,https://charts.bitnami.com/bitnami
 emqx/emqx-operator,emqx,https://repos.emqx.io/charts
 newrelic/nri-metadata-injection,newrelic,https://helm-charts.newrelic.com
+bitnami/flink,bitnami,https://charts.bitnami.com/bitnami
+bitnami/pinniped,bitnami,https://charts.bitnami.com/bitnami
+elastic/eck-stack,elastic,https://helm.elastic.co
+jetstack/cert-manager-approver-policy,jetstack,https://charts.jetstack.io
+jetstack/cert-manager-csi-driver-spiffe,jetstack,https://charts.jetstack.io
+linkerd/linkerd2-cni,linkerd,https://helm.linkerd.io/stable
+nginx-stable/nginx-ingress,nginx-stable,https://helm.nginx.com/stable
+open-telemetry/opentelemetry-kube-stack,open-telemetry,https://open-telemetry.github.io/opentelemetry-helm-charts
+prometheus-community/prometheus-systemd-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -48,3 +48,8 @@ bitnami/grafana-mimir,bitnami,https://charts.bitnami.com/bitnami
 # `securityContext.seLinuxOptions: null` where Helm omits the key entirely
 # (bitnami-common null securityContext field handling). (#31)
 bitnami/jasperreports,bitnami,https://charts.bitnami.com/bitnami
+#
+# prometheus-pgbouncer-exporter: connection-string env renders
+# "%!s(<nil>):5432/..." under Helm (printf %s of a nil host) but ":5432/..." under
+# jhelm; same nil-arg printf gap as linkerd-crds (#29).
+prometheus-community/prometheus-pgbouncer-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
Batch J toward the **300-chart 0.1.0 conformance gate**. All 9 render byte-identical to `helm template` with default values — **no engine changes**. Verified locally against helm v3.14.2.

## Added (9)
bitnami/flink, bitnami/pinniped, elastic/eck-stack, jetstack/cert-manager-approver-policy, jetstack/cert-manager-csi-driver-spiffe, linkerd/linkerd2-cni, nginx-stable/nginx-ingress, open-telemetry/opentelemetry-kube-stack, prometheus-community/prometheus-systemd-exporter

## Deferred to `failed.csv`
- **prometheus-community/prometheus-pgbouncer-exporter** — connection-string env renders `%!s(<nil>):5432/...` under Helm (printf `%s` of a nil host) vs `:5432/...` under jhelm; same nil-arg printf gap as linkerd-crds (#29, now 2 charts).

Chart count: **205 → 214**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)