### PR TITLE
sprig int/int64: coerce booleans to 1/0 (gitlab sidekiq env)

### DIFF
--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -6,8 +6,12 @@
 # Both render under `helm template` with the comparison-values in application-test.yaml,
 # so the remaining failure is a real jhelm bug (tracked here until fixed).
 #
-# gitlab: renders end-to-end and now emits the Gateway API resources Helm does
-# (HTTPRoute/TCPRoute/BackendTrafficPolicy — the parse-order #21 fix), but still diverges:
-# several shared-secrets/migrations/issuer Jobs differ by content-hash suffix, the Gateway
-# object is missing a couple of listeners, and a test-hook Pod has a random name suffix.
+# gitlab: renders end-to-end; the only remaining divergence is the shared-secrets/
+# migrations/issuer Jobs whose names carry a content-hash suffix from
+# `gitlab.jobNameSuffix` = sha256(.Chart.Version-.AppVersion-b64(toYaml(unset .Values
+# "local"))) | trunc 7. jhelm's coalesced .Values tree is ~5850 lines vs Helm's ~13029
+# (jhelm omits ~half the recursively-coalesced subchart defaults), so toYaml(.Values)
+# and thus the hash can never match — this needs a full Helm CoalesceValues/
+# ProcessDependencies reimplementation (the real scope of #21, a multi-session effort).
+# Also a webservice-test-runner Pod has a random name suffix (helm test hook).
 gitlab/gitlab,gitlab,https://charts.gitlab.io

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctions.java
@@ -83,6 +83,13 @@ public final class MathFunctions {
 			if (args[0] instanceof Number) {
 				return ((Number) args[0]).intValue();
 			}
+			// Sprig's int is cast.ToInt: a bool coerces to 1/0 (gitlab's sidekiq uses
+			// `int .Values.memoryKiller.daemonMode`). Without this a Boolean falls
+			// through
+			// to parseInt("true") and wrongly yields 0.
+			if (args[0] instanceof Boolean b) {
+				return b ? 1 : 0;
+			}
 			try {
 				return Integer.parseInt(String.valueOf(args[0]));
 			}
@@ -100,6 +107,10 @@ public final class MathFunctions {
 			}
 			if (args[0] instanceof Number) {
 				return ((Number) args[0]).longValue();
+			}
+			// Sprig's int64 is cast.ToInt64: a bool coerces to 1/0, matching int above.
+			if (args[0] instanceof Boolean b) {
+				return b ? 1L : 0L;
 			}
 			try {
 				return Long.parseLong(String.valueOf(args[0]));

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/MathFunctionsTest.java
@@ -32,13 +32,15 @@ class MathFunctionsTest {
 	}
 
 	@ParameterizedTest
-	@CsvSource(delimiter = '|',
-			value = { "{{ add 2 3 }}       | 5", "{{ add1 5 }}        | 6", "{{ sub 5 3 }}       | 2",
-					"{{ mul 3 4 }}       | 12", "{{ div 10 2 }}      | 5", "{{ div 1 2 }}       | 0",
-					"{{ div 7 3 }}       | 2", "{{ mod 10 3 }}      | 1", "{{ max 2 5 3 }}     | 5",
-					"{{ min 2 5 3 }}     | 2", "{{ len \"hello\" }} | 5", "{{ int \"42\" }}    | 42",
-					"{{ int64 \"123\" }} | 123", "{{ toString 42 }}   | 42", "{{ min 5 }}         | 5",
-					"{{ max 5 }}         | 5", "{{ add }}           | 0" })
+	@CsvSource(delimiter = '|', value = { "{{ add 2 3 }}       | 5", "{{ add1 5 }}        | 6",
+			"{{ sub 5 3 }}       | 2", "{{ mul 3 4 }}       | 12", "{{ div 10 2 }}      | 5", "{{ div 1 2 }}       | 0",
+			"{{ div 7 3 }}       | 2", "{{ mod 10 3 }}      | 1", "{{ max 2 5 3 }}     | 5", "{{ min 2 5 3 }}     | 2",
+			"{{ len \"hello\" }} | 5", "{{ int \"42\" }}    | 42", "{{ int64 \"123\" }} | 123",
+			"{{ toString 42 }}   | 42", "{{ min 5 }}         | 5", "{{ max 5 }}         | 5", "{{ add }}           | 0",
+			// Sprig's int/int64 (cast.ToInt) coerces a bool to 1/0 — gitlab's sidekiq
+			// renders `int .Values.memoryKiller.daemonMode`.
+			"{{ int true }}      | 1", "{{ int false }}     | 0", "{{ int64 true }}    | 1",
+			"{{ int64 false }}   | 0" })
 	void testExactMathFunction(String template, String expected) throws IOException, TemplateException {
 		assertEquals(expected, exec(template));
 	}


### PR DESCRIPTION
## What

Sprig's `int`/`int64` are `cast.ToInt`/`ToInt64`, which coerce a bool to `1`/`0`. jhelm's `toInt`/`toInt64` handled only `Number` and `String`, so a `Boolean` fell through to `parseInt("true")` → `NumberFormatException` → `0`.

gitlab's sidekiq deployment renders `{{ int $.Values.memoryKiller.daemonMode | quote }}` (default `true`), so `SIDEKIQ_DAEMON_MEMORY_KILLER` came out `"0"` instead of Helm's `"1"`.

## Fix

Add an explicit `Boolean` branch to both `toInt` and `toInt64` (`true` → 1, `false` → 0), matching sprig. Covered by new `MathFunctionsTest` cases (`int true`/`int false`/`int64 true`/`int64 false`).

## Result

Full **316-chart** comparison suite + sprig unit tests pass, zero regressions. This clears gitlab's one real **value** diff (the sidekiq env var).

`gitlab` stays in `failed.csv` for a separate, deeper reason documented in the updated note: its shared-secrets/migrations/issuer Job names carry a hash suffix from `gitlab.jobNameSuffix = sha256(… b64(toYaml(unset .Values "local")) …)`, and jhelm's coalesced `.Values` tree is only **~5,850 lines vs Helm's ~13,029** (jhelm omits ~half the recursively-coalesced subchart defaults). Matching that hash needs a full Helm `CoalesceValues`/`ProcessDependencies` reimplementation — the true scope of #21, a multi-session effort tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)