### PR TITLE
feat(gotmpl4j-core): html/template safe content types + stringify (S1, #415)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Content.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Content.java
@@ -1,0 +1,84 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.alexmond.gotmpl4j.GoFmt;
+
+/**
+ * Resolves a template value (or values) to a string and its {@link ContentType}, the way
+ * Go {@code html/template}'s {@code stringify} does. The contextual escapers call this
+ * first so a {@link SafeContent} of the matching type can be passed through verbatim
+ * while everything else is treated as {@link ContentType#PLAIN} untrusted text.
+ */
+public final class Content {
+
+	private Content() {
+	}
+
+	/**
+	 * Converts arguments to a string and the content type of the result, mirroring Go
+	 * {@code html/template}'s {@code stringify}. A single {@link SafeContent} argument
+	 * keeps its type; a single {@link String} is {@link ContentType#PLAIN}; anything else
+	 * (or multiple arguments) is rendered like {@code fmt.Sprint} as
+	 * {@link ContentType#PLAIN}, skipping {@code null} arguments for backward
+	 * compatibility (Go issue 25875).
+	 * @param args the arguments (typically the single evaluated pipeline value)
+	 * @return the rendered text and its content type
+	 */
+	public static Stringified stringify(Object... args) {
+		if (args.length == 1) {
+			Object a = indirect(args[0]);
+			if (a instanceof SafeContent safe) {
+				return new Stringified(safe.value(), safe.contentType());
+			}
+			if (a instanceof String s) {
+				return new Stringified(s, ContentType.PLAIN);
+			}
+		}
+		List<Object> kept = new ArrayList<>(args.length);
+		for (Object arg : args) {
+			// Skip untyped nil arguments for backward compatibility; without this they
+			// would be output as <nil>, escaped (Go issue 25875).
+			if (arg == null) {
+				continue;
+			}
+			kept.add(indirect(arg));
+		}
+		return new Stringified(sprintAll(kept), ContentType.PLAIN);
+	}
+
+	// Java has no pointer indirection (Go dereferences pointers / unwraps to a
+	// fmt.Stringer or error here); the value is returned as-is.
+	private static Object indirect(Object a) {
+		return a;
+	}
+
+	// Mirrors fmt.Sprint: operands are rendered with %v and a space is inserted between
+	// two adjacent operands when neither is a string.
+	private static String sprintAll(List<Object> operands) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < operands.size(); i++) {
+			if (i > 0 && !isStringLike(operands.get(i - 1)) && !isStringLike(operands.get(i))) {
+				sb.append(' ');
+			}
+			sb.append(GoFmt.sprint(operands.get(i)));
+		}
+		return sb.toString();
+	}
+
+	private static boolean isStringLike(Object o) {
+		return o instanceof String || o instanceof SafeContent;
+	}
+
+	/**
+	 * The result of {@link #stringify(Object...)}: the rendered text and the content type
+	 * it should be treated as.
+	 *
+	 * @param text the rendered string
+	 * @param type the content type
+	 */
+	public record Stringified(String text, ContentType type) {
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/ContentType.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/ContentType.java
@@ -1,0 +1,50 @@
+package org.alexmond.gotmpl4j.html;
+
+/**
+ * The kind of content a value carries, used by the contextual auto-escaper to decide
+ * whether (and how) to escape an interpolated value. Mirrors Go {@code html/template}'s
+ * {@code contentType}.
+ *
+ * <p>
+ * {@link #PLAIN} is ordinary, untrusted text that gets escaped for whatever context it
+ * appears in. The remaining typed kinds correspond to {@link SafeContent} wrappers that
+ * mark trusted content which bypasses the matching escaper.
+ */
+public enum ContentType {
+
+	/** Ordinary untrusted text; escaped for the surrounding context. */
+	PLAIN,
+
+	/** Known-safe CSS ({@code template.CSS}). */
+	CSS,
+
+	/** Known-safe HTML document fragment ({@code template.HTML}). */
+	HTML,
+
+	/**
+	 * Known-safe HTML attributes ({@code template.HTMLAttr}), e.g. {@code  dir="ltr"}.
+	 */
+	HTML_ATTR,
+
+	/** Known-safe ECMAScript expression ({@code template.JS}). */
+	JS,
+
+	/**
+	 * Known-safe JavaScript string body, to embed between quotes
+	 * ({@code template.JSStr}).
+	 */
+	JS_STR,
+
+	/** Known-safe URL or URL substring ({@code template.URL}). */
+	URL,
+
+	/** Known-safe {@code srcset} attribute value ({@code template.Srcset}). */
+	SRCSET,
+
+	/**
+	 * Content that affects how embedded content or network messages are formed, vetted or
+	 * interpreted; used by the attribute machinery for unsafe attributes.
+	 */
+	UNSAFE
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/SafeContent.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/SafeContent.java
@@ -1,0 +1,111 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.util.Objects;
+
+/**
+ * A string of content from a trusted source, tagged with the {@link ContentType} it is
+ * safe for. When the contextual auto-escaper (HTML mode) interpolates a
+ * {@code SafeContent} whose type matches the surrounding context, the value is emitted
+ * verbatim instead of being escaped. Mirrors the named string types in Go
+ * {@code html/template} — {@code template.HTML}, {@code template.CSS},
+ * {@code template.JS}, {@code template.JSStr}, {@code template.URL},
+ * {@code template.HTMLAttr}, {@code template.Srcset}.
+ *
+ * <p>
+ * <strong>Using these types is a security decision:</strong> the wrapped content is
+ * trusted and included verbatim, so it must come from a trusted source — never from
+ * untrusted input.
+ *
+ * <pre>{@code
+ * data.put("snippet", SafeContent.html("<b>bold</b>")); // emitted as-is in HTML text
+ * }</pre>
+ */
+public final class SafeContent {
+
+	private final String value;
+
+	private final ContentType type;
+
+	private SafeContent(String value, ContentType type) {
+		this.value = Objects.requireNonNull(value, "value");
+		this.type = type;
+	}
+
+	/** Wraps a known-safe HTML document fragment ({@code template.HTML}). */
+	public static SafeContent html(String value) {
+		return new SafeContent(value, ContentType.HTML);
+	}
+
+	/** Wraps known-safe CSS ({@code template.CSS}). */
+	public static SafeContent css(String value) {
+		return new SafeContent(value, ContentType.CSS);
+	}
+
+	/** Wraps known-safe HTML attributes ({@code template.HTMLAttr}). */
+	public static SafeContent htmlAttr(String value) {
+		return new SafeContent(value, ContentType.HTML_ATTR);
+	}
+
+	/** Wraps a known-safe ECMAScript expression ({@code template.JS}). */
+	public static SafeContent js(String value) {
+		return new SafeContent(value, ContentType.JS);
+	}
+
+	/** Wraps a known-safe JavaScript string body ({@code template.JSStr}). */
+	public static SafeContent jsStr(String value) {
+		return new SafeContent(value, ContentType.JS_STR);
+	}
+
+	/** Wraps a known-safe URL or URL substring ({@code template.URL}). */
+	public static SafeContent url(String value) {
+		return new SafeContent(value, ContentType.URL);
+	}
+
+	/** Wraps a known-safe {@code srcset} attribute value ({@code template.Srcset}). */
+	public static SafeContent srcset(String value) {
+		return new SafeContent(value, ContentType.SRCSET);
+	}
+
+	/**
+	 * The wrapped content.
+	 * @return the raw string value
+	 */
+	public String value() {
+		return this.value;
+	}
+
+	/**
+	 * The content type this value is trusted for.
+	 * @return the content type
+	 */
+	public ContentType contentType() {
+		return this.type;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof SafeContent other)) {
+			return false;
+		}
+		return this.type == other.type && this.value.equals(other.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.value, this.type);
+	}
+
+	/**
+	 * Returns the raw value, so a {@code SafeContent} stringifies to its content (e.g.
+	 * when rendered in text mode or by {@code print}).
+	 * @return the raw string value
+	 */
+	@Override
+	public String toString() {
+		return this.value;
+	}
+
+}

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/ContentTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/ContentTest.java
@@ -1,0 +1,60 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.alexmond.gotmpl4j.html.Content.Stringified;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ContentTest {
+
+	@Test
+	void safeContentKeepsItsType() {
+		assertEquals(new Stringified("<b>x</b>", ContentType.HTML), Content.stringify(SafeContent.html("<b>x</b>")));
+		assertEquals(new Stringified("a {color:red}", ContentType.CSS),
+				Content.stringify(SafeContent.css("a {color:red}")));
+		assertEquals(new Stringified("x+y", ContentType.JS), Content.stringify(SafeContent.js("x+y")));
+		assertEquals(new Stringified("foo\\nbar", ContentType.JS_STR),
+				Content.stringify(SafeContent.jsStr("foo\\nbar")));
+		assertEquals(new Stringified("/path?q=1", ContentType.URL), Content.stringify(SafeContent.url("/path?q=1")));
+		assertEquals(new Stringified(" dir=\"ltr\"", ContentType.HTML_ATTR),
+				Content.stringify(SafeContent.htmlAttr(" dir=\"ltr\"")));
+		assertEquals(new Stringified("a.png 1x", ContentType.SRCSET),
+				Content.stringify(SafeContent.srcset("a.png 1x")));
+	}
+
+	@Test
+	void plainStringIsPlain() {
+		assertEquals(new Stringified("<b>x</b>", ContentType.PLAIN), Content.stringify("<b>x</b>"));
+	}
+
+	@Test
+	void numbersAndOtherTypesRenderLikeSprint() {
+		assertEquals(new Stringified("42", ContentType.PLAIN), Content.stringify(42L));
+		assertEquals(new Stringified("3.5", ContentType.PLAIN), Content.stringify(3.5));
+		assertEquals(new Stringified("map[a:1]", ContentType.PLAIN), Content.stringify(Map.of("a", 1L)));
+	}
+
+	@Test
+	void nullArgumentsAreSkipped() {
+		// A lone null still yields empty (no <nil>), matching Go issue 25875.
+		assertEquals(new Stringified("", ContentType.PLAIN), Content.stringify((Object) null));
+		assertEquals(new Stringified("ab", ContentType.PLAIN), Content.stringify("a", null, "b"));
+	}
+
+	@Test
+	void spaceInsertedBetweenNonStringOperands() {
+		// fmt.Sprint inserts a space between two operands when neither is a string.
+		assertEquals(new Stringified("1 2", ContentType.PLAIN), Content.stringify(1L, 2L));
+		// ... but not when either side is a string.
+		assertEquals(new Stringified("1x2", ContentType.PLAIN), Content.stringify(1L, "x", 2L));
+	}
+
+	@Test
+	void safeContentStringifiesToItsValue() {
+		assertEquals("<b>x</b>", SafeContent.html("<b>x</b>").toString());
+	}
+
+}


### PR DESCRIPTION
Stage 1 of epic #414 (faithful port of Go `html/template` contextual auto-escaping). Closes #415.

Ports Go's `html/template/content.go`:
- **`ContentType`** enum — PLAIN/CSS/HTML/HTML_ATTR/JS/JS_STR/URL/SRCSET/UNSAFE.
- **`SafeContent`** — trusted content tagged with the type it's safe for, via factories `html/css/htmlAttr/js/jsStr/url/srcset` (the `template.HTML/CSS/JS/JSStr/URL/HTMLAttr/Srcset` named types). Stringifies to its raw value; later escaper stages emit it verbatim when its type matches the surrounding context.
- **`Content.stringify`** — resolves a value to `(text, ContentType)` like Go's `stringify`: a single `SafeContent` keeps its type, a single `String` is PLAIN, anything else renders via `fmt.Sprint` (`GoFmt.sprint`) as PLAIN, skipping `null` args (Go issue 25875).

**Safety:** pure new package `org.alexmond.gotmpl4j.html`, no engine wiring — default `text/template` behaviour and Helm parity untouched. Engine builds green incl. the 0.75 jacoco gate; `ContentTest` covers all typed/plain/sprint/null paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)