### PR TITLE
feat(gotmpl4j-core): html/template escapers (S2a, #416)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Context.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Context.java
@@ -2,6 +2,7 @@ package org.alexmond.gotmpl4j.html;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.alexmond.gotmpl4j.parse.Node;
 
@@ -99,7 +100,7 @@ public final class Context {
 	public boolean eq(Context d) {
 		return this.state == d.state && this.delim == d.delim && this.urlPart == d.urlPart && this.jsCtx == d.jsCtx
 				&& jsBraceDepthEquals(this.jsBraceDepth, d.jsBraceDepth) && this.attr == d.attr
-				&& this.element == d.element && this.err == d.err;
+				&& this.element == d.element && Objects.equals(this.err, d.err);
 	}
 
 	/**

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/CssEscapers.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/CssEscapers.java
@@ -1,0 +1,104 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Map;
+
+import org.alexmond.gotmpl4j.html.Content.Stringified;
+
+/**
+ * CSS contextual escapers ported from Go {@code html/template}'s css.go:
+ * {@code cssEscaper} (hex-escapes HTML/CSS specials) and {@code cssValueFilter} (filters
+ * unsafe CSS values).
+ */
+final class CssEscapers {
+
+	private static final Map<Integer, String> CSS_REPLACEMENT = Map.ofEntries(Map.entry(0, "\\0"),
+			Map.entry((int) '\t', "\\9"), Map.entry((int) '\n', "\\a"), Map.entry((int) '\f', "\\c"),
+			Map.entry((int) '\r', "\\d"), Map.entry((int) '"', "\\22"), Map.entry((int) '&', "\\26"),
+			Map.entry((int) '\'', "\\27"), Map.entry((int) '(', "\\28"), Map.entry((int) ')', "\\29"),
+			Map.entry((int) '+', "\\2b"), Map.entry((int) '/', "\\2f"), Map.entry((int) ':', "\\3a"),
+			Map.entry((int) ';', "\\3b"), Map.entry((int) '<', "\\3c"), Map.entry((int) '>', "\\3e"),
+			Map.entry((int) '\\', "\\\\"), Map.entry((int) '{', "\\7b"), Map.entry((int) '}', "\\7d"));
+
+	private CssEscapers() {
+	}
+
+	/** Escapes HTML and CSS special characters using {@code \<hex>} escapes. */
+	static String cssEscaper(Object... args) {
+		String s = Content.stringify(args).text();
+		StringBuilder b = null;
+		int written = 0;
+		int i = 0;
+		while (i < s.length()) {
+			int r = s.codePointAt(i);
+			int w = Character.charCount(r);
+			String repl = CSS_REPLACEMENT.get(r);
+			if (repl != null) {
+				if (b == null) {
+					b = new StringBuilder(s.length());
+				}
+				b.append(s, written, i).append(repl);
+				written = i + w;
+				// A trailing space terminates the hex escape so it does not absorb a
+				// following hex digit or space.
+				if (!"\\\\".equals(repl)
+						&& (written == s.length() || isHex(s.charAt(written)) || isCssSpace(s.charAt(written)))) {
+					b.append(' ');
+				}
+			}
+			i += w;
+		}
+		if (b == null) {
+			return s;
+		}
+		b.append(s, written, s.length());
+		return b.toString();
+	}
+
+	/**
+	 * Allows innocuous CSS values and filters out anything that could break out of
+	 * context.
+	 */
+	static String cssValueFilter(Object... args) {
+		Stringified r = Content.stringify(args);
+		if (r.type() == ContentType.CSS) {
+			return r.text();
+		}
+		byte[] b = CssLex.decodeCSS(r.text().getBytes(StandardCharsets.UTF_8));
+		StringBuilder id = new StringBuilder();
+		for (int i = 0; i < b.length; i++) {
+			int c = b[i] & 0xff;
+			switch (c) {
+				case 0, '"', '\'', '(', ')', '/', ';', '@', '[', '\\', ']', '`', '{', '}', '<', '>' -> {
+					return Escapers.FILTER_FAILSAFE;
+				}
+				case '-' -> {
+					// Disallow <!-- or --> ; "--" should not appear in valid identifiers.
+					if (i != 0 && (b[i - 1] & 0xff) == '-') {
+						return Escapers.FILTER_FAILSAFE;
+					}
+				}
+				default -> {
+					if (c < 0x80 && CssLex.isCSSNmchar(c)) {
+						id.append((char) c);
+					}
+				}
+			}
+		}
+		String idStr = id.toString().toLowerCase(Locale.ROOT);
+		if (idStr.contains("expression") || idStr.contains("mozbinding")) {
+			return Escapers.FILTER_FAILSAFE;
+		}
+		return new String(b, StandardCharsets.UTF_8);
+	}
+
+	private static boolean isHex(char c) {
+		return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+	}
+
+	private static boolean isCssSpace(char c) {
+		return c == '\t' || c == '\n' || c == '\f' || c == '\r' || c == ' ';
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Escapers.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Escapers.java
@@ -1,0 +1,53 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.alexmond.gotmpl4j.Function;
+
+/**
+ * Registry of the internal contextual escaper functions, keyed by the same names Go
+ * {@code html/template} uses (e.g. {@code _html_template_htmlescaper}). The escape pass
+ * appends these by name to action pipelines; the executor resolves them like any
+ * function.
+ *
+ * <p>
+ * {@code _html_template_jsvalescaper} (the JSON-marshaling JS value escaper) is
+ * registered separately once implemented.
+ */
+public final class Escapers {
+
+	/**
+	 * The string emitted when unsafe content reaches a CSS/URL context at runtime (Go's
+	 * {@code "ZgotmplZ"}).
+	 */
+	public static final String FILTER_FAILSAFE = "ZgotmplZ";
+
+	private Escapers() {
+	}
+
+	/**
+	 * The internal escaper functions, by Go name.
+	 * @return an ordered map of escaper name to implementation
+	 */
+	public static Map<String, Function> escapers() {
+		Map<String, Function> m = new LinkedHashMap<>();
+		m.put("_html_template_attrescaper", HtmlEscapers::attrEscaper);
+		m.put("_html_template_commentescaper", HtmlEscapers::commentEscaper);
+		m.put("_html_template_htmlescaper", HtmlEscapers::htmlEscaper);
+		m.put("_html_template_htmlnamefilter", HtmlEscapers::htmlNameFilter);
+		m.put("_html_template_nospaceescaper", HtmlEscapers::htmlNospaceEscaper);
+		m.put("_html_template_rcdataescaper", HtmlEscapers::rcdataEscaper);
+		m.put("_html_template_cssescaper", CssEscapers::cssEscaper);
+		m.put("_html_template_cssvaluefilter", CssEscapers::cssValueFilter);
+		m.put("_html_template_jsregexpescaper", JsEscapers::jsRegexpEscaper);
+		m.put("_html_template_jsstrescaper", JsEscapers::jsStrEscaper);
+		m.put("_html_template_jstmpllitescaper", JsEscapers::jsTmplLitEscaper);
+		m.put("_html_template_urlescaper", UrlEscapers::urlEscaper);
+		m.put("_html_template_urlfilter", UrlEscapers::urlFilter);
+		m.put("_html_template_urlnormalizer", UrlEscapers::urlNormalizer);
+		m.put("_html_template_srcsetescaper", UrlEscapers::srcsetFilterAndEscaper);
+		return m;
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/HtmlEscapers.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/HtmlEscapers.java
@@ -1,0 +1,213 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Map;
+
+import org.alexmond.gotmpl4j.html.Content.Stringified;
+
+/**
+ * HTML contextual escapers ported from Go {@code html/template}'s html.go: the text,
+ * quoted-attribute, unquoted-attribute and RCDATA escapers, the HTML name filter, the
+ * comment escaper, and {@code stripTags}.
+ */
+final class HtmlEscapers {
+
+	// Runes to escape inside a quoted attribute value or text node.
+	private static final Map<Integer, String> HTML_REPLACEMENT = Map.of(0, "�", (int) '"', "&#34;", (int) '&', "&amp;",
+			(int) '\'', "&#39;", (int) '+', "&#43;", (int) '<', "&lt;", (int) '>', "&gt;");
+
+	// Like HTML_REPLACEMENT but without '&', to avoid over-encoding existing entities.
+	private static final Map<Integer, String> HTML_NORM_REPLACEMENT = Map.of(0, "�", (int) '"', "&#34;", (int) '\'',
+			"&#39;", (int) '+', "&#43;", (int) '<', "&lt;", (int) '>', "&gt;");
+
+	// Runes to escape inside an unquoted attribute value (HTML specials +
+	// browser-derived).
+	private static final Map<Integer, String> HTML_NOSPACE_REPLACEMENT = Map.ofEntries(Map.entry(0, "&#xfffd;"),
+			Map.entry((int) '\t', "&#9;"), Map.entry((int) '\n', "&#10;"), Map.entry(0x0b, "&#11;"),
+			Map.entry((int) '\f', "&#12;"), Map.entry((int) '\r', "&#13;"), Map.entry((int) ' ', "&#32;"),
+			Map.entry((int) '"', "&#34;"), Map.entry((int) '&', "&amp;"), Map.entry((int) '\'', "&#39;"),
+			Map.entry((int) '+', "&#43;"), Map.entry((int) '<', "&lt;"), Map.entry((int) '=', "&#61;"),
+			Map.entry((int) '>', "&gt;"), Map.entry((int) '`', "&#96;"));
+
+	// Like HTML_NOSPACE_REPLACEMENT but without '&'.
+	private static final Map<Integer, String> HTML_NOSPACE_NORM_REPLACEMENT = Map.ofEntries(Map.entry(0, "&#xfffd;"),
+			Map.entry((int) '\t', "&#9;"), Map.entry((int) '\n', "&#10;"), Map.entry(0x0b, "&#11;"),
+			Map.entry((int) '\f', "&#12;"), Map.entry((int) '\r', "&#13;"), Map.entry((int) ' ', "&#32;"),
+			Map.entry((int) '"', "&#34;"), Map.entry((int) '\'', "&#39;"), Map.entry((int) '+', "&#43;"),
+			Map.entry((int) '<', "&lt;"), Map.entry((int) '=', "&#61;"), Map.entry((int) '>', "&gt;"),
+			Map.entry((int) '`', "&#96;"));
+
+	private HtmlEscapers() {
+	}
+
+	/** Escapes for inclusion in HTML text. */
+	static String htmlEscaper(Object... args) {
+		Stringified r = Content.stringify(args);
+		if (r.type() == ContentType.HTML) {
+			return r.text();
+		}
+		return htmlReplacer(r.text(), HTML_REPLACEMENT, true);
+	}
+
+	/** Escapes for inclusion in unquoted attribute values. */
+	static String htmlNospaceEscaper(Object... args) {
+		Stringified r = Content.stringify(args);
+		if (r.text().isEmpty()) {
+			return Escapers.FILTER_FAILSAFE;
+		}
+		if (r.type() == ContentType.HTML) {
+			return htmlReplacer(stripTags(r.text()), HTML_NOSPACE_NORM_REPLACEMENT, false);
+		}
+		return htmlReplacer(r.text(), HTML_NOSPACE_REPLACEMENT, false);
+	}
+
+	/** Escapes for inclusion in quoted attribute values. */
+	static String attrEscaper(Object... args) {
+		Stringified r = Content.stringify(args);
+		if (r.type() == ContentType.HTML) {
+			return htmlReplacer(stripTags(r.text()), HTML_NORM_REPLACEMENT, true);
+		}
+		return htmlReplacer(r.text(), HTML_REPLACEMENT, true);
+	}
+
+	/** Escapes for inclusion in an RCDATA element body. */
+	static String rcdataEscaper(Object... args) {
+		Stringified r = Content.stringify(args);
+		if (r.type() == ContentType.HTML) {
+			return htmlReplacer(r.text(), HTML_NORM_REPLACEMENT, true);
+		}
+		return htmlReplacer(r.text(), HTML_REPLACEMENT, true);
+	}
+
+	/**
+	 * Accepts valid parts of an HTML attribute/tag name, or a known-safe HTML attribute.
+	 */
+	static String htmlNameFilter(Object... args) {
+		Stringified r = Content.stringify(args);
+		if (r.type() == ContentType.HTML_ATTR) {
+			return r.text();
+		}
+		if (r.text().isEmpty()) {
+			// Avoid violating structure preservation, e.g. <input checked {{.K}}={{.V}}>.
+			return Escapers.FILTER_FAILSAFE;
+		}
+		String s = r.text().toLowerCase(Locale.ROOT);
+		if (AttrTypes.attrType(s) != ContentType.PLAIN) {
+			return Escapers.FILTER_FAILSAFE;
+		}
+		for (int i = 0; i < s.length(); i++) {
+			char ch = s.charAt(i);
+			if (!((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'z'))) {
+				return Escapers.FILTER_FAILSAFE;
+			}
+		}
+		return s;
+	}
+
+	/**
+	 * Drops content interpolated into HTML comments (the simplest, most secure policy).
+	 */
+	static String commentEscaper(Object... args) {
+		return "";
+	}
+
+	// htmlReplacer replaces runes per the table; when badRunes is false it also escapes
+	// certain non-character runes.
+	private static String htmlReplacer(String s, Map<Integer, String> table, boolean badRunes) {
+		StringBuilder b = null;
+		int written = 0;
+		int i = 0;
+		while (i < s.length()) {
+			int r = s.codePointAt(i);
+			int w = Character.charCount(r);
+			String repl = table.get(r);
+			if (repl == null && !badRunes && ((r >= 0xfdd0 && r <= 0xfdef) || (r >= 0xfff0 && r <= 0xffff))) {
+				repl = String.format("&#x%x;", r);
+			}
+			if (repl != null) {
+				if (b == null) {
+					b = new StringBuilder(s.length());
+				}
+				b.append(s, written, i).append(repl);
+				written = i + w;
+			}
+			i += w;
+		}
+		if (b == null) {
+			return s;
+		}
+		b.append(s, written, s.length());
+		return b.toString();
+	}
+
+	// stripTags returns only the text content of a snippet of HTML, using the transition
+	// machine so attribute values and "I <3 Ponies!" are not mangled.
+	private static String stripTags(String html) {
+		StringBuilder b = new StringBuilder();
+		byte[] s = html.getBytes(StandardCharsets.UTF_8);
+		Context c = new Context();
+		int i = 0;
+		boolean allText = true;
+		while (i != s.length) {
+			if (c.delim == Delim.NONE) {
+				State st = c.state;
+				if (c.element != Element.NONE && !st.isInTag()) {
+					st = State.RCDATA;
+				}
+				byte[] rest = java.util.Arrays.copyOfRange(s, i, s.length);
+				Transitions.Result tr = Transitions.transitionFor(st, c, rest);
+				Context d = tr.context();
+				int i1 = i + tr.consumed();
+				if (c.state == State.TEXT || c.state == State.RCDATA) {
+					int j = i1;
+					if (d.state != c.state) {
+						for (int j1 = j - 1; j1 >= i; j1--) {
+							if (s[j1] == '<') {
+								j = j1;
+								break;
+							}
+						}
+					}
+					b.append(new String(s, i, j - i, StandardCharsets.UTF_8));
+				}
+				else {
+					allText = false;
+				}
+				c = d;
+				i = i1;
+				continue;
+			}
+			int idx = Bytes.indexAny(s, i, delimEnds(c.delim));
+			if (idx < i) {
+				break;
+			}
+			int i1 = idx;
+			if (c.delim != Delim.SPACE_OR_TAG_END) {
+				i1++;
+			}
+			Context next = new Context();
+			next.state = State.TAG;
+			next.element = c.element;
+			c = next;
+			i = i1;
+		}
+		if (allText) {
+			return html;
+		}
+		if (c.state == State.TEXT || c.state == State.RCDATA) {
+			b.append(new String(s, i, s.length - i, StandardCharsets.UTF_8));
+		}
+		return b.toString();
+	}
+
+	private static String delimEnds(Delim delim) {
+		return switch (delim) {
+			case DOUBLE_QUOTE -> "\"";
+			case SINGLE_QUOTE -> "'";
+			case SPACE_OR_TAG_END -> " \t\n\f\r>";
+			default -> "";
+		};
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/JsEscapers.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/JsEscapers.java
@@ -1,0 +1,157 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.alexmond.gotmpl4j.html.Content.Stringified;
+
+/**
+ * JavaScript string/regexp contextual escapers ported from Go {@code html/template}'s
+ * js.go: {@code jsStrEscaper}, {@code jsTmplLitEscaper}, {@code jsRegexpEscaper} and the
+ * shared {@code replace}. ({@code jsValEscaper}, which needs JSON marshaling, lands
+ * separately.)
+ */
+final class JsEscapers {
+
+	// Control characters 0x00-0x1f always escaped (precedence over the per-context
+	// tables).
+	private static final Map<Integer, String> LOW_UNICODE = buildLowUnicode();
+
+	private static final Map<Integer, String> JS_STR = Map.ofEntries(Map.entry(0, "\\u0000"),
+			Map.entry((int) '\t', "\\t"), Map.entry((int) '\n', "\\n"), Map.entry(0x0b, "\\u000b"),
+			Map.entry((int) '\f', "\\f"), Map.entry((int) '\r', "\\r"), Map.entry((int) '"', "\\u0022"),
+			Map.entry((int) '`', "\\u0060"), Map.entry((int) '&', "\\u0026"), Map.entry((int) '\'', "\\u0027"),
+			Map.entry((int) '+', "\\u002b"), Map.entry((int) '/', "\\/"), Map.entry((int) '<', "\\u003c"),
+			Map.entry((int) '>', "\\u003e"), Map.entry((int) '\\', "\\\\"));
+
+	// Like JS_STR plus the JS template-literal specials $, {, }.
+	private static final Map<Integer, String> JS_BQ_STR = bqStr();
+
+	// Like JS_STR but without a backslash entry (does not over-encode existing escapes).
+	private static final Map<Integer, String> JS_STR_NORM = Map.ofEntries(Map.entry(0, "\\u0000"),
+			Map.entry((int) '\t', "\\t"), Map.entry((int) '\n', "\\n"), Map.entry(0x0b, "\\u000b"),
+			Map.entry((int) '\f', "\\f"), Map.entry((int) '\r', "\\r"), Map.entry((int) '"', "\\u0022"),
+			Map.entry((int) '&', "\\u0026"), Map.entry((int) '\'', "\\u0027"), Map.entry((int) '`', "\\u0060"),
+			Map.entry((int) '+', "\\u002b"), Map.entry((int) '/', "\\/"), Map.entry((int) '<', "\\u003c"),
+			Map.entry((int) '>', "\\u003e"));
+
+	private static final Map<Integer, String> JS_REGEXP = jsRegexp();
+
+	private JsEscapers() {
+	}
+
+	/** Escapes for inclusion between quotes in a JS string. */
+	static String jsStrEscaper(Object... args) {
+		Stringified r = Content.stringify(args);
+		if (r.type() == ContentType.JS_STR) {
+			return replace(r.text(), JS_STR_NORM);
+		}
+		return replace(r.text(), JS_STR);
+	}
+
+	/** Escapes for inclusion inside a JS template literal. */
+	static String jsTmplLitEscaper(Object... args) {
+		Stringified r = Content.stringify(args);
+		return replace(r.text(), JS_BQ_STR);
+	}
+
+	/** Escapes regexp specials so the value is matched literally in a regexp literal. */
+	static String jsRegexpEscaper(Object... args) {
+		Stringified r = Content.stringify(args);
+		String s = replace(r.text(), JS_REGEXP);
+		if (s.isEmpty()) {
+			// /{{.X}}/ should not become a line comment when .X is empty.
+			return "(?:)";
+		}
+		return s;
+	}
+
+	// replace replaces each rune of s per LOW_UNICODE (control chars) then the table,
+	// also
+	// escaping U+2028/U+2029.
+	private static String replace(String s, Map<Integer, String> table) {
+		StringBuilder b = null;
+		int written = 0;
+		int i = 0;
+		while (i < s.length()) {
+			int r = s.codePointAt(i);
+			int w = Character.charCount(r);
+			String repl = LOW_UNICODE.get(r);
+			if (repl == null) {
+				repl = table.get(r);
+			}
+			if (repl == null && r == 0x2028) {
+				repl = "\\u2028";
+			}
+			if (repl == null && r == 0x2029) {
+				repl = "\\u2029";
+			}
+			if (repl != null) {
+				if (b == null) {
+					b = new StringBuilder(s.length());
+				}
+				b.append(s, written, i).append(repl);
+				written = i + w;
+			}
+			i += w;
+		}
+		if (b == null) {
+			return s;
+		}
+		b.append(s, written, s.length());
+		return b.toString();
+	}
+
+	private static Map<Integer, String> buildLowUnicode() {
+		Map<Integer, String> m = new HashMap<>();
+		for (int i = 0; i <= 0x1f; i++) {
+			m.put(i, String.format("\\u%04x", i));
+		}
+		m.put((int) '\t', "\\t");
+		m.put((int) '\n', "\\n");
+		m.put((int) '\f', "\\f");
+		m.put((int) '\r', "\\r");
+		return Map.copyOf(m);
+	}
+
+	private static Map<Integer, String> bqStr() {
+		Map<Integer, String> m = new HashMap<>(JS_STR);
+		m.put((int) '$', "\\u0024");
+		m.put((int) '{', "\\u007b");
+		m.put((int) '}', "\\u007d");
+		return Map.copyOf(m);
+	}
+
+	private static Map<Integer, String> jsRegexp() {
+		Map<Integer, String> m = new HashMap<>();
+		m.put(0, "\\u0000");
+		m.put((int) '\t', "\\t");
+		m.put((int) '\n', "\\n");
+		m.put(0x0b, "\\u000b");
+		m.put((int) '\f', "\\f");
+		m.put((int) '\r', "\\r");
+		m.put((int) '"', "\\u0022");
+		m.put((int) '$', "\\$");
+		m.put((int) '&', "\\u0026");
+		m.put((int) '\'', "\\u0027");
+		m.put((int) '(', "\\(");
+		m.put((int) ')', "\\)");
+		m.put((int) '*', "\\*");
+		m.put((int) '+', "\\u002b");
+		m.put((int) '-', "\\-");
+		m.put((int) '.', "\\.");
+		m.put((int) '/', "\\/");
+		m.put((int) '<', "\\u003c");
+		m.put((int) '>', "\\u003e");
+		m.put((int) '?', "\\?");
+		m.put((int) '[', "\\[");
+		m.put((int) '\\', "\\\\");
+		m.put((int) ']', "\\]");
+		m.put((int) '^', "\\^");
+		m.put((int) '{', "\\{");
+		m.put((int) '|', "\\|");
+		m.put((int) '}', "\\}");
+		return Map.copyOf(m);
+	}
+
+}

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Transitions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Transitions.java
@@ -38,7 +38,19 @@ final class Transitions {
 	 * @return the new context and bytes consumed
 	 */
 	static Result transition(Context c, byte[] s) {
-		return switch (c.state) {
+		return transitionFor(c.state, c, s);
+	}
+
+	/**
+	 * Like {@link #transition} but dispatches on an explicit state, which
+	 * {@code stripTags} uses to force RCDATA scanning inside special element bodies.
+	 * @param state the state to dispatch on
+	 * @param c the current context (may be mutated)
+	 * @param s the literal text bytes
+	 * @return the new context and bytes consumed
+	 */
+	static Result transitionFor(State state, Context c, byte[] s) {
+		return switch (state) {
 			case TEXT -> tText(c, s);
 			case TAG -> tTag(c, s);
 			case ATTR_NAME -> tAttrName(c, s);

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/UrlEscapers.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/UrlEscapers.java
@@ -1,0 +1,177 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import org.alexmond.gotmpl4j.html.Content.Stringified;
+
+/**
+ * URL/srcset contextual escapers ported from Go {@code html/template}'s url.go:
+ * {@code urlFilter}, {@code urlEscaper}, {@code urlNormalizer} and
+ * {@code srcsetFilterAndEscaper}.
+ */
+final class UrlEscapers {
+
+	// Bit table marking HTML whitespace and ASCII alphanumerics (from Go url.go).
+	private static final int[] HTML_SPACE_AND_ALNUM = { 0x00, 0x36, 0x00, 0x00, 0x01, 0x00, 0xff, 0x03, 0xfe, 0xff,
+			0xff, 0x07, 0xfe, 0xff, 0xff, 0x07 };
+
+	private UrlEscapers() {
+	}
+
+	/**
+	 * Returns its input unless it has an unsafe scheme, in which case it defangs the URL.
+	 */
+	static String urlFilter(Object... args) {
+		Stringified r = Content.stringify(args);
+		if (r.type() == ContentType.URL) {
+			return r.text();
+		}
+		if (!isSafeUrl(r.text())) {
+			return "#" + Escapers.FILTER_FAILSAFE;
+		}
+		return r.text();
+	}
+
+	/** Produces output that can be embedded in a URL query. */
+	static String urlEscaper(Object... args) {
+		return urlProcessor(false, args);
+	}
+
+	/**
+	 * Normalizes URL content for a quoted string or {@code url(...)} (does not encode
+	 * '&').
+	 */
+	static String urlNormalizer(Object... args) {
+		return urlProcessor(true, args);
+	}
+
+	/** Filters and normalizes a comma-separated srcset value. */
+	static String srcsetFilterAndEscaper(Object... args) {
+		Stringified r = Content.stringify(args);
+		String text = r.text();
+		if (r.type() == ContentType.SRCSET) {
+			return text;
+		}
+		if (r.type() == ContentType.URL) {
+			StringBuilder b = new StringBuilder();
+			String s = processUrlOnto(text, true, b) ? b.toString() : text;
+			// Commas separate sources, so a URL's commas must be encoded.
+			return s.replace(",", "%2c");
+		}
+		byte[] s = text.getBytes(StandardCharsets.UTF_8);
+		StringBuilder b = new StringBuilder();
+		int written = 0;
+		for (int i = 0; i < s.length; i++) {
+			if (s[i] == ',') {
+				filterSrcsetElement(s, written, i, b);
+				b.append(',');
+				written = i + 1;
+			}
+		}
+		filterSrcsetElement(s, written, s.length, b);
+		return b.toString();
+	}
+
+	private static String urlProcessor(boolean norm, Object... args) {
+		Stringified r = Content.stringify(args);
+		boolean normalize = norm || r.type() == ContentType.URL;
+		StringBuilder b = new StringBuilder();
+		if (processUrlOnto(r.text(), normalize, b)) {
+			return b.toString();
+		}
+		return r.text();
+	}
+
+	// Appends a normalized/escaped URL to b; reports whether the output differs from s.
+	private static boolean processUrlOnto(String s, boolean norm, StringBuilder b) {
+		byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+		int written = 0;
+		for (int i = 0; i < bytes.length; i++) {
+			int c = bytes[i] & 0xff;
+			if (keepUrlByte(bytes, i, c, norm)) {
+				continue;
+			}
+			b.append(new String(bytes, written, i - written, StandardCharsets.UTF_8));
+			b.append('%').append(String.format("%02x", c));
+			written = i + 1;
+		}
+		b.append(new String(bytes, written, bytes.length - written, StandardCharsets.UTF_8));
+		return written != 0;
+	}
+
+	private static boolean keepUrlByte(byte[] bytes, int i, int c, boolean norm) {
+		switch (c) {
+			case '!', '#', '$', '&', '*', '+', ',', '/', ':', ';', '=', '?', '@', '[', ']' -> {
+				// Sub-delims/reserved: kept when normalizing, encoded otherwise.
+				return norm;
+			}
+			case '-', '.', '_', '~' -> {
+				return true;
+			}
+			case '%' -> {
+				// Do not re-encode a valid existing escape when normalizing.
+				return norm && i + 2 < bytes.length && CssLex.isHex(bytes[i + 1]) && CssLex.isHex(bytes[i + 2]);
+			}
+			default -> {
+				return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+			}
+		}
+	}
+
+	private static boolean isSafeUrl(String s) {
+		int colon = s.indexOf(':');
+		if (colon >= 0) {
+			String protocol = s.substring(0, colon);
+			if (!protocol.contains("/")) {
+				String p = protocol.toLowerCase(Locale.ROOT);
+				if (!p.equals("http") && !p.equals("https") && !p.equals("mailto")) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	private static void filterSrcsetElement(byte[] s, int left, int right, StringBuilder b) {
+		int start = left;
+		while (start < right && isHtmlSpace(s[start])) {
+			start++;
+		}
+		int end = right;
+		for (int i = start; i < right; i++) {
+			if (isHtmlSpace(s[i])) {
+				end = i;
+				break;
+			}
+		}
+		String url = new String(s, start, end - start, StandardCharsets.UTF_8);
+		if (isSafeUrl(url)) {
+			boolean metadataOk = true;
+			for (int i = end; i < right; i++) {
+				if (!isHtmlSpaceOrAsciiAlnum(s[i])) {
+					metadataOk = false;
+					break;
+				}
+			}
+			if (metadataOk) {
+				b.append(new String(s, left, start - left, StandardCharsets.UTF_8));
+				processUrlOnto(url, true, b);
+				b.append(new String(s, end, right - end, StandardCharsets.UTF_8));
+				return;
+			}
+		}
+		b.append('#').append(Escapers.FILTER_FAILSAFE);
+	}
+
+	private static boolean isHtmlSpace(byte b) {
+		int c = b & 0xff;
+		return c <= 0x20 && (HTML_SPACE_AND_ALNUM[c >> 3] & (1 << (c & 0x7))) != 0;
+	}
+
+	private static boolean isHtmlSpaceOrAsciiAlnum(byte b) {
+		int c = b & 0xff;
+		return c < 0x80 && (HTML_SPACE_AND_ALNUM[c >> 3] & (1 << (c & 0x7))) != 0;
+	}
+
+}

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/EscapersTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/EscapersTest.java
@@ -1,0 +1,92 @@
+package org.alexmond.gotmpl4j.html;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EscapersTest {
+
+	@Test
+	void htmlEscaperEscapesSpecialsAndHonoursSafeHtml() {
+		assertEquals("&lt;b&gt;Hi &amp; bye&lt;/b&gt;", HtmlEscapers.htmlEscaper("<b>Hi & bye</b>"));
+		assertEquals("O&#39;Reilly", HtmlEscapers.htmlEscaper("O'Reilly"));
+		// A SafeContent.html value passes through unescaped.
+		assertEquals("<b>bold</b>", HtmlEscapers.htmlEscaper(SafeContent.html("<b>bold</b>")));
+	}
+
+	@Test
+	void attrAndNospaceEscapers() {
+		assertEquals("a&#43;b", HtmlEscapers.attrEscaper("a+b"));
+		assertEquals("a&#32;b", HtmlEscapers.htmlNospaceEscaper("a b"));
+		assertEquals(Escapers.FILTER_FAILSAFE, HtmlEscapers.htmlNospaceEscaper(""));
+	}
+
+	@Test
+	void htmlNameFilter() {
+		assertEquals("class", HtmlEscapers.htmlNameFilter("class"));
+		// onclick is an event-handler attribute (script), so it is filtered out.
+		assertEquals(Escapers.FILTER_FAILSAFE, HtmlEscapers.htmlNameFilter("onclick"));
+		assertEquals(Escapers.FILTER_FAILSAFE, HtmlEscapers.htmlNameFilter("a b"));
+	}
+
+	@Test
+	void commentEscaperDropsContent() {
+		assertEquals("", HtmlEscapers.commentEscaper("anything at all"));
+	}
+
+	@Test
+	void jsStrEscaper() {
+		assertEquals("O\\u0027Reilly", JsEscapers.jsStrEscaper("O'Reilly"));
+		assertEquals("a\\u003cb", JsEscapers.jsStrEscaper("a<b"));
+		assertEquals("line1\\nline2", JsEscapers.jsStrEscaper("line1\nline2"));
+	}
+
+	@Test
+	void jsRegexpEscaper() {
+		assertEquals("foo\\.bar", JsEscapers.jsRegexpEscaper("foo.bar"));
+		assertEquals("(?:)", JsEscapers.jsRegexpEscaper(""));
+	}
+
+	@Test
+	void cssEscaper() {
+		// '(' -> \28 (no trailing space: next char 'x' is not a hex digit); ')' -> \29
+		// (trailing space terminates the escape at end of input).
+		assertEquals("url\\28x\\29 ", CssEscapers.cssEscaper("url(x)"));
+		assertEquals("a\\3a b", CssEscapers.cssEscaper("a:b"));
+	}
+
+	@Test
+	void cssValueFilter() {
+		assertEquals("12px", CssEscapers.cssValueFilter("12px"));
+		assertEquals(Escapers.FILTER_FAILSAFE, CssEscapers.cssValueFilter("expression(alert(1))"));
+		assertEquals(Escapers.FILTER_FAILSAFE, CssEscapers.cssValueFilter("foo;bar"));
+	}
+
+	@Test
+	void urlFilterBlocksUnsafeSchemes() {
+		assertEquals("/safe/path", UrlEscapers.urlFilter("/safe/path"));
+		assertEquals("http://example.com", UrlEscapers.urlFilter("http://example.com"));
+		assertEquals("#" + Escapers.FILTER_FAILSAFE, UrlEscapers.urlFilter("javascript:alert(1)"));
+	}
+
+	@Test
+	void urlEscaperAndNormalizer() {
+		assertEquals("a%3db%26c", UrlEscapers.urlEscaper("a=b&c"));
+		// The normalizer keeps reserved chars but encodes spaces.
+		assertEquals("/a/b?x=1%20", UrlEscapers.urlNormalizer("/a/b?x=1 "));
+	}
+
+	@Test
+	void srcsetFilterAndEscaper() {
+		assertEquals("/img.png 1x", UrlEscapers.srcsetFilterAndEscaper("/img.png 1x"));
+		// A javascript: URL in a srcset element is defanged.
+		assertEquals("#" + Escapers.FILTER_FAILSAFE, UrlEscapers.srcsetFilterAndEscaper("javascript:alert(1) 1x"));
+	}
+
+	@Test
+	void registryExposesGoNames() {
+		assertEquals(15, Escapers.escapers().size());
+		assertEquals("&lt;x&gt;", Escapers.escapers().get("_html_template_htmlescaper").invoke("<x>"));
+	}
+
+}


### PR DESCRIPTION
Stage 2a of epic #414 (faithful port of Go `html/template`). Part of #416 — all contextual escapers **except** the JSON-marshaling `jsValEscaper`, which follows in S2b.

Ports `html.go`, `css.go`, `url.go`, and the string/regexp escapers from `js.go`:
- **`HtmlEscapers`** — `htmlEscaper`, `attrEscaper`, `htmlNospaceEscaper`, `rcdataEscaper`, `htmlNameFilter`, `commentEscaper`, the replacement tables + `htmlReplacer`, and **`stripTags`** (drives the S4 transition machine to extract text content from an HTML fragment).
- **`JsEscapers`** — `jsStrEscaper`, `jsTmplLitEscaper`, `jsRegexpEscaper` + the shared `replace()` with the low-Unicode / string / template-literal / regexp tables.
- **`CssEscapers`** — `cssEscaper` (`\<hex>` escapes) and `cssValueFilter` (filters `expression(...)`, mismatched brackets, …).
- **`UrlEscapers`** — `urlFilter` (defangs `javascript:` etc.), `urlEscaper`, `urlNormalizer`, `srcsetFilterAndEscaper`, `processUrlOnto` over UTF-8 bytes.
- **`Escapers`** — registry mapping the Go internal names (`_html_template_*`) to engine `Function`s; `FILTER_FAILSAFE = "ZgotmplZ"`.
- `Transitions.transitionFor(state, …)` so `stripTags` can force RCDATA scanning inside special-element bodies.

**Safety:** pure/additive in `org.alexmond.gotmpl4j.html`, no engine wiring — default `text/template` and the 346-chart Helm parity untouched. Engine builds green incl. the 0.75 jacoco gate. `EscapersTest` checks outputs against known Go `html/template` values (html/attr/nospace/name-filter, jsStr/jsRegexp, css/cssValueFilter, urlFilter/escaper/normalizer, srcset). Feeds the escape pass (S5, #419).

🤖 Generated with [Claude Code](https://claude.com/claude-code)