### PR TITLE
Coalesce: null override deletes subchart default across the subchart boundary (closes signoz)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -534,12 +534,21 @@ public class Engine {
 		// * Null map entries are pruned for a subchart (depth > 0) but kept for the
 		// top-level release chart, mirroring Helm's coalesce ("a null key removes it",
 		// applied while coalescing subcharts).
-		mergedValues = prepareRenderValues(mergedValues, depth > 0);
+		// Pruned view for THIS chart's own rendering: Helm removes null keys while
+		// coalescing a subchart (depth > 0); the top-level release chart keeps them.
+		Map<String, Object> renderValues = prepareRenderValues(mergedValues, depth > 0);
+		// Unpruned view (null tombstones retained) for slicing down to subcharts. A
+		// parent's null override must survive to DELETE the subchart's same-named default
+		// (Helm's coalesce nil-deletion). Pruning before slicing drops the tombstone and
+		// lets the subchart re-introduce its default — e.g. signoz nulls
+		// clickhouse.zookeeper.image.registry to drop bitnami zookeeper's docker.io. The
+		// subchart prunes the null itself when it renders.
+		Map<String, Object> subchartSliceValues = prepareRenderValues(mergedValues, false);
 
 		// Validate merged values against the chart's JSON Schema (if present)
 		if (chart.getValuesSchema() != null) {
 			try {
-				schemaValidator.validate(chart.getMetadata().getName(), chart.getValuesSchema(), mergedValues);
+				schemaValidator.validate(chart.getMetadata().getName(), chart.getValuesSchema(), renderValues);
 			}
 			catch (SchemaValidationException ex) {
 				throw new TemplateRenderException("Values schema validation failed: " + ex.getMessage(), ex,
@@ -549,7 +558,7 @@ public class Engine {
 
 		// Wrap as Helm's chartutil.Values so `.Values.AsMap` resolves (gotohelm charts
 		// such as redpanda's console/operator read the raw map via {{ .Values.AsMap }}).
-		mergedValues = new Values(mergedValues);
+		mergedValues = new Values(renderValues);
 
 		Map<String, Object> context = new HashMap<>();
 		context.put("Values", mergedValues);
@@ -609,9 +618,11 @@ public class Engine {
 				}
 			}
 
-			// Subcharts are only rendered if enabled in Values
+			// Subcharts are only rendered if enabled in Values. Slice from the unpruned
+			// view so a parent's null override reaches the subchart and deletes its
+			// default.
 			@SuppressWarnings("unchecked")
-			Map<String, Object> subchartOverrides = (Map<String, Object>) mergedValues.getOrDefault(subchartName,
+			Map<String, Object> subchartOverrides = (Map<String, Object>) subchartSliceValues.getOrDefault(subchartName,
 					new HashMap<>());
 
 			if (log.isDebugEnabled()) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/SubchartValuePropagationTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/SubchartValuePropagationTest.java
@@ -90,6 +90,23 @@ class SubchartValuePropagationTest {
 	}
 
 	@Test
+	void testParentNullOverrideDeletesSubchartDefault() throws Exception {
+		// Helm's coalesce deletes a key whose override is null, even against the
+		// subchart's
+		// OWN default. The database subchart renders `port: {{ .Values.service.port }}`
+		// from its default 5432; a null override on database.service.port must delete it,
+		// not fall back to 5432. (Regression: jhelm pruned the null at the parent level
+		// before the subchart re-merged its default, re-introducing 5432.)
+		Chart chart = loadChart();
+		Map<String, Object> service = new HashMap<>();
+		service.put("port", null);
+		Map<String, Object> overrides = Map.of("database", Map.of("service", service));
+		String manifest = renderManifest(chart, overrides);
+		assertFalse(manifest.contains("port: 5432"),
+				"null override must delete the subchart's default port, not fall back to 5432: " + manifest);
+	}
+
+	@Test
 	void testGlobalValuePropagation() throws Exception {
 		Chart chart = loadChart();
 		String manifest = renderManifest(chart, Map.of());

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -340,3 +340,4 @@ milvus/milvus,milvus,https://zilliztech.github.io/milvus-helm/
 yugabyte/yugaware,yugabyte,https://charts.yugabyte.com
 datawire/emissary-ingress,datawire,https://app.getambassador.io
 bitnami/fluent-bit,bitnami,https://charts.bitnami.com/bitnami
+signoz/signoz,signoz,https://charts.signoz.io


### PR DESCRIPTION
## What

Helm's `CoalesceValues` deletes a key whose (parent/user) override is `null` — **including against a subchart's own default**. `signoz` nulls `clickhouse.zookeeper.image.registry` (a YAML anchor → `global.imageRegistry: null`) to drop bitnami zookeeper's `registry: docker.io` default, so the image renders `signoz/zookeeper`, not `docker.io/signoz/zookeeper`.

jhelm pruned the cancelling `null` at the **parent** level (`prepareRenderValues`, `depth > 0`) *before* slicing to the subchart, so the subchart re-merged its own `values.yaml` and re-introduced `docker.io`. Helm coalesces once top-down and carries the deletion through to the leaf.

## Fix

Keep two views of the merged tree:
- **Render this chart** from the *pruned* view (nulls removed for subcharts, kept for the top-level release chart — unchanged behavior).
- **Slice down to subcharts** from an *unpruned* view that retains the null tombstone.

The subchart's null override then deletes its same-named default, and the subchart prunes the null itself when it renders.

## Result

Full **343-chart** suite + jhelm-core unit tests pass, zero regressions. New `SubchartValuePropagationTest#testParentNullOverrideDeletesSubchartDefault`. Promotes `signoz/signoz` (342 → 343).

This is the first concrete piece of the coalesce-parity work (#34). `gitlab` (#21, `.Values` size) and `signoz/k8s-infra` (a different env-value-null mechanism) remain — tracked in #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)