### PR TITLE
fix(engine): model values numbers as float64 like Helm (#27, +3 charts)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -10,6 +10,7 @@ import org.alexmond.jhelm.gotemplate.GoTemplate;
 import org.alexmond.jhelm.gotemplate.parse.Node;
 
 import java.io.StringWriter;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -510,14 +511,17 @@ public class Engine {
 		// .Values.<subchartName>.*
 		mergeSubchartDefaults(chart, mergedValues);
 
-		// Helm nil-prunes a chart's values while *coalescing a subchart* ("setting a key
-		// to null removes it"), so a subchart default like `seLinuxOptions: null` never
-		// reaches a `toYaml`/`hasKey`. The top-level release chart's own values are used
-		// as-is and keep their nulls, so only prune for subcharts (depth > 0). Deep-copy
-		// because mergeValues shares nested map references with the cached chart values.
-		if (depth > 0) {
-			mergedValues = pruneNullValues(mergedValues);
-		}
+		// Normalise the merged values to match Helm's value model (deep copy —
+		// mergeValues
+		// shares nested map references with the cached chart values):
+		// * Numbers become Double, because Helm loads values via JSON where every number
+		// is a float64. Interpolated directly this changes large ints (>=1e6) to Go's
+		// scientific notation (`1000000` -> `1e+06`); `int`/`len` results stay Long and
+		// render plain.
+		// * Null map entries are pruned for a subchart (depth > 0) but kept for the
+		// top-level release chart, mirroring Helm's coalesce ("a null key removes it",
+		// applied while coalescing subcharts).
+		mergedValues = prepareRenderValues(mergedValues, depth > 0);
 
 		// Validate merged values against the chart's JSON Schema (if present)
 		if (chart.getValuesSchema() != null) {
@@ -905,28 +909,31 @@ public class Engine {
 	}
 
 	/**
-	 * Returns a deep copy of a values map with every null-valued map entry removed,
-	 * recursing through nested maps and lists. Mirrors Helm's coalesce behaviour where a
-	 * {@code null} value removes its key (so it is absent from
-	 * {@code toYaml}/{@code hasKey}). Null elements inside lists are preserved, as Helm
-	 * only prunes table keys. A copy is made because {@link #mergeValues} shares nested
-	 * map references with cached chart values, which must not be mutated.
+	 * Returns a deep copy of the merged values normalised to Helm's value model: every
+	 * integer-typed number becomes a {@code Double} (Helm loads values via JSON, where
+	 * all numbers are {@code float64}), and — when {@code pruneNulls} is set (subchart
+	 * render) — null-valued map entries are dropped (Helm's "a null key removes it"
+	 * coalesce rule; the top-level chart keeps its nulls). Null elements inside lists are
+	 * preserved, as Helm only prunes table keys. A copy is made because
+	 * {@link #mergeValues} shares nested map references with cached chart values, which
+	 * must not be mutated.
 	 * @param values the merged values map
-	 * @return a pruned deep copy
+	 * @param pruneNulls whether to drop null map entries (true for subcharts)
+	 * @return a normalised deep copy
 	 */
 	@SuppressWarnings("unchecked")
-	private Map<String, Object> pruneNullValues(Map<String, Object> values) {
-		return (Map<String, Object>) pruneNullsDeep(values);
+	private Map<String, Object> prepareRenderValues(Map<String, Object> values, boolean pruneNulls) {
+		return (Map<String, Object>) prepareValueNode(values, pruneNulls);
 	}
 
 	@SuppressWarnings("unchecked")
-	private Object pruneNullsDeep(Object node) {
+	private Object prepareValueNode(Object node, boolean pruneNulls) {
 		if (node instanceof Map) {
 			Map<String, Object> src = (Map<String, Object>) node;
 			Map<String, Object> out = new LinkedHashMap<>();
 			for (Map.Entry<String, Object> entry : src.entrySet()) {
-				if (entry.getValue() != null) {
-					out.put(entry.getKey(), pruneNullsDeep(entry.getValue()));
+				if (!pruneNulls || entry.getValue() != null) {
+					out.put(entry.getKey(), prepareValueNode(entry.getValue(), pruneNulls));
 				}
 			}
 			return out;
@@ -935,9 +942,17 @@ public class Engine {
 			List<Object> src = (List<Object>) node;
 			List<Object> out = new ArrayList<>(src.size());
 			for (Object item : src) {
-				out.add(pruneNullsDeep(item));
+				out.add(prepareValueNode(item, pruneNulls));
 			}
 			return out;
+		}
+		// Helm's values numbers are all float64; integer types become Double so a direct
+		// interpolation matches Go's float formatting. Double/Float and BigDecimal are
+		// left
+		// as-is (already floating), and booleans/strings are untouched.
+		if (node instanceof Integer || node instanceof Long || node instanceof Short || node instanceof Byte
+				|| node instanceof BigInteger) {
+			return ((Number) node).doubleValue();
 		}
 		return node;
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SchemaValidator.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SchemaValidator.java
@@ -83,7 +83,7 @@ public class SchemaValidator {
 		if (schema.has("enum")) {
 			boolean valid = false;
 			for (JsonNode enumVal : schema.get("enum")) {
-				if (enumVal.equals(value)) {
+				if (jsonValueEquals(enumVal, value)) {
 					valid = true;
 					break;
 				}
@@ -130,7 +130,7 @@ public class SchemaValidator {
 	private void validateType(String type, JsonNode value, String path, List<String> errors) {
 		boolean valid = switch (type) {
 			case "string" -> value.isString();
-			case "integer" -> value.isIntegralNumber();
+			case "integer" -> isIntegerValue(value);
 			case "number" -> value.isNumber();
 			case "boolean" -> value.isBoolean();
 			case "array" -> value.isArray();
@@ -141,6 +141,40 @@ public class SchemaValidator {
 		if (!valid) {
 			errors.add(path + ": expected type " + type + " but was " + nodeTypeName(value));
 		}
+	}
+
+	/**
+	 * Equality for {@code enum}/{@code const} that compares numbers by value, so a schema
+	 * integer like {@code 443} matches a values float64 {@code 443.0} (Helm loads values
+	 * as float64; JSON-Schema enum equality is numeric, not type-strict).
+	 * @param a one node
+	 * @param b the other node
+	 * @return whether they are equal for schema purposes
+	 */
+	private static boolean jsonValueEquals(JsonNode a, JsonNode b) {
+		if (a.isNumber() && b.isNumber()) {
+			return a.doubleValue() == b.doubleValue();
+		}
+		return a.equals(b);
+	}
+
+	/**
+	 * JSON Schema's {@code integer} matches any number with zero fractional part,
+	 * including a float like {@code 8080.0}. Helm loads values as float64, so chart
+	 * ports/replicas arrive as whole doubles; accept them as integers (the validator must
+	 * not be stricter than Helm's).
+	 * @param value the value node
+	 * @return whether {@code value} is an integer for schema purposes
+	 */
+	private static boolean isIntegerValue(JsonNode value) {
+		if (value.isIntegralNumber()) {
+			return true;
+		}
+		if (value.isFloatingPointNumber()) {
+			double d = value.doubleValue();
+			return !Double.isInfinite(d) && !Double.isNaN(d) && d == Math.floor(d);
+		}
+		return false;
 	}
 
 	private String nodeTypeName(JsonNode node) {

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -302,3 +302,6 @@ linkerd/linkerd-crds,linkerd,https://helm.linkerd.io/stable
 prometheus-community/prometheus-pgbouncer-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts
 bitnami/jasperreports,bitnami,https://charts.bitnami.com/bitnami
 bitnami/osclass,bitnami,https://charts.bitnami.com/bitnami
+argo/argo-events,argo,https://argoproj.github.io/argo-helm
+zalando/postgres-operator,zalando,https://opensource.zalando.com/postgres-operator/charts/postgres-operator
+gloo/gloo,gloo,https://storage.googleapis.com/solo-public-helm

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -12,25 +12,11 @@
 # object is missing a couple of listeners, and a test-hook Pod has a random name suffix.
 gitlab/gitlab,gitlab,https://charts.gitlab.io
 #
-# argo-events: Helm renders a large integer values default in scientific notation.
-# The controller-config ConfigMap interpolates
-# `{{ .Values.configs.jetstream.streamConfig.maxMsgs }}` (default 1000000) directly;
-# Helm loads values numbers as float64 so it prints `1e+06`, jhelm keeps the integer
-# and prints `1000000`. Matching Helm's large-int->scientific gotcha would require
-# treating every values.yaml integer as a double (risky, affects all direct
-# interpolations); deferred. (#27)
-argo/argo-events,argo,https://argoproj.github.io/argo-helm
-#
 # kyverno-policies: several ClusterPolicy resources carry a
 # `kyverno.io/kubernetes-version` annotation (e.g. ">=1.25.0-0") that jhelm renders
 # empty. The value comes from each policy's own annotations block; jhelm drops it.
 # Needs investigation. (#28)
 kyverno/kyverno-policies,kyverno,https://kyverno.github.io/kyverno/
-#
-# zalando/postgres-operator: same large-int->scientific-notation gap as argo-events
-# (#27) -- the pod PriorityClass `value: 1000000` renders as `1e+06` under Helm
-# (values numbers are float64) but `1000000` under jhelm.
-zalando/postgres-operator,zalando,https://opensource.zalando.com/postgres-operator/charts/postgres-operator
 #
 # bitnami grafana-loki / grafana-mimir: jhelm omits the bundled memcached
 # subcomponents (memcachedfrontend/chunks/index StatefulSet/Service/SA/PDB/NetworkPolicy)
@@ -51,11 +37,6 @@ kong/ingress,kong,https://charts.konghq.com
 # redpanda/console: jhelm renders zero resources where Helm renders the console
 # Deployment/Service/ConfigMap/Secret/SA; a top-level conditional-enablement gap.
 redpanda/console,redpanda,https://charts.redpanda.com
-#
-# gloo/gloo: Settings.validationServerGrpcMaxSizeBytes (104857600) renders as
-# `1.048576E8` under Helm (values float64 scientific notation) vs `104857600`
-# under jhelm; same large-int gap as argo-events/zalando (#27).
-gloo/gloo,gloo,https://storage.googleapis.com/solo-public-helm
 #
 # yugabyte/yugabyte: renders end-to-end now (the printf wrong-type marker fix removed
 # the `%d`-of-string crash), but still omits two serviceEndpoints Services

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ListFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ListFunctions.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.alexmond.jhelm.gotemplate.Function;
+import org.alexmond.jhelm.gotemplate.GoFmt;
 import org.alexmond.jhelm.gotemplate.FunctionExecutionException;
 
 /**
@@ -607,6 +608,11 @@ public final class ListFunctions {
 		};
 	}
 
+	// Go-style stringify so a float64 element renders like helm template (8 -> "8").
+	private static String goStr(Object value) {
+		return (value instanceof Number n) ? GoFmt.number(n) : String.valueOf(value);
+	}
+
 	private static Function join() {
 		return (args) -> {
 			if (args.length < 2) {
@@ -618,17 +624,17 @@ public final class ListFunctions {
 			}
 			String sep = String.valueOf(args[0]);
 			if (listObj instanceof Collection) {
-				return ((Collection<?>) listObj).stream().map(String::valueOf).collect(Collectors.joining(sep));
+				return ((Collection<?>) listObj).stream().map(ListFunctions::goStr).collect(Collectors.joining(sep));
 			}
 			else if (listObj.getClass().isArray()) {
 				int len = Array.getLength(listObj);
 				List<String> strs = new ArrayList<>();
 				for (int i = 0; i < len; i++) {
-					strs.add(String.valueOf(Array.get(listObj, i)));
+					strs.add(goStr(Array.get(listObj, i)));
 				}
 				return String.join(sep, strs);
 			}
-			return String.valueOf(listObj);
+			return goStr(listObj);
 		};
 	}
 

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctions.java
@@ -10,6 +10,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import lombok.extern.slf4j.Slf4j;
 
 import org.alexmond.jhelm.gotemplate.Function;
+import org.alexmond.jhelm.gotemplate.GoFmt;
 
 /**
  * Math and numeric conversion functions from Sprig library. Includes basic arithmetic,
@@ -137,7 +138,10 @@ public final class MathFunctions {
 			// "null". Charts rely on this, e.g. `eq (toString .x) "<nil>"` to test
 			// whether
 			// a value is unset (opentelemetry-collector.serviceEnabled).
-			return (args[0] == null) ? "<nil>" : String.valueOf(args[0]);
+			if (args[0] == null) {
+				return "<nil>";
+			}
+			return (args[0] instanceof Number n) ? GoFmt.number(n) : String.valueOf(args[0]);
 		};
 	}
 

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 import org.alexmond.jhelm.gotemplate.Function;
+import org.alexmond.jhelm.gotemplate.GoFmt;
 import org.alexmond.jhelm.gotemplate.FunctionExecutionException;
 
 /**
@@ -318,6 +319,12 @@ public final class StringFunctions {
 		return (args) -> args.length >= 2 && String.valueOf(args[1]).endsWith(String.valueOf(args[0]));
 	}
 
+	// Stringify Go-style so a float64 renders like helm template (8080 -> "8080",
+	// 1000000 -> "1e+06") instead of Java's "8080.0".
+	private static String goStr(Object value) {
+		return (value instanceof Number n) ? GoFmt.number(n) : String.valueOf(value);
+	}
+
 	private static Function quote() {
 		return (args) -> {
 			StringBuilder out = new StringBuilder();
@@ -328,8 +335,7 @@ public final class StringFunctions {
 				if (!out.isEmpty()) {
 					out.append(' ');
 				}
-				String escaped = String.valueOf(arg)
-					.replace("\\", "\\\\")
+				String escaped = goStr(arg).replace("\\", "\\\\")
 					.replace("\"", "\\\"")
 					.replace("\n", "\\n")
 					.replace("\r", "\\r")
@@ -350,7 +356,7 @@ public final class StringFunctions {
 				if (!out.isEmpty()) {
 					out.append(' ');
 				}
-				out.append('\'').append(arg).append('\'');
+				out.append('\'').append(goStr(arg)).append('\'');
 			}
 			return out.toString();
 		};
@@ -359,7 +365,7 @@ public final class StringFunctions {
 	private static Function cat() {
 		return (args) -> Arrays.stream(args)
 			.filter((arg) -> arg != null)
-			.map(String::valueOf)
+			.map(StringFunctions::goStr)
 			.filter((s) -> !s.isEmpty())
 			.collect(Collectors.joining(" "));
 	}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
@@ -601,10 +601,9 @@ public final class Functions {
 			return ((Number) arg).longValue();
 		}
 		if (spec == 's' && (arg instanceof Double || arg instanceof Float)) {
-			double d = ((Number) arg).doubleValue();
-			if (d == Math.rint(d) && !Double.isInfinite(d) && Math.abs(d) < 1e15) {
-				return (long) d;
-			}
+			// Go's %v (rewritten to %s) prints a float64 with %g, so a values number
+			// renders like helm template (3.0 -> "3", 1000000 -> "1e+06").
+			return GoFmt.floatString(((Number) arg).doubleValue());
 		}
 		return arg;
 	}
@@ -728,7 +727,10 @@ public final class Functions {
 	 * {@code fmt.Sprint(nil)} which produces {@code "<nil>"} for nil values.
 	 */
 	static String sprintValue(Object value) {
-		return (value != null) ? String.valueOf(value) : "<nil>";
+		if (value == null) {
+			return "<nil>";
+		}
+		return (value instanceof Number n) ? GoFmt.number(n) : String.valueOf(value);
 	}
 
 	public static boolean isTrue(Object arg) {

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/GoFmt.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/GoFmt.java
@@ -1,0 +1,74 @@
+package org.alexmond.jhelm.gotemplate;
+
+import java.math.BigDecimal;
+
+/**
+ * Formats values the way Go's {@code fmt} package does, so template output matches
+ * {@code helm template}. Helm loads chart values via JSON, where every number is a
+ * {@code float64}; rendering such a value to text (directly, or through {@code quote},
+ * {@code toString}, {@code printf %v}, {@code print}, …) therefore uses Go's float
+ * formatting, which switches to scientific notation for magnitudes {@code >= 1e6} (and
+ * {@code < 1e-4}). Integer types ({@code int} results of
+ * {@code int}/{@code len}/literals) render as plain decimals.
+ *
+ * <p>
+ * This is distinct from {@code toYaml}, whose numbers follow {@code sigs.k8s.io/yaml}
+ * (JSON) formatting and never use scientific notation; that path must not call here.
+ */
+public final class GoFmt {
+
+	private GoFmt() {
+	}
+
+	/**
+	 * Formats a number the way Go's {@code fmt.Sprint} would: a floating-point value
+	 * ({@link Double}/{@link Float}) uses {@link #floatString}, any other number renders
+	 * as a plain decimal.
+	 * @param number the number
+	 * @return the Go-formatted string
+	 */
+	public static String number(Number number) {
+		if (number instanceof Double d) {
+			return floatString(d);
+		}
+		if (number instanceof Float f) {
+			return floatString(f);
+		}
+		return String.valueOf(number);
+	}
+
+	/**
+	 * Renders a {@code double} the way Go's {@code fmt} prints a {@code float64} (the
+	 * shortest %g form): scientific notation when the decimal exponent is {@code < -4} or
+	 * {@code >= 6} (e.g. {@code 1000000 -> 1e+06}, {@code 0.00001 -> 1e-05}), otherwise a
+	 * plain decimal with no trailing zeros ({@code 3.0 -> 3}, {@code 999999 -> 999999}).
+	 * @param d the value
+	 * @return the Go-formatted string
+	 */
+	public static String floatString(double d) {
+		if (Double.isNaN(d)) {
+			return "NaN";
+		}
+		if (Double.isInfinite(d)) {
+			return (d > 0) ? "+Inf" : "-Inf";
+		}
+		if (d == 0.0) {
+			return "0";
+		}
+		String sign = (d < 0) ? "-" : "";
+		// Double.toString yields the shortest round-tripping decimal; BigDecimal
+		// preserves
+		// those exact digits, and stripTrailingZeros normalises 1000000.0 -> 1E+6 etc.
+		BigDecimal bd = new BigDecimal(Double.toString(Math.abs(d))).stripTrailingZeros();
+		String digits = bd.unscaledValue().toString();
+		int exp = bd.precision() - bd.scale() - 1;
+		if (exp < -4 || exp >= 6) {
+			String mantissa = (digits.length() == 1) ? digits : digits.charAt(0) + "." + digits.substring(1);
+			String expSign = (exp < 0) ? "-" : "+";
+			String absExp = Integer.toString(Math.abs(exp));
+			return sign + mantissa + "e" + expSign + ((absExp.length() < 2) ? "0" + absExp : absExp);
+		}
+		return sign + bd.toPlainString();
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/exec/ValuePrinter.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/exec/ValuePrinter.java
@@ -5,6 +5,8 @@ import java.io.Writer;
 import java.util.Collection;
 import java.util.Map;
 
+import org.alexmond.jhelm.gotemplate.GoFmt;
+
 final class ValuePrinter {
 
 	private ValuePrinter() {
@@ -60,17 +62,13 @@ final class ValuePrinter {
 	}
 
 	/**
-	 * Format a value to match Go's fmt.Sprint behavior. Whole-number floating-point
-	 * values are rendered without a decimal point (e.g. 1.0 → "1").
+	 * Format a value to match Go's {@code fmt.Sprint}. Numbers are formatted by
+	 * {@link GoFmt#number} (a values {@code float64} uses Go's %g, so e.g.
+	 * {@code 1000000 -> 1e+06}); other types fall back to {@link String#valueOf}.
 	 */
-	private static String formatScalar(Object value) {
-		if (value instanceof Double d && d == Math.floor(d) && !Double.isInfinite(d) && d >= Long.MIN_VALUE
-				&& d <= Long.MAX_VALUE) {
-			return String.valueOf(d.longValue());
-		}
-		if (value instanceof Float f && f == Math.floor(f) && !Float.isInfinite(f) && f >= Long.MIN_VALUE
-				&& f <= Long.MAX_VALUE) {
-			return String.valueOf(f.longValue());
+	static String formatScalar(Object value) {
+		if (value instanceof Number n) {
+			return GoFmt.number(n);
 		}
 		return String.valueOf(value);
 	}

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/exec/ValuePrinterTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/exec/ValuePrinterTest.java
@@ -60,6 +60,17 @@ class ValuePrinterTest {
 		assertEquals("value=1", render("value={{ .val }}", data));
 	}
 
+	@ParameterizedTest // expected values captured from `helm template` (Go fmt float64
+						// %v)
+	@CsvSource({ "0.0, 0", "3.0, 3", "1.5, 1.5", "100000.0, 100000", "999999.0, 999999", "1000000.0, 1e+06",
+			"5000000.0, 5e+06", "1234567.0, 1.234567e+06", "12345678.0, 1.2345678e+07", "104857600.0, 1.048576e+08",
+			"268435456.0, 2.68435456e+08", "1073741824.0, 1.073741824e+09", "200000000.0, 2e+08", "-5000000.0, -5e+06",
+			"12345678.9, 1.23456789e+07", "0.0001, 0.0001", "0.00001, 1e-05", "1.0E15, 1e+15", "1.0E20, 1e+20",
+			"1.0E21, 1e+21" })
+	void testGoFloatStringMatchesHelm(double input, String expected) {
+		assertEquals(expected, org.alexmond.jhelm.gotemplate.GoFmt.floatString(input));
+	}
+
 	private String render(String template, Map<String, Object> data) throws TemplateException, IOException {
 		GoTemplate tmpl = new GoTemplate();
 		tmpl.parse("test", template);


### PR DESCRIPTION
The deep one from the `failed.csv` backlog (#27).

## Bug
Helm loads chart values via JSON, so **every values number is a `float64`**. Interpolating one directly uses Go's float formatting, which switches to **scientific notation at magnitude ≥ 1e6** (and < 1e-4): `maxMsgs: 1000000` → `1e+06`, `validationServerGrpcMaxSizeBytes: 104857600` → `1.048576e+08`. jhelm kept values ints as `Long` and printed them plain, diverging from `helm template`.

## Fix — adopt Helm's value model
- **`Engine.prepareRenderValues`** converts every integer-typed values number to `Double` (deep copy; folds in the existing subchart null-prune). `int`/`len` results stay `Long` and render plain, exactly as Helm's `int64`.
- **New `GoFmt`** formats a `float64` with Go's shortest `%g`. The boundary (`exp < -4 || exp >= 6`) and digit form were captured from `helm template` and pinned in `ValuePrinterTest` (e.g. `999999 → 999999`, `1000000 → 1e+06`, `268435456 → 2.68435456e+08`).
- Routed through **every number→string site** that feeds output: `ValuePrinter` (direct `{{ }}`), `quote`/`squote`/`cat`, `toString`, list `join`, `print`/`println`, and `printf %v`/`%s`. **`toYaml` is deliberately untouched** — it follows `sigs.k8s.io/yaml` (JSON) formatting, never scientific.
- **`SchemaValidator`** no longer rejects whole-number floats: `integer` accepts `8080.0`, and `enum` equality compares numbers by value (`443 == 443.0`) — matching Helm/JSON-Schema (the validator must not be stricter than Helm).

## Verification
Ran the **full comparison suite — all 307 charts pass, zero regressions**. The fix was developed against that suite: 119 → 38 → 3 → 0 failures as each number→string path and the schema validator were brought to parity.

Unblocks **argo/argo-events**, **zalando/postgres-operator**, **gloo/gloo** (moved `failed.csv` → `charts.csv`, **304 → 307**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)