### PR TITLE
fix(core): instantiate a subchart once per alias (#30, +2 charts)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Chart.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Chart.java
@@ -11,7 +11,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class Chart {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartMetadata.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartMetadata.java
@@ -10,7 +10,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.ChartLoadException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.model.Dependency;
 import org.alexmond.jhelm.core.util.ValuesLoader;
 
 @Slf4j
@@ -80,7 +81,7 @@ public class ChartLoader {
 		}
 
 		// Load dependencies (subcharts)
-		List<Chart> dependencies = loadDependencies(chartDir);
+		List<Chart> dependencies = loadDependencies(chartDir, metadata.getDependencies());
 
 		// Load README
 		String readme = null;
@@ -119,7 +120,7 @@ public class ChartLoader {
 			.build();
 	}
 
-	private List<Chart> loadDependencies(File chartDir) throws IOException {
+	private List<Chart> loadDependencies(File chartDir, List<Dependency> metaDeps) throws IOException {
 		File chartsDir = new File(chartDir, "charts");
 		List<Chart> dependencies = new ArrayList<>();
 		if (!chartsDir.exists() || !chartsDir.isDirectory()) {
@@ -133,9 +134,43 @@ public class ChartLoader {
 					subchart.setAlias(subchartDir.getName());
 				}
 				dependencies.add(subchart);
+				addAliasInstances(dependencies, subchart, metaDeps);
 			}
 		}
 		return dependencies;
+	}
+
+	/**
+	 * Helm stores a subchart aliased multiple times (e.g. grafana-loki aliases the single
+	 * {@code memcached} chart as {@code memcachedfrontend}/{@code memcachedchunks}/…) as
+	 * one directory, instantiated once per alias at render time. The on-disk chart is
+	 * loaded once, so for every alias beyond the first add a copy (with its own metadata)
+	 * addressed by that alias; the base keeps the first alias. A single (or no) alias is
+	 * left to the engine's alias application.
+	 * @param dependencies the dependency list being built (appended to)
+	 * @param base the subchart loaded once from disk
+	 * @param metaDeps the parent's Chart.yaml dependency declarations
+	 */
+	private void addAliasInstances(List<Chart> dependencies, Chart base, List<Dependency> metaDeps) {
+		if (metaDeps == null) {
+			return;
+		}
+		List<Dependency> aliases = new ArrayList<>();
+		for (Dependency dep : metaDeps) {
+			if (base.getMetadata().getName().equals(dep.getName()) && dep.getAlias() != null
+					&& !dep.getAlias().isEmpty()) {
+				aliases.add(dep);
+			}
+		}
+		if (aliases.size() <= 1) {
+			return;
+		}
+		base.setAlias(aliases.get(0).getAlias());
+		for (int i = 1; i < aliases.size(); i++) {
+			ChartMetadata metaCopy = base.getMetadata().toBuilder().build();
+			Chart copy = base.toBuilder().metadata(metaCopy).alias(aliases.get(i).getAlias()).build();
+			dependencies.add(copy);
+		}
 	}
 
 	private void loadTemplatesRecursive(File dir, String path, List<Chart.Template> templates) throws IOException {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -859,12 +859,21 @@ public class Engine {
 		if (deps == null) {
 			return null;
 		}
-		String chartName = subchart.getMetadata().getName();
+		// An exact alias match wins over any name match — when one subchart is aliased
+		// several times (e.g. grafana-loki's memcached -> memcachedfrontend/chunks/…),
+		// the
+		// alias is the only thing that tells the instances apart, so it must be checked
+		// across ALL dependencies before falling back to the chart name.
 		String chartAlias = subchart.getAlias();
-		for (Dependency dep : deps) {
-			if (dep.getAlias() != null && dep.getAlias().equals(chartAlias)) {
-				return dep;
+		if (chartAlias != null) {
+			for (Dependency dep : deps) {
+				if (chartAlias.equals(dep.getAlias())) {
+					return dep;
+				}
 			}
+		}
+		String chartName = subchart.getMetadata().getName();
+		for (Dependency dep : deps) {
 			if (dep.getName().equals(chartName)) {
 				return dep;
 			}

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -305,3 +305,5 @@ bitnami/osclass,bitnami,https://charts.bitnami.com/bitnami
 argo/argo-events,argo,https://argoproj.github.io/argo-helm
 zalando/postgres-operator,zalando,https://opensource.zalando.com/postgres-operator/charts/postgres-operator
 gloo/gloo,gloo,https://storage.googleapis.com/solo-public-helm
+bitnami/grafana-loki,bitnami,https://charts.bitnami.com/bitnami
+kong/ingress,kong,https://charts.konghq.com

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -18,21 +18,16 @@ gitlab/gitlab,gitlab,https://charts.gitlab.io
 # Needs investigation. (#28)
 kyverno/kyverno-policies,kyverno,https://kyverno.github.io/kyverno/
 #
-# bitnami grafana-loki / grafana-mimir: jhelm omits the bundled memcached
-# subcomponents (memcachedfrontend/chunks/index StatefulSet/Service/SA/PDB/NetworkPolicy)
-# and the matching ConfigMap cache stanzas that Helm renders by default. (#30)
-bitnami/grafana-loki,bitnami,https://charts.bitnami.com/bitnami
+# bitnami/grafana-mimir: the multi-alias memcached subcomponents now render (the
+# subchart multi-alias fix), but the mimir.yaml ConfigMap is still mostly empty —
+# jhelm omits ~16 config stanzas (activity_tracker, *_storage, blocks_storage, …)
+# that Helm builds. A separate mimir config-generation gap, not the memcached one.
 bitnami/grafana-mimir,bitnami,https://charts.bitnami.com/bitnami
 #
 # pomerium/pomerium: the per-Deployment config `checksum` annotation differs because
 # the checksummed config embeds generated shared/cookie secrets (randAlphaNum),
 # same #237 class as checksum/* but with a bare `checksum` key.
 pomerium/pomerium,pomerium,https://helm.pomerium.io
-#
-# kong/ingress: jhelm omits the bundled `gateway` subchart resources
-# (Deployment/Service/ServiceAccount for *-gateway*); subchart-enablement gap
-# (same class as the bitnami grafana memcached omission, #30).
-kong/ingress,kong,https://charts.konghq.com
 #
 # redpanda/console: jhelm renders zero resources where Helm renders the console
 # Deployment/Service/ConfigMap/Secret/SA; a top-level conditional-enablement gap.


### PR DESCRIPTION
From the `failed.csv` backlog (#30 — subchart/conditional enablement).

## Bug
Helm stores a subchart that's **aliased several times** (e.g. grafana-loki/mimir alias the single `charts/memcached` as `memcachedfrontend`/`memcachedchunks`/`memcachedindex…`; kong/ingress aliases `kong` as `gateway`) as **one** directory, instantiated once per alias at render time. jhelm loaded the directory once and rendered a single instance, so the other aliases' resources were silently dropped (grafana-loki was missing its `memcachedfrontend` StatefulSet/Service/SA/PDB/NetworkPolicy, etc.).

## Fix
- **`ChartLoader.addAliasInstances`** — when Chart.yaml aliases one loaded subchart more than once, add a copy (its own `ChartMetadata` via `toBuilder`) per extra alias; the base keeps the first alias. `Chart`/`ChartMetadata` get `@Builder(toBuilder = true)`.
- **`Engine.findDependencyMetadata`** — match an exact **alias** across *all* dependencies before falling back to the chart **name**. Previously a name match on an earlier dep beat an alias match on a later dep, so every `memcached*` instance resolved to the first dependency and collapsed via the rendered-charts dedup (the actual reason only one instance rendered).

## Result
- **bitnami/grafana-loki** and **kong/ingress** now byte-identical → moved `failed.csv` → `charts.csv` (**307 → 309**).
- **grafana-mimir**'s memcached subcomponents now render; its remaining failure is an unrelated `mimir.yaml` config-generation gap (re-noted in `failed.csv`).
- **Full comparison suite passes for all 309 charts**; core unit tests + checkstyle/PMD/JaCoCo green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)