### PR TITLE
.Files includes crds/ + render non-underscore templates (closes projectcapsule/capsule)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
@@ -194,7 +194,12 @@ public class ChartLoader {
 		}
 	}
 
-	private static final Set<String> EXCLUDED_DIRS = Set.of("templates", "charts", "crds");
+	// Dirs whose files are NOT exposed via .Files. Helm excludes only templates/ and
+	// charts/ — crds/ files ARE included in .Files (Helm's loader routes them to the
+	// default/Files case), so templates can read them: e.g. projectcapsule/capsule wraps
+	// each CRD in a ConfigMap via `.Files.Glob "crds/**.yaml"`. crds/ is still loaded
+	// separately as Chart.Crd for CRD installation; this only governs .Files visibility.
+	private static final Set<String> EXCLUDED_DIRS = Set.of("templates", "charts");
 
 	private static final Set<String> EXCLUDED_FILES = Set.of("Chart.yaml", "Chart.lock", "values.yaml",
 			"values.schema.json", "README.md", ".helmignore");

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -659,7 +659,14 @@ public class Engine {
 		List<Chart.Template> sorted = new ArrayList<>(chart.getTemplates());
 		sorted.sort(Comparator.comparing(Chart.Template::getName, Comparator.reverseOrder()));
 		for (Chart.Template t : sorted) {
-			if (!t.getName().endsWith(".yaml") && !t.getName().endsWith(".yml")) {
+			// Helm renders every file under templates/ as a manifest source EXCEPT
+			// partials (basename starts with `_`) and NOTES.txt — the extension is
+			// irrelevant, so a non-underscore `.tpl` is rendered too (e.g.
+			// projectcapsule/capsule's crds.tpl, which emits the CRD ConfigMaps).
+			String name = t.getName();
+			int slash = name.lastIndexOf('/');
+			String base = (slash >= 0) ? name.substring(slash + 1) : name;
+			if (base.startsWith("_") || "NOTES.txt".equals(base)) {
 				continue;
 			}
 			try {

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -320,3 +320,4 @@ grafana/tempo-distributed,grafana,https://grafana.github.io/helm-charts
 fluxcd-community/flux2,fluxcd-community,https://fluxcd-community.github.io/helm-charts
 headlamp/headlamp,headlamp,https://kubernetes-sigs.github.io/headlamp/
 dragonfly/dragonfly,dragonfly,https://dragonflyoss.github.io/helm-charts/
+projectcapsule/capsule,projectcapsule,https://projectcapsule.github.io/charts


### PR DESCRIPTION
## What

`projectcapsule/capsule` renders each CRD as a ConfigMap via the hook template `templates/hooks/crd-lifecycle/crds.tpl`, which ranges over `.Files.Glob "crds/**.yaml"`. jhelm produced **zero** of the 11 `capsule-crds-*` ConfigMaps, for two Helm-parity gaps — both needed:

**1. `crds/` was excluded from `.Files`.** Helm's loader routes `crds/` files to the default/`Files` case, so they're visible via `.Files` (templates can read them). jhelm listed `"crds"` in `EXCLUDED_DIRS`. `crds/` is still loaded separately as `Chart.Crd` for CRD installation — this only restores `.Files` visibility.

**2. jhelm rendered only `.yaml`/`.yml` templates.** Helm renders every file under `templates/` as a manifest source **except** partials (basename starts with `_`) and `NOTES.txt` — the extension is irrelevant, so a non-underscore `.tpl` like `crds.tpl` is rendered. jhelm now matches that rule.

## Result

Full **323-chart** comparison suite + jhelm-core unit tests pass, zero regressions. Promotes `projectcapsule/capsule` (322 → 323).

🤖 Generated with [Claude Code](https://claude.com/claude-code)