### PR TITLE
Render subcharts before parent templates (closes grafana/oncall)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -597,10 +597,16 @@ public class Engine {
 
 		StringBuilder sb = new StringBuilder();
 
-		// Render current chart templates
-		renderChartTemplates(chart, context, sb);
-
-		// Render subcharts
+		// Render subcharts first, then this chart's own templates, so that when an
+		// umbrella
+		// and a subchart emit a resource with the SAME name (e.g. grafana/oncall: the
+		// grafana subchart's fullname collapses to the release name because it contains
+		// "grafana", so both create ServiceAccount/release-grafana-oncall) the PARENT's
+		// resource is the one that survives a kind+name dedup — matching Helm, whose
+		// manifest orders charts/<sub>/... before templates/... within each kind.
+		// Subchart
+		// values are sliced from subchartSliceValues (computed before any rendering), so
+		// order does not affect them.
 		List<Dependency> parentDepMeta = (chart.getMetadata() != null) ? chart.getMetadata().getDependencies() : null;
 		for (Chart subchart : chart.getDependencies()) {
 			// Use alias as lookup key when set (alias takes precedence over chart name)
@@ -657,6 +663,9 @@ public class Engine {
 			}
 			sb.append(renderWithSubcharts(subchart, subchartOverrides, releaseInfo, renderedCharts, depth + 1));
 		}
+
+		// This chart's own templates render last (see the ordering note above).
+		renderChartTemplates(chart, context, sb);
 
 		return sb.toString();
 	}

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -87,6 +87,12 @@ jhelmtest:
       - resource: "Secret/*"
         path: "stringData.authentication-jwt-signingkey"
         reason: "JWT signing key is a randAlphaNum value generated per render"
+    "[grafana/oncall]":
+      # The migrate Job name embeds `now | date` (job-migrate.yaml), so Helm and jhelm
+      # each produce a different timestamp suffix and the resource key never matches.
+      - resource: "Job/release-grafana-oncall-engine-migrate-*"
+        path: "*"
+        reason: "migrate Job name has a per-render now-timestamp suffix"
   # Value overrides for charts that Helm cannot render with default values. The same
   # overrides are applied to both Helm and jhelm, so any divergence is a real jhelm bug.
   comparison-values:

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -343,3 +343,4 @@ bitnami/fluent-bit,bitnami,https://charts.bitnami.com/bitnami
 signoz/signoz,signoz,https://charts.signoz.io
 signoz/k8s-infra,signoz,https://charts.signoz.io
 kuma/kuma,kuma,https://kumahq.github.io/charts
+grafana/oncall,grafana,https://grafana.github.io/helm-charts


### PR DESCRIPTION
## What

When an umbrella and one of its subcharts emit a resource with the **same** kind+name, the parent's copy must win the dedup, matching Helm.

`grafana/oncall` hits this: the grafana subchart's `fullname` collapses to the release name (`release-grafana-oncall` *contains* `"grafana"`), so **both** the umbrella and the grafana subchart create `ServiceAccount`/`Secret` named `release-grafana-oncall`. Helm orders `charts/<sub>/…` before `templates/…` within each kind, so the umbrella's (oncall-labelled) resource is last and survives the kind/name dedup. jhelm rendered the parent **first**, so the grafana subchart's copy won → the SA/Secret carried grafana's labels (+ stray `namespace`/`automountServiceAccountToken`).

## How

Render the subchart loop **before** `renderChartTemplates`, so this chart's own resources come last. Subchart values are sliced from `subchartSliceValues` (computed before any rendering), so render order does not affect values — confirmed by the full suite.

## Tests

Full **346-chart** suite passes, **zero regressions** (the order change is global). The migrate Job name embeds `now | date`, so its key never matches across renders — added to `comparison-ignores`. Promotes `grafana/oncall` (345 → 346).

🤖 Generated with [Claude Code](https://claude.com/claude-code)