### PR TITLE
fix(core): expose .Chart.KubeVersion (#28, +1 chart)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartMetadata.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartMetadata.java
@@ -28,6 +28,11 @@ public class ChartMetadata {
 
 	private String appVersion;
 
+	// The chart's supported Kubernetes version range from Chart.yaml (Helm's
+	// .Chart.KubeVersion), e.g. ">=1.25.0-0". Charts interpolate it directly, e.g.
+	// kyverno-policies' `default .Chart.KubeVersion .Values.kubeVersionOverride`.
+	private String kubeVersion;
+
 	private List<Dependency> dependencies;
 
 	private Map<String, String> annotations;

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -308,3 +308,4 @@ gloo/gloo,gloo,https://storage.googleapis.com/solo-public-helm
 bitnami/grafana-loki,bitnami,https://charts.bitnami.com/bitnami
 kong/ingress,kong,https://charts.konghq.com
 pomerium/pomerium,pomerium,https://helm.pomerium.io
+kyverno/kyverno-policies,kyverno,https://kyverno.github.io/kyverno/

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -12,12 +12,6 @@
 # object is missing a couple of listeners, and a test-hook Pod has a random name suffix.
 gitlab/gitlab,gitlab,https://charts.gitlab.io
 #
-# kyverno-policies: several ClusterPolicy resources carry a
-# `kyverno.io/kubernetes-version` annotation (e.g. ">=1.25.0-0") that jhelm renders
-# empty. The value comes from each policy's own annotations block; jhelm drops it.
-# Needs investigation. (#28)
-kyverno/kyverno-policies,kyverno,https://kyverno.github.io/kyverno/
-#
 # bitnami/grafana-mimir: the multi-alias memcached subcomponents now render (the
 # subchart multi-alias fix), but the mimir.yaml ConfigMap is still mostly empty —
 # jhelm omits ~16 config stanzas (activity_tracker, *_storage, blocks_storage, …)


### PR DESCRIPTION
From the `failed.csv` backlog (#28).

## Bug
`ChartMetadata` didn't parse Chart.yaml's `kubeVersion` field, so `.Chart.KubeVersion` rendered empty. kyverno-policies stamps every ClusterPolicy with:
```
kyverno.io/kubernetes-version: "{{ default .Chart.KubeVersion .Values.kubeVersionOverride }}"
```
so all 11 policies lost the `>=1.25.0-0` annotation Helm emits.

## Fix
Add the `kubeVersion` field to `ChartMetadata` — Jackson parses it from Chart.yaml, and the existing `.Chart.*` field resolver exposes it as `.Chart.KubeVersion` (same path as `.Chart.AppVersion`).

Unblocks **kyverno/kyverno-policies** (`failed.csv` → `charts.csv`, **310 → 311**). Full comparison suite passes for all 311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)