### PR TITLE
Support gotohelm charts: .Values.AsMap + Helm reverse define-order (closes redpanda console/operator)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Values.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Values.java
@@ -1,0 +1,34 @@
+package org.alexmond.jhelm.core.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Implements Helm's {@code .Values} template object. Helm exposes {@code .Values} as
+ * {@code chartutil.Values}, a {@code map[string]interface{}} that <em>also</em> carries
+ * an {@code AsMap()} method returning the underlying map.
+ *
+ * <p>
+ * Charts transpiled by {@code gotohelm} (e.g. redpanda's console and operator) rely on
+ * {@code {{ $dot.Values.AsMap }}} to obtain the raw values map. Modelling {@code .Values}
+ * as a plain map made {@code .AsMap} an absent key that resolved to {@code nil}, so every
+ * value read downstream came back null. Like {@link ChartFiles}, this is a map that also
+ * exposes a helper method; the template executor resolves {@code AsMap} by name (falling
+ * back from map-key lookup) once the key is absent.
+ */
+@SuppressWarnings("PMD.MethodNamingConventions")
+public class Values extends HashMap<String, Object> {
+
+	public Values(Map<String, Object> values) {
+		super(values);
+	}
+
+	/**
+	 * @return the underlying values map (this instance), matching
+	 * {@code chartutil.Values.AsMap()}
+	 */
+	public Map<String, Object> AsMap() {
+		return this;
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartFiles;
 import org.alexmond.jhelm.core.model.Dependency;
+import org.alexmond.jhelm.core.model.Values;
 import org.alexmond.jhelm.core.model.VersionSet;
 
 @Slf4j
@@ -287,13 +288,23 @@ public class Engine {
 			if (aExtra != bExtra) {
 				return aExtra ? -1 : 1;
 			}
-			// Within a group, parse in Helm's full-path order so that a same-name define
-			// shared by distinct subcharts (e.g. gitlab's umbrella vs openbao
-			// gitlab.gatewayApi.route.enabled) resolves to the same winner as Helm.
+			// Reproduce Helm's same-name define winner (last Parse wins). Two rules,
+			// both verified against `helm template`:
+			// * Across directories (parent templates/ vs subchart charts/<x>/templates/):
+			// ascending directory order, so the parent's define is parsed last and wins
+			// (e.g. gitlab umbrella vs openbao; define-order regression #21).
+			// * Within one directory: the alphabetically SMALLER filename wins, so parse
+			// filenames in DESCENDING order (the smaller is parsed last). This is how
+			// one chart shipping two files for the same template resolves — e.g. redpanda
+			// console's _console.serviceaccount.tpl beats the stale
+			// _serviceaccount.go.tpl.
+			// Directory-then-reverse-filename is a proper total order (transitive).
 			String aPath = templateFullPath.getOrDefault(a, a);
 			String bPath = templateFullPath.getOrDefault(b, b);
-			int cmp = aPath.compareTo(bPath);
-			return (cmp != 0) ? cmp : a.compareTo(b);
+			String aDir = aPath.substring(0, aPath.lastIndexOf('/') + 1);
+			String bDir = bPath.substring(0, bPath.lastIndexOf('/') + 1);
+			int dirCmp = aDir.compareTo(bDir);
+			return (dirCmp != 0) ? dirCmp : bPath.compareTo(aPath);
 		}).toList();
 
 		for (String name : sortedNames) {
@@ -536,6 +547,10 @@ public class Engine {
 			}
 		}
 
+		// Wrap as Helm's chartutil.Values so `.Values.AsMap` resolves (gotohelm charts
+		// such as redpanda's console/operator read the raw map via {{ .Values.AsMap }}).
+		mergedValues = new Values(mergedValues);
+
 		Map<String, Object> context = new HashMap<>();
 		context.put("Values", mergedValues);
 		context.put("Chart", chart.getMetadata());
@@ -562,7 +577,7 @@ public class Engine {
 					new HashMap<>());
 			Map<String, Object> subchartContext = new HashMap<>();
 			subchartContext.put("Chart", dep.getMetadata());
-			subchartContext.put("Values", subchartValues);
+			subchartContext.put("Values", new Values(subchartValues));
 			subchartContext.put("Release", releaseInfo);
 			subcharts.put(depKey, subchartContext);
 		}

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -66,6 +66,12 @@ jhelmtest:
       - resource: "ConfigMap/*"
         path: "data.config.yaml.login_token.signing_key"
         reason: "signing_key is a randAlphaNum value regenerated per render"
+    "[redpanda/console]":
+      # The JWT signing key defaults to randAlphaNum 32 when unset (chart.DotToState),
+      # so Helm and jhelm each generate a different value every render.
+      - resource: "Secret/*"
+        path: "stringData.authentication-jwt-signingkey"
+        reason: "JWT signing key is a randAlphaNum value generated per render"
   # Value overrides for charts that Helm cannot render with default values. The same
   # overrides are applied to both Helm and jhelm, so any divergence is a real jhelm bug.
   comparison-values:

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -311,3 +311,5 @@ pomerium/pomerium,pomerium,https://helm.pomerium.io
 kyverno/kyverno-policies,kyverno,https://kyverno.github.io/kyverno/
 victoria-metrics/victoria-metrics-distributed,vm,https://victoriametrics.github.io/helm-charts
 yugabyte/yugabyte,yugabyte,https://charts.yugabyte.com
+redpanda/console,redpanda,https://charts.redpanda.com
+redpanda/operator,redpanda,https://charts.redpanda.com

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -17,11 +17,3 @@ gitlab/gitlab,gitlab,https://charts.gitlab.io
 # jhelm omits ~16 config stanzas (activity_tracker, *_storage, blocks_storage, …)
 # that Helm builds. A separate mimir config-generation gap, not the memcached one.
 bitnami/grafana-mimir,bitnami,https://charts.bitnami.com/bitnami
-#
-# redpanda/console: jhelm renders zero resources where Helm renders the console
-# Deployment/Service/ConfigMap/Secret/SA; a top-level conditional-enablement gap.
-redpanda/console,redpanda,https://charts.redpanda.com
-#
-# redpanda/operator: jhelm renders zero resources where Helm renders the full
-# operator (Deployment/RBAC/Job/etc.); conditional-enablement gap (as redpanda/console).
-redpanda/operator,redpanda,https://charts.redpanda.com


### PR DESCRIPTION
## What

`redpanda/console` and `redpanda/operator` are `gotohelm`-transpiled (Go → Helm) charts. Both previously rendered as a single all-`null` Service with the rest of the resources missing. Two distinct engine gaps were responsible — fixing them closes **both** charts.

## Root causes

**1. `.Values.AsMap` returned nil.** Helm exposes `.Values` as `chartutil.Values`, a `map[string]interface{}` that *also* carries an `AsMap()` method. gotohelm's generated code obtains the raw map via `{{ $dot.Values.AsMap }}` (`chart.DotToState`). jhelm modelled `.Values` as a plain map, so `.AsMap` was an absent key → `nil`, and every value read downstream came back null.

*Fix:* a `Values` map subclass exposing a no-arg `AsMap()` that returns itself — mirroring the existing `.Files`/`ChartFiles` pattern. The executor's existing "fall back to a no-arg helper method when the map key is absent" logic resolves it with no change to the gotemplate module. Both the per-chart and per-subchart `.Values` contexts are wrapped.

**2. Same-directory duplicate-define winner was backwards.** When two files in the same `templates/` dir define the same template, Helm's last-`Parse`-wins makes the alphabetically **smaller** filename win — verified against `helm template` (`_aaa.tpl` beats `_bbb.tpl`). console ships **both** `_console.serviceaccount.tpl` (the current `RenderState` API) and a stale `_serviceaccount.go.tpl`. Helm uses the former; jhelm (forward order) used the latter, which reads `$state.Values.AsMap` — nil on the internal merge map — and dropped the `ServiceAccount`.

*Fix:* order the define-parse by **directory ascending, then filename descending**, so within a directory the smaller filename is parsed last and wins, while a parent chart's define still beats a subchart's (the parent `templates/` dir sorts after the subchart `charts/<x>/templates/` dir). This is a proper total order and keeps the #21 umbrella-vs-subchart regression (`DefineOrderTest`) green.

## Tests

The JWT signing key defaults to `randAlphaNum 32` per render, so it's added to `comparison-ignores` like other per-render randomness. **Full 315-chart `helm template` comparison suite + all 495 jhelm-core unit tests pass with zero regressions**; `validate` (checkstyle/PMD) clean. Promotes `redpanda/console` and `redpanda/operator` from `failed.csv` to `charts.csv` (313 → 315).

🤖 Generated with [Claude Code](https://claude.com/claude-code)