### PR TITLE
Enable 13 charts (270 -> 283) toward 300 parity gate

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -268,3 +268,16 @@ prometheus-community/prometheus-operator-admission-webhook,prometheus-community,
 spark-operator/spark-operator,spark-operator,https://kubeflow.github.io/spark-operator
 victoria-metrics/victoria-logs-single,vm,https://victoriametrics.github.io/helm-charts
 victoria-metrics/victoria-metrics-auth,vm,https://victoriametrics.github.io/helm-charts
+apisix/apisix-dashboard,apisix,https://charts.apiseven.com
+backstage/backstage,backstage,https://backstage.github.io/charts
+bitnami/kubeapps,bitnami,https://charts.bitnami.com/bitnami
+bitnami/seaweedfs,bitnami,https://charts.bitnami.com/bitnami
+grafana/loki-stack,grafana,https://grafana.github.io/helm-charts
+istio/ztunnel,istio,https://istio-release.storage.googleapis.com/charts
+jetstack/cert-manager-google-cas-issuer,jetstack,https://charts.jetstack.io
+k8up/k8up,k8up,https://k8up-io.github.io/k8up
+nats/nack,nats,https://nats-io.github.io/k8s/helm/charts
+prometheus-community/prometheus-fastly-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+prometheus-community/prometheus-modbus-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+prometheus-community/prometheus-yet-another-cloudwatch-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+victoria-metrics/victoria-logs-cluster,vm,https://victoriametrics.github.io/helm-charts

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -71,3 +71,18 @@ kong/ingress,kong,https://charts.konghq.com
 # redpanda/console: jhelm renders zero resources where Helm renders the console
 # Deployment/Service/ConfigMap/Secret/SA; a top-level conditional-enablement gap.
 redpanda/console,redpanda,https://charts.redpanda.com
+#
+# gloo/gloo: Settings.validationServerGrpcMaxSizeBytes (104857600) renders as
+# `1.048576E8` under Helm (values float64 scientific notation) vs `104857600`
+# under jhelm; same large-int gap as argo-events/zalando (#27).
+gloo/gloo,gloo,https://storage.googleapis.com/solo-public-helm
+#
+# yugabyte/yugabyte: render error "d != java.lang.String" in tserver-gflags-secret.yaml (#32).
+yugabyte/yugabyte,yugabyte,https://charts.yugabyte.com
+#
+# redpanda/operator: jhelm renders zero resources where Helm renders the full
+# operator (Deployment/RBAC/Job/etc.); conditional-enablement gap (as redpanda/console).
+redpanda/operator,redpanda,https://charts.redpanda.com
+#
+# victoria-metrics-distributed: jhelm omits one VMRule (victoria-node.rules).
+victoria-metrics/victoria-metrics-distributed,vm,https://victoriametrics.github.io/helm-charts


### PR DESCRIPTION
Batch O toward the **300-chart 0.1.0 conformance gate**. All 13 render byte-identical to `helm template` with default values — **no engine changes**. Verified locally against helm v3.14.2.

## Added (13)
apisix/apisix-dashboard, backstage/backstage, bitnami/kubeapps, bitnami/seaweedfs, grafana/loki-stack, istio/ztunnel, jetstack/cert-manager-google-cas-issuer, k8up/k8up, nats/nack, prometheus-community/prometheus-fastly-exporter, prometheus-community/prometheus-modbus-exporter, prometheus-community/prometheus-yet-another-cloudwatch-exporter, victoria-metrics/victoria-logs-cluster

## Deferred to `failed.csv`
- **gloo/gloo** — `validationServerGrpcMaxSizeBytes` large-int scientific notation (#27, now 3 charts)
- **yugabyte/yugabyte** — render error `d != java.lang.String` (#32)
- **redpanda/operator** — renders zero resources (conditional gap)
- **victoria-metrics/victoria-metrics-distributed** — one missing VMRule

Chart count: **270 → 283**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)