### PR TITLE
sprig merge: skip nil source value for an absent key (closes kuma)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -342,3 +342,4 @@ datawire/emissary-ingress,datawire,https://app.getambassador.io
 bitnami/fluent-bit,bitnami,https://charts.bitnami.com/bitnami
 signoz/signoz,signoz,https://charts.signoz.io
 signoz/k8s-infra,signoz,https://charts.signoz.io
+kuma/kuma,kuma,https://kumahq.github.io/charts

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctions.java
@@ -244,7 +244,15 @@ public final class DictFunctions {
 					dst.put(key, srcVal);
 				}
 			}
-			else {
+			else if (overwrite || srcVal != null) {
+				// Plain `merge` (overwrite=false) does not add an absent key whose source
+				// value is nil — e.g. kuma `merge`s an env name->value dict where
+				// KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS is null, which Helm drops and jhelm
+				// previously kept as an extra env var. mergeOverwrite/mustMergeOverwrite
+				// still add nil (gotohelm builds structs with nil fields via
+				// mustMergeOverwrite, e.g. redpanda); other empty values ("", false, 0)
+				// are
+				// added in both modes.
 				dst.put(key, srcVal);
 			}
 		}

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/jhelm/gotemplate/sprig/functions/DictFunctionsTest.java
@@ -1,0 +1,49 @@
+package org.alexmond.jhelm.gotemplate.sprig.functions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.alexmond.jhelm.gotemplate.Function;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DictFunctionsTest {
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> invoke(String name, Object dst, Map<String, Object> src) {
+		Function fn = DictFunctions.getFunctions().get(name);
+		return (Map<String, Object>) fn.invoke(new Object[] { dst, src });
+	}
+
+	@Test
+	void testMergeSkipsNilSourceForAbsentKey() {
+		// mergo (Helm's `merge`) does not add an absent key whose source value is nil,
+		// but
+		// still adds other empty values ("", false, 0). kuma relies on this to drop a
+		// null-valued env var.
+		Map<String, Object> src = new HashMap<>();
+		src.put("nilv", null);
+		src.put("emptystr", "");
+		src.put("zero", 0);
+		src.put("real", "x");
+		Map<String, Object> result = invoke("merge", new HashMap<>(), src);
+		assertFalse(result.containsKey("nilv"), "merge must drop an absent key with a nil source value");
+		assertTrue(result.containsKey("emptystr"), "merge keeps an empty-string value");
+		assertTrue(result.containsKey("zero"), "merge keeps a zero value");
+		assertEquals("x", result.get("real"));
+	}
+
+	@Test
+	void testMergeOverwriteKeepsNilSourceForAbsentKey() {
+		// mergeOverwrite/mustMergeOverwrite DO add a nil-valued absent key — gotohelm
+		// (e.g. redpanda) builds structs with nil fields this way.
+		Map<String, Object> src = new HashMap<>();
+		src.put("nilv", null);
+		Map<String, Object> result = invoke("mergeOverwrite", new HashMap<>(), src);
+		assertTrue(result.containsKey("nilv"), "mergeOverwrite keeps a nil-valued absent key");
+	}
+
+}


### PR DESCRIPTION
## What

Helm's `merge` (mergo, no override) does not copy a **nil** source value into a key **absent** from the destination. kuma's control-plane deployment builds an env-name→value dict and `merge`s it; `KUMA_MULTIZONE_ZONE_GLOBAL_ADDRESS` has an empty value (`kdsGlobalAddress: ""` → null), so Helm drops it while jhelm added it as an extra env var — shifting the whole (name-sorted) env list and producing 29 diffs.

## How

jhelm's `deepMerge` added every absent key unconditionally. Gate the absent-key add on `overwrite || srcVal != null`:
- plain `merge` (overwrite=false) **skips** a nil source value for an absent key;
- `mergeOverwrite`/`mustMergeOverwrite` still add nil — gotohelm (e.g. redpanda) builds structs with nil fields via `mustMergeOverwrite`, and dropping those breaks it;
- other empty values (`""`, `false`, `0`) are added in both modes — some charts depend on that.

A blanket "skip all empty source values" caused **9 regressions**; this narrow gate is the exact mergo behavior these charts rely on.

## Tests

New `DictFunctionsTest` covering both modes. Full **345-chart** suite + sprig unit tests pass, zero regressions. Promotes `kuma/kuma` (344 → 345).

🤖 Generated with [Claude Code](https://claude.com/claude-code)