### PR TITLE
fix(gotmpl4j-core): print inserts spaces between non-string operands (#435)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/Functions.java
@@ -385,13 +385,19 @@ public final class Functions {
 	}
 
 	private static Function print() {
-		// In Go, fmt.Sprint adds spaces between operands when neither is a string.
-		// For Helm templates, all values are typically strings, so concatenate without
-		// spaces.
-		// NOTE: This fixes grafana/grafana but may cause issues with charts using Bitnami
-		// common helpers
-		// that rely on specific print behavior with regexReplaceAll
-		return (args) -> Arrays.stream(args).map(Functions::sprintValue).collect(Collectors.joining(""));
+		// Go's fmt.Sprint inserts a space between two adjacent operands when neither is a
+		// string. (Helm values are usually strings, so this rarely adds spaces in
+		// practice.)
+		return (args) -> {
+			StringBuilder sb = new StringBuilder();
+			for (int i = 0; i < args.length; i++) {
+				if (i > 0 && !(args[i - 1] instanceof String) && !(args[i] instanceof String)) {
+					sb.append(' ');
+				}
+				sb.append(sprintValue(args[i]));
+			}
+			return sb.toString();
+		};
 	}
 
 	private static Function printf() {

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
@@ -44,8 +44,8 @@ class TvalConformanceTest {
 			"parens in pipeline", "parens: $ in paren in pipe", "parens: spaces and args",
 			// #434 {{else with}} chains not parsed.
 			"with else with", "with else with chain",
-			// #435 print missing operand spaces / octal+underscore literals.
-			"print 123", "print multi", "print multi2", "octal0",
+			// #441 octal integer literal (0377) lexed as decimal.
+			"octal0",
 			// #437 slice does not support strings.
 			"string[:]", "string[0:1]", "string[1:]", "string[1:2]",
 			// #438 range '=' assignment does not update the outer variable.
@@ -139,7 +139,7 @@ class TvalConformanceTest {
 			}
 		}
 		assertTrue(unexpected.isEmpty(), () -> "unexpected text/template field-access divergences (regressions):\n"
-				+ String.join("\n", unexpected) + "\n(known divergences are tracked in #431, #433-#438)");
+				+ String.join("\n", unexpected) + "\n(known divergences: #431, #433, #434, #437, #438, #441)");
 	}
 
 	private static String decode(String b64) {


### PR DESCRIPTION
Closes #435. `print` joined all operands with no separator; Go's `fmt.Sprint` adds a space between two adjacent operands **when neither is a string**.

- `{{print 1 2 3}}` → `1 2 3` (was `123`)
- `{{print `a` `b`}}` → `ab` (strings, no space) — unchanged
- also fixes the underscore / hex-float numeric-literal print cases

The old no-space behaviour was a deliberate Helm workaround, but charts pass values as **strings** (so no spurious spaces appear), making this match Go/Helm.

## jhelm keeps working
**346/346 charts pass** (full `parity-run.sh`) — including the Bitnami common-helper charts the old code comment worried about. Engine builds green incl. the 0.75 jacoco gate.

Octal-literal lexing (`0377`→`377`) is a separate lexer issue, tracked in #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)