### PR TITLE
feat(gotmpl4j-core): render()->String + CompiledTemplate handle (#38)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/CompiledTemplate.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/CompiledTemplate.java
@@ -1,0 +1,68 @@
+package org.alexmond.gotmpl4j;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * An immutable handle to a single named template within a compiled {@link GoTemplate}
+ * set, bound once so callers render it without repeating the name.
+ *
+ * <p>
+ * Obtain one via {@link GoTemplate#compiled(String)}. The underlying {@link GoTemplate}
+ * is parsed once and {@code execute} builds a fresh executor per call, so a handle is
+ * safe to reuse across threads.
+ *
+ * <pre>{@code
+ * CompiledTemplate greeting = template.compiled("greeting");
+ * String out = greeting.render(Map.of("Name", "world"));
+ * }</pre>
+ */
+public final class CompiledTemplate {
+
+	private final GoTemplate template;
+
+	private final String name;
+
+	CompiledTemplate(GoTemplate template, String name) {
+		this.template = template;
+		this.name = name;
+	}
+
+	/**
+	 * Renders this template to a {@code String}.
+	 * @param data the root data object (the template's {@code .})
+	 * @return the rendered output
+	 * @throws TemplateExecutionException if execution fails
+	 */
+	public String render(Object data) throws TemplateExecutionException {
+		try {
+			return this.template.render(this.name, data);
+		}
+		catch (TemplateNotFoundException ex) {
+			// The name was validated when this handle was created and the set is
+			// immutable,
+			// so this cannot normally happen; surface it as an execution failure.
+			throw new TemplateExecutionException("Bound template '" + this.name + "' is no longer present", ex);
+		}
+	}
+
+	/**
+	 * Renders this template to the given {@link Writer}.
+	 * @param data the root data object (the template's {@code .})
+	 * @param writer the destination
+	 * @throws IOException if writing fails
+	 * @throws TemplateException if execution fails
+	 */
+	public void render(Object data, Writer writer) throws IOException, TemplateException {
+		this.template.execute(this.name, data, writer);
+	}
+
+	/**
+	 * The bound template name.
+	 * @return the template name
+	 */
+	public String name() {
+		return this.name;
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/GoTemplate.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/GoTemplate.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -166,6 +167,54 @@ public class GoTemplate {
 		}
 		Executor executor = new Executor(rootNodes, functions);
 		executor.execute(name, data, writer);
+	}
+
+	/**
+	 * Execute the main template and return the result as a {@code String}. Convenience
+	 * over {@link #execute(Object, Writer)} for callers that want a string rather than
+	 * supplying a {@link Writer}.
+	 * @param data the root data object (the template's {@code .})
+	 * @return the rendered output
+	 * @throws TemplateNotFoundException if no main template has been parsed
+	 * @throws TemplateExecutionException if execution fails
+	 */
+	public String render(Object data) throws TemplateNotFoundException, TemplateExecutionException {
+		return render(name, data);
+	}
+
+	/**
+	 * Execute a named template from this set and return the result as a {@code String}.
+	 * Convenience over {@link #execute(String, Object, Writer)}.
+	 * @param name the template name
+	 * @param data the root data object (the template's {@code .})
+	 * @return the rendered output
+	 * @throws TemplateNotFoundException if no template with the given name exists
+	 * @throws TemplateExecutionException if execution fails
+	 */
+	public String render(String name, Object data) throws TemplateNotFoundException, TemplateExecutionException {
+		StringWriter writer = new StringWriter();
+		try {
+			execute(name, data, writer);
+		}
+		catch (IOException ex) {
+			// A StringWriter never performs I/O; an IOException here is not expected.
+			throw new TemplateExecutionException("Unexpected I/O error rendering '" + name + "'", ex);
+		}
+		return writer.toString();
+	}
+
+	/**
+	 * Return an immutable handle to a named template in this set, bound once so it can be
+	 * rendered repeatedly without repeating the name.
+	 * @param name the template name
+	 * @return a handle bound to the named template
+	 * @throws TemplateNotFoundException if no template with the given name exists
+	 */
+	public CompiledTemplate compiled(String name) throws TemplateNotFoundException {
+		if (name == null || !rootNodes.containsKey(name)) {
+			throw new TemplateNotFoundException(String.format("Template '%s' not found.", name));
+		}
+		return new CompiledTemplate(this, name);
 	}
 
 	/**

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/CompiledTemplateTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/CompiledTemplateTest.java
@@ -1,0 +1,60 @@
+package org.alexmond.gotmpl4j;
+
+import java.io.StringWriter;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CompiledTemplateTest {
+
+	@Test
+	void renderMainTemplateToString() throws Exception {
+		GoTemplate template = new GoTemplate();
+		template.parse("greeting", "Hello {{ .Name }}");
+
+		assertEquals("Hello world", template.render(Map.of("Name", "world")));
+	}
+
+	@Test
+	void renderNamedTemplateToString() throws Exception {
+		GoTemplate template = new GoTemplate();
+		template.parse("greeting", "Hello {{ .Name }}");
+
+		assertEquals("Hello world", template.render("greeting", Map.of("Name", "world")));
+	}
+
+	@Test
+	void renderUnknownNameThrowsNotFound() throws Exception {
+		GoTemplate template = new GoTemplate();
+		template.parse("greeting", "Hi");
+
+		assertThrows(TemplateNotFoundException.class, () -> template.render("missing", Map.of()));
+	}
+
+	@Test
+	void compiledHandleBindsNameAndRenders() throws Exception {
+		GoTemplate template = new GoTemplate();
+		template.parse("greeting", "Hello {{ .Name }}");
+
+		CompiledTemplate handle = template.compiled("greeting");
+
+		assertEquals("greeting", handle.name());
+		assertEquals("Hello world", handle.render(Map.of("Name", "world")));
+
+		StringWriter writer = new StringWriter();
+		handle.render(Map.of("Name", "writer"), writer);
+		assertEquals("Hello writer", writer.toString());
+	}
+
+	@Test
+	void compiledUnknownNameThrowsNotFound() throws Exception {
+		GoTemplate template = new GoTemplate();
+		template.parse("greeting", "Hi");
+
+		assertThrows(TemplateNotFoundException.class, () -> template.compiled("missing"));
+	}
+
+}


### PR DESCRIPTION
EPIC #36 child #38. Adds ergonomic public API to the standalone engine, matching the `process(...)->String` shape callers expect from Thymeleaf/FreeMarker.

## Added (`gotmpl4j-core`)
- **`GoTemplate.render(data)` / `render(name, data)`** — execute to a `String` without supplying a `Writer`. Wraps `execute()` over a `StringWriter`; the impossible `StringWriter` `IOException` is rethrown as `TemplateExecutionException`. Unknown name → `TemplateNotFoundException`, same as `execute`.
- **`CompiledTemplate`** — an immutable handle binding a `GoTemplate` to one template name, obtained via `GoTemplate.compiled(name)` (validates the name exists). Exposes `render(data)->String`, `render(data, Writer)`, and `name()`. Lets a caller (e.g. the planned MVC ViewResolver, #42) resolve a view name once and render it repeatedly.

## Safety
- Purely additive — `execute()` and all existing behaviour unchanged.
- Engine builds green including the 0.75 jacoco line-coverage gate; new `CompiledTemplateTest` covers main/named render, both not-found paths, and the handle's String + Writer renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)