### PR TITLE
fix(gotmpl4j-core): printf %g prints Go's shortest float (#436)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/Functions.java
@@ -410,6 +410,12 @@ public final class Functions {
 			format = format.replaceAll("%p", "%s"); // %(p) -> %s
 			format = format.replaceAll("%t", "%b"); // Go bool verb %t -> Java %b (Java %t
 													// is dates)
+			// A bare %g/%G prints the shortest float64 in Go, but Java's %g uses fixed
+			// precision (3.5 -> "3.50000"). Route it through %s, which formats a float
+			// via
+			// GoFmt (Go's shortest %g). Specifiers with flags/precision (%.3g) are
+			// untouched.
+			format = format.replaceAll("(?<!%)%([gG])(?![0-9a-zA-Z.])", "%s");
 			// %q is kept for now — unlike %s it double-quotes its argument (Go strconv.
 			// Quote), so the corresponding arg is quoted below before %q -> %s.
 

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/FunctionsTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/FunctionsTest.java
@@ -460,10 +460,11 @@ class FunctionsTest {
 
 	@Test
 	void testPrintfFloatFormatWithInteger() throws Exception {
-		// Go's %g accepts any numeric type; Java's requires float/double (#304)
+		// Go's %g accepts any numeric type and prints the shortest float (#304, #436);
+		// 5432 -> "5432", not Java's fixed-precision "5432.00".
 		Function printf = Functions.GO_BUILTINS.get("printf");
-		assertEquals("5432.00", printf.invoke(new Object[] { "%g", 5432 }));
-		assertEquals("5432.00", printf.invoke(new Object[] { "%g", 5432L }));
+		assertEquals("5432", printf.invoke(new Object[] { "%g", 5432 }));
+		assertEquals("5432", printf.invoke(new Object[] { "%g", 5432L }));
 		assertEquals("3.000000", printf.invoke(new Object[] { "%f", 3 }));
 	}
 
@@ -479,9 +480,11 @@ class FunctionsTest {
 		// Mixed %d and %g in same format string — each arg coerced independently
 		Function printf = Functions.GO_BUILTINS.get("printf");
 		assertEquals("port=9092 rate=1.500000", printf.invoke(new Object[] { "port=%d rate=%f", 9092.0, 1.5 }));
-		assertEquals("count=3 ratio=42.0000", printf.invoke(new Object[] { "count=%d ratio=%g", 3.0, 42 }));
-		// Gitea postgresql-ha.dns pattern: %s args before %g with Integer port
-		assertEquals("host.ns.svc.cluster:5432.00",
+		assertEquals("count=3 ratio=42", printf.invoke(new Object[] { "count=%d ratio=%g", 3.0, 42 }));
+		// Gitea postgresql-ha.dns pattern: %s args before %g with port (Helm loads values
+		// as
+		// float64, so %g prints the shortest form -> "5432", matching helm).
+		assertEquals("host.ns.svc.cluster:5432",
 				printf.invoke(new Object[] { "%s.%s.svc.%s:%g", "host", "ns", "cluster", 5432 }));
 	}
 

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
@@ -46,8 +46,6 @@ class TvalConformanceTest {
 			"with else with", "with else with chain",
 			// #435 print missing operand spaces / octal+underscore literals.
 			"print 123", "print multi", "print multi2", "octal0",
-			// #436 printf %g not Go-shortest.
-			"printf float",
 			// #437 slice does not support strings.
 			"string[:]", "string[0:1]", "string[1:]", "string[1:2]",
 			// #438 range '=' assignment does not update the outer variable.


### PR DESCRIPTION
Closes #436. A bare `{{printf "%g" x}}` delegated to Java's `%g` (fixed 6 significant digits — `3.5` → `3.50000`); Go prints the **shortest** round-tripping form (`3.5`→`3.5`, `5432.0`→`5432`, `1e6`→`1e+06`).

**Fix:** route a bare `%g`/`%G` through `%s`, which already formats a float via `GoFmt.floatString` (Go's shortest `%g`). Specifiers with flags/precision (`%.2g`→`3.1`) are untouched.

Helm loads values as **float64**, so a chart's `printf "%g" port` gets a float and now matches `helm template` (`5432`, not `5432.00`). Updated the two `FunctionsTest` cases that had codified the old Java-precision output, and removed `printf float` from the #439 conformance ledger.

## jhelm keeps working
**346/346 charts pass** (full `parity-run.sh`, unchanged). Engine builds green incl. the 0.75 jacoco gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)