### PR TITLE
Enable 13 charts (242 -> 255) toward 300 parity gate

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -240,3 +240,16 @@ victoria-metrics/victoria-metrics-cluster,vm,https://victoriametrics.github.io/h
 victoria-metrics/victoria-metrics-operator,vm,https://victoriametrics.github.io/helm-charts
 victoria-metrics/victoria-metrics-single,vm,https://victoriametrics.github.io/helm-charts
 kuberay/kuberay-operator,kuberay,https://ray-project.github.io/kuberay-helm
+apisix/apisix-ingress-controller,apisix,https://charts.apiseven.com
+bitnami/jupyterhub,bitnami,https://charts.bitnami.com/bitnami
+bitnami/mastodon,bitnami,https://charts.bitnami.com/bitnami
+bitnami/odoo,bitnami,https://charts.bitnami.com/bitnami
+elastic/apm-server,elastic,https://helm.elastic.co
+elastic/filebeat,elastic,https://helm.elastic.co
+elastic/kibana,elastic,https://helm.elastic.co
+elastic/logstash,elastic,https://helm.elastic.co
+elastic/metricbeat,elastic,https://helm.elastic.co
+mariadb-operator/mariadb-operator,mariadb-operator,https://helm.mariadb.com/mariadb-operator
+newrelic/nri-statsd,newrelic,https://helm-charts.newrelic.com
+ory/oathkeeper,ory,https://k8s.ory.sh/helm/charts
+prometheus-community/prometheus-ipmi-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -62,3 +62,8 @@ bitnami/osclass,bitnami,https://charts.bitnami.com/bitnami
 # the checksummed config embeds generated shared/cookie secrets (randAlphaNum),
 # same #237 class as checksum/* but with a bare `checksum` key.
 pomerium/pomerium,pomerium,https://helm.pomerium.io
+#
+# kong/ingress: jhelm omits the bundled `gateway` subchart resources
+# (Deployment/Service/ServiceAccount for *-gateway*); subchart-enablement gap
+# (same class as the bitnami grafana memcached omission, #30).
+kong/ingress,kong,https://charts.konghq.com


### PR DESCRIPTION
Batch M toward the **300-chart 0.1.0 conformance gate**. All 13 render byte-identical to `helm template` with default values — **no engine changes**. Verified locally against helm v3.14.2.

## Added (13)
apisix/apisix-ingress-controller, bitnami/jupyterhub, bitnami/mastodon, bitnami/odoo, elastic/apm-server, elastic/filebeat, elastic/kibana, elastic/logstash, elastic/metricbeat, mariadb-operator/mariadb-operator, newrelic/nri-statsd, ory/oathkeeper, prometheus-community/prometheus-ipmi-exporter

## Deferred to `failed.csv`
- **kong/ingress** — jhelm omits the bundled `gateway` subchart resources (Deployment/Service/ServiceAccount); subchart-enablement gap (#30 class).

Chart count: **242 → 255**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)