### PR TITLE
fromYaml: allow duplicate keys (last wins) and surface parse errors (closes grafana-mimir)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -313,3 +313,4 @@ victoria-metrics/victoria-metrics-distributed,vm,https://victoriametrics.github.
 yugabyte/yugabyte,yugabyte,https://charts.yugabyte.com
 redpanda/console,redpanda,https://charts.redpanda.com
 redpanda/operator,redpanda,https://charts.redpanda.com
+bitnami/grafana-mimir,bitnami,https://charts.bitnami.com/bitnami

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -11,9 +11,3 @@
 # several shared-secrets/migrations/issuer Jobs differ by content-hash suffix, the Gateway
 # object is missing a couple of listeners, and a test-hook Pod has a random name suffix.
 gitlab/gitlab,gitlab,https://charts.gitlab.io
-#
-# bitnami/grafana-mimir: the multi-alias memcached subcomponents now render (the
-# subchart multi-alias fix), but the mimir.yaml ConfigMap is still mostly empty —
-# jhelm omits ~16 config stanzas (activity_tracker, *_storage, blocks_storage, …)
-# that Helm builds. A separate mimir config-generation gap, not the memcached one.
-bitnami/grafana-mimir,bitnami,https://charts.bitnami.com/bitnami

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -113,7 +113,14 @@ public final class ConversionFunctions {
 			}
 		};
 
-		return LoadSettings.builder().setSchema(schema).build();
+		// Allow duplicate mapping keys (last wins), matching Helm's fromYaml. Helm parses
+		// via sigs.k8s.io/yaml (YAML -> JSON -> Go), where a repeated key silently takes
+		// the last value; SnakeYAML Engine rejects duplicates by default. Some charts
+		// legitimately emit a key twice in a generated config (e.g.
+		// bitnami/grafana-mimir's
+		// mimir.yaml repeats `ingester:`), so rejecting it would discard the whole
+		// document.
+		return LoadSettings.builder().setSchema(schema).setAllowDuplicateKeys(true).build();
 	}
 
 	/**
@@ -288,8 +295,16 @@ public final class ConversionFunctions {
 				return (result instanceof Map<?, ?> map) ? map : new LinkedHashMap<>();
 			}
 			catch (Exception ex) {
+				// Match Helm's fromYaml, which surfaces a parse failure under an "Error"
+				// key
+				// (m["Error"] = err) rather than silently returning an empty map — a
+				// silent
+				// empty map hides real bugs (it wiped bitnami/grafana-mimir's whole
+				// config).
 				log.debug("fromYaml failed: {}", ex.getMessage());
-				return new LinkedHashMap<>();
+				Map<String, Object> error = new LinkedHashMap<>();
+				error.put("Error", ex.getMessage());
+				return error;
 			}
 		};
 	}
@@ -340,8 +355,11 @@ public final class ConversionFunctions {
 				return (result instanceof List<?> list) ? list : Collections.emptyList();
 			}
 			catch (Exception ex) {
+				// Match Helm's fromYamlArray, which returns [err.Error()] on a parse
+				// failure
+				// rather than silently swallowing it into an empty list.
 				log.debug("fromYamlArray failed: {}", ex.getMessage());
-				return Collections.emptyList();
+				return List.of(String.valueOf(ex.getMessage()));
 			}
 		};
 	}

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -365,6 +366,39 @@ class ConversionFunctionsTest {
 		assertEquals(Map.of(), fromYaml.invoke(new Object[] {}));
 		assertEquals(Map.of(), fromYaml.invoke(new Object[] { null }));
 		assertEquals(Map.of(), fromYaml.invoke(new Object[] { "  " }));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testFromYamlDuplicateKeyTakesLast() {
+		// Helm parses via sigs.k8s.io/yaml where a repeated key silently takes the last
+		// value (bitnami/grafana-mimir's mimir.yaml repeats `ingester:`). SnakeYAML
+		// Engine
+		// rejects duplicates by default; jhelm must allow them and keep the last.
+		Function fromYaml = functions().get("fromYaml");
+		Map<String, Object> result = (Map<String, Object>) fromYaml
+			.invoke(new Object[] { "a:\n  first: 1\na:\n  second: 2\n" });
+		Map<String, Object> a = (Map<String, Object>) result.get("a");
+		assertEquals(2, ((Number) a.get("second")).intValue(), "last duplicate key value wins");
+		assertFalse(a.containsKey("first"), "earlier duplicate key is dropped, not merged");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testFromYamlParseErrorReturnsErrorKey() {
+		// Helm's fromYaml surfaces a parse failure under an "Error" key rather than
+		// silently returning an empty map (which would hide the failure).
+		Function fromYaml = functions().get("fromYaml");
+		Map<String, Object> result = (Map<String, Object>) fromYaml.invoke(new Object[] { "a: b: c" });
+		assertNotNull(result.get("Error"), "parse failure must surface under an Error key");
+	}
+
+	@Test
+	void testFromYamlArrayParseErrorReturnsError() {
+		// Helm's fromYamlArray returns [err] on a parse failure, not an empty list.
+		Function fromYamlArray = functions().get("fromYamlArray");
+		List<?> result = (List<?>) fromYamlArray.invoke(new Object[] { "- a: b: c" });
+		assertEquals(1, result.size(), "parse failure must surface as a single-element error list");
 	}
 
 	@Test


### PR DESCRIPTION
## What

`bitnami/grafana-mimir`'s `mimir.yaml` ConfigMap rendered as `{}` — all 16 config stanzas (`activity_tracker`, `blocks_storage`, `server`, `memberlist`, …) silently dropped.

## Root cause

The chart builds the config via:

```gotmpl
mergeOverwrite (include "common.tplvalues.render" (dict "value" .Values.mimir.configuration "context" $) | fromYaml) .Values.mimir.overrideConfiguration | toYaml
```

The `tpl` render is correct (verified: produces valid YAML with all 16 keys). But the generated config **repeats a top-level key** — `ingester:` appears twice. Helm parses via `sigs.k8s.io/yaml` (YAML → JSON → Go), where a duplicate key silently takes the **last** value. jhelm's SnakeYAML Engine rejects duplicate keys by default, so `fromYaml` threw — and its `catch` block **silently returned an empty map**, wiping the entire document.

## Fix

- **Allow duplicate mapping keys (last wins)** in the `fromYaml`/`fromYamlArray` load settings (`setAllowDuplicateKeys(true)`), matching Helm/Go. Verified: last-wins yields exactly Helm's expected `ingester: {ring: {…}}`.
- **Stop silently swallowing parse failures.** Helm's `fromYaml` returns `{"Error": err}` and `fromYamlArray` returns `[err]` on a parse error; jhelm now does the same. A real parse failure is now visible instead of masked as an empty map — that silent swallow is exactly what hid this bug.

## Tests

New `ConversionFunctionsTest` cases for duplicate-key last-wins and the Error-key parse-failure behavior. **Full 316-chart `helm template` comparison suite + all jhelm-gotemplate-helm unit tests pass, zero regressions.** Promotes `bitnami/grafana-mimir` from `failed.csv` to `charts.csv` (315 → 316).

🤖 Generated with [Claude Code](https://claude.com/claude-code)