### PR TITLE
fix(core): prune null values when coalescing a subchart (+2 charts)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -510,6 +510,15 @@ public class Engine {
 		// .Values.<subchartName>.*
 		mergeSubchartDefaults(chart, mergedValues);
 
+		// Helm nil-prunes a chart's values while *coalescing a subchart* ("setting a key
+		// to null removes it"), so a subchart default like `seLinuxOptions: null` never
+		// reaches a `toYaml`/`hasKey`. The top-level release chart's own values are used
+		// as-is and keep their nulls, so only prune for subcharts (depth > 0). Deep-copy
+		// because mergeValues shares nested map references with the cached chart values.
+		if (depth > 0) {
+			mergedValues = pruneNullValues(mergedValues);
+		}
+
 		// Validate merged values against the chart's JSON Schema (if present)
 		if (chart.getValuesSchema() != null) {
 			try {
@@ -893,6 +902,44 @@ public class Engine {
 		}
 		// No condition path resolved — include by default
 		return true;
+	}
+
+	/**
+	 * Returns a deep copy of a values map with every null-valued map entry removed,
+	 * recursing through nested maps and lists. Mirrors Helm's coalesce behaviour where a
+	 * {@code null} value removes its key (so it is absent from
+	 * {@code toYaml}/{@code hasKey}). Null elements inside lists are preserved, as Helm
+	 * only prunes table keys. A copy is made because {@link #mergeValues} shares nested
+	 * map references with cached chart values, which must not be mutated.
+	 * @param values the merged values map
+	 * @return a pruned deep copy
+	 */
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> pruneNullValues(Map<String, Object> values) {
+		return (Map<String, Object>) pruneNullsDeep(values);
+	}
+
+	@SuppressWarnings("unchecked")
+	private Object pruneNullsDeep(Object node) {
+		if (node instanceof Map) {
+			Map<String, Object> src = (Map<String, Object>) node;
+			Map<String, Object> out = new LinkedHashMap<>();
+			for (Map.Entry<String, Object> entry : src.entrySet()) {
+				if (entry.getValue() != null) {
+					out.put(entry.getKey(), pruneNullsDeep(entry.getValue()));
+				}
+			}
+			return out;
+		}
+		if (node instanceof List) {
+			List<Object> src = (List<Object>) node;
+			List<Object> out = new ArrayList<>(src.size());
+			for (Object item : src) {
+				out.add(pruneNullsDeep(item));
+			}
+			return out;
+		}
+		return node;
 	}
 
 	private Map<String, Object> mergeValues(Map<String, Object> defaults, Map<String, Object> overrides) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -191,6 +191,36 @@ class EngineTest {
 	}
 
 	@Test
+	void testSubchartNullValuesPrunedButTopLevelKept() {
+		// Helm drops null-valued keys while coalescing a subchart ("setting a key to null
+		// removes it"), but keeps them for the top-level release chart. Render the key
+		// set
+		// of an identical map in both and confirm the subchart loses its null key.
+		Map<String, Object> subCtx = new HashMap<>();
+		subCtx.put("a", 1);
+		subCtx.put("b", null);
+		Chart subchart = simpleChart("sub", "1.0.0",
+				List.of(tmpl("k.yaml", "subkeys:{{ range $k, $v := .Values.ctx }} {{ $k }}{{ end }}")),
+				Map.of("ctx", subCtx));
+
+		Map<String, Object> parentCtx = new HashMap<>();
+		parentCtx.put("a", 1);
+		parentCtx.put("b", null);
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder().name("parent").version("1.0.0").build())
+			.templates(List.of(tmpl("k.yaml", "parentkeys:{{ range $k, $v := .Values.ctx }} {{ $k }}{{ end }}")))
+			.values(Map.of("ctx", parentCtx))
+			.dependencies(List.of(subchart))
+			.build();
+
+		String result = engine.render(parent, Map.of(), releaseInfo());
+		assertTrue(result.contains("parentkeys: a b"), "top-level null key kept: " + result);
+		assertTrue(result.contains("subkeys: a\n") || result.trim().endsWith("subkeys: a"),
+				"subchart null key pruned: " + result);
+		assertFalse(result.contains("subkeys: a b"), "subchart must not keep null key: " + result);
+	}
+
+	@Test
 	void testManySubchartHelpersDoNotExplodeNodeMap() {
 		// Regression for #311: createChartPrefixedAliases used to re-alias the entire
 		// named-template set on every helper file, compounding chart prefixes across

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -300,3 +300,5 @@ percona/psmdb-db,percona,https://percona.github.io/percona-helm-charts
 percona/pxc-db,percona,https://percona.github.io/percona-helm-charts
 linkerd/linkerd-crds,linkerd,https://helm.linkerd.io/stable
 prometheus-community/prometheus-pgbouncer-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
+bitnami/jasperreports,bitnami,https://charts.bitnami.com/bitnami
+bitnami/osclass,bitnami,https://charts.bitnami.com/bitnami

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -38,15 +38,6 @@ zalando/postgres-operator,zalando,https://opensource.zalando.com/postgres-operat
 bitnami/grafana-loki,bitnami,https://charts.bitnami.com/bitnami
 bitnami/grafana-mimir,bitnami,https://charts.bitnami.com/bitnami
 #
-# bitnami/jasperreports: the bundled mariadb StatefulSet renders
-# `securityContext.seLinuxOptions: null` where Helm omits the key entirely
-# (bitnami-common null securityContext field handling). (#31)
-bitnami/jasperreports,bitnami,https://charts.bitnami.com/bitnami
-#
-# bitnami/osclass: same bundled-mariadb seLinuxOptions: null vs omitted-key quirk
-# as jasperreports (#31).
-bitnami/osclass,bitnami,https://charts.bitnami.com/bitnami
-#
 # pomerium/pomerium: the per-Deployment config `checksum` annotation differs because
 # the checksummed config embeds generated shared/cookie secrets (randAlphaNum),
 # same #237 class as checksum/* but with a bare `checksum` key.


### PR DESCRIPTION
Second of the `failed.csv` backlog (#31).

## Bug
Helm drops a values key whose value is `null` while **coalescing a subchart** ("setting a key to null removes it"), so a subchart default like bitnami-common's `containerSecurityContext.seLinuxOptions: null` never reaches an `omit | toYaml` or `hasKey`. The **top-level** release chart keeps its own nulls. jhelm kept the null in both, so subchart resources emitted `seLinuxOptions: null` where Helm omits the key.

## Fix
For a subchart render (`depth > 0`), deep-copy the merged values pruning null-valued map entries (recursing into nested maps and list elements; null **list** elements are kept, as Helm only prunes table keys). The top-level chart is left untouched. A copy is required because `mergeValues` shares nested map references with the cached chart values.

## Verified
- **bitnami/jasperreports**, **bitnami/osclass** (bundled mariadb) now byte-identical to `helm template` — moved failed.csv → charts.csv (**300 → 302**).
- Added a focused `EngineTest` (subchart null pruned, top-level null kept).
- Regression-checked 13 subchart-heavy charts: wordpress, drupal, magento, moodle, keycloak, redis, postgresql-ha, harbor, kube-prometheus-stack, grafana/loki, apache-airflow, consul, nextcloud — all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)