### PR TITLE
Fix `:=` block-scoping in Executor (Go text/template semantics)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/exec/Executor.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/exec/Executor.java
@@ -59,6 +59,30 @@ public class Executor {
 	// Variable storage for template execution context
 	private final Map<String, Object> variables = new HashMap<>();
 
+	// Block-scope undo logs. Each {{if}}/{{with}}/range-iteration pushes a frame; a `:=`
+	// declaration inside records how to undo itself, so the declaration is unwound when
+	// the
+	// block exits (Go scopes `:=` to its block). `=` assignments are not logged and
+	// persist.
+	private final java.util.Deque<List<ScopeUndo>> scopeStack = new java.util.ArrayDeque<>();
+
+	private void pushScope() {
+		scopeStack.push(new ArrayList<>());
+	}
+
+	private void popScope() {
+		List<ScopeUndo> frame = scopeStack.pop();
+		for (int i = frame.size() - 1; i >= 0; i--) {
+			ScopeUndo u = frame.get(i);
+			if (u.existed()) {
+				variables.put(u.name(), u.previous());
+			}
+			else {
+				variables.remove(u.name());
+			}
+		}
+	}
+
 	// Root data for $ variable
 	private Object rootData;
 
@@ -169,12 +193,21 @@ public class Executor {
 
 	private void writeIf(Writer writer, IfNode ifNode, Object data, BeanInfo beanInfo)
 			throws IOException, TemplateExecutionException, TemplateNotFoundException {
-		Object value = executePipe(ifNode.getPipeNode(), data, beanInfo);
-		if (isTrue(value)) {
-			writeNode(writer, ifNode.getIfListNode(), data, beanInfo);
+		// `{{ if $x := … }}` scopes the declaration to the if/else; body `:=`
+		// declarations
+		// are block-scoped too. Push a scope over the whole construct and unwind on exit.
+		pushScope();
+		try {
+			Object value = executePipe(ifNode.getPipeNode(), data, beanInfo);
+			if (isTrue(value)) {
+				writeNode(writer, ifNode.getIfListNode(), data, beanInfo);
+			}
+			else if (ifNode.getElseListNode() != null) {
+				writeNode(writer, ifNode.getElseListNode(), data, beanInfo);
+			}
 		}
-		else if (ifNode.getElseListNode() != null) {
-			writeNode(writer, ifNode.getElseListNode(), data, beanInfo);
+		finally {
+			popScope();
 		}
 	}
 
@@ -319,6 +352,11 @@ public class Executor {
 	 */
 	private boolean writeRangeItem(Writer writer, RangeNode rangeNode, Object value)
 			throws IOException, TemplateExecutionException, TemplateNotFoundException {
+		// Each iteration body is its own scope, so a `:=` inside does not leak to the
+		// next
+		// iteration or past the range (the loop variables themselves are managed
+		// separately).
+		pushScope();
 		try {
 			writeRangeValue(writer, rangeNode, value);
 		}
@@ -327,6 +365,9 @@ public class Executor {
 		}
 		catch (BreakSignal ex) {
 			return true;
+		}
+		finally {
+			popScope();
 		}
 		return false;
 	}
@@ -346,13 +387,19 @@ public class Executor {
 
 	private void writeWith(Writer writer, WithNode withNode, Object data, BeanInfo beanInfo)
 			throws IOException, TemplateExecutionException, TemplateNotFoundException {
-		Object value = executePipe(withNode.getPipeNode(), data, beanInfo);
-		if (isTrue(value)) {
-			BeanInfo valueBeanInfo = getBeanInfo(value);
-			writeNode(writer, withNode.getIfListNode(), value, valueBeanInfo);
+		pushScope();
+		try {
+			Object value = executePipe(withNode.getPipeNode(), data, beanInfo);
+			if (isTrue(value)) {
+				BeanInfo valueBeanInfo = getBeanInfo(value);
+				writeNode(writer, withNode.getIfListNode(), value, valueBeanInfo);
+			}
+			else if (withNode.getElseListNode() != null) {
+				writeNode(writer, withNode.getElseListNode(), data, beanInfo);
+			}
 		}
-		else if (withNode.getElseListNode() != null) {
-			writeNode(writer, withNode.getElseListNode(), data, beanInfo);
+		finally {
+			popScope();
 		}
 	}
 
@@ -367,9 +414,13 @@ public class Executor {
 
 		Object value = executePipe(templateNode.getPipeNode(), data, beanInfo);
 		BeanInfo valueBeanInfo = (value != null) ? getBeanInfo(value) : null;
-		// Go resets $ and clears outer variables when entering a nested template
+		// Go resets $ and clears outer variables when entering a nested template; its
+		// block
+		// scopes belong to the callee, so swap in a fresh scope stack too.
 		Map<String, Object> savedVariables = new HashMap<>(this.variables);
+		java.util.Deque<List<ScopeUndo>> savedScopes = new java.util.ArrayDeque<>(this.scopeStack);
 		this.variables.clear();
+		this.scopeStack.clear();
 		this.variables.put("$", value);
 		try {
 			writeNode(writer, listNode, value, valueBeanInfo);
@@ -377,6 +428,8 @@ public class Executor {
 		finally {
 			this.variables.clear();
 			this.variables.putAll(savedVariables);
+			this.scopeStack.clear();
+			this.scopeStack.addAll(savedScopes);
 		}
 	}
 
@@ -405,6 +458,13 @@ public class Executor {
 			for (VariableNode variable : pipeNode.getVariables()) {
 				if (variable != null) {
 					String varName = variable.getIdentifier(0);
+					// A `:=` declaration inside a block records an undo entry so it is
+					// unwound on block exit (Go scopes it to the block). A top-level
+					// declaration (no open scope) and any `=` assignment just persist.
+					if (pipeNode.isDeclare() && !scopeStack.isEmpty()) {
+						scopeStack.peek()
+							.add(new ScopeUndo(varName, variables.containsKey(varName), variables.get(varName)));
+					}
 					// Store the value even if it's null or empty string, matching Helm
 					// behavior
 					variables.put(varName, value);
@@ -875,6 +935,12 @@ public class Executor {
 
 	private void printValue(Writer writer, Object value) throws IOException {
 		ValuePrinter.printValue(writer, value);
+	}
+
+	// One block-scoped `:=` declaration's undo record: restore {@code previous} if the
+	// name
+	// {@code existed} before the declaration, otherwise remove it, when the block exits.
+	private record ScopeUndo(String name, boolean existed, Object previous) {
 	}
 
 }

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/parse/Parser.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/parse/Parser.java
@@ -496,6 +496,13 @@ public class Parser {
 
 		switch (nextToken.type()) {
 			case ASSIGN:
+				// `$x = …` updates an existing variable (persists past the block),
+				// unlike `:=` which declares a block-scoped one.
+				pipeNode.setDeclare(false);
+				moveToNextNonSpaceToken(lexer, state);
+				pipeNode.append(new VariableNode(variableToken.value()));
+				state.variables.add(variableToken.value());
+				break;
 			case DECLARE:
 				moveToNextNonSpaceToken(lexer, state);
 				pipeNode.append(new VariableNode(variableToken.value()));

--- a/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/parse/PipeNode.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/jhelm/gotemplate/parse/PipeNode.java
@@ -16,8 +16,17 @@ public class PipeNode implements Node {
 
 	private final List<CommandNode> commands = new LinkedList<>();
 
+	// true for a `:=` declaration (and range vars), false for a `=` assignment. A
+	// declaration is scoped to its enclosing block; an assignment updates the existing
+	// variable and persists past the block (Go text/template semantics).
+	private boolean declare = true;
+
 	public PipeNode(String context) {
 		this.context = context;
+	}
+
+	public void setDeclare(boolean declare) {
+		this.declare = declare;
 	}
 
 	public void append(VariableNode variableNode) {

--- a/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/VariableScopingTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/jhelm/gotemplate/VariableScopingTest.java
@@ -1,0 +1,53 @@
+package org.alexmond.jhelm.gotemplate;
+
+import java.io.StringWriter;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Go text/template variable scoping: {@code :=} is block-scoped, {@code =} persists. */
+class VariableScopingTest {
+
+	private String render(String t) throws Exception {
+		return render(t, Map.of());
+	}
+
+	private String render(String t, Map<String, Object> data) throws Exception {
+		GoTemplate tmpl = new GoTemplate();
+		tmpl.parse("p", t);
+		StringWriter w = new StringWriter();
+		tmpl.execute(data, w);
+		return w.toString();
+	}
+
+	@Test
+	void declareInIfBlockDoesNotLeakToOuter() throws Exception {
+		// `:=` inside {{if}} is scoped to the block; the outer $x is restored after
+		// {{end}}.
+		assertEquals("inner=inner after=outer", render(
+				"{{- $x := \"outer\" -}}{{ if true }}{{ $x := \"inner\" }}inner={{ $x }} {{ end }}after={{ $x }}"));
+	}
+
+	@Test
+	void assignInIfBlockPersists() throws Exception {
+		// `=` updates the existing variable and persists past the block (accumulator
+		// pattern).
+		assertEquals("after=set", render("{{- $x := \"\" -}}{{ if true }}{{ $x = \"set\" }}{{ end }}after={{ $x }}"));
+	}
+
+	@Test
+	void declareInRangeDoesNotLeakPastRange() throws Exception {
+		// `:=` inside a range body must not leak to a read after the range.
+		assertEquals("[ab]outer",
+				render("{{- $x := \"outer\" -}}[{{ range $i := .items }}{{ $x := $i }}{{ $x }}{{ end }}]{{ $x }}",
+						Map.of("items", java.util.List.of("a", "b"))));
+	}
+
+	@Test
+	void nestedDeclareShadowsThenRestores() throws Exception {
+		assertEquals("a b a",
+				render("{{- $x := \"a\" -}}{{ $x }}{{ if true }} {{ $x := \"b\" }}{{ $x }}{{ end }} {{ $x }}"));
+	}
+
+}


### PR DESCRIPTION
## What

Go text/template scopes a `:=` **declaration** to its enclosing block — the variable is restored to its prior value (or removed entirely) when the `{{if}}`, `{{with}}`, or `{{range}}` block exits. A `=` **assignment** instead updates the existing variable and persists past the block:

```gotmpl
{{ $x := "outer" }}{{ if true }}{{ $x := "inner" }}{{ end }}{{ $x }}   → outer   (declare, scoped)
{{ $x := "" }}{{ if true }}{{ $x = "set" }}{{ end }}{{ $x }}            → set     (assign, persists)
```

jhelm used a single flat `variables` map and the parser did not distinguish `DECLARE` (`:=`) from `ASSIGN` (`=`), so a `:=` inside a block leaked to the outer scope.

## How

- **PipeNode** — add a `declare` flag (`true` for `:=`, `false` for `=`).
- **Parser** — set `declare=false` on the `ASSIGN` branch; `DECLARE` keeps the default.
- **Executor** — maintain a scope stack. On entering `if`/`with`/`range`, push a frame; record an undo entry (prior value, or absence) for each in-block `:=`; replay the frame in reverse on block exit. `writeTemplate` saves/clears/restores the stack alongside `variables`, matching the existing variable-isolation boundary for `{{ template }}` calls.

## Tests

New `VariableScopingTest`: declare-doesn't-leak, assign-persists (accumulator), range-scope-doesn't-leak, nested-shadow-then-restore. Module unit tests green.

This is the yugabyte scoping gap (#32). It makes `yugabyted-ui-service` render. The **full 312-chart `helm template` comparison suite passes with zero regressions.** (yugabyte itself stays in `failed.csv` — it has a separate, unrelated manifest-splitter divergence around inline `--- # comment` separators.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)