### PR TITLE
fix(gotemplate): printf supports Go %t bool and whole-float %v

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
@@ -403,6 +403,8 @@ public final class Functions {
 			format = format.replaceAll("%#?v", "%s"); // %v and %#(v) -> %s
 			format = format.replaceAll("%T", "%s"); // %(T) -> %s
 			format = format.replaceAll("%p", "%s"); // %(p) -> %s
+			format = format.replaceAll("%t", "%b"); // Go bool verb %t -> Java %b (Java %t
+													// is dates)
 			// %q is kept for now — unlike %s it double-quotes its argument (Go strconv.
 			// Quote), so the corresponding arg is quoted below before %q -> %s.
 
@@ -420,19 +422,7 @@ public final class Functions {
 			for (int i = 0; i < realArgs.length; i++) {
 				Object arg = (args[i + 1] != null) ? args[i + 1] : "";
 				char spec = (i < specTypes.size()) ? specTypes.get(i) : '\0';
-				if (spec == 'q') {
-					// Go's %q double-quotes the value with Go-syntax escaping.
-					arg = goQuote(arg);
-				}
-				else if (arg instanceof Number) {
-					if ("eEfgG".indexOf(spec) >= 0 && (arg instanceof Integer || arg instanceof Long)) {
-						arg = ((Number) arg).doubleValue();
-					}
-					else if ("doxXb".indexOf(spec) >= 0 && (arg instanceof Double || arg instanceof Float)) {
-						arg = ((Number) arg).longValue();
-					}
-				}
-				realArgs[i] = arg;
+				realArgs[i] = coercePrintfArg(arg, spec);
 			}
 			// The %q arguments are now pre-quoted strings, so render them with %s.
 			format = format.replaceAll("%q", "%s");
@@ -464,6 +454,38 @@ public final class Functions {
 				return String.format(neutralizeInvalidFormatSpecifiers(format), realArgs);
 			}
 		};
+	}
+
+	/**
+	 * Coerces a single {@code printf} argument so Java's {@link String#format} matches
+	 * Go's {@code fmt} for the given (already Java-translated) verb: {@code %q}
+	 * pre-quotes, integer/float verbs widen/narrow as Go would, and {@code %s} (also the
+	 * rewritten {@code %v}) renders a whole {@code float64} without a trailing
+	 * {@code .0}.
+	 * @param arg the argument value (never {@code null} — callers pass {@code ""})
+	 * @param spec the format verb the argument is bound to
+	 * @return the coerced argument
+	 */
+	private static Object coercePrintfArg(Object arg, char spec) {
+		if (spec == 'q') {
+			return goQuote(arg);
+		}
+		if (!(arg instanceof Number)) {
+			return arg;
+		}
+		if ("eEfgG".indexOf(spec) >= 0 && (arg instanceof Integer || arg instanceof Long)) {
+			return ((Number) arg).doubleValue();
+		}
+		if ("doxXb".indexOf(spec) >= 0 && (arg instanceof Double || arg instanceof Float)) {
+			return ((Number) arg).longValue();
+		}
+		if (spec == 's' && (arg instanceof Double || arg instanceof Float)) {
+			double d = ((Number) arg).doubleValue();
+			if (d == Math.rint(d) && !Double.isInfinite(d) && Math.abs(d) < 1e15) {
+				return (long) d;
+			}
+		}
+		return arg;
 	}
 
 	/**

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
@@ -95,6 +95,24 @@ class FunctionsTest {
 	}
 
 	@Test
+	void testPrintfBooleanVerb() {
+		// Go's %t prints true/false; Java's %t is a date prefix, so jhelm maps it to %b.
+		Function printf = Functions.GO_BUILTINS.get("printf");
+		assertEquals("--enable-leader-election=true",
+				printf.invoke(new Object[] { "--enable-leader-election=%t", true }));
+		assertEquals("x=false", printf.invoke(new Object[] { "x=%t", false }));
+	}
+
+	@Test
+	void testPrintfWholeFloatHasNoTrailingZero() {
+		// Go's %v prints a whole float64 without ".0" (values.yaml `qps: 100.0` ->
+		// "100").
+		Function printf = Functions.GO_BUILTINS.get("printf");
+		assertEquals("--qps=100", printf.invoke(new Object[] { "--qps=%v", 100.0 }));
+		assertEquals("1.5", printf.invoke(new Object[] { "%v", 1.5 }));
+	}
+
+	@Test
 	void testPrintfEmitsMissingMarkerForSurplusVerbs() {
 		// Go prints `%!s(MISSING)` for a verb with no argument instead of aborting;
 		// bitnami harbor's noProxy helper feeds 7 args to an 11-verb format string.


### PR DESCRIPTION
Two Go `printf` parity gaps, both surfaced by **kuberay/kuberay-operator**:

## `%t` boolean verb
Go's `%t` prints `true`/`false`. Java's `%t` is a date/time prefix, so a format like `--enable-leader-election=%t` left the literal `%t` in the output. Translate `%t` → Java `%b` before formatting (alongside the existing `%v`/`%T`/`%p` translations).

## Whole-float `%v`
Go's `%v` prints a whole `float64` without a trailing `.0` — `values.yaml` `qps: 100.0` renders `100`, not `100.0`. Render an integral `Double`/`Float` (after the `%v`→`%s` rewrite, magnitude < 1e15) as a `long` so `%s` matches.

The per-argument coercion is extracted into `coercePrintfArg(arg, spec)` to keep `printf` under the method-length limit. Added unit tests for both verbs; **kuberay/kuberay-operator** now renders byte-identical to `helm template`.

> Note: this is distinct from the large-int → scientific-notation gap (#27, e.g. `1000000`→`1e+06`), which goes through direct `{{ }}` interpolation, not printf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)