### PR TITLE
fix(gotmpl4j-core): slice supports strings (#437)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/Functions.java
@@ -352,6 +352,13 @@ public final class Functions {
 				return null;
 			}
 			Object container = args[0];
+			if (container instanceof String str) {
+				// Go's slice also works on strings (a byte slice): slice "xyz" 1 2 ->
+				// "y".
+				int from = (args.length > 1) ? ((Number) args[1]).intValue() : 0;
+				int to = (args.length > 2) ? ((Number) args[2]).intValue() : str.length();
+				return str.substring(from, to);
+			}
 			int size;
 			if (container instanceof List) {
 				size = ((List<?>) container).size();

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
@@ -46,8 +46,6 @@ class TvalConformanceTest {
 			"with else with", "with else with chain",
 			// #441 octal integer literal (0377) lexed as decimal.
 			"octal0",
-			// #437 slice does not support strings.
-			"string[:]", "string[0:1]", "string[1:]", "string[1:2]",
 			// #438 range '=' assignment does not update the outer variable.
 			"issue56490");
 
@@ -139,7 +137,7 @@ class TvalConformanceTest {
 			}
 		}
 		assertTrue(unexpected.isEmpty(), () -> "unexpected text/template field-access divergences (regressions):\n"
-				+ String.join("\n", unexpected) + "\n(known divergences: #431, #433, #434, #437, #438, #441)");
+				+ String.join("\n", unexpected) + "\n(known divergences: #431, #433, #434, #438, #441)");
 	}
 
 	private static String decode(String b64) {


### PR DESCRIPTION
Closes #437. `slice` returned `null` for a string; Go's `slice` also works on strings (a byte slice):
- `{{slice "xyz" 1 2}}` → `y`
- `{{slice "xyz" 1}}` → `yz`
- `{{slice "xyz"}}` → `xyz`

Added a `String` branch (substring) before the list/array handling.

## jhelm keeps working
**346/346 charts pass** (full `parity-run.sh`). Engine builds green incl. the 0.75 jacoco gate. Found via the exec_test.go field-access conformance (#439).

🤖 Generated with [Claude Code](https://claude.com/claude-code)