### PR TITLE
Add 6 charts at Helm byte-parity (316 -> 322)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -314,3 +314,9 @@ yugabyte/yugabyte,yugabyte,https://charts.yugabyte.com
 redpanda/console,redpanda,https://charts.redpanda.com
 redpanda/operator,redpanda,https://charts.redpanda.com
 bitnami/grafana-mimir,bitnami,https://charts.bitnami.com/bitnami
+coredns/coredns,coredns,https://coredns.github.io/helm
+aws-ebs-csi-driver/aws-ebs-csi-driver,aws-ebs-csi-driver,https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+grafana/tempo-distributed,grafana,https://grafana.github.io/helm-charts
+fluxcd-community/flux2,fluxcd-community,https://fluxcd-community.github.io/helm-charts
+headlamp/headlamp,headlamp,https://kubernetes-sigs.github.io/headlamp/
+dragonfly/dragonfly,dragonfly,https://dragonflyoss.github.io/helm-charts/


### PR DESCRIPTION
Six more charts render byte-identical to `helm template`, batch-tested via `KpsComparisonTest#compareSingleChart` and confirmed by the full 322-chart comparison suite (zero regressions):

- `coredns/coredns`
- `aws-ebs-csi-driver/aws-ebs-csi-driver`
- `grafana/tempo-distributed`
- `fluxcd-community/flux2`
- `headlamp/headlamp`
- `dragonfly/dragonfly`

No engine changes — these already pass on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)