### PR TITLE
feat(gotmpl4j-core): html/template jsValEscaper + Go-faithful JSON marshal (S2b, #416)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Escapers.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Escapers.java
@@ -10,10 +10,6 @@ import org.alexmond.gotmpl4j.Function;
  * {@code html/template} uses (e.g. {@code _html_template_htmlescaper}). The escape pass
  * appends these by name to action pipelines; the executor resolves them like any
  * function.
- *
- * <p>
- * {@code _html_template_jsvalescaper} (the JSON-marshaling JS value escaper) is
- * registered separately once implemented.
  */
 public final class Escapers {
 
@@ -43,6 +39,7 @@ public final class Escapers {
 		m.put("_html_template_jsregexpescaper", JsEscapers::jsRegexpEscaper);
 		m.put("_html_template_jsstrescaper", JsEscapers::jsStrEscaper);
 		m.put("_html_template_jstmpllitescaper", JsEscapers::jsTmplLitEscaper);
+		m.put("_html_template_jsvalescaper", JsEscapers::jsValEscaper);
 		m.put("_html_template_urlescaper", UrlEscapers::urlEscaper);
 		m.put("_html_template_urlfilter", UrlEscapers::urlFilter);
 		m.put("_html_template_urlnormalizer", UrlEscapers::urlNormalizer);

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/JsEscapers.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/JsEscapers.java
@@ -6,10 +6,9 @@ import java.util.Map;
 import org.alexmond.gotmpl4j.html.Content.Stringified;
 
 /**
- * JavaScript string/regexp contextual escapers ported from Go {@code html/template}'s
- * js.go: {@code jsStrEscaper}, {@code jsTmplLitEscaper}, {@code jsRegexpEscaper} and the
- * shared {@code replace}. ({@code jsValEscaper}, which needs JSON marshaling, lands
- * separately.)
+ * JavaScript contextual escapers ported from Go {@code html/template}'s js.go:
+ * {@code jsValEscaper} (a value as a JSON literal), {@code jsStrEscaper},
+ * {@code jsTmplLitEscaper}, {@code jsRegexpEscaper} and the shared {@code replace}.
  */
 final class JsEscapers {
 
@@ -38,6 +37,68 @@ final class JsEscapers {
 	private static final Map<Integer, String> JS_REGEXP = jsRegexp();
 
 	private JsEscapers() {
+	}
+
+	/**
+	 * Escapes a value to a JS expression (a JSON literal) with no side effects or free
+	 * variables, mirroring Go {@code jsValEscaper}. A {@link SafeContent} of type JS is
+	 * emitted verbatim; one of type JS_STR is wrapped in quotes; anything else is
+	 * rendered as Go-compatible JSON. The result is padded with spaces when it abuts an
+	 * identifier so it cannot run into an adjacent keyword.
+	 * @param args the value(s)
+	 * @return the JS expression
+	 */
+	static String jsValEscaper(Object... args) {
+		Object a;
+		if (args.length == 1) {
+			if (args[0] instanceof SafeContent sc) {
+				if (sc.contentType() == ContentType.JS) {
+					return sc.value();
+				}
+				if (sc.contentType() == ContentType.JS_STR) {
+					return "\"" + sc.value() + "\"";
+				}
+			}
+			a = args[0];
+		}
+		else {
+			a = sprintArgs(args);
+		}
+		String json;
+		try {
+			json = JsonMarshal.marshal(a);
+		}
+		catch (JsonMarshal.JsonException ex) {
+			return " /* " + sanitizeError(ex.getMessage()) + " */null ";
+		}
+		if (json.isEmpty()) {
+			// In `x=y/{{.}}*z` a value marshaling to "" must not yield `x=y/*z`.
+			return " null ";
+		}
+		boolean pad = JsLex.isJSIdentPart(json.codePointAt(0))
+				|| JsLex.isJSIdentPart(json.codePointBefore(json.length()));
+		String body = json.replace("\u2028", "\\u2028").replace("\u2029", "\\u2029");
+		return pad ? " " + body + " " : body;
+	}
+
+	// fmt.Sprint of multiple arguments (a space is inserted between two non-strings).
+	private static String sprintArgs(Object[] args) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < args.length; i++) {
+			if (i > 0 && !(args[i - 1] instanceof String) && !(args[i] instanceof String)) {
+				sb.append(' ');
+			}
+			sb.append(org.alexmond.gotmpl4j.GoFmt.sprint(args[i]));
+		}
+		return sb.toString();
+	}
+
+	// Prevents a marshaling error message (interpolated as a JS comment) from terminating
+	// the comment or the script block.
+	private static String sanitizeError(String message) {
+		String m = message.replaceAll("(?i)<(/?)script", "\\\\x3C$1script");
+		m = m.replace("*/", "* /");
+		return m.replace("<!--", "\\x3C!--");
 	}
 
 	/** Escapes for inclusion between quotes in a JS string. */

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/JsonMarshal.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/JsonMarshal.java
@@ -1,0 +1,176 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A minimal JSON marshaler matching Go {@code encoding/json}'s default
+ * ({@code escapeHTML}) output over the gotmpl4j value model
+ * (string/number/boolean/null/map/list). Used by {@link JsEscapers#jsValEscaper} so a
+ * value interpolated into a JS value context is the same JSON Go would produce.
+ *
+ * <p>
+ * Notable Go-isms reproduced: {@code <}, {@code >}, {@code &} in strings are escaped as
+ * {@code <}/{@code >}/{@code &}; {@code U+2028}/{@code U+2029} are escaped; map keys are
+ * sorted; whole floats print without a decimal point ({@code 8080.0 -> 8080}); very
+ * small/large floats use exponent form.
+ */
+final class JsonMarshal {
+
+	private JsonMarshal() {
+	}
+
+	/**
+	 * Marshals a value to JSON like Go's {@code json.Marshal}.
+	 * @param value the value
+	 * @return the JSON text
+	 */
+	static String marshal(Object value) {
+		StringBuilder b = new StringBuilder();
+		write(b, value);
+		return b.toString();
+	}
+
+	private static void write(StringBuilder b, Object value) {
+		switch (value) {
+			case null -> b.append("null");
+			case String s -> writeString(b, s);
+			case SafeContent sc -> writeString(b, sc.value());
+			case Boolean bool -> b.append(bool ? "true" : "false");
+			case Double d -> b.append(jsonFloat(d));
+			case Float f -> b.append(jsonFloat(f));
+			case Number n -> b.append(n.toString());
+			case Map<?, ?> map -> writeMap(b, map);
+			case Collection<?> coll -> writeArray(b, coll);
+			default -> writeOther(b, value);
+		}
+	}
+
+	private static void writeOther(StringBuilder b, Object value) {
+		if (value.getClass().isArray()) {
+			List<Object> list = new ArrayList<>();
+			int len = java.lang.reflect.Array.getLength(value);
+			for (int i = 0; i < len; i++) {
+				list.add(java.lang.reflect.Array.get(value, i));
+			}
+			writeArray(b, list);
+		}
+		else {
+			// Fall back to the string form (Go would use a Stringer/encoding here).
+			writeString(b, String.valueOf(value));
+		}
+	}
+
+	private static void writeMap(StringBuilder b, Map<?, ?> map) {
+		List<String> keys = new ArrayList<>();
+		for (Object k : map.keySet()) {
+			keys.add(String.valueOf(k));
+		}
+		keys.sort(null);
+		b.append('{');
+		for (int i = 0; i < keys.size(); i++) {
+			if (i > 0) {
+				b.append(',');
+			}
+			String key = keys.get(i);
+			writeString(b, key);
+			b.append(':');
+			write(b, map.get(rawKey(map, key)));
+		}
+		b.append('}');
+	}
+
+	// Find the original key object equal (by string form) to the sorted string key.
+	private static Object rawKey(Map<?, ?> map, String key) {
+		if (map.containsKey(key)) {
+			return key;
+		}
+		for (Object k : map.keySet()) {
+			if (String.valueOf(k).equals(key)) {
+				return k;
+			}
+		}
+		return key;
+	}
+
+	private static void writeArray(StringBuilder b, Collection<?> coll) {
+		b.append('[');
+		boolean first = true;
+		for (Object e : coll) {
+			if (!first) {
+				b.append(',');
+			}
+			write(b, e);
+			first = false;
+		}
+		b.append(']');
+	}
+
+	private static void writeString(StringBuilder b, String s) {
+		b.append('"');
+		int i = 0;
+		while (i < s.length()) {
+			int r = s.codePointAt(i);
+			int w = Character.charCount(r);
+			switch (r) {
+				case '"' -> b.append("\\\"");
+				case '\\' -> b.append("\\\\");
+				case '\n' -> b.append("\\n");
+				case '\r' -> b.append("\\r");
+				case '\t' -> b.append("\\t");
+				case 0x2028 -> b.append("\\u2028");
+				case 0x2029 -> b.append("\\u2029");
+				default -> {
+					if (r < 0x20 || r == '<' || r == '>' || r == '&') {
+						b.append(String.format("\\u%04x", r));
+					}
+					else {
+						b.appendCodePoint(r);
+					}
+				}
+			}
+			i += w;
+		}
+		b.append('"');
+	}
+
+	// Go encoding/json float64 formatting: whole/normal floats use plain decimal; very
+	// small (|x| < 1e-6) or very large (|x| >= 1e21) use exponent form.
+	private static String jsonFloat(double f) {
+		if (Double.isNaN(f) || Double.isInfinite(f)) {
+			String which = Double.isNaN(f) ? "NaN" : ((f > 0) ? "+Inf" : "-Inf");
+			throw new JsonException("json: unsupported value: " + which);
+		}
+		if (f == 0.0) {
+			return "0";
+		}
+		double abs = Math.abs(f);
+		if (abs < 1e-6 || abs >= 1e21) {
+			BigDecimal bd = new BigDecimal(Double.toString(abs)).stripTrailingZeros();
+			String digits = bd.unscaledValue().toString();
+			int exp = bd.precision() - bd.scale() - 1;
+			String mantissa = (digits.length() == 1) ? digits : digits.charAt(0) + "." + digits.substring(1);
+			String es = (exp < 0) ? "-" : "+";
+			String ea = Integer.toString(Math.abs(exp));
+			// Go: e+NN keeps a min of 2 exponent digits; e-N is trimmed to its minimum.
+			if (es.equals("+") && ea.length() < 2) {
+				ea = "0" + ea;
+			}
+			return ((f < 0) ? "-" : "") + mantissa + "e" + es + ea;
+		}
+		return new BigDecimal(Double.toString(f)).stripTrailingZeros().toPlainString();
+	}
+
+	/** Thrown for values Go {@code json.Marshal} rejects (NaN, infinities). */
+	static final class JsonException extends RuntimeException {
+
+		JsonException(String message) {
+			super(message);
+		}
+
+	}
+
+}

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/EscapersTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/EscapersTest.java
@@ -85,7 +85,7 @@ class EscapersTest {
 
 	@Test
 	void registryExposesGoNames() {
-		assertEquals(15, Escapers.escapers().size());
+		assertEquals(16, Escapers.escapers().size());
 		assertEquals("&lt;x&gt;", Escapers.escapers().get("_html_template_htmlescaper").invoke("<x>"));
 	}
 

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/JsValEscaperTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/JsValEscaperTest.java
@@ -1,0 +1,70 @@
+package org.alexmond.gotmpl4j.html;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JsValEscaperTest {
+
+	@Test
+	void jsonMarshalStrings() {
+		assertEquals("\"foo\"", JsonMarshal.marshal("foo"));
+		assertEquals("\"a\\\"b\"", JsonMarshal.marshal("a\"b"));
+		// <, >, & are escaped like Go's encoding/json (escapeHTML default on).
+		assertEquals("\"\\u003cb\\u003e \\u0026 x\"", JsonMarshal.marshal("<b> & x"));
+		assertEquals("\"tab\\tend\"", JsonMarshal.marshal("tab\tend"));
+	}
+
+	@Test
+	void jsonMarshalNumbersAndBools() {
+		assertEquals("42", JsonMarshal.marshal(42L));
+		assertEquals("3.5", JsonMarshal.marshal(3.5));
+		// Whole floats print without a decimal point.
+		assertEquals("8080", JsonMarshal.marshal(8080.0));
+		assertEquals("0.0001", JsonMarshal.marshal(0.0001));
+		// Very small / very large floats use exponent form.
+		assertEquals("1e-07".replace("e-07", "e-7"), JsonMarshal.marshal(1e-7));
+		assertEquals("1e+21", JsonMarshal.marshal(1e21));
+		assertEquals("true", JsonMarshal.marshal(Boolean.TRUE));
+		assertEquals("null", JsonMarshal.marshal(null));
+	}
+
+	@Test
+	void jsonMarshalMapSortsKeys() {
+		Map<String, Object> m = new LinkedHashMap<>();
+		m.put("b", 2L);
+		m.put("a", 1L);
+		assertEquals("{\"a\":1,\"b\":2}", JsonMarshal.marshal(m));
+	}
+
+	@Test
+	void jsonMarshalList() {
+		assertEquals("[1,2,3]", JsonMarshal.marshal(List.of(1L, 2L, 3L)));
+		assertEquals("[\"x\",\"y\"]", JsonMarshal.marshal(List.of("x", "y")));
+	}
+
+	@Test
+	void jsValEscaperWrapsAndPads() {
+		// A JSON string boundary is not an identifier part, so no padding.
+		assertEquals("\"foo\"", JsEscapers.jsValEscaper("foo"));
+		// A number's digits are identifier parts, so it is padded so it cannot merge with
+		// a
+		// neighbouring keyword.
+		assertEquals(" 42 ", JsEscapers.jsValEscaper(42L));
+		assertEquals(" true ", JsEscapers.jsValEscaper(Boolean.TRUE));
+		assertEquals(" null ", JsEscapers.jsValEscaper((Object) null));
+		assertEquals("\"\\u003cb\\u003e\"", JsEscapers.jsValEscaper("<b>"));
+	}
+
+	@Test
+	void jsValEscaperHonoursSafeJs() {
+		// template.JS is emitted verbatim; template.JSStr is wrapped in quotes.
+		assertEquals("x + 1", JsEscapers.jsValEscaper(SafeContent.js("x + 1")));
+		assertEquals("\"abc\"", JsEscapers.jsValEscaper(SafeContent.jsStr("abc")));
+	}
+
+}


### PR DESCRIPTION
Completes the escapers for epic #414 — the last of Go's 16 contextual escapers, `jsValEscaper`. Closes #416.

- **`JsonMarshal`** — a JSON marshaler matching Go `encoding/json`'s default (`escapeHTML`) output over the gotmpl4j value model: strings escape `<`/`>`/`&` as `<`/`>`/`&` and `U+2028`/`U+2029`; **map keys are sorted**; whole floats print without a decimal point (`8080.0` → `8080`); very small/large floats use exponent form (`1e-7`, `1e+21`); NaN/Inf rejected like Go.
- **`JsEscapers.jsValEscaper`** — emits a `SafeContent` JS value verbatim, wraps a `SafeContent` JSStr in quotes, else marshals to JSON; **pads** the result with spaces when it abuts a JS identifier so it can't run into a keyword (`42` → ` 42 `); sanitizes a marshal-error message so it can't break out of the JS comment/script block.
- Registered as `_html_template_jsvalescaper` — the registry is now the full **16 escapers**.

**Safety:** pure/additive, no engine wiring — default `text/template` and the 346-chart Helm parity untouched. Engine builds green incl. the 0.75 jacoco gate. `JsValEscaperTest` covers the marshaler (strings/numbers/bools/maps/lists, HTML escaping, sorted keys, float forms) and the escaper's wrapping/padding/safe-type behaviour.

With this, **S2 is complete** — every contextual escaper is ported. Next is the escape pass (S5, #419) that wires them onto action pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)