### PR TITLE
feat(gotmpl4j-core): html/template transition state machine (S4, #418)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/AttrTypes.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/AttrTypes.java
@@ -1,0 +1,108 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.util.Map;
+
+/**
+ * Maps HTML attribute names to the {@link ContentType} of their value, mirroring Go
+ * {@code html/template}'s {@code attrTypeMap} and {@code attrType} (attr.go). Used by the
+ * transition machine to decide the context an attribute value is interpolated in (URL,
+ * CSS, JS, srcset, …).
+ */
+final class AttrTypes {
+
+	// Derived from HTML5 plus the %URI-typed HTML4 attributes. An attribute that affects
+	// or
+	// can mask the encoding/interpretation of other content, or the contents/idempotency/
+	// credentials of a network message, is UNSAFE.
+	private static final Map<String, ContentType> ATTR_TYPE_MAP = buildMap();
+
+	private AttrTypes() {
+	}
+
+	/**
+	 * A conservative (upper-bound-on-authority) guess at the type of the lower-case named
+	 * attribute.
+	 * @param attrName the lower-case attribute name
+	 * @return the content type of the attribute's value
+	 */
+	static ContentType attrType(String attrName) {
+		String name = attrName;
+		if (name.startsWith("data-")) {
+			// Strip data- so the custom-attribute heuristics below apply widely.
+			name = name.substring(5);
+		}
+		else {
+			int colon = name.indexOf(':');
+			if (colon >= 0) {
+				String prefix = name.substring(0, colon);
+				if (prefix.equals("xmlns")) {
+					return ContentType.URL;
+				}
+				// Treat svg:href and xlink:href as href below.
+				name = name.substring(colon + 1);
+			}
+		}
+		ContentType mapped = ATTR_TYPE_MAP.get(name);
+		if (mapped != null) {
+			return mapped;
+		}
+		// Partial event-handler names are script.
+		if (name.startsWith("on")) {
+			return ContentType.JS;
+		}
+		// Heuristics to prevent "javascript:..." injection in custom data/other
+		// attributes
+		// (developers store URL content in attrs containing src/uri/url).
+		if (name.contains("src") || name.contains("uri") || name.contains("url")) {
+			return ContentType.URL;
+		}
+		return ContentType.PLAIN;
+	}
+
+	private static Map<String, ContentType> buildMap() {
+		ContentType plain = ContentType.PLAIN;
+		ContentType url = ContentType.URL;
+		ContentType unsafe = ContentType.UNSAFE;
+		ContentType css = ContentType.CSS;
+		ContentType html = ContentType.HTML;
+		ContentType srcset = ContentType.SRCSET;
+		return Map.ofEntries(Map.entry("accept", plain), Map.entry("accept-charset", unsafe), Map.entry("action", url),
+				Map.entry("alt", plain), Map.entry("archive", url), Map.entry("async", unsafe),
+				Map.entry("autocomplete", plain), Map.entry("autofocus", plain), Map.entry("autoplay", plain),
+				Map.entry("background", url), Map.entry("border", plain), Map.entry("checked", plain),
+				Map.entry("cite", url), Map.entry("challenge", unsafe), Map.entry("charset", unsafe),
+				Map.entry("class", plain), Map.entry("classid", url), Map.entry("codebase", url),
+				Map.entry("cols", plain), Map.entry("colspan", plain), Map.entry("content", unsafe),
+				Map.entry("contenteditable", plain), Map.entry("contextmenu", plain), Map.entry("controls", plain),
+				Map.entry("coords", plain), Map.entry("crossorigin", unsafe), Map.entry("data", url),
+				Map.entry("datetime", plain), Map.entry("default", plain), Map.entry("defer", unsafe),
+				Map.entry("dir", plain), Map.entry("dirname", plain), Map.entry("disabled", plain),
+				Map.entry("draggable", plain), Map.entry("dropzone", plain), Map.entry("enctype", unsafe),
+				Map.entry("for", plain), Map.entry("form", unsafe), Map.entry("formaction", url),
+				Map.entry("formenctype", unsafe), Map.entry("formmethod", unsafe), Map.entry("formnovalidate", unsafe),
+				Map.entry("formtarget", plain), Map.entry("headers", plain), Map.entry("height", plain),
+				Map.entry("hidden", plain), Map.entry("high", plain), Map.entry("href", url),
+				Map.entry("hreflang", plain), Map.entry("http-equiv", unsafe), Map.entry("icon", url),
+				Map.entry("id", plain), Map.entry("ismap", plain), Map.entry("keytype", unsafe),
+				Map.entry("kind", plain), Map.entry("label", plain), Map.entry("lang", plain),
+				Map.entry("language", unsafe), Map.entry("list", plain), Map.entry("longdesc", url),
+				Map.entry("loop", plain), Map.entry("low", plain), Map.entry("manifest", url), Map.entry("max", plain),
+				Map.entry("maxlength", plain), Map.entry("media", plain), Map.entry("mediagroup", plain),
+				Map.entry("method", unsafe), Map.entry("min", plain), Map.entry("multiple", plain),
+				Map.entry("name", plain), Map.entry("novalidate", unsafe), Map.entry("open", plain),
+				Map.entry("optimum", plain), Map.entry("pattern", unsafe), Map.entry("placeholder", plain),
+				Map.entry("poster", url), Map.entry("profile", url), Map.entry("preload", plain),
+				Map.entry("pubdate", plain), Map.entry("radiogroup", plain), Map.entry("readonly", plain),
+				Map.entry("rel", unsafe), Map.entry("required", plain), Map.entry("reversed", plain),
+				Map.entry("rows", plain), Map.entry("rowspan", plain), Map.entry("sandbox", unsafe),
+				Map.entry("spellcheck", plain), Map.entry("scope", plain), Map.entry("scoped", plain),
+				Map.entry("seamless", plain), Map.entry("selected", plain), Map.entry("shape", plain),
+				Map.entry("size", plain), Map.entry("sizes", plain), Map.entry("span", plain), Map.entry("src", url),
+				Map.entry("srcdoc", html), Map.entry("srclang", plain), Map.entry("srcset", srcset),
+				Map.entry("start", plain), Map.entry("step", plain), Map.entry("style", css),
+				Map.entry("tabindex", plain), Map.entry("target", plain), Map.entry("title", plain),
+				Map.entry("type", unsafe), Map.entry("usemap", url), Map.entry("value", unsafe),
+				Map.entry("width", plain), Map.entry("wrap", plain), Map.entry("xmlns", url));
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Bytes.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Bytes.java
@@ -1,0 +1,113 @@
+package org.alexmond.gotmpl4j.html;
+
+/**
+ * Byte-slice helpers mirroring the {@code bytes} package operations the Go
+ * {@code html/template} transition machine relies on. The escaper works on UTF-8
+ * {@code byte[]} (not {@code char[]}) so byte offsets stay identical to Go's, which
+ * indexes raw bytes. All "set" arguments are ASCII, matching Go's usage.
+ */
+final class Bytes {
+
+	private Bytes() {
+	}
+
+	/**
+	 * Index of the first {@code b} at or after {@code from}, or -1 (like
+	 * bytes.IndexByte).
+	 */
+	static int indexByte(byte[] s, int from, byte b) {
+		for (int i = from; i < s.length; i++) {
+			if (s[i] == b) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * Index of the first byte at or after {@code from} that is one of the ASCII bytes in
+	 * {@code set}, or -1 (like bytes.IndexAny with an ASCII cutset).
+	 */
+	static int indexAny(byte[] s, int from, String set) {
+		for (int i = from; i < s.length; i++) {
+			int c = s[i] & 0xff;
+			if (c < 0x80 && set.indexOf(c) >= 0) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	/** Whether any byte at or after {@code from} is in the ASCII {@code set}. */
+	static boolean containsAny(byte[] s, int from, String set) {
+		return indexAny(s, from, set) != -1;
+	}
+
+	/** Index of the first occurrence of {@code sub} at or after {@code from}, or -1. */
+	static int index(byte[] s, int from, byte[] sub) {
+		if (sub.length == 0) {
+			return from;
+		}
+		int last = s.length - sub.length;
+		for (int i = from; i <= last; i++) {
+			if (regionEquals(s, i, sub)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * Whether {@code s[off..off+lit.length]} equals {@code lit} exactly (bounds-checked).
+	 */
+	static boolean regionEquals(byte[] s, int off, byte[] lit) {
+		if (off < 0 || off + lit.length > s.length) {
+			return false;
+		}
+		for (int i = 0; i < lit.length; i++) {
+			if (s[off + i] != lit[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Whether {@code s[off..off+lit.length]} equals {@code lit} ignoring ASCII case
+	 * (bounds-checked), like bytes.EqualFold restricted to ASCII.
+	 */
+	static boolean regionEqualsFold(byte[] s, int off, byte[] lit) {
+		if (off < 0 || off + lit.length > s.length) {
+			return false;
+		}
+		for (int i = 0; i < lit.length; i++) {
+			if (toLowerAscii(s[off + i]) != toLowerAscii(lit[i])) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/** ASCII lower-cases a single byte. */
+	static byte toLowerAscii(byte b) {
+		if (b >= 'A' && b <= 'Z') {
+			return (byte) (b + ('a' - 'A'));
+		}
+		return b;
+	}
+
+	/** ASCII lower-cases the bytes {@code s[from..to]} into a {@link String}. */
+	static String toLowerAscii(byte[] s, int from, int to) {
+		StringBuilder sb = new StringBuilder(to - from);
+		for (int i = from; i < to; i++) {
+			sb.append((char) (toLowerAscii(s[i]) & 0xff));
+		}
+		return sb.toString();
+	}
+
+	/** Encodes a {@link String} to its UTF-8 bytes. */
+	static byte[] utf8(String s) {
+		return s.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/CssLex.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/CssLex.java
@@ -1,0 +1,191 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * CSS lexical helpers from Go {@code html/template}'s css.go that the transition machine
+ * needs: {@link #endsWithCSSKeyword}, {@link #decodeCSS}, and the small predicates around
+ * them.
+ */
+final class CssLex {
+
+	private static final int MAX_RUNE = 0x10ffff;
+
+	private CssLex() {
+	}
+
+	/**
+	 * Whether {@code b[0..len]} ends with an ident case-insensitively matching the
+	 * lower-case {@code kw} (mirrors {@code endsWithCSSKeyword}).
+	 * @param b the bytes
+	 * @param len the effective length to consider
+	 * @param kw the lower-case keyword
+	 * @return {@code true} if {@code b} ends with the keyword as a whole ident
+	 */
+	static boolean endsWithCSSKeyword(byte[] b, int len, String kw) {
+		int i = len - kw.length();
+		if (i < 0) {
+			return false;
+		}
+		if (i != 0) {
+			// The char just before must not itself be an ident char (else too long).
+			int start = i - 1;
+			while (start > 0 && (b[start] & 0xc0) == 0x80) {
+				start--;
+			}
+			if (isCSSNmchar(decodeRune(b, start, i))) {
+				return false;
+			}
+		}
+		return Bytes.toLowerAscii(b, i, len).equals(kw);
+	}
+
+	/**
+	 * Whether the rune is allowed anywhere in a CSS identifier (the CSS3 nmchar
+	 * production, ignoring multi-rune escapes).
+	 * @param r the rune
+	 * @return {@code true} if a CSS nmchar
+	 */
+	static boolean isCSSNmchar(int r) {
+		return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_'
+				|| (r >= 0x80 && r <= 0xd7ff) || (r >= 0xe000 && r <= 0xfffd) || (r >= 0x10000 && r <= 0x10ffff);
+	}
+
+	/** Whether the byte is a hex digit. */
+	static boolean isHex(byte c) {
+		return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+	}
+
+	/** Whether the byte is a CSS space char (wc). */
+	static boolean isCSSSpace(byte b) {
+		return switch (b) {
+			case '\t', '\n', '\f', '\r', ' ' -> true;
+			default -> false;
+		};
+	}
+
+	/**
+	 * Decodes CSS3 escapes in {@code s}, returning the input unchanged if there are none,
+	 * or a new array otherwise (mirrors {@code decodeCSS}).
+	 * @param s the bytes
+	 * @return the decoded bytes
+	 */
+	static byte[] decodeCSS(byte[] s) {
+		if (Bytes.indexByte(s, 0, (byte) '\\') == -1) {
+			return s;
+		}
+		ByteArrayOutputStream out = new ByteArrayOutputStream(s.length);
+		int pos = 0;
+		while (pos < s.length) {
+			int i = Bytes.indexByte(s, pos, (byte) '\\');
+			if (i == -1) {
+				i = s.length;
+			}
+			out.write(s, pos, i - pos);
+			pos = i;
+			if (s.length - pos < 2) {
+				break;
+			}
+			if (isHex(s[pos + 1])) {
+				int j = 2;
+				while (pos + j < s.length && j < 7 && isHex(s[pos + j])) {
+					j++;
+				}
+				int r = hexDecode(s, pos + 1, pos + j);
+				if (r > MAX_RUNE) {
+					r /= 16;
+					j--;
+				}
+				byte[] enc = encodeRune(r);
+				out.write(enc, 0, enc.length);
+				pos = skipCSSSpace(s, pos + j);
+			}
+			else {
+				int n = runeLen(s, pos + 1);
+				out.write(s, pos + 1, n);
+				pos = pos + 1 + n;
+			}
+		}
+		return out.toByteArray();
+	}
+
+	private static int hexDecode(byte[] s, int from, int to) {
+		int n = 0;
+		for (int i = from; i < to; i++) {
+			byte c = s[i];
+			n <<= 4;
+			if (c >= '0' && c <= '9') {
+				n |= c - '0';
+			}
+			else if (c >= 'a' && c <= 'f') {
+				n |= c - 'a' + 10;
+			}
+			else if (c >= 'A' && c <= 'F') {
+				n |= c - 'A' + 10;
+			}
+		}
+		return n;
+	}
+
+	private static int skipCSSSpace(byte[] c, int pos) {
+		if (pos >= c.length) {
+			return pos;
+		}
+		switch (c[pos]) {
+			case '\t', '\n', '\f', ' ' -> {
+				return pos + 1;
+			}
+			case '\r' -> {
+				if (pos + 1 < c.length && c[pos + 1] == '\n') {
+					return pos + 2;
+				}
+				return pos + 1;
+			}
+			default -> {
+				return pos;
+			}
+		}
+	}
+
+	private static byte[] encodeRune(int cp) {
+		return new String(Character.toChars(cp)).getBytes(StandardCharsets.UTF_8);
+	}
+
+	private static int runeLen(byte[] s, int idx) {
+		int b0 = s[idx] & 0xff;
+		int len;
+		if (b0 < 0x80) {
+			len = 1;
+		}
+		else if (b0 < 0xe0) {
+			len = 2;
+		}
+		else if (b0 < 0xf0) {
+			len = 3;
+		}
+		else {
+			len = 4;
+		}
+		return Math.min(len, s.length - idx);
+	}
+
+	private static int decodeRune(byte[] s, int start, int end) {
+		int b0 = s[start] & 0xff;
+		if (b0 < 0x80) {
+			return b0;
+		}
+		if (b0 < 0xe0 && start + 1 < end) {
+			return ((b0 & 0x1f) << 6) | (s[start + 1] & 0x3f);
+		}
+		if (b0 < 0xf0 && start + 2 < end) {
+			return ((b0 & 0x0f) << 12) | ((s[start + 1] & 0x3f) << 6) | (s[start + 2] & 0x3f);
+		}
+		if (start + 3 < end) {
+			return ((b0 & 0x07) << 18) | ((s[start + 1] & 0x3f) << 12) | ((s[start + 2] & 0x3f) << 6)
+					| (s[start + 3] & 0x3f);
+		}
+		return b0;
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/JsLex.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/JsLex.java
@@ -1,0 +1,142 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.util.Set;
+
+/**
+ * JavaScript lexical helpers from Go {@code html/template}'s js.go that the transition
+ * machine needs: {@link #nextJSCtx} (does a {@code /} start a regexp or a division?),
+ * {@link #isJSIdentPart}, and {@link #isJsType}.
+ */
+final class JsLex {
+
+	// JS whitespace per the \s class (used to right-trim a token run in nextJSCtx).
+	private static final Set<Integer> JS_WHITESPACE = Set.of(0x0c, 0x0a, 0x0d, 0x09, 0x0b, 0x20, 0xa0, 0x1680, 0x2000,
+			0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007, 0x2008, 0x2009, 0x200a, 0x2028, 0x2029, 0x202f,
+			0x205f, 0x3000, 0xfeff);
+
+	// Reserved JS keywords that can precede a regular expression literal.
+	private static final Set<String> REGEXP_PRECEDER_KEYWORDS = Set.of("break", "case", "continue", "delete", "do",
+			"else", "finally", "in", "instanceof", "return", "throw", "try", "typeof", "void");
+
+	private static final Set<String> JS_MIME_TYPES = Set.of("", "application/ecmascript", "application/javascript",
+			"application/json", "application/ld+json", "application/x-ecmascript", "application/x-javascript", "module",
+			"text/ecmascript", "text/javascript", "text/javascript1.0", "text/javascript1.1", "text/javascript1.2",
+			"text/javascript1.3", "text/javascript1.4", "text/javascript1.5", "text/jscript", "text/livescript",
+			"text/x-ecmascript", "text/x-javascript");
+
+	private JsLex() {
+	}
+
+	/**
+	 * Returns the context that decides whether a {@code /} following the run of tokens
+	 * {@code s[0..len]} starts a regexp literal or a division operator (mirrors
+	 * {@code nextJSCtx}). Assumes the run has no string/comment/regexp/division tokens.
+	 * @param s the token bytes
+	 * @param len the effective length of {@code s} to consider
+	 * @param preceding the prior JS context (returned for an all-whitespace run)
+	 * @return the resulting JS context
+	 */
+	static JsCtx nextJSCtx(byte[] s, int len, JsCtx preceding) {
+		int n = trimRightJsWhitespace(s, len);
+		if (n == 0) {
+			return preceding;
+		}
+		int c = s[n - 1] & 0xff;
+		switch (c) {
+			case '+', '-' -> {
+				// ++ and -- are not regexp preceders, but a single + or - is.
+				int start = n - 1;
+				while (start > 0 && (s[start - 1] & 0xff) == c) {
+					start--;
+				}
+				return (((n - start) & 1) == 1) ? JsCtx.REGEXP : JsCtx.DIV_OP;
+			}
+			case '.' -> {
+				// Handle "42." -> division.
+				if (n != 1 && s[n - 2] >= '0' && s[n - 2] <= '9') {
+					return JsCtx.DIV_OP;
+				}
+				return JsCtx.REGEXP;
+			}
+			case ',', '<', '>', '=', '*', '%', '&', '|', '^', '?', '!', '~', '(', '[', ':', ';', '{', '}' -> {
+				return JsCtx.REGEXP;
+			}
+			default -> {
+				// Look for a trailing IdentifierName and check it against the keyword
+				// set.
+				int j = n;
+				while (j > 0 && isJSIdentPart(s[j - 1] & 0xff)) {
+					j--;
+				}
+				if (REGEXP_PRECEDER_KEYWORDS
+					.contains(new String(s, j, n - j, java.nio.charset.StandardCharsets.UTF_8))) {
+					return JsCtx.REGEXP;
+				}
+			}
+		}
+		// A punctuator/string/identifier that precedes a division operator.
+		return JsCtx.DIV_OP;
+	}
+
+	/**
+	 * Whether the rune is a JS identifier part (handles every codepoint that can occur in
+	 * a numeric literal or keyword).
+	 * @param r the rune
+	 * @return {@code true} if an identifier part
+	 */
+	static boolean isJSIdentPart(int r) {
+		return r == '$' || (r >= '0' && r <= '9') || (r >= 'A' && r <= 'Z') || r == '_' || (r >= 'a' && r <= 'z');
+	}
+
+	/**
+	 * Whether a MIME type should be treated as JavaScript (for
+	 * {@code <script type=...>}).
+	 * @param mimeType the raw type attribute value
+	 * @return {@code true} if JavaScript
+	 */
+	static boolean isJsType(String mimeType) {
+		String type = mimeType;
+		int semi = type.indexOf(';');
+		if (semi >= 0) {
+			type = type.substring(0, semi);
+		}
+		type = type.toLowerCase(java.util.Locale.ROOT).strip();
+		return JS_MIME_TYPES.contains(type);
+	}
+
+	// Rune-aware right-trim of JS whitespace; returns the new effective length.
+	private static int trimRightJsWhitespace(byte[] s, int len) {
+		int end = len;
+		while (end > 0) {
+			int start = end - 1;
+			while (start > 0 && (s[start] & 0xc0) == 0x80) {
+				start--;
+			}
+			int cp = decodeRune(s, start, end);
+			if (!JS_WHITESPACE.contains(cp)) {
+				break;
+			}
+			end = start;
+		}
+		return end;
+	}
+
+	private static int decodeRune(byte[] s, int start, int end) {
+		int b0 = s[start] & 0xff;
+		if (b0 < 0x80) {
+			return b0;
+		}
+		if (b0 < 0xe0 && start + 1 < end) {
+			return ((b0 & 0x1f) << 6) | (s[start + 1] & 0x3f);
+		}
+		if (b0 < 0xf0 && start + 2 < end) {
+			return ((b0 & 0x0f) << 12) | ((s[start + 1] & 0x3f) << 6) | (s[start + 2] & 0x3f);
+		}
+		if (start + 3 < end) {
+			return ((b0 & 0x07) << 18) | ((s[start + 1] & 0x3f) << 12) | ((s[start + 2] & 0x3f) << 6)
+					| (s[start + 3] & 0x3f);
+		}
+		return b0;
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Transitions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Transitions.java
@@ -1,0 +1,746 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * The HTML/JS/CSS context transition machine, ported from Go {@code html/template}'s
+ * transition.go. Given a {@link Context} and a run of literal template text (as UTF-8
+ * {@code byte[]}, to keep byte offsets identical to Go), {@link #transition} advances the
+ * context and reports how many bytes it consumed. The escape pass drives this over the
+ * text between actions to learn each action's context.
+ */
+final class Transitions {
+
+	private static final byte[] COMMENT_START = Bytes.utf8("<!--");
+
+	private static final byte[] COMMENT_END = Bytes.utf8("-->");
+
+	private static final byte[] BLOCK_COMMENT_END = Bytes.utf8("*/");
+
+	private static final byte[] SPECIAL_TAG_END_PREFIX = Bytes.utf8("</");
+
+	private static final String TAG_END_SEPARATORS = "> \t\n\f/";
+
+	private static final byte[] SCRIPT_TAG = Bytes.utf8("</script");
+
+	private static final Map<String, Element> ELEMENT_NAME_MAP = Map.of("script", Element.SCRIPT, "style",
+			Element.STYLE, "textarea", Element.TEXTAREA, "title", Element.TITLE, "meta", Element.META);
+
+	private Transitions() {
+	}
+
+	/**
+	 * Advances {@code c} across the literal text {@code s} (consuming a prefix of it).
+	 * @param c the current context (may be mutated)
+	 * @param s the literal text bytes
+	 * @return the new context and bytes consumed
+	 */
+	static Result transition(Context c, byte[] s) {
+		return switch (c.state) {
+			case TEXT -> tText(c, s);
+			case TAG -> tTag(c, s);
+			case ATTR_NAME -> tAttrName(c, s);
+			case AFTER_NAME -> tAfterName(c, s);
+			case BEFORE_VALUE -> tBeforeValue(c, s);
+			case HTML_CMT -> tHTMLCmt(c, s);
+			case RCDATA -> tSpecialTagEnd(c, s);
+			case ATTR -> tAttr(c, s);
+			case URL, SRCSET -> tURL(c, s);
+			case META_CONTENT -> tMetaContent(c, s);
+			case META_CONTENT_URL -> tMetaContentURL(c, s);
+			case JS -> tJS(c, s);
+			case JS_DQ_STR, JS_SQ_STR, JS_REGEXP -> tJSDelimited(c, s);
+			case JS_TMPL_LIT -> tJSTmpl(c, s);
+			case JS_BLOCK_CMT, CSS_BLOCK_CMT -> tBlockCmt(c, s);
+			case JS_LINE_CMT, JS_HTML_OPEN_CMT, JS_HTML_CLOSE_CMT, CSS_LINE_CMT -> tLineCmt(c, s);
+			case CSS -> tCSS(c, s);
+			case CSS_DQ_STR, CSS_SQ_STR, CSS_DQ_URL, CSS_SQ_URL, CSS_URL -> tCSSStr(c, s);
+			case ERROR -> tError(c, s);
+			default -> throw new IllegalStateException("no transition for state " + c.state);
+		};
+	}
+
+	private static Result tText(Context c, byte[] s) {
+		int k = 0;
+		while (true) {
+			int i = Bytes.indexByte(s, k, (byte) '<');
+			if (i < 0 || i + 1 == s.length) {
+				return new Result(c, s.length);
+			}
+			if (i + 4 <= s.length && Bytes.regionEquals(s, i, COMMENT_START)) {
+				Context r = new Context();
+				r.state = State.HTML_CMT;
+				return new Result(r, i + 4);
+			}
+			i++;
+			boolean end = false;
+			if (s[i] == '/') {
+				if (i + 1 == s.length) {
+					return new Result(c, s.length);
+				}
+				end = true;
+				i++;
+			}
+			EatTag tag = eatTagName(s, i);
+			if (tag.end != i) {
+				Element e = end ? Element.NONE : tag.element;
+				Context r = new Context();
+				r.state = State.TAG;
+				r.element = e;
+				return new Result(r, tag.end);
+			}
+			k = tag.end;
+		}
+	}
+
+	private static Result tTag(Context c, byte[] s) {
+		int i = eatWhiteSpace(s, 0);
+		if (i == s.length) {
+			return new Result(c, s.length);
+		}
+		if (s[i] == '>') {
+			if (c.element == Element.META) {
+				Context r = new Context();
+				r.state = State.TEXT;
+				return new Result(r, i + 1);
+			}
+			Context r = new Context();
+			r.state = elementContentType(c.element);
+			r.element = c.element;
+			return new Result(r, i + 1);
+		}
+		EatAttr ea = eatAttrName(s, i);
+		if (ea.err != null) {
+			return errorResult(ea.err, s.length);
+		}
+		int j = ea.end;
+		if (i == j) {
+			EscapeError err = EscapeError.errorf(EscapeErrorCode.ERR_BAD_HTML, null, 0,
+					"expected space, attr name, or end of tag, but got %s", quote(s, i, Math.min(s.length, i + 32)));
+			return errorResult(err, s.length);
+		}
+		String attrName = Bytes.toLowerAscii(s, i, j);
+		Attr attr = Attr.NONE;
+		if (c.element == Element.SCRIPT && attrName.equals("type")) {
+			attr = Attr.SCRIPT_TYPE;
+		}
+		else if (c.element == Element.META && attrName.equals("content")) {
+			attr = Attr.META_CONTENT;
+		}
+		else {
+			attr = switch (AttrTypes.attrType(attrName)) {
+				case URL -> Attr.URL;
+				case CSS -> Attr.STYLE;
+				case JS -> Attr.SCRIPT;
+				case SRCSET -> Attr.SRCSET;
+				default -> Attr.NONE;
+			};
+		}
+		Context r = new Context();
+		r.state = (j == s.length) ? State.ATTR_NAME : State.AFTER_NAME;
+		r.element = c.element;
+		r.attr = attr;
+		return new Result(r, j);
+	}
+
+	private static Result tAttrName(Context c, byte[] s) {
+		EatAttr ea = eatAttrName(s, 0);
+		if (ea.err != null) {
+			return errorResult(ea.err, s.length);
+		}
+		if (ea.end != s.length) {
+			c.state = State.AFTER_NAME;
+		}
+		return new Result(c, ea.end);
+	}
+
+	private static Result tAfterName(Context c, byte[] s) {
+		int i = eatWhiteSpace(s, 0);
+		if (i == s.length) {
+			return new Result(c, s.length);
+		}
+		if (s[i] != '=') {
+			// A valueless attribute followed by another attr or the tag end.
+			c.state = State.TAG;
+			return new Result(c, i);
+		}
+		c.state = State.BEFORE_VALUE;
+		return new Result(c, i + 1);
+	}
+
+	private static Result tBeforeValue(Context c, byte[] s) {
+		int i = eatWhiteSpace(s, 0);
+		if (i == s.length) {
+			return new Result(c, s.length);
+		}
+		Delim delim = Delim.SPACE_OR_TAG_END;
+		if (s[i] == '\'') {
+			delim = Delim.SINGLE_QUOTE;
+			i++;
+		}
+		else if (s[i] == '"') {
+			delim = Delim.DOUBLE_QUOTE;
+			i++;
+		}
+		c.state = attrStartState(c.attr);
+		c.delim = delim;
+		return new Result(c, i);
+	}
+
+	private static Result tHTMLCmt(Context c, byte[] s) {
+		int i = Bytes.index(s, 0, COMMENT_END);
+		if (i != -1) {
+			return new Result(new Context(), i + 3);
+		}
+		return new Result(c, s.length);
+	}
+
+	private static Result tSpecialTagEnd(Context c, byte[] s) {
+		if (c.element != Element.NONE) {
+			// "</script" within a script literal/comment is ignored so it can be escaped.
+			if (c.element == Element.SCRIPT && (c.state.isInScriptLiteral() || c.state.isComment())) {
+				return new Result(c, s.length);
+			}
+			int i = indexTagEnd(s, specialTagEndMarker(c.element));
+			if (i != -1) {
+				return new Result(new Context(), i);
+			}
+		}
+		return new Result(c, s.length);
+	}
+
+	private static Result tAttr(Context c, byte[] s) {
+		return new Result(c, s.length);
+	}
+
+	private static Result tURL(Context c, byte[] s) {
+		if (Bytes.containsAny(s, 0, "#?")) {
+			c.urlPart = UrlPart.QUERY_OR_FRAG;
+		}
+		else if (s.length != eatWhiteSpace(s, 0) && c.urlPart == UrlPart.NONE) {
+			c.urlPart = UrlPart.PRE_QUERY;
+		}
+		return new Result(c, s.length);
+	}
+
+	private static Result tJS(Context c, byte[] s) {
+		int i = Bytes.indexAny(s, 0, "\"`'/{}<-#");
+		if (i == -1) {
+			c.jsCtx = JsLex.nextJSCtx(s, s.length, c.jsCtx);
+			return new Result(c, s.length);
+		}
+		c.jsCtx = JsLex.nextJSCtx(s, i, c.jsCtx);
+		return stepJS(c, s, i);
+	}
+
+	private static Result stepJS(Context c, byte[] s, int start) {
+		int i = start;
+		switch (s[i]) {
+			case '"' -> {
+				c.state = State.JS_DQ_STR;
+				c.jsCtx = JsCtx.REGEXP;
+			}
+			case '\'' -> {
+				c.state = State.JS_SQ_STR;
+				c.jsCtx = JsCtx.REGEXP;
+			}
+			case '`' -> {
+				c.state = State.JS_TMPL_LIT;
+				c.jsCtx = JsCtx.REGEXP;
+			}
+			case '/' -> {
+				if (i + 1 < s.length && s[i + 1] == '/') {
+					c.state = State.JS_LINE_CMT;
+					i++;
+				}
+				else if (i + 1 < s.length && s[i + 1] == '*') {
+					c.state = State.JS_BLOCK_CMT;
+					i++;
+				}
+				else if (c.jsCtx == JsCtx.REGEXP) {
+					c.state = State.JS_REGEXP;
+				}
+				else if (c.jsCtx == JsCtx.DIV_OP) {
+					c.jsCtx = JsCtx.REGEXP;
+				}
+				else {
+					EscapeError err = EscapeError.errorf(EscapeErrorCode.ERR_SLASH_AMBIG, null, 0,
+							"'/' could start a division or regexp: %s", quote(s, i, Math.min(s.length, i + 32)));
+					return errorResult(err, s.length);
+				}
+			}
+			case '<' -> {
+				if (i + 3 < s.length && Bytes.regionEquals(s, i, COMMENT_START)) {
+					c.state = State.JS_HTML_OPEN_CMT;
+					i += 3;
+				}
+			}
+			case '-' -> {
+				if (i + 2 < s.length && Bytes.regionEquals(s, i, COMMENT_END)) {
+					c.state = State.JS_HTML_CLOSE_CMT;
+					i += 2;
+				}
+			}
+			case '#' -> {
+				if (i + 1 < s.length && s[i + 1] == '!') {
+					c.state = State.JS_LINE_CMT;
+					i++;
+				}
+			}
+			case '{' -> {
+				if (c.jsBraceDepth == null || c.jsBraceDepth.isEmpty()) {
+					return new Result(c, i + 1);
+				}
+				int last = c.jsBraceDepth.size() - 1;
+				c.jsBraceDepth.set(last, c.jsBraceDepth.get(last) + 1);
+			}
+			case '}' -> {
+				if (c.jsBraceDepth == null || c.jsBraceDepth.isEmpty()) {
+					return new Result(c, i + 1);
+				}
+				int last = c.jsBraceDepth.size() - 1;
+				int depth = c.jsBraceDepth.get(last) - 1;
+				c.jsBraceDepth.set(last, depth);
+				if (depth >= 0) {
+					return new Result(c, i + 1);
+				}
+				c.jsBraceDepth.remove(last);
+				c.state = State.JS_TMPL_LIT;
+			}
+			default -> throw new IllegalStateException("unreachable");
+		}
+		return new Result(c, i + 1);
+	}
+
+	private static Result tJSTmpl(Context c, byte[] s) {
+		int k = 0;
+		while (true) {
+			int i = Bytes.indexAny(s, k, "`\\$");
+			if (i == -1) {
+				break;
+			}
+			switch (s[i]) {
+				case '\\' -> {
+					i++;
+					if (i == s.length) {
+						return errorResult(
+								EscapeError.errorf(EscapeErrorCode.ERR_PARTIAL_ESCAPE, null, 0,
+										"unfinished escape sequence in JS string: %s", quote(s, 0, s.length)),
+								s.length);
+					}
+				}
+				case '$' -> {
+					if (s.length >= i + 2 && s[i + 1] == '{') {
+						if (c.jsBraceDepth == null) {
+							c.jsBraceDepth = new ArrayList<>();
+						}
+						c.jsBraceDepth.add(0);
+						c.state = State.JS;
+						return new Result(c, i + 2);
+					}
+				}
+				case '`' -> {
+					c.state = State.JS;
+					return new Result(c, i + 1);
+				}
+				default -> {
+				}
+			}
+			k = i + 1;
+		}
+		return new Result(c, s.length);
+	}
+
+	private static Result tJSDelimited(Context c, byte[] s) {
+		String specials = "\\\"";
+		if (c.state == State.JS_SQ_STR) {
+			specials = "\\'";
+		}
+		else if (c.state == State.JS_REGEXP) {
+			specials = "\\/[]";
+		}
+		boolean inCharset = false;
+		int k = 0;
+		while (true) {
+			int i = Bytes.indexAny(s, k, specials);
+			if (i == -1) {
+				break;
+			}
+			switch (s[i]) {
+				case '\\' -> {
+					i++;
+					if (i == s.length) {
+						return errorResult(
+								EscapeError.errorf(EscapeErrorCode.ERR_PARTIAL_ESCAPE, null, 0,
+										"unfinished escape sequence in JS string: %s", quote(s, 0, s.length)),
+								s.length);
+					}
+				}
+				case '[' -> {
+					inCharset = true;
+				}
+				case ']' -> {
+					inCharset = false;
+				}
+				case '/' -> {
+					// "</script" in a regex literal: '/' does not close it.
+					if (i > 0 && Bytes.regionEqualsFold(s, i - 1, SCRIPT_TAG)) {
+						i++;
+					}
+					else if (!inCharset) {
+						c.state = State.JS;
+						c.jsCtx = JsCtx.DIV_OP;
+						return new Result(c, i + 1);
+					}
+				}
+				default -> {
+					if (!inCharset) {
+						c.state = State.JS;
+						c.jsCtx = JsCtx.DIV_OP;
+						return new Result(c, i + 1);
+					}
+				}
+			}
+			k = i + 1;
+		}
+		if (inCharset) {
+			return errorResult(EscapeError.errorf(EscapeErrorCode.ERR_PARTIAL_CHARSET, null, 0,
+					"unfinished JS regexp charset: %s", quote(s, 0, s.length)), s.length);
+		}
+		return new Result(c, s.length);
+	}
+
+	private static Result tBlockCmt(Context c, byte[] s) {
+		int i = Bytes.index(s, 0, BLOCK_COMMENT_END);
+		if (i == -1) {
+			return new Result(c, s.length);
+		}
+		switch (c.state) {
+			case JS_BLOCK_CMT -> {
+				c.state = State.JS;
+			}
+			case CSS_BLOCK_CMT -> {
+				c.state = State.CSS;
+			}
+			default -> throw new IllegalStateException(c.state.toString());
+		}
+		return new Result(c, i + 2);
+	}
+
+	private static Result tLineCmt(Context c, byte[] s) {
+		State endState;
+		int i;
+		switch (c.state) {
+			case JS_LINE_CMT, JS_HTML_OPEN_CMT, JS_HTML_CLOSE_CMT -> {
+				endState = State.JS;
+				i = indexJsLineEnd(s);
+			}
+			case CSS_LINE_CMT -> {
+				endState = State.CSS;
+				i = Bytes.indexAny(s, 0, "\n\f\r");
+			}
+			default -> throw new IllegalStateException(c.state.toString());
+		}
+		if (i == -1) {
+			return new Result(c, s.length);
+		}
+		c.state = endState;
+		// The line terminator is recognised separately, so it is not consumed here.
+		return new Result(c, i);
+	}
+
+	private static Result tCSS(Context c, byte[] s) {
+		int k = 0;
+		while (true) {
+			int i = Bytes.indexAny(s, k, "(\"'/");
+			if (i == -1) {
+				return new Result(c, s.length);
+			}
+			switch (s[i]) {
+				case '(' -> {
+					int pEnd = trimRightWc(s, i);
+					if (CssLex.endsWithCSSKeyword(s, pEnd, "url")) {
+						int j = skipWcLeft(s, i + 1);
+						if (j != s.length && s[j] == '"') {
+							c.state = State.CSS_DQ_URL;
+							j++;
+						}
+						else if (j != s.length && s[j] == '\'') {
+							c.state = State.CSS_SQ_URL;
+							j++;
+						}
+						else {
+							c.state = State.CSS_URL;
+						}
+						return new Result(c, j);
+					}
+				}
+				case '/' -> {
+					if (i + 1 < s.length) {
+						if (s[i + 1] == '/') {
+							c.state = State.CSS_LINE_CMT;
+							return new Result(c, i + 2);
+						}
+						if (s[i + 1] == '*') {
+							c.state = State.CSS_BLOCK_CMT;
+							return new Result(c, i + 2);
+						}
+					}
+				}
+				case '"' -> {
+					c.state = State.CSS_DQ_STR;
+					return new Result(c, i + 1);
+				}
+				case '\'' -> {
+					c.state = State.CSS_SQ_STR;
+					return new Result(c, i + 1);
+				}
+				default -> {
+				}
+			}
+			k = i + 1;
+		}
+	}
+
+	private static Result tCSSStr(Context c, byte[] s) {
+		String endAndEsc = switch (c.state) {
+			case CSS_DQ_STR, CSS_DQ_URL -> "\\\"";
+			case CSS_SQ_STR, CSS_SQ_URL -> "\\'";
+			case CSS_URL -> "\\\t\n\f\r )";
+			default -> throw new IllegalStateException(c.state.toString());
+		};
+		int k = 0;
+		while (true) {
+			int i = Bytes.indexAny(s, k, endAndEsc);
+			if (i == -1) {
+				Result r = tURL(c, CssLex.decodeCSS(Arrays.copyOfRange(s, k, s.length)));
+				return new Result(r.context, k + r.consumed);
+			}
+			if (s[i] == '\\') {
+				i++;
+				if (i == s.length) {
+					return errorResult(EscapeError.errorf(EscapeErrorCode.ERR_PARTIAL_ESCAPE, null, 0,
+							"unfinished escape sequence in CSS string: %s", quote(s, 0, s.length)), s.length);
+				}
+			}
+			else {
+				c.state = State.CSS;
+				return new Result(c, i + 1);
+			}
+			Result r = tURL(c, CssLex.decodeCSS(Arrays.copyOfRange(s, 0, i + 1)));
+			c = r.context;
+			k = i + 1;
+		}
+	}
+
+	private static Result tError(Context c, byte[] s) {
+		return new Result(c, s.length);
+	}
+
+	private static Result tMetaContent(Context c, byte[] s) {
+		byte[] url = Bytes.utf8("url");
+		for (int i = 0; i < s.length; i++) {
+			if (i + 3 <= s.length - 1 && Bytes.regionEqualsFold(s, i, url)) {
+				int j = eatWhiteSpace(s, i + 3);
+				if (j < s.length && s[j] == '=') {
+					c.state = State.META_CONTENT_URL;
+					return new Result(c, j + 1);
+				}
+			}
+		}
+		return new Result(c, s.length);
+	}
+
+	private static Result tMetaContentURL(Context c, byte[] s) {
+		for (int i = 0; i < s.length; i++) {
+			if (s[i] == ';') {
+				c.state = State.META_CONTENT;
+				return new Result(c, i + 1);
+			}
+		}
+		return new Result(c, s.length);
+	}
+
+	// indexTagEnd finds the case-insensitive special tag end "</tag<sep>", returning the
+	// absolute index of "</", or -1.
+	private static int indexTagEnd(byte[] s, byte[] tag) {
+		int from = 0;
+		while (from < s.length) {
+			int absI = Bytes.index(s, from, SPECIAL_TAG_END_PREFIX);
+			if (absI == -1) {
+				return -1;
+			}
+			int afterPrefix = absI + SPECIAL_TAG_END_PREFIX.length;
+			if (tag.length <= s.length - afterPrefix && Bytes.regionEqualsFold(s, afterPrefix, tag)) {
+				int afterTag = afterPrefix + tag.length;
+				if (afterTag < s.length && TAG_END_SEPARATORS.indexOf(s[afterTag] & 0xff) != -1) {
+					return absI;
+				}
+				from = afterTag;
+			}
+			else {
+				from = afterPrefix;
+			}
+		}
+		return -1;
+	}
+
+	private static EatTag eatTagName(byte[] s, int i) {
+		if (i == s.length || !asciiAlpha(s[i] & 0xff)) {
+			return new EatTag(i, Element.NONE);
+		}
+		int j = i + 1;
+		while (j < s.length) {
+			int x = s[j] & 0xff;
+			if (asciiAlphaNum(x)) {
+				j++;
+			}
+			else if ((x == ':' || x == '-') && j + 1 < s.length && asciiAlphaNum(s[j + 1] & 0xff)) {
+				j += 2;
+			}
+			else {
+				break;
+			}
+		}
+		Element e = ELEMENT_NAME_MAP.getOrDefault(Bytes.toLowerAscii(s, i, j), Element.NONE);
+		return new EatTag(j, e);
+	}
+
+	private static EatAttr eatAttrName(byte[] s, int i) {
+		for (int j = i; j < s.length; j++) {
+			switch (s[j]) {
+				case ' ', '\t', '\n', '\f', '\r', '=', '>' -> {
+					return new EatAttr(j, null);
+				}
+				case '\'', '"', '<' -> {
+					EscapeError err = EscapeError.errorf(EscapeErrorCode.ERR_BAD_HTML, null, 0,
+							"%s in attribute name: %s", quote(s, j, j + 1), quote(s, i, Math.min(s.length, i + 32)));
+					return new EatAttr(-1, err);
+				}
+				default -> {
+				}
+			}
+		}
+		return new EatAttr(s.length, null);
+	}
+
+	private static int eatWhiteSpace(byte[] s, int i) {
+		for (int j = i; j < s.length; j++) {
+			switch (s[j]) {
+				case ' ', '\t', '\n', '\f', '\r' -> {
+				}
+				default -> {
+					return j;
+				}
+			}
+		}
+		return s.length;
+	}
+
+	private static int indexJsLineEnd(byte[] s) {
+		for (int i = 0; i < s.length; i++) {
+			int b = s[i] & 0xff;
+			if (b == '\n' || b == '\r') {
+				return i;
+			}
+			// U+2028 (E2 80 A8) and U+2029 (E2 80 A9) are JS line terminators.
+			if (b == 0xe2 && i + 2 < s.length && (s[i + 1] & 0xff) == 0x80
+					&& ((s[i + 2] & 0xff) == 0xa8 || (s[i + 2] & 0xff) == 0xa9)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private static int trimRightWc(byte[] s, int end) {
+		int j = end;
+		while (j > 0 && isWc(s[j - 1])) {
+			j--;
+		}
+		return j;
+	}
+
+	private static int skipWcLeft(byte[] s, int from) {
+		int j = from;
+		while (j < s.length && isWc(s[j])) {
+			j++;
+		}
+		return j;
+	}
+
+	private static boolean isWc(byte b) {
+		return switch (b) {
+			case '\t', '\n', '\f', '\r', ' ' -> true;
+			default -> false;
+		};
+	}
+
+	private static boolean asciiAlpha(int c) {
+		return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+	}
+
+	private static boolean asciiAlphaNum(int c) {
+		return asciiAlpha(c) || (c >= '0' && c <= '9');
+	}
+
+	private static State elementContentType(Element element) {
+		return switch (element) {
+			case SCRIPT -> State.JS;
+			case STYLE -> State.CSS;
+			case TEXTAREA, TITLE -> State.RCDATA;
+			default -> State.TEXT;
+		};
+	}
+
+	private static State attrStartState(Attr attr) {
+		return switch (attr) {
+			case SCRIPT -> State.JS;
+			case STYLE -> State.CSS;
+			case URL -> State.URL;
+			case SRCSET -> State.SRCSET;
+			case META_CONTENT -> State.META_CONTENT;
+			default -> State.ATTR;
+		};
+	}
+
+	private static byte[] specialTagEndMarker(Element element) {
+		return switch (element) {
+			case SCRIPT -> Bytes.utf8("script");
+			case STYLE -> Bytes.utf8("style");
+			case TEXTAREA -> Bytes.utf8("textarea");
+			case TITLE -> Bytes.utf8("title");
+			default -> Bytes.utf8("");
+		};
+	}
+
+	private static Result errorResult(EscapeError err, int consumed) {
+		Context r = new Context();
+		r.state = State.ERROR;
+		r.err = err;
+		return new Result(r, consumed);
+	}
+
+	// A best-effort %q-style quote of s[from..to] for error messages.
+	private static String quote(byte[] s, int from, int to) {
+		return '"' + new String(s, from, Math.max(0, to - from), java.nio.charset.StandardCharsets.UTF_8) + '"';
+	}
+
+	/**
+	 * The result of a transition: the new context and the number of bytes consumed from
+	 * the front of the input.
+	 *
+	 * @param context the resulting context
+	 * @param consumed the number of bytes consumed
+	 */
+	record Result(Context context, int consumed) {
+	}
+
+	private record EatTag(int end, Element element) {
+	}
+
+	private record EatAttr(int end, EscapeError err) {
+	}
+
+}

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/TransitionsTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/TransitionsTest.java
@@ -1,0 +1,132 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TransitionsTest {
+
+	// Drives the transition machine across the whole input, as the escape pass does, and
+	// returns the resulting context. (Raw transitions, so this does not force the RCDATA
+	// scanning the escape pass applies inside <script>/<style> bodies.)
+	private static Context run(String html) {
+		Context c = new Context();
+		byte[] s = html.getBytes(StandardCharsets.UTF_8);
+		int pos = 0;
+		while (pos < s.length) {
+			byte[] sub = Arrays.copyOfRange(s, pos, s.length);
+			Transitions.Result r = Transitions.transition(c, sub);
+			if (r.consumed() == 0) {
+				break;
+			}
+			c = r.context();
+			pos += r.consumed();
+		}
+		return c;
+	}
+
+	@Test
+	void plainTextStaysText() {
+		assertEquals(State.TEXT, run("").state);
+		assertEquals(State.TEXT, run("Hello world").state);
+		assertEquals(State.TEXT, run("<p>Hello</p>").state);
+	}
+
+	@Test
+	void insideTag() {
+		Context c = run("<a ");
+		assertEquals(State.TAG, c.state);
+		assertEquals(Element.NONE, c.element);
+	}
+
+	@Test
+	void urlAttributeContext() {
+		Context before = run("<a href=");
+		assertEquals(State.BEFORE_VALUE, before.state);
+		assertEquals(Attr.URL, before.attr);
+
+		Context quoted = run("<a href=\"");
+		assertEquals(State.URL, quoted.state);
+		assertEquals(Delim.DOUBLE_QUOTE, quoted.delim);
+		assertEquals(Attr.URL, quoted.attr);
+
+		Context unquoted = run("<a href=");
+		assertEquals(Attr.URL, unquoted.attr);
+	}
+
+	@Test
+	void styleAttributeIsCss() {
+		Context c = run("<p style=\"");
+		assertEquals(State.CSS, c.state);
+		assertEquals(Delim.DOUBLE_QUOTE, c.delim);
+	}
+
+	@Test
+	void eventHandlerAttributeIsJs() {
+		Context c = run("<button onclick=\"");
+		assertEquals(State.JS, c.state);
+	}
+
+	@Test
+	void scriptAndStyleElements() {
+		assertEquals(Element.SCRIPT, run("<script").element);
+		Context style = run("<style>");
+		assertEquals(State.CSS, style.state);
+		assertEquals(Element.STYLE, style.element);
+		Context script = run("<script>");
+		assertEquals(State.JS, script.state);
+		assertEquals(Element.SCRIPT, script.element);
+	}
+
+	@Test
+	void htmlComment() {
+		assertEquals(State.HTML_CMT, run("<!-- comment ").state);
+		assertEquals(State.TEXT, run("<!-- comment -->").state);
+	}
+
+	@Test
+	void urlQueryPart() {
+		// After the '?', the URL part becomes query/fragment.
+		Context c = run("<a href=\"/path?q=");
+		assertEquals(State.URL, c.state);
+		assertEquals(UrlPart.QUERY_OR_FRAG, c.urlPart);
+	}
+
+	@Test
+	void nextJsCtxRegexpVsDivision() {
+		// A '/' after '=' or '(' starts a regexp; after an identifier/number it divides.
+		assertEquals(JsCtx.REGEXP, JsLex.nextJSCtx(b("x ="), 3, JsCtx.REGEXP));
+		assertEquals(JsCtx.DIV_OP, JsLex.nextJSCtx(b("x"), 1, JsCtx.REGEXP));
+		assertEquals(JsCtx.DIV_OP, JsLex.nextJSCtx(b("42"), 2, JsCtx.REGEXP));
+		assertEquals(JsCtx.REGEXP, JsLex.nextJSCtx(b("return"), 6, JsCtx.REGEXP));
+	}
+
+	@Test
+	void attrTypeClassification() {
+		assertEquals(ContentType.URL, AttrTypes.attrType("href"));
+		assertEquals(ContentType.CSS, AttrTypes.attrType("style"));
+		assertEquals(ContentType.JS, AttrTypes.attrType("onclick"));
+		assertEquals(ContentType.SRCSET, AttrTypes.attrType("srcset"));
+		assertEquals(ContentType.URL, AttrTypes.attrType("data-src"));
+		assertEquals(ContentType.PLAIN, AttrTypes.attrType("class"));
+	}
+
+	@Test
+	void cssHelpers() {
+		assertTrue(CssLex.endsWithCSSKeyword(b("background:url"), 14, "url"));
+		assertFalse(CssLex.endsWithCSSKeyword(b("curl"), 4, "url"));
+		assertArrayEquals(b("AB"), CssLex.decodeCSS(b("\\41\\42")));
+		assertArrayEquals(b("plain"), CssLex.decodeCSS(b("plain")));
+	}
+
+	private static byte[] b(String s) {
+		return s.getBytes(StandardCharsets.UTF_8);
+	}
+
+}


### PR DESCRIPTION
Stage 4 of epic #414 (faithful port of Go `html/template`). Closes #418.

Ports `transition.go` — the HTML/JS/CSS context state machine — plus the lexical helpers it depends on from `attr.go`, `js.go`, `css.go`:

- **`Transitions`** — `transition(Context, byte[])` advances the parser context across a run of literal text and returns bytes consumed. All `t*` functions (text/tag/attr-name/after-name/before-value/html-comment/special-tag-end/attr/url/js/js-delimited/js-template-literal/block-comment/line-comment/css/css-string/meta-content/…) plus `eatTagName`/`eatAttrName`/`eatWhiteSpace`/`indexTagEnd` and the element/attr transition tables.
- **`AttrTypes`** — `attrType` + the HTML5 `attrTypeMap` (URL/CSS/JS/srcset/unsafe/…).
- **`JsLex`** — `nextJSCtx` (the regexp-vs-division one-token lookbehind), `isJSIdentPart`, `isJsType`.
- **`CssLex`** — `endsWithCSSKeyword`, `decodeCSS` (CSS3 escape decoding), and the small predicates.
- **`Bytes`** — `byte[]` helpers so the machine runs over UTF-8 bytes with **Go-identical offsets** (Go indexes raw bytes; using `char`/`String` would diverge on multibyte input).

**Safety:** pure/additive in `org.alexmond.gotmpl4j.html`, no engine wiring — default `text/template` and the 346-chart Helm parity are untouched. Engine builds green incl. the 0.75 jacoco gate. `TransitionsTest` drives the machine over representative HTML/attribute/script/style/comment inputs and checks the JS/CSS/attr lexers. Feeds the escape pass (S5, #419).

🤖 Generated with [Claude Code](https://claude.com/claude-code)