### PR TITLE
Add 2 charts at Helm byte-parity (340 -> 342)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -338,3 +338,5 @@ weaviate/weaviate,weaviate,https://weaviate.github.io/weaviate-helm
 qdrant/qdrant,qdrant,https://qdrant.github.io/qdrant-helm
 milvus/milvus,milvus,https://zilliztech.github.io/milvus-helm/
 yugabyte/yugaware,yugabyte,https://charts.yugabyte.com
+datawire/emissary-ingress,datawire,https://app.getambassador.io
+bitnami/fluent-bit,bitnami,https://charts.bitnami.com/bitnami


### PR DESCRIPTION
- `datawire/emissary-ingress`
- `bitnami/fluent-bit`

Full 342-chart comparison suite passes, zero regressions. No engine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)