### PR TITLE
feat(gotmpl4j-core): opt-in html/template mode on GoTemplate (S6, #420)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/GoTemplate.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/GoTemplate.java
@@ -12,10 +12,16 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.gotmpl4j.exec.Executor;
+import org.alexmond.gotmpl4j.html.Escaper;
+import org.alexmond.gotmpl4j.html.Escapers;
 import org.alexmond.gotmpl4j.parse.Node;
 import org.alexmond.gotmpl4j.parse.Parser;
 import org.alexmond.gotmpl4j.util.IOUtils;
@@ -48,6 +54,17 @@ public class GoTemplate {
 	private final Map<String, Node> rootNodes;
 
 	private String name;
+
+	private boolean htmlEscape;
+
+	@Getter(AccessLevel.NONE)
+	private Escaper escaper;
+
+	@Getter(AccessLevel.NONE)
+	private final Set<String> escapedNames = ConcurrentHashMap.newKeySet();
+
+	@Getter(AccessLevel.NONE)
+	private final ReentrantLock escapeLock = new ReentrantLock();
 
 	/**
 	 * Create a new GoTemplate with default settings. Auto-discovers
@@ -165,8 +182,39 @@ public class GoTemplate {
 		if (name == null || !rootNodes.containsKey(name)) {
 			throw new TemplateNotFoundException(String.format("Template '%s' not found.", name));
 		}
+		if (htmlEscape) {
+			ensureEscaped(name);
+		}
 		Executor executor = new Executor(rootNodes, functions);
 		executor.execute(name, data, writer);
+	}
+
+	/**
+	 * Enables opt-in {@code html/template} contextual auto-escaping: the named template
+	 * is rewritten (lazily, on first execution) so interpolated values are escaped for
+	 * the HTML/JS/CSS/URL context they appear in, and the internal escaper functions are
+	 * registered. The default mode is {@code text/template} (no escaping), matching Helm.
+	 */
+	void enableHtmlEscaping() {
+		this.htmlEscape = true;
+		this.functions.putAll(Escapers.escapers());
+		this.escaper = new Escaper(this.rootNodes);
+	}
+
+	private void ensureEscaped(String name) {
+		if (escapedNames.contains(name)) {
+			return;
+		}
+		escapeLock.lock();
+		try {
+			if (!escapedNames.contains(name)) {
+				escaper.escapeOne(name);
+				escapedNames.add(name);
+			}
+		}
+		finally {
+			escapeLock.unlock();
+		}
 	}
 
 	/**
@@ -254,7 +302,19 @@ public class GoTemplate {
 
 		private boolean autoDiscovery = true;
 
+		private boolean htmlEscaping;
+
 		Builder() {
+		}
+
+		/**
+		 * Enable opt-in {@code html/template} contextual auto-escaping. The default is
+		 * {@code text/template} (no escaping), which is what Helm uses.
+		 * @return this builder
+		 */
+		public Builder htmlEscaping() {
+			this.htmlEscaping = true;
+			return this;
 		}
 
 		/**
@@ -328,6 +388,10 @@ public class GoTemplate {
 			// Raw functions override everything
 			if (extraFunctions != null) {
 				template.functions.putAll(extraFunctions);
+			}
+
+			if (htmlEscaping) {
+				template.enableHtmlEscaping();
 			}
 
 			return template;

--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Escaper.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/html/Escaper.java
@@ -79,20 +79,25 @@ public final class Escaper {
 
 	private RangeContext rangeContext;
 
-	private Escaper(Map<String, Node> templates) {
+	/**
+	 * Creates an escaper over a template set. One instance may escape several entry
+	 * templates ({@link #escapeOne}); its output cache persists so a template reached
+	 * from more than one entry is escaped only once.
+	 * @param templates the template set (rootNodes), mutated in place
+	 */
+	public Escaper(Map<String, Node> templates) {
 		this.templates = templates;
 	}
 
 	/**
-	 * Rewrites the named template (and the templates it reaches) so all output is
-	 * contextually escaped. Mutates the nodes in {@code templates} in place.
-	 * @param templates the template set (rootNodes)
+	 * Rewrites a single named template (and the templates it reaches) so all output is
+	 * contextually escaped. Idempotent: re-escaping an already-escaped entry is a cheap
+	 * cache hit.
 	 * @param name the entry template name
 	 * @throws EscapeError if the template cannot be safely escaped
 	 */
-	public static void escape(Map<String, Node> templates, String name) {
-		Escaper e = new Escaper(templates);
-		Tree res = e.escapeTree(new Context(), templates.get(name), name, 0);
+	public void escapeOne(String name) {
+		Tree res = escapeTree(new Context(), this.templates.get(name), name, 0);
 		Context c = res.context();
 		if (c.err != null) {
 			EscapeError ce = c.err;
@@ -101,7 +106,18 @@ public final class Escaper {
 		if (c.state != State.TEXT) {
 			throw new EscapeError(EscapeErrorCode.ERR_END_CONTEXT, null, name, 0, "ends in a non-text context: " + c);
 		}
-		e.commit();
+		commit();
+	}
+
+	/**
+	 * Rewrites the named template (and the templates it reaches) so all output is
+	 * contextually escaped. Convenience for a single entry.
+	 * @param templates the template set (rootNodes)
+	 * @param name the entry template name
+	 * @throws EscapeError if the template cannot be safely escaped
+	 */
+	public static void escape(Map<String, Node> templates, String name) {
+		new Escaper(templates).escapeOne(name);
 	}
 
 	private Context escapeNode(Context c, Node n) {
@@ -556,6 +572,11 @@ public final class Escaper {
 		for (Map.Entry<TextNode, String> en : this.textNodeEdits.entrySet()) {
 			en.getKey().setText(en.getValue());
 		}
+		// Keep the output cache (so shared templates are not re-escaped) but clear the
+		// per-pass edits and call set so a later escapeOne does not re-apply them.
+		this.actionNodeEdits.clear();
+		this.textNodeEdits.clear();
+		this.called.clear();
 	}
 
 	// Ensures the pipeline ends with the escaper commands in s, merging a trailing

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/HtmlModeTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/HtmlModeTest.java
@@ -1,0 +1,68 @@
+package org.alexmond.gotmpl4j;
+
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+
+import org.alexmond.gotmpl4j.html.EscapeError;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests the opt-in {@code html/template} mode on {@link GoTemplate} (epic #414 S6): when
+ * enabled the engine contextually auto-escapes; by default it stays {@code text/template}
+ * (no escaping), preserving Helm parity.
+ */
+class HtmlModeTest {
+
+	private static String render(GoTemplate t, String name, Object data) throws Exception {
+		StringWriter w = new StringWriter();
+		t.execute(name, data, w);
+		return w.toString();
+	}
+
+	@Test
+	void defaultModeDoesNotEscape() throws Exception {
+		// Plain text/template: values are emitted verbatim (this is what Helm relies on).
+		GoTemplate t = new GoTemplate();
+		t.parse("doc", "<p>{{.}}</p>");
+		assertEquals("<p><b></p>", render(t, "doc", "<b>"));
+	}
+
+	@Test
+	void htmlModeEscapesByContext() throws Exception {
+		GoTemplate t = GoTemplate.builder().htmlEscaping().build();
+		t.parse("doc", "<p>{{.}}</p><a href=\"{{.}}\">x</a>");
+		assertEquals("<p>&lt;b&gt;</p><a href=\"%3cb%3e\">x</a>", render(t, "doc", "<b>"));
+	}
+
+	@Test
+	void htmlModeIsIdempotentAcrossRenders() throws Exception {
+		GoTemplate t = GoTemplate.builder().htmlEscaping().build();
+		t.parse("doc", "<p>{{.}}</p>");
+		assertEquals("<p>&lt;b&gt;</p>", render(t, "doc", "<b>"));
+		// A second render must not double-escape (escape runs once, then is cached).
+		assertEquals("<p>&lt;a&gt;</p>", render(t, "doc", "<a>"));
+	}
+
+	@Test
+	void htmlModeEscapesMultipleViewsSharingAPartial() throws Exception {
+		GoTemplate t = GoTemplate.builder().htmlEscaping().build();
+		t.parse("a", "<p>{{template \"shared\" .}}|{{.}}</p>");
+		t.parse("b", "<div>{{template \"shared\" .}}</div>");
+		t.parse("shared", "{{.}}");
+		assertEquals("<p>&lt;x&gt;|&lt;x&gt;</p>", render(t, "a", "<x>"));
+		assertEquals("<div>&lt;x&gt;</div>", render(t, "b", "<x>"));
+	}
+
+	@Test
+	void htmlModeReportsNonTextEndContext() {
+		GoTemplate t = GoTemplate.builder().htmlEscaping().build();
+		assertThrows(EscapeError.class, () -> {
+			t.parse("doc", "<a href=\"{{.}}");
+			render(t, "doc", "x");
+		});
+	}
+
+}


### PR DESCRIPTION
Stage 6 of epic #414 — wires the escape pass (S5) into the engine as an **opt-in mode**. Closes #420 (and #37, the original umbrella line item).

- **`GoTemplate.builder().htmlEscaping()`** enables contextual auto-escaping. When on, the engine registers the internal escaper functions and — lazily on first `execute` of a name (thread-safe via a lock, idempotent via an escaped-name set) — runs `Escaper` over the parse tree, so values are escaped for the HTML/JS/CSS/URL context they appear in.
- **`Escaper` made reusable**: a public constructor + `escapeOne(name)` with a persistent output cache (a template reached from several entry points is escaped once); `commit()` now clears per-pass edits but keeps the cache.

## Default unchanged
`new GoTemplate()` and the plain builder stay **`text/template`** (no escaping). Helm uses only `text/template`, so the 346-chart byte-parity is structurally untouched — HTML escaping never runs unless explicitly opted in.

```java
GoTemplate t = GoTemplate.builder().htmlEscaping().build();
t.parse("doc", "<p>{{.}}</p>");
t.render("doc", "<b>");   // -> "<p>&lt;b&gt;</p>"
```

`HtmlModeTest` covers: default mode does not escape; HTML mode escapes by context (text + URL attr); idempotent across renders; multiple views sharing a partial; non-text end context reported. Engine builds green incl. the 0.75 jacoco gate.

Only **S7** (port Go's `escape_test.go` conformance suite) remains in the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)