### PR TITLE
chore: reusable chart-parity scripts + allowlist

### DIFF
--- a/.claude/scripts/parity/README.md
+++ b/.claude/scripts/parity/README.md
@@ -1,0 +1,43 @@
+# Chart-parity helper scripts
+
+Reusable scripts that automate the repetitive jhelm ↔ `helm template` parity loop
+(driving `charts.csv` toward the 0.1.0 conformance gate). They wrap the same Maven
+invocations used by `KpsComparisonTest`, parse the surefire output, and always restore
+`single.csv` to its dev placeholder on exit.
+
+| Script | What it does | Cost |
+|--------|--------------|------|
+| `chart-test.sh` | Test candidate charts; categorised PASS / COMPFAIL / RENDERFAIL / FETCHFAIL / HELMFAIL / DUP. Skips charts already in `charts.csv`. | one render per batch |
+| `chart-diff.sh` | Render one chart and print the full jhelm-vs-helm diff (every diff / missing resource). Leaves manifests in `target/test-output/`. | one render |
+| `parity-run.sh` | Run the **full** suite over all of `charts.csv` and summarise failures — the definitive regression for engine changes. | minutes (all charts) |
+| `lib.sh` | Shared paths + the Maven wrappers + the log classifier. Sourced by the others. | — |
+
+## Examples
+
+```bash
+# Test a batch of candidates (rows are chartName,repoId,repoUrl — same as charts.csv)
+.claude/scripts/parity/chart-test.sh \
+  prometheus-community/prometheus-json-exporter,prometheus-community,https://prometheus-community.github.io/helm-charts \
+  dexidp/dex,dexidp,https://charts.dexidp.io
+
+# …or from a file / stdin
+.claude/scripts/parity/chart-test.sh -f /tmp/candidates.txt
+
+# Diagnose a failing chart (full diff). Looks the repo up from charts.csv/failed.csv
+# when given just a name.
+.claude/scripts/parity/chart-diff.sh argo/argo-events
+
+# Full regression after an engine change (what the nightly parity job runs)
+.claude/scripts/parity/parity-run.sh            # summary
+.claude/scripts/parity/parity-run.sh --fails-only
+```
+
+## Workflow these encode
+
+1. `chart-test.sh` a batch → promote `PASS` rows into `charts.csv`.
+2. `COMPFAIL`/`RENDERFAIL` → `chart-diff.sh <name>` to see the divergence; fix the engine
+   or move the chart to `failed.csv` (real bug) / `charts-skip.csv` (helm itself fails) /
+   add a `comparison-ignore` in `application-test.yaml` (random/timestamp content).
+3. After any engine change, `parity-run.sh` to confirm no regressions across all charts.
+
+See the `jhelm-300-chart-campaign` memory for the surrounding branch/PR conventions.

