### PR TITLE
Add 6 charts at Helm byte-parity (328 -> 334)

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -72,6 +72,15 @@ jhelmtest:
       - resource: "APIService/*"
         path: "spec.caBundle"
         reason: "caBundle is a generated TLS cert that differs every render"
+    "[timescale/timescaledb-single]":
+      # The certificate Secret holds a genSignedCert TLS cert/key and the credentials
+      # Secret holds randAlphaNum passwords — both regenerated per render.
+      - resource: "Secret/release-timescale-timescaledb-single-certificate"
+        path: "stringData.*"
+        reason: "TLS cert/key generated per render"
+      - resource: "Secret/release-timescale-timescaledb-single-credentials"
+        path: "stringData.*"
+        reason: "Patroni passwords are randAlphaNum, generated per render"
     "[redpanda/console]":
       # The JWT signing key defaults to randAlphaNum 32 when unset (chart.DotToState),
       # so Helm and jhelm each generate a different value every render.

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -326,3 +326,9 @@ karmada/karmada,karmada,https://raw.githubusercontent.com/karmada-io/karmada/mas
 ot-helm/redis-operator,ot-helm,https://ot-container-kit.github.io/helm-charts/
 runix/pgadmin4,runix,https://helm.runix.net
 agones/agones,agones,https://agones.dev/chart/stable
+trino/trino,trino,https://trinodb.github.io/charts
+community-charts/mlflow,community-charts,https://community-charts.github.io/helm-charts
+fluent/fluentd,fluent,https://fluent.github.io/helm-charts
+couchbase/couchbase-operator,couchbase,https://couchbase-partners.github.io/helm-charts/
+netdata/netdata,netdata,https://netdata.github.io/helmchart/
+timescale/timescaledb-single,timescale,https://charts.timescale.com


### PR DESCRIPTION
Six more charts render byte-identical to `helm template`, batch-tested and confirmed by the full 334-chart suite (zero regressions):

- `trino/trino`
- `community-charts/mlflow`
- `fluent/fluentd`
- `couchbase/couchbase-operator`
- `netdata/netdata`
- `timescale/timescaledb-single` — its `*-certificate` and `*-credentials` Secrets hold a per-render `genSignedCert` TLS cert/key and `randAlphaNum` Patroni passwords; added to `comparison-ignores`.

No engine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)