### PR TITLE
fix(gotemplate): printf renders nil arg as Go's %!verb(<nil>) marker (+2 charts)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -298,3 +298,5 @@ ory/oathkeeper-maester,ory,https://k8s.ory.sh/helm/charts
 parca/parca,parca,https://parca-dev.github.io/helm-charts
 percona/psmdb-db,percona,https://percona.github.io/percona-helm-charts
 percona/pxc-db,percona,https://percona.github.io/percona-helm-charts
+linkerd/linkerd-crds,linkerd,https://helm.linkerd.io/stable
+prometheus-community/prometheus-pgbouncer-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -27,12 +27,6 @@ argo/argo-events,argo,https://argoproj.github.io/argo-helm
 # Needs investigation. (#28)
 kyverno/kyverno-policies,kyverno,https://kyverno.github.io/kyverno/
 #
-# linkerd-crds: the CRDs stamp `linkerd.io/created-by: linkerd/helm %!s(<nil>)` --
-# Helm's printf hits a nil arg for %s and emits Go's bad-verb error string
-# (`%!s(<nil>)`). jhelm renders a nil %s arg as empty. Matching Go's printf error
-# formatting for nil is a niche parity gap. (#29)
-linkerd/linkerd-crds,linkerd,https://helm.linkerd.io/stable
-#
 # zalando/postgres-operator: same large-int->scientific-notation gap as argo-events
 # (#27) -- the pod PriorityClass `value: 1000000` renders as `1e+06` under Helm
 # (values numbers are float64) but `1000000` under jhelm.
@@ -48,11 +42,6 @@ bitnami/grafana-mimir,bitnami,https://charts.bitnami.com/bitnami
 # `securityContext.seLinuxOptions: null` where Helm omits the key entirely
 # (bitnami-common null securityContext field handling). (#31)
 bitnami/jasperreports,bitnami,https://charts.bitnami.com/bitnami
-#
-# prometheus-pgbouncer-exporter: connection-string env renders
-# "%!s(<nil>):5432/..." under Helm (printf %s of a nil host) but ":5432/..." under
-# jhelm; same nil-arg printf gap as linkerd-crds (#29).
-prometheus-community/prometheus-pgbouncer-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
 #
 # bitnami/osclass: same bundled-mariadb seLinuxOptions: null vs omitted-key quirk
 # as jasperreports (#31).

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
@@ -398,6 +398,9 @@ public final class Functions {
 				return "";
 			}
 			String format = String.valueOf(args[0]);
+			// Verbs as written, before translation — needed to render a nil argument the
+			// way Go does (it keys the marker off the original verb, e.g. %v vs %s).
+			List<Character> origVerbs = extractVerbs(format);
 
 			// Translate Go format verbs to Java equivalents
 			format = format.replaceAll("%#?v", "%s"); // %v and %#(v) -> %s
@@ -412,17 +415,23 @@ public final class Functions {
 			// Go's printf is lenient (any numeric type for %d/%g); Java is strict.
 			// Must track non-numeric specs (%s, %c, etc.) to maintain correct
 			// positional alignment with arguments.
-			Matcher specMatcher = Pattern.compile("%[^%]*?([a-zA-Z])").matcher(format);
-			List<Character> specTypes = new ArrayList<>();
-			while (specMatcher.find()) {
-				specTypes.add(specMatcher.group(1).charAt(0));
-			}
+			List<Character> specTypes = extractVerbs(format);
 
 			Object[] realArgs = new Object[args.length - 1];
 			for (int i = 0; i < realArgs.length; i++) {
-				Object arg = (args[i + 1] != null) ? args[i + 1] : "";
 				char spec = (i < specTypes.size()) ? specTypes.get(i) : '\0';
-				realArgs[i] = coercePrintfArg(arg, spec);
+				if (args[i + 1] == null) {
+					// Go prints a bad-verb marker for a nil argument: `%v` -> `<nil>`,
+					// every other verb -> `%!verb(<nil>)`. We only have a plain-string
+					// slot
+					// here (spec 's', also the rewritten %v), so emit the marker as text;
+					// other verbs keep the historical empty-string rendering.
+					char ov = (i < origVerbs.size()) ? origVerbs.get(i) : spec;
+					realArgs[i] = (spec == 's') ? goNilMarker(ov) : "";
+				}
+				else {
+					realArgs[i] = coercePrintfArg(args[i + 1], spec);
+				}
 			}
 			// The %q arguments are now pre-quoted strings, so render them with %s.
 			format = format.replaceAll("%q", "%s");
@@ -454,6 +463,32 @@ public final class Functions {
 				return String.format(neutralizeInvalidFormatSpecifiers(format), realArgs);
 			}
 		};
