### PR TITLE
Enable 12 charts (214 -> 226) toward 300 parity gate

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -56,6 +56,11 @@ jhelmtest:
       - resource: "Deployment/*"
         path: "spec.template.metadata.annotations.hooks-hash"
         reason: "content hash differs by toYaml serialization, not semantics (#237)"
+    "[cetic/nifi]":
+      # flow.xml embeds uuidv4-generated registry/rootGroup ids that differ every render.
+      - resource: "ConfigMap/*"
+        path: "data.flow.xml"
+        reason: "flow.xml contains uuidv4-generated ids regenerated per render"
   # Value overrides for charts that Helm cannot render with default values. The same
   # overrides are applied to both Helm and jhelm, so any divergence is a real jhelm bug.
   comparison-values:

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -212,3 +212,15 @@ linkerd/linkerd2-cni,linkerd,https://helm.linkerd.io/stable
 nginx-stable/nginx-ingress,nginx-stable,https://helm.nginx.com/stable
 open-telemetry/opentelemetry-kube-stack,open-telemetry,https://open-telemetry.github.io/opentelemetry-helm-charts
 prometheus-community/prometheus-systemd-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+bitnami/gitea,bitnami,https://charts.bitnami.com/bitnami
+bitnami/mediawiki,bitnami,https://charts.bitnami.com/bitnami
+bitnami/minio,bitnami,https://charts.bitnami.com/bitnami
+bitnami/opencart,bitnami,https://charts.bitnami.com/bitnami
+bitnami/owncloud,bitnami,https://charts.bitnami.com/bitnami
+bitnami/phpbb,bitnami,https://charts.bitnami.com/bitnami
+bitnami/prestashop,bitnami,https://charts.bitnami.com/bitnami
+bitnami/sonarqube,bitnami,https://charts.bitnami.com/bitnami
+bitnami/suitecrm,bitnami,https://charts.bitnami.com/bitnami
+bitnami/vault,bitnami,https://charts.bitnami.com/bitnami
+codecentric/keycloakx,codecentric,https://codecentric.github.io/helm-charts
+cetic/nifi,cetic,https://cetic.github.io/helm-charts


### PR DESCRIPTION
Batch K toward the **300-chart 0.1.0 conformance gate**. Verified locally against helm v3.14.2.

## Added (12)
**Byte-identical, no engine change (11):** bitnami/gitea, bitnami/mediawiki, bitnami/minio, bitnami/opencart, bitnami/owncloud, bitnami/phpbb, bitnami/prestashop, bitnami/sonarqube, bitnami/suitecrm, bitnami/vault, codecentric/keycloakx

**With a comparison-ignore (1):**
- **cetic/nifi** — its `flow.xml` ConfigMap embeds `uuidv4`-generated registry/rootGroup ids regenerated every render; added an ignore for `ConfigMap data.flow.xml` (same class as the existing random/timestamp ignores).

Chart count: **214 → 226**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)