### PR TITLE
fix(gotemplate): toString/print of a map matches Go fmt.Sprint (+1 chart)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -307,3 +307,4 @@ zalando/postgres-operator,zalando,https://opensource.zalando.com/postgres-operat
 gloo/gloo,gloo,https://storage.googleapis.com/solo-public-helm
 bitnami/grafana-loki,bitnami,https://charts.bitnami.com/bitnami
 kong/ingress,kong,https://charts.konghq.com
+pomerium/pomerium,pomerium,https://helm.pomerium.io

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -24,11 +24,6 @@ kyverno/kyverno-policies,kyverno,https://kyverno.github.io/kyverno/
 # that Helm builds. A separate mimir config-generation gap, not the memcached one.
 bitnami/grafana-mimir,bitnami,https://charts.bitnami.com/bitnami
 #
-# pomerium/pomerium: the per-Deployment config `checksum` annotation differs because
-# the checksummed config embeds generated shared/cookie secrets (randAlphaNum),
-# same #237 class as checksum/* but with a bare `checksum` key.
-pomerium/pomerium,pomerium,https://helm.pomerium.io
-#
 # redpanda/console: jhelm renders zero resources where Helm renders the console
 # Deployment/Service/ConfigMap/Secret/SA; a top-level conditional-enablement gap.
 redpanda/console,redpanda,https://charts.redpanda.com

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ListFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/ListFunctions.java
@@ -610,7 +610,7 @@ public final class ListFunctions {
 
 	// Go-style stringify so a float64 element renders like helm template (8 -> "8").
 	private static String goStr(Object value) {
-		return (value instanceof Number n) ? GoFmt.number(n) : String.valueOf(value);
+		return GoFmt.sprint(value);
 	}
 
 	private static Function join() {

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctions.java
@@ -138,10 +138,8 @@ public final class MathFunctions {
 			// "null". Charts rely on this, e.g. `eq (toString .x) "<nil>"` to test
 			// whether
 			// a value is unset (opentelemetry-collector.serviceEnabled).
-			if (args[0] == null) {
-				return "<nil>";
-			}
-			return (args[0] instanceof Number n) ? GoFmt.number(n) : String.valueOf(args[0]);
+			// Go's fmt.Sprint: nil -> "<nil>", a map -> "map[k:v …]" (sorted), etc.
+			return GoFmt.sprint(args[0]);
 		};
 	}
 

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/StringFunctions.java
@@ -322,7 +322,7 @@ public final class StringFunctions {
 	// Stringify Go-style so a float64 renders like helm template (8080 -> "8080",
 	// 1000000 -> "1e+06") instead of Java's "8080.0".
 	private static String goStr(Object value) {
-		return (value instanceof Number n) ? GoFmt.number(n) : String.valueOf(value);
+		return GoFmt.sprint(value);
 	}
 
 	private static Function quote() {

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/Functions.java
@@ -727,10 +727,7 @@ public final class Functions {
 	 * {@code fmt.Sprint(nil)} which produces {@code "<nil>"} for nil values.
 	 */
 	static String sprintValue(Object value) {
-		if (value == null) {
-			return "<nil>";
-		}
-		return (value instanceof Number n) ? GoFmt.number(n) : String.valueOf(value);
+		return GoFmt.sprint(value);
 	}
 
 	public static boolean isTrue(Object arg) {

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/GoFmt.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/GoFmt.java
@@ -1,6 +1,12 @@
 package org.alexmond.jhelm.gotemplate;
 
+import java.lang.reflect.Array;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Formats values the way Go's {@code fmt} package does, so template output matches
@@ -18,6 +24,61 @@ import java.math.BigDecimal;
 public final class GoFmt {
 
 	private GoFmt() {
+	}
+
+	/**
+	 * Formats a value the way Go's {@code fmt.Sprint}/{@code %v} does, recursively: a map
+	 * renders as {@code map[k1:v1 k2:v2]} with keys sorted (Go sorts map keys for stable
+	 * output), a slice/array as {@code [e1 e2 e3]}, {@code nil} as {@code <nil>}, numbers
+	 * via {@link #number}, and everything else via {@link String#valueOf}. Used by
+	 * {@code toString}/{@code print}/{@code quote}/… so e.g. {@code toString} of a map
+	 * matches {@code helm template} instead of Java's {@code {k=v}}.
+	 * @param value the value
+	 * @return the Go-formatted string
+	 */
+	public static String sprint(Object value) {
+		if (value == null) {
+			return "<nil>";
+		}
+		if (value instanceof Number n) {
+			return number(n);
+		}
+		if (value instanceof Map<?, ?> map) {
+			List<Map.Entry<?, ?>> entries = new ArrayList<>(map.entrySet());
+			entries.sort(Comparator.comparing((e) -> String.valueOf(e.getKey())));
+			StringBuilder sb = new StringBuilder("map[");
+			for (int i = 0; i < entries.size(); i++) {
+				if (i > 0) {
+					sb.append(' ');
+				}
+				sb.append(sprint(entries.get(i).getKey())).append(':').append(sprint(entries.get(i).getValue()));
+			}
+			return sb.append(']').toString();
+		}
+		if (value instanceof Collection<?> coll) {
+			StringBuilder sb = new StringBuilder("[");
+			boolean first = true;
+			for (Object e : coll) {
+				if (!first) {
+					sb.append(' ');
+				}
+				sb.append(sprint(e));
+				first = false;
+			}
+			return sb.append(']').toString();
+		}
+		if (value.getClass().isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+			int len = Array.getLength(value);
+			for (int i = 0; i < len; i++) {
+				if (i > 0) {
+					sb.append(' ');
+				}
+				sb.append(sprint(Array.get(value, i)));
+			}
+			return sb.append(']').toString();
+		}
+		return String.valueOf(value);
 	}
 
 	/**

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/exec/ValuePrinter.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/exec/ValuePrinter.java
@@ -2,8 +2,6 @@ package org.alexmond.jhelm.gotemplate.exec;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Collection;
-import java.util.Map;
 
 import org.alexmond.jhelm.gotemplate.GoFmt;
 
@@ -12,65 +10,17 @@ final class ValuePrinter {
 	private ValuePrinter() {
 	}
 
+	/**
+	 * Writes a value to output the way Go's {@code fmt.Sprint} would: a values
+	 * {@code float64} uses Go's %g ({@code 1000000 -> 1e+06}), a map renders as
+	 * {@code map[k:v …]} with sorted keys, a slice as {@code [a b c]}. A {@code null}
+	 * renders nothing (Go's text/template prints an absent action as empty here).
+	 */
 	static void printValue(Writer writer, Object value) throws IOException {
 		if (value == null) {
 			return;
 		}
-		if (value instanceof String s) {
-			writer.write(s);
-		}
-		else if (value instanceof Number || value instanceof Boolean) {
-			writer.write(formatScalar(value));
-		}
-		else if (value instanceof Collection<?> coll) {
-			printCollection(writer, coll);
-		}
-		else if (value instanceof Map<?, ?> map) {
-			printMap(writer, map);
-		}
-		else {
-			writer.write("[object " + value.getClass().getSimpleName() + "]");
-		}
-	}
-
-	private static void printCollection(Writer writer, Collection<?> coll) throws IOException {
-		// Match Go's fmt.Sprint format: [item1 item2 item3]
-		writer.write("[");
-		boolean first = true;
-		for (Object item : coll) {
-			if (!first) {
-				writer.write(" ");
-			}
-			writer.write(formatScalar(item));
-			first = false;
-		}
-		writer.write("]");
-	}
-
-	private static void printMap(Writer writer, Map<?, ?> map) throws IOException {
-		// Match Go's fmt.Sprint format: map[key1:val1 key2:val2]
-		writer.write("map[");
-		boolean first = true;
-		for (Map.Entry<?, ?> e : map.entrySet()) {
-			if (!first) {
-				writer.write(" ");
-			}
-			writer.write(formatScalar(e.getKey()) + ":" + formatScalar(e.getValue()));
-			first = false;
-		}
-		writer.write("]");
-	}
-
-	/**
-	 * Format a value to match Go's {@code fmt.Sprint}. Numbers are formatted by
-	 * {@link GoFmt#number} (a values {@code float64} uses Go's %g, so e.g.
-	 * {@code 1000000 -> 1e+06}); other types fall back to {@link String#valueOf}.
-	 */
-	static String formatScalar(Object value) {
-		if (value instanceof Number n) {
-			return GoFmt.number(n);
-		}
-		return String.valueOf(value);
+		writer.write(GoFmt.sprint(value));
 	}
 
 }

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/exec/ValuePrinterTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/exec/ValuePrinterTest.java
@@ -55,6 +55,16 @@ class ValuePrinterTest {
 	}
 
 	@Test
+	void testMapKeysSortedLikeGoFmt() throws Exception {
+		// Go's fmt.Sprint sorts map keys for stable output; insertion order is b,c,a.
+		java.util.LinkedHashMap<String, Object> m = new java.util.LinkedHashMap<>();
+		m.put("b", 2);
+		m.put("c", 3);
+		m.put("a", 1);
+		assertEquals("map[a:1 b:2 c:3]", render("{{ .val }}", Map.of("val", m)));
+	}
+
+	@Test
 	void testStringConcatenation() throws Exception {
 		Map<String, Object> data = Map.of("val", 1.0);
 		assertEquals("value=1", render("value={{ .val }}", data));


### PR DESCRIPTION
From the `failed.csv` backlog (pomerium).

## Bug
Go's `fmt.Sprint` renders a map as `map[k1:v1 k2:v2]` with keys **sorted** (stable output) and a slice as `[a b c]`. jhelm stringified composites via Java's `String.valueOf` (`{k=v}`, **insertion order**) for `toString`/`print`/`quote`/`join`, and printed maps **unsorted** for direct `{{ }}` output.

That's a *deterministic* divergence, so anything derived from it differed. pomerium hashes `print … (toString .Values.authenticate.idp) … (toString .Values.databroker.storage)` into each Deployment's `checksum` annotation — so all four pods got a different checksum than Helm (not per-render randomness; the values were stable).

## Fix
Add `GoFmt.sprint` — recursive Go `fmt.Sprint`: sorted-key `map[…]`, `[…]` slices/arrays, `<nil>`, numbers via the existing `%g` path, everything else `String.valueOf`. Route **every** composite-stringifying site through it: `ValuePrinter` (direct output), `toString`, `print`/`println`, and the `quote`/`squote`/`cat`/`join` helpers. **`toYaml`/`toJson` are untouched** (JSON/YAML serialisation, not `fmt`).

## Result
- **pomerium/pomerium** byte-identical → `failed.csv` → `charts.csv` (**309 → 310**).
- **Full comparison suite passes for all 310 charts**, no regressions; module unit tests + checkstyle/PMD/JaCoCo green. Added a sorted-map unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)