### PR TITLE
feat(gotmpl4j-core): html/template context model + error types (S3, #417)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Attr.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Attr.java
@@ -1,0 +1,25 @@
+package org.alexmond.gotmpl4j.html;
+
+/**
+ * The current HTML attribute, from {@link State#ATTR_NAME} until the tag/text states.
+ * Mirrors Go {@code html/template}'s {@code attr} (context.go); declaration order matches
+ * Go's {@code iota} order.
+ */
+public enum Attr {
+
+	/** A normal attribute, or no attribute. */
+	NONE,
+	/** An event-handler attribute (its value is JavaScript). */
+	SCRIPT,
+	/** The {@code type} attribute of a {@code <script>} element. */
+	SCRIPT_TYPE,
+	/** The {@code style} attribute (its value is CSS). */
+	STYLE,
+	/** An attribute whose value is a URL. */
+	URL,
+	/** A {@code srcset} attribute. */
+	SRCSET,
+	/** The {@code content} attribute of a {@code <meta>} element. */
+	META_CONTENT
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Context.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Context.java
@@ -1,0 +1,158 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.alexmond.gotmpl4j.parse.Node;
+
+/**
+ * Describes the state an HTML parser must be in when it reaches the output of a
+ * particular template node. Mirrors Go {@code html/template}'s {@code context}
+ * (context.go).
+ *
+ * <p>
+ * The zero value (default constructor) is the start context — {@link State#TEXT} with
+ * every other field at its first/none value — for a template producing an HTML fragment.
+ * The escaper threads a {@code Context} through the parse tree, advancing it across
+ * literal text (the transition machine) and using it to pick an escaper for each action.
+ *
+ * <p>
+ * Fields are mutable and package-private; the transition machine works on
+ * {@link #copy()}d copies (Go passes {@code context} by value), so callers must not share
+ * a single instance across branches without copying.
+ */
+public final class Context {
+
+	State state = State.TEXT;
+
+	Delim delim = Delim.NONE;
+
+	UrlPart urlPart = UrlPart.NONE;
+
+	JsCtx jsCtx = JsCtx.REGEXP;
+
+	/**
+	 * For each open JS template-literal interpolation, the depth of braces seen, so the
+	 * next {@code }} can be matched to its interpolation. {@code null} when not in one
+	 * (mirrors Go's nil slice).
+	 */
+	List<Integer> jsBraceDepth;
+
+	Attr attr = Attr.NONE;
+
+	Element element = Element.NONE;
+
+	/** The {@code range} node, for break/continue handling. */
+	Node n;
+
+	/** Set (with {@link State#ERROR}) once escaping has failed. */
+	EscapeError err;
+
+	/**
+	 * The HTML-parser state.
+	 * @return the state
+	 */
+	public State state() {
+		return this.state;
+	}
+
+	/**
+	 * The current attribute delimiter.
+	 * @return the delimiter
+	 */
+	public Delim delim() {
+		return this.delim;
+	}
+
+	/**
+	 * The error that ended escaping, if any.
+	 * @return the escape error, or {@code null}
+	 */
+	public EscapeError err() {
+		return this.err;
+	}
+
+	/**
+	 * Returns a deep copy of this context (the {@code jsBraceDepth} list is cloned).
+	 * @return a copy
+	 */
+	public Context copy() {
+		Context copy = new Context();
+		copy.state = this.state;
+		copy.delim = this.delim;
+		copy.urlPart = this.urlPart;
+		copy.jsCtx = this.jsCtx;
+		copy.jsBraceDepth = (this.jsBraceDepth != null) ? new ArrayList<>(this.jsBraceDepth) : null;
+		copy.attr = this.attr;
+		copy.element = this.element;
+		copy.n = this.n;
+		copy.err = this.err;
+		return copy;
+	}
+
+	/**
+	 * Reports whether two contexts are equal (the {@code err} is compared by identity, as
+	 * in Go; a {@code null} and an empty {@code jsBraceDepth} are considered equal).
+	 * @param d the other context
+	 * @return {@code true} if equal
+	 */
+	public boolean eq(Context d) {
+		return this.state == d.state && this.delim == d.delim && this.urlPart == d.urlPart && this.jsCtx == d.jsCtx
+				&& jsBraceDepthEquals(this.jsBraceDepth, d.jsBraceDepth) && this.attr == d.attr
+				&& this.element == d.element && this.err == d.err;
+	}
+
+	/**
+	 * Produces a template-name suffix that distinguishes a template escaped in this
+	 * context from one escaped in a different context (mirrors Go's {@code mangle}). The
+	 * default ({@link State#TEXT}) context yields the input name unchanged.
+	 * @param templateName the base template name
+	 * @return the mangled name
+	 */
+	public String mangle(String templateName) {
+		if (this.state == State.TEXT) {
+			return templateName;
+		}
+		StringBuilder s = new StringBuilder(templateName).append("$htmltemplate_").append(this.state);
+		if (this.delim != Delim.NONE) {
+			s.append('_').append(this.delim);
+		}
+		if (this.urlPart != UrlPart.NONE) {
+			s.append('_').append(this.urlPart);
+		}
+		if (this.jsCtx != JsCtx.REGEXP) {
+			s.append('_').append(this.jsCtx);
+		}
+		if (this.jsBraceDepth != null) {
+			s.append("_jsBraceDepth(").append(this.jsBraceDepth).append(')');
+		}
+		if (this.attr != Attr.NONE) {
+			s.append('_').append(this.attr);
+		}
+		if (this.element != Element.NONE) {
+			s.append('_').append(this.element);
+		}
+		return s.toString();
+	}
+
+	@Override
+	public String toString() {
+		return "{" + this.state + " " + this.delim + " " + this.urlPart + " " + this.jsCtx + " " + this.jsBraceDepth
+				+ " " + this.attr + " " + this.element + " " + this.err + "}";
+	}
+
+	private static boolean jsBraceDepthEquals(List<Integer> a, List<Integer> b) {
+		int sizeA = (a != null) ? a.size() : 0;
+		int sizeB = (b != null) ? b.size() : 0;
+		if (sizeA != sizeB) {
+			return false;
+		}
+		for (int i = 0; i < sizeA; i++) {
+			if (!a.get(i).equals(b.get(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Delim.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Delim.java
@@ -1,0 +1,19 @@
+package org.alexmond.gotmpl4j.html;
+
+/**
+ * The delimiter that will end the current HTML attribute. Mirrors Go
+ * {@code html/template}'s {@code delim} (context.go); declaration order matches Go's
+ * {@code iota} order.
+ */
+public enum Delim {
+
+	/** Outside any attribute. */
+	NONE,
+	/** A double quote ({@code "}) closes the attribute. */
+	DOUBLE_QUOTE,
+	/** A single quote ({@code '}) closes the attribute. */
+	SINGLE_QUOTE,
+	/** A space or {@code >} closes the attribute. */
+	SPACE_OR_TAG_END
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Element.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Element.java
@@ -1,0 +1,24 @@
+package org.alexmond.gotmpl4j.html;
+
+/**
+ * The HTML element when inside a start tag or special body. Certain elements (e.g.
+ * {@code <script>}, {@code <style>}) have bodies treated differently from
+ * {@link State#TEXT}. Mirrors Go {@code html/template}'s {@code element} (context.go);
+ * declaration order matches Go's {@code iota} order.
+ */
+public enum Element {
+
+	/** Outside a special tag or special element body. */
+	NONE,
+	/** A {@code <script>} raw-text element with JS (or no) type. */
+	SCRIPT,
+	/** A {@code <style>} raw-text element. */
+	STYLE,
+	/** A {@code <textarea>} RCDATA element. */
+	TEXTAREA,
+	/** A {@code <title>} RCDATA element. */
+	TITLE,
+	/** A {@code <meta>} element. */
+	META
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/EscapeError.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/EscapeError.java
@@ -1,0 +1,94 @@
+package org.alexmond.gotmpl4j.html;
+
+import org.alexmond.gotmpl4j.TemplateException;
+import org.alexmond.gotmpl4j.parse.Node;
+
+/**
+ * Describes a problem encountered while contextually escaping a template (HTML mode).
+ * Mirrors Go {@code html/template}'s {@code Error} (error.go). It is both stored on a
+ * {@link Context} to mark the infectious {@link State#ERROR} state and thrown by the
+ * escape pass, so it extends the engine's {@link TemplateException} hierarchy.
+ */
+public final class EscapeError extends TemplateException {
+
+	private final transient EscapeErrorCode code;
+
+	private final transient Node node;
+
+	private final String name;
+
+	private final transient String description;
+
+	/**
+	 * Creates an escape error.
+	 * @param code the kind of error
+	 * @param node the offending node, if known (overrides name/line in the message)
+	 * @param name the template name in which the error occurred
+	 * @param line the source line, or 0
+	 * @param description a human-readable description
+	 */
+	public EscapeError(EscapeErrorCode code, Node node, String name, int line, String description) {
+		super(format(name, line, description), line, -1);
+		this.code = code;
+		this.node = node;
+		this.name = name;
+		this.description = description;
+	}
+
+	/**
+	 * Creates an escape error from a format string, mirroring Go's {@code errorf}. The
+	 * template name is filled in later by the escape pass.
+	 * @param code the kind of error
+	 * @param node the offending node, if known
+	 * @param line the source line, or 0
+	 * @param format a {@link String#format}-style format string
+	 * @param args the format arguments
+	 * @return a new escape error
+	 */
+	public static EscapeError errorf(EscapeErrorCode code, Node node, int line, String format, Object... args) {
+		return new EscapeError(code, node, "", line, String.format(format, args));
+	}
+
+	/**
+	 * The kind of error.
+	 * @return the error code
+	 */
+	public EscapeErrorCode code() {
+		return this.code;
+	}
+
+	/**
+	 * The offending node, if known.
+	 * @return the node, or {@code null}
+	 */
+	public Node node() {
+		return this.node;
+	}
+
+	/**
+	 * The template name in which the error occurred.
+	 * @return the template name (possibly empty)
+	 */
+	public String templateName() {
+		return this.name;
+	}
+
+	/**
+	 * The human-readable description.
+	 * @return the description
+	 */
+	public String description() {
+		return this.description;
+	}
+
+	private static String format(String name, int line, String description) {
+		if (line != 0) {
+			return "html/template:" + name + ":" + line + ": " + description;
+		}
+		if (name != null && !name.isEmpty()) {
+			return "html/template:" + name + ": " + description;
+		}
+		return "html/template: " + description;
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/EscapeErrorCode.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/EscapeErrorCode.java
@@ -1,0 +1,43 @@
+package org.alexmond.gotmpl4j.html;
+
+/**
+ * A code for a kind of error encountered while contextually escaping a template. Mirrors
+ * Go {@code html/template}'s {@code ErrorCode} (error.go); declaration order matches Go's
+ * {@code iota} order.
+ */
+public enum EscapeErrorCode {
+
+	/** No error. */
+	OK,
+	/** A pipeline appears in an ambiguous context within a URL. */
+	ERR_AMBIG_CONTEXT,
+	/** Malformed HTML: expected space, attr name or end of tag. */
+	ERR_BAD_HTML,
+	/**
+	 * {@code {{if}}}/{@code {{range}}}/{@code {{with}}} branches end in different
+	 * contexts.
+	 */
+	ERR_BRANCH_END,
+	/** A template ends in a non-text context. */
+	ERR_END_CONTEXT,
+	/** A referenced template does not exist. */
+	ERR_NO_SUCH_TEMPLATE,
+	/** The output context for a template cannot be computed (e.g. bad recursion). */
+	ERR_OUTPUT_CONTEXT,
+	/** An unfinished JS regexp character set. */
+	ERR_PARTIAL_CHARSET,
+	/** An unfinished escape sequence (action follows a backslash). */
+	ERR_PARTIAL_ESCAPE,
+	/** A range loop re-entry would end in a different context. */
+	ERR_RANGE_LOOP_REENTRY,
+	/** A {@code /} could start either a division or a regexp. */
+	ERR_SLASH_AMBIG,
+	/** A predefined escaper ({@code html}/{@code urlquery}) is disallowed here. */
+	ERR_PREDEFINED_ESCAPER,
+	/**
+	 * A pipeline appears in a JS template literal (deprecated in Go; retained for
+	 * parity).
+	 */
+	ERR_JS_TEMPLATE
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/JsCtx.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/JsCtx.java
@@ -1,0 +1,17 @@
+package org.alexmond.gotmpl4j.html;
+
+/**
+ * Whether a {@code /} starts a regular-expression literal or a division operator. Mirrors
+ * Go {@code html/template}'s {@code jsCtx} (context.go); declaration order matches Go's
+ * {@code iota} order.
+ */
+public enum JsCtx {
+
+	/** A {@code /} would start a regexp literal. */
+	REGEXP,
+	/** A {@code /} would start a division operator. */
+	DIV_OP,
+	/** A {@code /} is ambiguous due to context joining. */
+	UNKNOWN
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/State.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/State.java
@@ -1,0 +1,114 @@
+package org.alexmond.gotmpl4j.html;
+
+/**
+ * A high-level HTML-parser state describing where, within an HTML document, the output of
+ * a template node lands. Mirrors Go {@code html/template}'s {@code state} (context.go);
+ * the declaration order matches Go's {@code iota} order.
+ *
+ * <p>
+ * The zero value {@link #TEXT} is the start state for a template that produces an HTML
+ * fragment.
+ */
+public enum State {
+
+	/** Parsed character data, outside any tag, directive, comment or special body. */
+	TEXT,
+	/** Before an HTML attribute or the end of a tag. */
+	TAG,
+	/** Inside an attribute name: between the carets in {@code  ^name^ = value}. */
+	ATTR_NAME,
+	/** After an attribute name but before any {@code =}. */
+	AFTER_NAME,
+	/** After the {@code =} but before the value. */
+	BEFORE_VALUE,
+	/** Inside an {@code <!-- HTML comment -->}. */
+	HTML_CMT,
+	/** Inside an RCDATA element body ({@code <textarea>} or {@code <title>}). */
+	RCDATA,
+	/** Inside an HTML attribute whose content is plain text. */
+	ATTR,
+	/** Inside an HTML attribute whose content is a URL. */
+	URL,
+	/** Inside an HTML {@code srcset} attribute. */
+	SRCSET,
+	/** Inside an event handler or {@code <script>} element. */
+	JS,
+	/** Inside a JavaScript double-quoted string. */
+	JS_DQ_STR,
+	/** Inside a JavaScript single-quoted string. */
+	JS_SQ_STR,
+	/** Inside a JavaScript back-quoted template literal. */
+	JS_TMPL_LIT,
+	/** Inside a JavaScript regexp literal. */
+	JS_REGEXP,
+	/** Inside a JavaScript {@code /* block comment *}{@code /}. */
+	JS_BLOCK_CMT,
+	/** Inside a JavaScript {@code //} line comment. */
+	JS_LINE_CMT,
+	/** Inside a JavaScript {@code <!--} HTML-like comment. */
+	JS_HTML_OPEN_CMT,
+	/** Inside a JavaScript {@code -->} HTML-like comment. */
+	JS_HTML_CLOSE_CMT,
+	/** Inside a {@code <style>} element or {@code style} attribute. */
+	CSS,
+	/** Inside a CSS double-quoted string. */
+	CSS_DQ_STR,
+	/** Inside a CSS single-quoted string. */
+	CSS_SQ_STR,
+	/** Inside a CSS double-quoted {@code url("...")}. */
+	CSS_DQ_URL,
+	/** Inside a CSS single-quoted {@code url('...')}. */
+	CSS_SQ_URL,
+	/** Inside a CSS unquoted {@code url(...)}. */
+	CSS_URL,
+	/** Inside a CSS {@code /* block comment *}{@code /}. */
+	CSS_BLOCK_CMT,
+	/** Inside a CSS {@code //} line comment. */
+	CSS_LINE_CMT,
+	/** An infectious error state outside any valid HTML/CSS/JS construct. */
+	ERROR,
+	/** Inside an HTML {@code <meta>} element {@code content} attribute. */
+	META_CONTENT,
+	/** Inside a {@code url=} part of a {@code <meta>} {@code content} attribute. */
+	META_CONTENT_URL,
+	/** Unreachable code after a {@code {{break}}} or {@code {{continue}}}. */
+	DEAD;
+
+	/**
+	 * Whether this state holds content meant for template authors, not end users or
+	 * machines (i.e. a comment).
+	 * @return {@code true} for the HTML/JS/CSS comment states
+	 */
+	public boolean isComment() {
+		return switch (this) {
+			case HTML_CMT, JS_BLOCK_CMT, JS_LINE_CMT, JS_HTML_OPEN_CMT, JS_HTML_CLOSE_CMT, CSS_BLOCK_CMT,
+					CSS_LINE_CMT ->
+				true;
+			default -> false;
+		};
+	}
+
+	/**
+	 * Whether this state occurs solely inside an HTML tag.
+	 * @return {@code true} inside a tag (name/attr machinery)
+	 */
+	public boolean isInTag() {
+		return switch (this) {
+			case TAG, ATTR_NAME, AFTER_NAME, BEFORE_VALUE, ATTR -> true;
+			default -> false;
+		};
+	}
+
+	/**
+	 * Whether this is one of the literal states within a {@code <script>} tag, where
+	 * {@code <!--}, {@code <script}, and {@code </script} need special treatment.
+	 * @return {@code true} inside a JS string/regexp literal
+	 */
+	public boolean isInScriptLiteral() {
+		return switch (this) {
+			case JS_DQ_STR, JS_SQ_STR, JS_TMPL_LIT, JS_REGEXP -> true;
+			default -> false;
+		};
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/UrlPart.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/UrlPart.java
@@ -1,0 +1,19 @@
+package org.alexmond.gotmpl4j.html;
+
+/**
+ * A part of an RFC 3986 hierarchical URL, used to pick a URL encoding strategy. Mirrors
+ * Go {@code html/template}'s {@code urlPart} (context.go); declaration order matches Go's
+ * {@code iota} order.
+ */
+public enum UrlPart {
+
+	/** Not in a URL, or possibly at its very start. */
+	NONE,
+	/** In the scheme, authority or path (before any {@code ?}). */
+	PRE_QUERY,
+	/** In the query or fragment (after {@code ?}). */
+	QUERY_OR_FRAG,
+	/** Ambiguous due to joining of contexts before and after the query separator. */
+	UNKNOWN
+
+}

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/ContextTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/ContextTest.java
@@ -1,0 +1,83 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ContextTest {
+
+	@Test
+	void zeroValueIsStartContext() {
+		Context c = new Context();
+		assertEquals(State.TEXT, c.state());
+		assertEquals(Delim.NONE, c.delim());
+		assertEquals(UrlPart.NONE, c.urlPart);
+		assertEquals(JsCtx.REGEXP, c.jsCtx);
+		assertEquals(Attr.NONE, c.attr);
+		assertEquals(Element.NONE, c.element);
+	}
+
+	@Test
+	void eqComparesAllFields() {
+		Context a = new Context();
+		Context b = new Context();
+		assertTrue(a.eq(b));
+
+		b.state = State.JS;
+		assertFalse(a.eq(b));
+	}
+
+	@Test
+	void eqTreatsNullAndEmptyJsBraceDepthAsEqual() {
+		Context a = new Context();
+		Context b = new Context();
+		b.jsBraceDepth = List.of();
+		assertTrue(a.eq(b));
+
+		b.jsBraceDepth = List.of(1);
+		assertFalse(a.eq(b));
+	}
+
+	@Test
+	void copyIsIndependent() {
+		Context a = new Context();
+		a.state = State.URL;
+		a.jsBraceDepth = new java.util.ArrayList<>(List.of(2));
+
+		Context b = a.copy();
+		assertTrue(a.eq(b));
+		assertNotSame(a.jsBraceDepth, b.jsBraceDepth);
+
+		b.jsBraceDepth.add(3);
+		assertEquals(1, a.jsBraceDepth.size());
+	}
+
+	@Test
+	void mangleIsIdentityForTextAndDistinctOtherwise() {
+		Context text = new Context();
+		assertEquals("view", text.mangle("view"));
+
+		Context js = new Context();
+		js.state = State.JS;
+		Context url = new Context();
+		url.state = State.URL;
+		assertFalse(js.mangle("view").equals(url.mangle("view")));
+		assertTrue(js.mangle("view").startsWith("view$htmltemplate_"));
+	}
+
+	@Test
+	void statePredicates() {
+		assertTrue(State.HTML_CMT.isComment());
+		assertFalse(State.TEXT.isComment());
+		assertTrue(State.ATTR_NAME.isInTag());
+		assertFalse(State.JS.isInTag());
+		assertTrue(State.JS_DQ_STR.isInScriptLiteral());
+		assertFalse(State.JS.isInScriptLiteral());
+	}
+
+}


### PR DESCRIPTION
Stage 3 of epic #414 (faithful port of Go `html/template`). Closes #417.

Ports `context.go` + `error.go`:
- **Enums** `State` (31 HTML/JS/CSS parser states), `Delim`, `UrlPart`, `JsCtx`, `Attr`, `Element` — declaration order matches Go's `iota`. `State` carries `isComment` / `isInTag` / `isInScriptLiteral`.
- **`Context`** — the per-node parser context (state/delim/urlPart/jsCtx/jsBraceDepth/attr/element/node/err) with `eq()`, `copy()` (deep-copies `jsBraceDepth`), and `mangle()` for per-context template-name distinction. Mutable + copy-on-branch, mirroring Go's by-value `context`.
- **`EscapeErrorCode`** + **`EscapeError`** (extends `TemplateException`, so it can both mark the infectious `ERROR` state on a `Context` and be thrown by the escape pass).

**Safety:** pure/additive, no engine wiring — default `text/template` and Helm parity untouched. Engine builds green incl. the 0.75 jacoco gate; `ContextTest` covers eq/copy/mangle and the state predicates. Feeds the transition machine (S4, #418) and escape pass (S5, #419).

🤖 Generated with [Claude Code](https://claude.com/claude-code)