### PR TITLE
Enable victoria-metrics-distributed (311 -> 312)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -309,3 +309,4 @@ bitnami/grafana-loki,bitnami,https://charts.bitnami.com/bitnami
 kong/ingress,kong,https://charts.konghq.com
 pomerium/pomerium,pomerium,https://helm.pomerium.io
 kyverno/kyverno-policies,kyverno,https://kyverno.github.io/kyverno/
+victoria-metrics/victoria-metrics-distributed,vm,https://victoriametrics.github.io/helm-charts

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -31,6 +31,3 @@ yugabyte/yugabyte,yugabyte,https://charts.yugabyte.com
 # redpanda/operator: jhelm renders zero resources where Helm renders the full
 # operator (Deployment/RBAC/Job/etc.); conditional-enablement gap (as redpanda/console).
 redpanda/operator,redpanda,https://charts.redpanda.com
-#
-# victoria-metrics-distributed: jhelm omits one VMRule (victoria-node.rules).
-victoria-metrics/victoria-metrics-distributed,vm,https://victoriametrics.github.io/helm-charts


### PR DESCRIPTION
The missing VMRule now renders after the recent engine fixes (float64 value model / Go fmt.Sprint / multi-alias subcharts). Verified byte-identical; moved `failed.csv` → `charts.csv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)