### PR TITLE
Expose Helm's .Chart.IsRoot (closes signoz/k8s-infra)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartMetadata.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartMetadata.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.core.model;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,5 +37,25 @@ public class ChartMetadata {
 	private List<Dependency> dependencies;
 
 	private Map<String, String> annotations;
+
+	// Helm's .Chart.IsRoot: true for the chart being installed (the top-level release
+	// chart), false when rendered as a subchart. Set per render by the engine, so it is
+	// excluded from Chart.yaml (de)serialization. Charts branch on it, e.g.
+	// signoz/k8s-infra's otel.endpoint only builds a default `{{ if not .Chart.IsRoot
+	// }}`.
+	// The explicit getIsRoot() exposes it to templates as `.Chart.IsRoot` (Lombok's
+	// boolean getter would be isRoot()/property "root", resolving as .Chart.Root
+	// instead).
+	// Boxed Boolean (not primitive) so Lombok's @AllArgsConstructor — which Jackson uses
+	// as the creator — accepts a null when the key is absent from Chart.yaml instead of
+	// failing FAIL_ON_NULL_FOR_PRIMITIVES.
+	@JsonIgnore
+	private Boolean root;
+
+	@JsonIgnore
+	@SuppressWarnings("PMD.BooleanGetMethodName")
+	public boolean getIsRoot() {
+		return Boolean.TRUE.equals(this.root);
+	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -560,6 +560,9 @@ public class Engine {
 		// such as redpanda's console/operator read the raw map via {{ .Values.AsMap }}).
 		mergedValues = new Values(renderValues);
 
+		// Helm's .Chart.IsRoot: true only for the top-level release chart (depth 0).
+		chart.getMetadata().setRoot(depth == 0);
+
 		Map<String, Object> context = new HashMap<>();
 		context.put("Values", mergedValues);
 		context.put("Chart", chart.getMetadata());

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/ChartIsRootTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/ChartIsRootTest.java
@@ -1,0 +1,42 @@
+package org.alexmond.jhelm.core;
+
+import java.io.File;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.Engine;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Helm's {@code .Chart.IsRoot} is true only for the chart being installed (the top-level
+ * release chart) and false when the same template runs as a subchart. The test chart
+ * emits {@code .Chart.IsRoot} from both the parent and a subchart ConfigMap.
+ */
+class ChartIsRootTest {
+
+	@Test
+	void testIsRootTrueForParentFalseForSubchart() throws Exception {
+		ChartLoader chartLoader = new ChartLoader();
+		Engine engine = new Engine();
+		InstallAction installAction = new InstallAction(engine, null);
+
+		Chart chart = chartLoader.load(new File("src/test/resources/test-charts/chart-isroot"));
+		assertNotNull(chart, "Chart should be loaded");
+		Release release = installAction.install(chart, "r", "default", Map.of(), 1, true);
+		String manifest = release.getManifest();
+
+		// Parent ConfigMap: the release chart is root.
+		assertTrue(manifest.contains("name: parent") && manifest.contains("isRoot: \"true\""),
+				"parent .Chart.IsRoot must be true: " + manifest);
+		// Subchart ConfigMap: rendered as a subchart, so not root.
+		assertTrue(manifest.contains("name: sub") && manifest.contains("isRoot: \"false\""),
+				"subchart .Chart.IsRoot must be false: " + manifest);
+	}
+
+}

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -341,3 +341,4 @@ yugabyte/yugaware,yugabyte,https://charts.yugabyte.com
 datawire/emissary-ingress,datawire,https://app.getambassador.io
 bitnami/fluent-bit,bitnami,https://charts.bitnami.com/bitnami
 signoz/signoz,signoz,https://charts.signoz.io
+signoz/k8s-infra,signoz,https://charts.signoz.io

--- a/jhelm-core/src/test/resources/test-charts/chart-isroot/Chart.yaml
+++ b/jhelm-core/src/test/resources/test-charts/chart-isroot/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: chart-isroot
+version: 0.1.0
+dependencies:
+  - name: sub
+    version: 0.1.0

--- a/jhelm-core/src/test/resources/test-charts/chart-isroot/charts/sub/Chart.yaml
+++ b/jhelm-core/src/test/resources/test-charts/chart-isroot/charts/sub/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: sub
+version: 0.1.0

--- a/jhelm-core/src/test/resources/test-charts/chart-isroot/charts/sub/templates/cm.yaml
+++ b/jhelm-core/src/test/resources/test-charts/chart-isroot/charts/sub/templates/cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sub
+data:
+  isRoot: "{{ .Chart.IsRoot }}"

--- a/jhelm-core/src/test/resources/test-charts/chart-isroot/templates/cm.yaml
+++ b/jhelm-core/src/test/resources/test-charts/chart-isroot/templates/cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: parent
+data:
+  isRoot: "{{ .Chart.IsRoot }}"


### PR DESCRIPTION
## What

Helm sets `.Chart.IsRoot` **true** for the chart being installed (the top-level release chart) and **false** when the same template runs as a subchart. jhelm didn't expose it, so `.Chart.IsRoot` resolved nil/false everywhere.

`signoz/k8s-infra`'s `otel.endpoint` helper builds a default endpoint only `{{ else if not .Chart.IsRoot }}`, so jhelm emitted `…-otel-collector:4318` where Helm (IsRoot=true at the root) emits nothing → the `OTEL_EXPORTER_OTLP_ENDPOINT` env value diverged.

## How

- **ChartMetadata**: add a boxed `Boolean root` with an explicit `getIsRoot()` so the template resolver matches `.Chart.IsRoot` (Lombok's boolean getter would be `isRoot()` → property `root` → `.Chart.Root`). `@JsonIgnore` keeps it out of Chart.yaml (de)serialization; `Boolean` rather than `boolean` so Lombok's `@AllArgsConstructor` — which Jackson uses as the creator — tolerates a `null` when the key is absent (avoids `FAIL_ON_NULL_FOR_PRIMITIVES`).
- **Engine**: `setRoot(depth == 0)` before building the render context.

## Tests

New `ChartIsRootTest` with a small `chart-isroot` test chart asserts parent `IsRoot=true`, subchart `IsRoot=false`. Full **343-chart** suite + jhelm-core unit tests pass, zero regressions. Promotes `signoz/k8s-infra` (343 → 344).

Second concrete piece of the coalesce/metadata parity work (#34); `gitlab` (#21) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)