+	}
+
+	/**
+	 * Extracts the conversion verb (trailing letter) of each {@code %} specifier in a
+	 * format string, in order, skipping escaped {@code %%}. Used to align arguments with
+	 * their verbs for per-argument coercion.
+	 * @param format the format string
+	 * @return the verbs in left-to-right order
+	 */
+	private static List<Character> extractVerbs(String format) {
+		Matcher m = Pattern.compile("%[^%]*?([a-zA-Z])").matcher(format);
+		List<Character> verbs = new ArrayList<>();
+		while (m.find()) {
+			verbs.add(m.group(1).charAt(0));
+		}
+		return verbs;
+	}
+
+	/**
+	 * Renders Go's bad-verb marker for a {@code nil} argument: {@code %v} yields
+	 * {@code <nil>}; every other verb yields {@code %!verb(<nil>)}.
+	 * @param verb the original (pre-translation) format verb
+	 * @return the Go nil marker text
+	 */
+	private static String goNilMarker(char verb) {
+		return (verb == 'v') ? "<nil>" : "%!" + verb + "(<nil>)";
 	}
 
 	/**

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/FunctionsTest.java
@@ -113,6 +113,17 @@ class FunctionsTest {
 	}
 
 	@Test
+	void testPrintfNilArgEmitsGoMarker() {
+		// Go prints a bad-verb marker for a nil arg: %s -> %!s(<nil>), %v -> <nil>.
+		Function printf = Functions.GO_BUILTINS.get("printf");
+		assertEquals("linkerd/helm %!s(<nil>)", printf.invoke(new Object[] { "linkerd/helm %s", null }));
+		assertEquals("%!s(<nil>):5432", printf.invoke(new Object[] { "%s:5432", null }));
+		assertEquals("<nil>", printf.invoke(new Object[] { "%v", null }));
+		// A present value is unaffected.
+		assertEquals("host:5432", printf.invoke(new Object[] { "%s:5432", "host" }));
+	}
+
+	@Test
 	void testPrintfEmitsMissingMarkerForSurplusVerbs() {
 		// Go prints `%!s(MISSING)` for a verb with no argument instead of aborting;
 		// bitnami harbor's noProxy helper feeds 7 args to an 11-verb format string.

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/NullHandlingTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/NullHandlingTest.java
@@ -32,10 +32,11 @@ class NullHandlingTest {
 	}
 
 	@Test
-	void testNullInPrintfProducesEmpty() throws Exception {
+	void testNullInPrintfMatchesGoFmtMarker() throws Exception {
+		// Go's fmt prints `%!s(<nil>)` for a nil %s argument (not an empty string).
 		Map<String, Object> data = new HashMap<>();
 		data.put("name", null);
-		assertEquals("release-", render("{{ printf \"%s-%s\" \"release\" .name }}", data));
+		assertEquals("release-%!s(<nil>)", render("{{ printf \"%s-%s\" \"release\" .name }}", data));
 	}
 
 	@Test


### PR DESCRIPTION
First of the `failed.csv` backlog (#29).

## Bug
Go's `fmt` prints a bad-verb marker for a `nil` argument — `%v` → `<nil>`, every other verb → `%!verb(<nil>)` — never an empty string. jhelm coalesced a nil `printf` argument to `""`, so connection strings and annotations built with `printf` diverged from `helm template`.

## Fix
Capture the original (pre-translation) verbs and, for a nil argument bound to a string slot (`%s`, also the rewritten `%v`), emit the Go marker; other verbs keep the previous empty rendering. Per-arg verb extraction factored into `extractVerbs()`.

Risk is low: only a *nil* `%s`/`%v` arg changes, and any chart that hit it was already failing (Helm renders the marker, jhelm rendered empty) — so no passing chart regresses. Spot-checked harbor/kong/istiod/kuberay/vm-single: still byte-identical.

## Unblocks (moved failed.csv → charts.csv)
- **linkerd/linkerd-crds** — `linkerd.io/created-by: linkerd/helm %!s(<nil>)`
- **prometheus-community/prometheus-pgbouncer-exporter** — DSN `%!s(<nil>):5432/...`

Updates `testNullInPrintfProducesEmpty` → `testNullInPrintfMatchesGoFmtMarker` (now consistent with the existing `println` nil test). **charts.csv 300 → 302.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)