### PR TITLE
Fix manifest splitter for inline `--- # comment` separators (closes yugabyte)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -202,43 +202,31 @@ public class Engine {
 			return manifest;
 		}
 
-		// Normalize the manifest first - ensure it doesn't start/end with ---
 		String normalized = manifest.trim();
 
-		// Fix any ---# patterns (separator immediately followed by comment)
-		// This happens when templates use {{- if -}} around separators
-		normalized = normalized.replace("---#", "---\n#");
-
-		// Remove leading --- if present
-		while (normalized.startsWith("---")) {
-			normalized = normalized.substring(3).trim();
-		}
-
-		// Remove trailing --- if present
-		while (normalized.endsWith("---")) {
-			normalized = normalized.substring(0, normalized.length() - 3).trim();
-		}
-
-		// Split by YAML document separator patterns:
-		// 1. \n---\n (standard separator with blank line)
-		// 2. \n--- followed by newline with content (template-generated separator)
-		// Trailing whitespace after the --- is allowed (YAML treats "--- " as a
-		// separator;
-		// some charts emit it literally), otherwise the following resource is glued onto
-		// the previous document and disappears from the resource set.
-		String[] docs = normalized.split("\\n---[ \\t]*(?=\\n)");
+		// Split on YAML document separators the way Helm does. Helm's splitter
+		// (regexp "(?:^|\\s*\\n)---\\s*") treats any line that begins with "---" as a
+		// separator and consumes the trailing whitespace, so an inline "--- # comment"
+		// (e.g. yugabyte's templates/secrets.yaml) is a separator whose comment becomes
+		// the next document's content — the preceding resource is terminated cleanly.
+		// Splitting only on a "---" alone on its own line glued such inline separators
+		// onto the previous document (producing "------ # comment"), corrupting it so it
+		// no longer parsed as a resource. The "---" must be at column 0; an indented
+		// "---" inside a block scalar is content, not a separator (Helm behaves the
+		// same).
+		String[] docs = normalized.split("(?m)^---[ \\t]*");
 		StringBuilder cleaned = new StringBuilder();
 
 		for (String doc : docs) {
-			String trimmed = doc.trim();
-			// Skip empty documents, standalone separators, and documents that are just
-			// comments after a separator
-			if (!trimmed.isEmpty() && !trimmed.equals("---") && !trimmed.startsWith("---")) {
-				if (cleaned.length() > 0) {
-					cleaned.append("\n---\n");
-				}
-				cleaned.append(trimmed);
+			String trimmed = doc.strip();
+			// Skip empty documents and comment-only documents (no resource content).
+			if (trimmed.isEmpty() || isCommentOnly(trimmed)) {
+				continue;
 			}
+			if (cleaned.length() > 0) {
+				cleaned.append("\n---\n");
+			}
+			cleaned.append(trimmed);
 		}
 
 		// Add final newline if there's content
@@ -247,6 +235,20 @@ public class Engine {
 		}
 
 		return cleaned.toString();
+	}
+
+	/**
+	 * @return {@code true} if every non-blank line of the document is a YAML comment, so
+	 * the document carries no resource content and can be dropped
+	 */
+	private boolean isCommentOnly(String doc) {
+		for (String line : doc.split("\n")) {
+			String stripped = line.strip();
+			if (!stripped.isEmpty() && !stripped.startsWith("#")) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private void collectNamedTemplates(Chart chart) {

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -310,3 +310,4 @@ kong/ingress,kong,https://charts.konghq.com
 pomerium/pomerium,pomerium,https://helm.pomerium.io
 kyverno/kyverno-policies,kyverno,https://kyverno.github.io/kyverno/
 victoria-metrics/victoria-metrics-distributed,vm,https://victoriametrics.github.io/helm-charts
+yugabyte/yugabyte,yugabyte,https://charts.yugabyte.com

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -22,12 +22,6 @@ bitnami/grafana-mimir,bitnami,https://charts.bitnami.com/bitnami
 # Deployment/Service/ConfigMap/Secret/SA; a top-level conditional-enablement gap.
 redpanda/console,redpanda,https://charts.redpanda.com
 #
-# yugabyte/yugabyte: renders end-to-end now (the printf wrong-type marker fix removed
-# the `%d`-of-string crash), but still omits two serviceEndpoints Services
-# (yb-tserver-service, yugabyted-ui-service) -- a deep service-scope conditional gap
-# in service-endpoints.yaml (`if eq $service "true"` over an include result). (#32)
-yugabyte/yugabyte,yugabyte,https://charts.yugabyte.com
-#
 # redpanda/operator: jhelm renders zero resources where Helm renders the full
 # operator (Deployment/RBAC/Job/etc.); conditional-enablement gap (as redpanda/console).
 redpanda/operator,redpanda,https://charts.redpanda.com


### PR DESCRIPTION
## What

Helm splits rendered manifests with the regex `(?:^|\s*\n)---\s*`: any line beginning with `---` is a document separator, and the trailing whitespace is consumed — so an inline `--- # comment` is a separator whose comment becomes the *next* document's content, and the preceding resource is terminated cleanly.

`yugabyte`'s `templates/secrets.yaml` emits exactly this:

```gotmpl
{{- $root := . -}}
--- # Create secrets from other namespaces for masters.
{{- include "yugabyte.envsecrets" $data }}
--- # Create secrets from other namespaces for tservers.
```

jhelm's `cleanManifest` split only on a `---` **alone on its own line** (`\n---[ \t]*(?=\n)`), so the inline `--- # comment` was not recognized and got glued onto the previous document, producing `------ # comment` (six dashes). That corrupted the preceding resource so it no longer parsed as YAML — `yugabyte`'s `Service/yb-tserver-service` silently vanished from the resource set (reported "missing in JHelm").

## How

- Split on `(?m)^---[ \t]*` instead — a column-0 `---` plus trailing horizontal whitespace, matching Helm. An **indented** `---` inside a block scalar stays content (Helm behaves identically; its `---` must also follow a newline at column 0).
- Drop empty and comment-only documents via a new `isCommentOnly` helper (jhelm emits no `# Source:` headers; the comparison is semantic).
- Removes the old ad-hoc `---#` replace and leading/trailing `---` strip loops — the new split + per-chunk `strip()` subsumes them.

## Result

Full **313-chart** `helm template` comparison suite passes with **zero regressions**. `EngineTest` (98 tests) green. Promotes `yugabyte/yugabyte` from `failed.csv` to `charts.csv` (312 → 313).

🤖 Generated with [Claude Code](https://claude.com/claude-code)