--- a/.claude/scripts/parity/chart-diff.sh
+++ b/.claude/scripts/parity/chart-diff.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# chart-diff.sh — render one chart and show the full jhelm-vs-helm comparison detail
+# (every diff / missing resource), for diagnosing a COMPFAIL/RENDERFAIL chart.
+#
+# Usage:
+#   chart-diff.sh CHART,REPOID,REPOURL
+#   chart-diff.sh chartName        # if the chart is already in charts.csv/failed.csv
+#
+# After a run the rendered manifests are left on disk for inspection:
+#   jhelm-core/target/test-output/actual_<chart>.yaml     (jhelm)
+#   jhelm-core/target/test-output/expected_<chart>.yaml   (helm)
+
+. "$(dirname "$0")/lib.sh"
+
+arg="${1:-}"; [[ -n "$arg" ]] || { echo "usage: chart-diff.sh CHART[,REPOID,REPOURL]" >&2; exit 2; }
+
+if [[ "$arg" == *,* ]]; then
+  row="$arg"
+else
+  # Look the chart up in charts.csv / failed.csv to recover repoId + url.
+  row="$(grep -hE "^$arg," "$CHARTS_CSV" "$FAILED_CSV" 2>/dev/null | head -1 || true)"
+  [[ -n "$row" ]] || { echo "chart '$arg' not found in charts.csv/failed.csv — pass the full CHART,REPOID,REPOURL row" >&2; exit 2; }
+fi
+name="${row%%,*}"
+
+trap restore_single_csv EXIT
+printf '%s\n' "$row" > "$SINGLE_CSV"
+
+echo "${c_dim}rendering $name (jhelm + helm)...${c_off}" >&2
+log="$(mktemp)"; run_single_chart_test > "$log"
+
+case "$(classify_chart "$name" "$log")" in
+  PASS) echo "${c_green}$name — All resources match Helm output.${c_off}" ;;
+  RENDERFAIL)
+    echo "${c_red}$name — jhelm render error:${c_off}"
+    grep "$name - JHelm rendering failed" "$log" | head -1 | grep -oE "chart '[^>]*" | head -1 ;;
+  FETCHFAIL) echo "${c_yellow}$name — could not fetch (chart/version not found).${c_off}" ;;
+  HELMFAIL)  echo "${c_yellow}$name — helm template itself fails with default values.${c_off}" ;;
+  *)
+    echo "${c_red}$name — comparison failure(s):${c_off}"
+    # Print the diff block: from the failure header to the next blank/failed.csv line.
+    awk -v c="$name" '
+      $0 ~ c" - [0-9]+ comparison failure" {p=1}
+      p {print}
+      p && /failed.csv:/ {exit}
+    ' "$log" | sed -E 's/^\[[0-9].*KpsComparisonTest.*//; /^\s*$/d' | head -60 ;;
+esac
+rm -f "$log"
+echo
+echo "${c_dim}Manifests: target/test-output/actual_*${name//\//_}*.yaml (jhelm) vs expected_* (helm)${c_off}" >&2

--- a/.claude/scripts/parity/chart-test.sh
+++ b/.claude/scripts/parity/chart-test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# chart-test.sh — test candidate Helm charts against `helm template` and print a
+# categorised summary. This is the core campaign loop: stage charts in single.csv,
+# run the single-chart comparison, parse pass/fail, restore single.csv.
+#
+# Usage:
+#   chart-test.sh CHART,REPOID,REPOURL [more rows...]      # rows as args
+#   chart-test.sh -f candidates.txt                        # rows from a file
+#   cat candidates.txt | chart-test.sh                     # rows from stdin
+#
+# Each row is `chartName,repoId,repoUrl` (same format as charts.csv). Rows whose
+# chartName is already in charts.csv are skipped and reported as DUP.
+#
+# Output: one line per chart — PASS / COMPFAIL / RENDERFAIL / FETCHFAIL / HELMFAIL —
+# with the first diff for comparison failures. Exit 0 iff every non-dup chart PASSed.
+
+. "$(dirname "$0")/lib.sh"
+
+candidates=()
+if [[ "${1:-}" == "-f" ]]; then
+  [[ -f "${2:-}" ]] || { echo "no such file: ${2:-}" >&2; exit 2; }
+  mapfile -t candidates < <(grep -vE '^\s*#|^\s*$' "$2")
+elif [[ $# -gt 0 ]]; then
+  candidates=("$@")
+else
+  mapfile -t candidates < <(grep -vE '^\s*#|^\s*$' /dev/stdin)
+fi
+[[ ${#candidates[@]} -gt 0 ]] || { echo "no candidate rows given" >&2; exit 2; }
+
+# Split into to-test vs already-present duplicates.
+mapfile -t have < <(existing_chart_names)
+declare -A have_set=(); for h in "${have[@]}"; do have_set["$h"]=1; done
+to_test=(); dups=()
+for row in "${candidates[@]}"; do
+  name="${row%%,*}"
+  if [[ -n "${have_set[$name]:-}" ]]; then dups+=("$name"); else to_test+=("$row"); fi
+done
+
+if [[ ${#dups[@]} -gt 0 ]]; then
+  for d in "${dups[@]}"; do printf '%s  DUP%s  %s (already in charts.csv)\n' "$c_yellow" "$c_off" "$d"; done
+fi
+[[ ${#to_test[@]} -gt 0 ]] || { echo "nothing new to test"; exit 0; }
+
+trap restore_single_csv EXIT
+printf '%s\n' "${to_test[@]}" > "$SINGLE_CSV"
+
+echo "${c_dim}testing ${#to_test[@]} chart(s) via KpsComparisonTest#compareSingleChart...${c_off}" >&2
+log="$(mktemp)"; run_single_chart_test > "$log"
+
+fails=0
+for row in "${to_test[@]}"; do
+  name="${row%%,*}"
+  case "$(classify_chart "$name" "$log")" in
+    PASS)       printf '%s  PASS%s        %s\n' "$c_green" "$c_off" "$name" ;;
+    COMPFAIL)   diff="$(grep -A2 "$name - [0-9]* comparison failure" "$log" | grep -E ': expected=|missing in JHelm|diff\(s\)' | head -1 | sed 's/^[[:space:]]*//')"
+                printf '%s  COMPFAIL%s    %s  %s%s%s\n' "$c_red" "$c_off" "$name" "$c_dim" "${diff:-(see log)}" "$c_off"; fails=$((fails+1)) ;;
+    RENDERFAIL) err="$(grep "$name - JHelm rendering failed" "$log" | head -1 | grep -oE "template '[^']*'[^>]*" | head -1)"
+                printf '%s  RENDERFAIL%s  %s  %s%s%s\n' "$c_red" "$c_off" "$name" "$c_dim" "${err:-render error}" "$c_off"; fails=$((fails+1)) ;;
+    HELMFAIL)   printf '%s  HELMFAIL%s    %s  %s(helm template itself fails — charts-skip.csv)%s\n' "$c_yellow" "$c_off" "$name" "$c_dim" "$c_off" ;;
+    FETCHFAIL)  printf '%s  FETCHFAIL%s   %s  %s(chart/version not found — check name/repo)%s\n' "$c_yellow" "$c_off" "$name" "$c_dim" "$c_off" ;;
+    *)          printf '%s  UNKNOWN%s     %s\n' "$c_yellow" "$c_off" "$name"; fails=$((fails+1)) ;;
+  esac
+done
+rm -f "$log"
+
+echo
+echo "${c_dim}Tip: promote PASS charts into charts.csv; send COMPFAIL/RENDERFAIL through chart-diff.sh.${c_off}" >&2
+[[ $fails -eq 0 ]]

--- a/.claude/scripts/parity/lib.sh
+++ b/.claude/scripts/parity/lib.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Shared helpers for the jhelm chart-parity scripts.
+# Source this from the other scripts: . "$(dirname "$0")/lib.sh"
+
+set -euo pipefail
+
+# Repo root = two levels up from .claude/scripts/parity
+PARITY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$PARITY_DIR/../../.." && pwd)"
+
+CHARTS_CSV="$REPO_ROOT/jhelm-core/src/test/resources/charts.csv"
+FAILED_CSV="$REPO_ROOT/jhelm-core/src/test/resources/failed.csv"
+SINGLE_CSV="$REPO_ROOT/jhelm-core/src/test/resources/single.csv"
+SKIP_CSV="$REPO_ROOT/jhelm-core/src/test/resources/charts-skip.csv"
+# The dev placeholder single.csv is restored to after every run.
+SINGLE_PLACEHOLDER='dandydev-charts/redis-ha,dandydev-charts,https://dandydeveloper.github.io/charts/'
+
+c_green=$'\033[32m'; c_red=$'\033[31m'; c_yellow=$'\033[33m'; c_dim=$'\033[2m'; c_off=$'\033[0m'
+
+# mvn wrapper that builds jhelm-core + upstream engine modules and runs only the
+# untagged single-chart comparison test. Quiet; returns the surefire log on stdout.
+run_single_chart_test() {
+  ( cd "$REPO_ROOT" && ./mvnw -q -pl jhelm-core -am test \
+      -Dtest='KpsComparisonTest#compareSingleChart' \
+      -Dsurefire.failIfNoSpecifiedTests=false 2>&1 ) || true
+}
+
+# Run the FULL tagged comparison suite over charts.csv (every chart). Slow + networked.
+run_full_parity() {
+  ( cd "$REPO_ROOT" && ./mvnw -q -pl jhelm-core -am test \
+      -Dtest='KpsComparisonTest#compareAllTopCharts' \
+      -Dsurefire.excludedGroups= -Dgroups=comparison \
+      -Dsurefire.failIfNoSpecifiedTests=false 2>&1 ) || true
+}
+
+# Restore single.csv to its dev placeholder. Registered as an EXIT trap by callers.
+restore_single_csv() { printf '%s\n' "$SINGLE_PLACEHOLDER" > "$SINGLE_CSV"; }
+
+# Chart names already present in charts.csv (one per line).
+existing_chart_names() { cut -d, -f1 "$CHARTS_CSV" | grep -v '^$' | sort -u; }
+
+# Categorise a captured surefire log (stdin) for a given chart name, echoing one of:
+# PASS | COMPFAIL | RENDERFAIL | FETCHFAIL | HELMFAIL | UNKNOWN
+classify_chart() {
+  local chart="$1" log="$2"
+  if grep -qF "$chart - All resources match Helm output" "$log"; then echo PASS
+  elif grep -qE "$chart - [0-9]+ comparison failure" "$log"; then echo COMPFAIL
+  elif grep -qF "$chart - JHelm rendering failed" "$log"; then echo RENDERFAIL
+  elif grep -qF "$chart - Helm template failed, skipping" "$log"; then echo HELMFAIL
+  elif grep -qiE "Failed to pull chart $chart|No versions found for chart" "$log"; then echo FETCHFAIL
+  else echo UNKNOWN; fi
+}

--- a/.claude/scripts/parity/parity-run.sh
+++ b/.claude/scripts/parity/parity-run.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# parity-run.sh — run the FULL chart-parity suite (every chart in charts.csv) and
+# print a categorised summary. This is the definitive regression for engine changes
+# (it's what the nightly parity CI job runs). Slow + network-bound.
+#
+# Usage:
+#   parity-run.sh                 # run all charts.csv, summarise
+#   parity-run.sh --fails-only    # only list the failing charts
+#
+# Exit 0 iff the whole suite passed.
+
+. "$(dirname "$0")/lib.sh"
+
+fails_only=0; [[ "${1:-}" == "--fails-only" ]] && fails_only=1
+
+total="$(grep -cv '^$' "$CHARTS_CSV")"
+echo "${c_dim}running the full parity suite over $total charts (this takes a few minutes)...${c_off}" >&2
+log="$(mktemp)"; run_full_parity > "$log"
+
+summary="$(grep -E 'Tests run: [0-9]+, Failures' "$log" | tail -1)"
+echo "${summary:-(no surefire summary — build may have failed; see below)}"
+
+# Categorised failure list.
+mapfile -t failing < <(grep -Eo '[a-z0-9._/-]+ - ([0-9]+ comparison failure|JHelm rendering failed)' "$log" | sort -u)
+if [[ ${#failing[@]} -eq 0 ]]; then
+  if grep -q 'BUILD FAILURE' "$log" && [[ -z "$summary" ]]; then
+    echo "${c_red}build failed before tests ran:${c_off}"; grep -E '\[ERROR\]' "$log" | grep -vE 'For more information|Re-run|help' | head -8
+    rm -f "$log"; exit 1
+  fi
+  echo "${c_green}All charts pass.${c_off}"; rm -f "$log"; exit 0
+fi
+
+echo "${c_red}${#failing[@]} failing:${c_off}"
+for f in "${failing[@]}"; do
+  name="${f% - *}"
+  if [[ "$f" == *"JHelm rendering failed"* ]]; then
+    [[ $fails_only -eq 1 ]] && { echo "$name"; continue; }
+    printf '  %sRENDERFAIL%s  %s\n' "$c_red" "$c_off" "$name"
+  else
+    [[ $fails_only -eq 1 ]] && { echo "$name"; continue; }
+    diff="$(grep -A2 "$name - [0-9]* comparison failure" "$log" | grep -E ': expected=|missing in JHelm' | head -1 | sed 's/^[[:space:]]*//' | cut -c1-100)"
+    printf '  %sCOMPFAIL%s    %s  %s%s%s\n' "$c_red" "$c_off" "$name" "$c_dim" "${diff}" "$c_off"
+  fi
+done
+rm -f "$log"
+exit 1

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(.claude/scripts/parity/chart-test.sh:*)",
+      "Bash(.claude/scripts/parity/chart-diff.sh:*)",
+      "Bash(.claude/scripts/parity/parity-run.sh:*)",
+      "Bash(./.claude/scripts/parity/chart-test.sh:*)",
+      "Bash(./.claude/scripts/parity/chart-diff.sh:*)",
+      "Bash(./.claude/scripts/parity/parity-run.sh:*)",
+      "Bash(python3 .claude/scripts/fix_fqn.py:*)",
+      "Bash(python3 .claude/scripts/fix_violations.py:*)",
+      "Bash(python3 .claude/scripts/test_500_charts.py:*)"
+    ]
+  }
+}


### PR DESCRIPTION
Reusable scripts that automate the repetitive jhelm ↔ `helm template` parity loop used to drive `charts.csv` toward the 0.1.0 conformance gate, plus a permission allowlist so they don't trip per-command prompts.

## Scripts (`.claude/scripts/parity/`)
| Script | Purpose |
|--------|---------|
| `chart-test.sh` | Test candidate charts → categorised **PASS / COMPFAIL / RENDERFAIL / FETCHFAIL / HELMFAIL / DUP** (with first diff). Skips charts already in `charts.csv`. Accepts args, `-f file`, or stdin. |
| `chart-diff.sh` | Render one chart and print the full jhelm-vs-helm diff (every diff / missing resource); leaves manifests in `target/test-output/`. |
| `parity-run.sh` | Run the **full** suite over all of `charts.csv` and summarise failures — the definitive regression for engine changes. |
| `lib.sh` | Shared paths, Maven wrappers, surefire-log classifier. |

Each wraps the same Maven invocation `KpsComparisonTest` uses, parses surefire output, and **always restores `single.csv`** on exit (EXIT trap). Smoke-tested: dup-detection, an end-to-end fetch-fail run, and `single.csv` restore.

## Allowlist (`.claude/settings.json`)
Allowlists the three parity scripts and the existing `fix_fqn.py`/`fix_violations.py`/`test_500_charts.py` helpers. Because each script encapsulates a whole multi-command operation (mvnw + grep + sed + restore), one auto-approved call replaces a permission prompt per underlying command. Only these specific project scripts are allowed — not arbitrary `python3`/`bash`.

See `.claude/scripts/parity/README.md` for the full workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)