### PR TITLE
ci: per-module UniTrack reporting (split-by-module)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
           url: ${{ vars.UNITRACK_URL }}
           token: ${{ secrets.UNITRACK_TOKEN }}
           # soft-fail: reporting to UniTrack must never fail the build.
+          split-by-module: "true"
           # jhelm's tests embed full rendered charts in surefire system-out — ~GBs of XML,
           # >100MB even gzipped. Until surefire <redirectTestOutputToFile>true</...> trims that
           # (or you shard per-module with a shared run-key), upload coverage for everything plus


### PR DESCRIPTION
Adds split-by-module so each module reports as its own UniTrack coverage component, plus a rollup.