### PR TITLE
Values loader: parse YAML 1.1 booleans (on/off/yes/no) like Helm (closes yugaware)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesLoader.java
@@ -3,6 +3,8 @@ package org.alexmond.jhelm.core.util;
 import org.snakeyaml.engine.v2.api.ConstructNode;
 import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.nodes.Node;
+import org.snakeyaml.engine.v2.nodes.ScalarNode;
 import org.snakeyaml.engine.v2.nodes.Tag;
 import org.snakeyaml.engine.v2.resolver.CoreScalarResolver;
 import org.snakeyaml.engine.v2.resolver.ScalarResolver;
@@ -20,9 +22,12 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Utility for loading Helm values YAML files, including multi-document files.
@@ -37,10 +42,28 @@ import java.util.Map;
  */
 public final class ValuesLoader {
 
-	private static final Schema HELM_SCHEMA = createHelmSchema();
-
 	private ValuesLoader() {
 	}
+
+	/**
+	 * YAML 1.1 boolean tokens, matching Helm's value parser (sigs.k8s.io/yaml -> yaml.v2,
+	 * which is YAML 1.1). Helm resolves {@code yes/no/on/off/y/n} (and case variants) as
+	 * booleans, not strings — e.g. yugabyte/yugaware's {@code huge_pages: off} renders as
+	 * {@code 'false'}. SnakeYAML Engine's core schema (YAML 1.2) only knows true/false,
+	 * so jhelm kept the literal strings and diverged.
+	 */
+	private static final Set<String> YAML11_TRUE = Set.of("y", "Y", "yes", "Yes", "YES", "true", "True", "TRUE", "on",
+			"On", "ON");
+
+	private static final Set<String> YAML11_FALSE = Set.of("n", "N", "no", "No", "NO", "false", "False", "FALSE", "off",
+			"Off", "OFF");
+
+	private static final Pattern YAML11_BOOL = Pattern
+		.compile("^(?:y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)$");
+
+	// Declared after the YAML11_* constants it depends on: static fields initialise in
+	// source order, so createHelmSchema() must not run before those are set.
+	private static final Schema HELM_SCHEMA = createHelmSchema();
 
 	private static Schema createHelmSchema() {
 		CoreScalarResolver resolver = new CoreScalarResolver(true);
@@ -48,7 +71,12 @@ public final class ValuesLoader {
 		// includes ~. Add ~ to the first-char lookup so the resolver checks
 		// the NULL regex for tilde values (YAML 1.1/1.2 null literal).
 		resolver.addImplicitResolver(Tag.NULL, CoreScalarResolver.NULL, "~");
-		Map<Tag, ConstructNode> constructors = new CoreSchema().getSchemaTagConstructors();
+		// Resolve YAML 1.1 boolean tokens (yes/no/on/off/y/n) as booleans like Helm.
+		resolver.addImplicitResolver(Tag.BOOL, YAML11_BOOL, "yYnNtTfFoO");
+		Map<Tag, ConstructNode> constructors = new HashMap<>(new CoreSchema().getSchemaTagConstructors());
+		// The core BOOL constructor only understands true/false; replace it with one that
+		// also maps the YAML 1.1 tokens this resolver now tags as BOOL.
+		constructors.put(Tag.BOOL, new Yaml11BoolConstructor());
 		return new Schema() {
 			@Override
 			public ScalarResolver getScalarResolver() {
@@ -148,6 +176,28 @@ public final class ValuesLoader {
 				base.put(entry.getKey(), overrideVal);
 			}
 		}
+	}
+
+	/**
+	 * Constructs a Boolean from a scalar the {@link #YAML11_BOOL} resolver tagged as
+	 * {@code !!bool} — handles the YAML 1.1 tokens (yes/no/on/off/y/n) in addition to
+	 * true/false, matching Helm's yaml.v2 value parsing.
+	 */
+	private static final class Yaml11BoolConstructor implements ConstructNode {
+
+		@Override
+		public Object construct(Node node) {
+			String value = ((ScalarNode) node).getValue();
+			if (YAML11_TRUE.contains(value)) {
+				return Boolean.TRUE;
+			}
+			if (YAML11_FALSE.contains(value)) {
+				return Boolean.FALSE;
+			}
+			// Should not happen — the resolver only tags the tokens above as BOOL.
+			return Boolean.parseBoolean(value);
+		}
+
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesLoaderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesLoaderTest.java
@@ -43,6 +43,32 @@ class ValuesLoaderTest {
 	}
 
 	@Test
+	void testYaml11BooleansParsedLikeHelm() throws IOException {
+		// Helm's value parser (sigs.k8s.io/yaml -> yaml.v2, YAML 1.1) resolves
+		// yes/no/on/off/y/n (and case variants) as booleans, not strings.
+		File f = writeValues("""
+				a: on
+				b: off
+				c: yes
+				d: no
+				e: "on"
+				f: y
+				g: Off
+				h: true
+				""");
+		Map<String, Object> result = ValuesLoader.load(f);
+		assertEquals(Boolean.TRUE, result.get("a"));
+		assertEquals(Boolean.FALSE, result.get("b"));
+		assertEquals(Boolean.TRUE, result.get("c"));
+		assertEquals(Boolean.FALSE, result.get("d"));
+		// A quoted token stays a string (the resolver only fires on plain scalars).
+		assertEquals("on", result.get("e"));
+		assertEquals(Boolean.TRUE, result.get("f"));
+		assertEquals(Boolean.FALSE, result.get("g"));
+		assertEquals(Boolean.TRUE, result.get("h"));
+	}
+
+	@Test
 	void testMultiDocumentNonOverlapping() throws IOException {
 		File f = writeValues("""
 				key1: value1

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -337,3 +337,4 @@ openfunction/openfunction,openfunction,https://openfunction.github.io/charts/
 weaviate/weaviate,weaviate,https://weaviate.github.io/weaviate-helm
 qdrant/qdrant,qdrant,https://qdrant.github.io/qdrant-helm
 milvus/milvus,milvus,https://zilliztech.github.io/milvus-helm/
+yugabyte/yugaware,yugabyte,https://charts.yugabyte.com


### PR DESCRIPTION
## What

Helm parses chart values via `sigs.k8s.io/yaml` → `yaml.v2` (**YAML 1.1**), where `yes`/`no`/`on`/`off`/`y`/`n` (and case variants) are **booleans**. jhelm's `ValuesLoader` uses SnakeYAML Engine's core schema (YAML 1.2), which only knows `true`/`false`, so it kept those tokens as strings.

Surfaced by `yugabyte/yugaware`: `postgres.sampleConfig` has `logging_collector: on` / `huge_pages: off`, rendered via `{{ squote $v }}` — Helm emits `'true'`/`'false'`, jhelm emitted `'on'`/`'off'`.

## Fix

Add a YAML 1.1 boolean implicit resolver + a constructor mapping the full `yaml.v2` token set to `Boolean`, inside the existing `HELM_SCHEMA`. Quoted scalars (`"on"`) stay strings — the resolver only fires on plain scalars (covered by the new `ValuesLoaderTest` case).

Broadening jhelm to match Helm's set can only *fix* divergences, never create them in already-passing charts (a value that rendered identically before still does).

## Result

Full **339-chart** suite + `ValuesLoaderTest` pass, **zero regressions**. Promotes `yugabyte/yugaware` (339 → 340).

🤖 Generated with [Claude Code](https://claude.com/claude-code)