### PR TITLE
Add 5 charts at Helm byte-parity (334 -> 339)

### DIFF
--- a/jhelm-core/src/test/resources/charts-skip.csv
+++ b/jhelm-core/src/test/resources/charts-skip.csv
@@ -11,6 +11,8 @@ bitnami/common,Helm fails: library charts are not installable
 stakater/application,Helm fails with default values: "Undefined image for application container" (requires image value)
 zitadel/zitadel,Helm fails with default values (requires masterkey / external domain config)
 kubecost/cost-analyzer,Helm fails with default values (requires kubecostToken / provider config)
+newrelic/nri-bundle,Helm fails with default values (requires licenseKey / cluster name)
+temporal/temporal,Helm fails with default values (cassandra/schema job config required)
 #
 # --- Download failures (external repo issues) ---
 twuni/docker-registry,Repo DNS failure

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -332,3 +332,8 @@ fluent/fluentd,fluent,https://fluent.github.io/helm-charts
 couchbase/couchbase-operator,couchbase,https://couchbase-partners.github.io/helm-charts/
 netdata/netdata,netdata,https://netdata.github.io/helmchart/
 timescale/timescaledb-single,timescale,https://charts.timescale.com
+cnpg/cloudnative-pg,cnpg,https://cloudnative-pg.github.io/charts
+openfunction/openfunction,openfunction,https://openfunction.github.io/charts/
+weaviate/weaviate,weaviate,https://weaviate.github.io/weaviate-helm
+qdrant/qdrant,qdrant,https://qdrant.github.io/qdrant-helm
+milvus/milvus,milvus,https://zilliztech.github.io/milvus-helm/


### PR DESCRIPTION
Five more charts render byte-identical to `helm template` (full 339-chart suite, zero regressions):

- `cnpg/cloudnative-pg`
- `openfunction/openfunction`
- `weaviate/weaviate`
- `qdrant/qdrant`
- `milvus/milvus`

Also records two charts whose own `helm template` fails on defaults (not jhelm bugs) in `charts-skip.csv`: `newrelic/nri-bundle`, `temporal/temporal`.

No engine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)