### PR TITLE
docs: 0.1.0 conformance gate met (300/300 charts)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,10 +26,19 @@ byte-parity gate against `helm template` plus an extraction-ready template engin
 * YAML document splitting tolerates a `---` separator with trailing whitespace, so the
   following resource is no longer glued onto the previous document.
 * `merge`/`mergeOverwrite`/`fromYaml` no longer throw on immutable maps.
+* `title` matches Go's `strings.Title`: it title-cases the letter after a separator and
+  leaves the rest of each word untouched (`xtrabackupSidecar` -> `XtrabackupSidecar`).
+* `index x` with no indexing keys returns `x` itself (Go semantics), instead of `null`.
+* `printf` matches Go's `fmt` for several verbs: `%t` prints `true`/`false`, a whole
+  `float64` via `%v` prints without a trailing `.0`, and surplus verbs emit
+  `%!verb(MISSING)` instead of aborting the render.
 
 === Build & coverage
 
 * Spring Boot 4.0.6; `spring-retry` migrated to the `spring-core` retry API.
-* Comparison-suite coverage grown from 54 to 90 charts, all rendering identically to Helm
-  (k8s-monitoring, kube-prometheus-stack, victoria-metrics-k8s-stack, istio, consul,
-  airflow, datadog, and more).
+* Comparison-suite coverage grown from 54 to *300 charts*, all rendering identically to
+  Helm — meeting the 0.1.0 conformance gate. Spans the bitnami library, the
+  prometheus-community exporters, grafana/loki/mimir/tempo, istio, elastic/eck,
+  victoria-metrics, the ory/percona/mongodb/kuberay/strimzi operators, and many more.
+* The chart-parity suite is tagged `comparison` and excluded from the default build, so
+  `mvn verify` stays fast; the full suite runs in a dedicated CI job.

--- a/docs/modules/ROOT/pages/roadmap.adoc
+++ b/docs/modules/ROOT/pages/roadmap.adoc
@@ -19,13 +19,13 @@ extraction-ready engine*. The release is cut via `maven_release.yml`
 | *≥ 300 charts* render byte-identical to `helm template` in CI (the `KpsComparisonTest`
   suite, `charts.csv`), order-independent and with only the documented comparison-ignores
   (random/timestamp names, generated secrets/certs).
-| 90 / 300
+| ✅ 300 / 300
 
 | Engine maturity
 | The Go template engine (`jhelm-gotemplate` + `-sprig` + `-helm`) is in a *very advanced,
   extraction-ready state* — see "`gotmpl4j` readiness" below. The 300-chart suite is its
   de-facto conformance test.
-| In progress
+| Advanced — 300-chart suite green; remaining gaps tracked as discrete issues
 
 | Supported surface
 | All modules ship as supported: `gotemplate`/`sprig`/`helm` (engine), `core` (chart


### PR DESCRIPTION
Follow-up to #380 (which crossed 300 charts).

- **roadmap.adoc** — conformance-gate row → `✅ 300 / 300`; engine-maturity row → "Advanced — 300-chart suite green".
- **CHANGELOG.adoc** — record the 90→300 coverage growth, the parity-suite test-split, and the engine fixes from the campaign (`title` = strings.Title, single-arg `index`, `printf` `%t`/whole-float/`%!verb(MISSING)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)