### PR TITLE
Add 5 charts at Helm byte-parity (323 -> 328)

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -66,6 +66,12 @@ jhelmtest:
       - resource: "ConfigMap/*"
         path: "data.config.yaml.login_token.signing_key"
         reason: "signing_key is a randAlphaNum value regenerated per render"
+    "[agones/agones]":
+      # caBundle is a genCA/genSignedCert TLS cert, regenerated per render (same
+      # class as the webhook TLS certs ignored globally above).
+      - resource: "APIService/*"
+        path: "spec.caBundle"
+        reason: "caBundle is a generated TLS cert that differs every render"
     "[redpanda/console]":
       # The JWT signing key defaults to randAlphaNum 32 when unset (chart.DotToState),
       # so Helm and jhelm each generate a different value every render.

--- a/jhelm-core/src/test/resources/charts-skip.csv
+++ b/jhelm-core/src/test/resources/charts-skip.csv
@@ -9,6 +9,8 @@
 argo/argocd-apps,Renders 0 documents with default values (creates CRs from empty lists)
 bitnami/common,Helm fails: library charts are not installable
 stakater/application,Helm fails with default values: "Undefined image for application container" (requires image value)
+zitadel/zitadel,Helm fails with default values (requires masterkey / external domain config)
+kubecost/cost-analyzer,Helm fails with default values (requires kubecostToken / provider config)
 #
 # --- Download failures (external repo issues) ---
 twuni/docker-registry,Repo DNS failure

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -321,3 +321,8 @@ fluxcd-community/flux2,fluxcd-community,https://fluxcd-community.github.io/helm-
 headlamp/headlamp,headlamp,https://kubernetes-sigs.github.io/headlamp/
 dragonfly/dragonfly,dragonfly,https://dragonflyoss.github.io/helm-charts/
 projectcapsule/capsule,projectcapsule,https://projectcapsule.github.io/charts
+kubevela/vela-core,kubevela,https://kubevela.github.io/charts
+karmada/karmada,karmada,https://raw.githubusercontent.com/karmada-io/karmada/master/charts
+ot-helm/redis-operator,ot-helm,https://ot-container-kit.github.io/helm-charts/
+runix/pgadmin4,runix,https://helm.runix.net
+agones/agones,agones,https://agones.dev/chart/stable


### PR DESCRIPTION
Five more charts render byte-identical to `helm template`, batch-tested via `KpsComparisonTest#compareSingleChart` and confirmed by the full 328-chart suite (zero regressions):

- `kubevela/vela-core`
- `karmada/karmada`
- `ot-helm/redis-operator`
- `runix/pgadmin4`
- `agones/agones` — its `APIService` `spec.caBundle` is a per-render `genCA`/`genSignedCert` TLS cert, added to `comparison-ignores` (same class as the webhook certs already ignored globally).

Also records two charts whose own `helm template` fails with default values (not jhelm bugs) in `charts-skip.csv`: `zitadel/zitadel`, `kubecost/cost-analyzer`.

No engine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)