### PR TITLE
fix(gotmpl4j-core): support {{else with}} / {{else range}} chains (#434)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/parse/Parser.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/parse/Parser.java
@@ -256,6 +256,13 @@ public class Parser {
 
 		switch (token.type()) {
 			case IF:
+			case WITH:
+			case RANGE:
+				// {{else if}} / {{else with}} / {{else range}} chains: push the keyword
+				// back
+				// and mark the else; the next parse iteration nests the branch, sharing
+				// the
+				// outer {{end}} (as Go does).
 				moveToPrevItem(lexer, state);
 				listNode.append(new ElseNode());
 				break;
@@ -358,7 +365,7 @@ public class Parser {
 		moveToPrevItem(lexer, state);
 
 		WithNode withNode = new WithNode();
-		parseBranch(withNode, lexer, "with", false, state);
+		parseBranch(withNode, lexer, "with", true, state);
 		listNode.append(withNode);
 	}
 
@@ -388,11 +395,24 @@ public class Parser {
 					throwUnexpectError("missing token", state);
 				}
 
-				if (token.type() == TokenType.IF) {
+				// {{else if}} / {{else with}} / {{else range}} chains share the outer
+				// {{end}}: parse the keyword's branch as the else clause (as Go does).
+				TokenType elseBranch = token.type();
+				if (elseBranch == TokenType.IF || elseBranch == TokenType.WITH || elseBranch == TokenType.RANGE) {
 					moveToNextNonSpaceToken(lexer, state);
 
 					ListNode elseListNode = new ListNode();
-					parseIf(elseListNode, lexer, state);
+					switch (elseBranch) {
+						case IF:
+							parseIf(elseListNode, lexer, state);
+							break;
+						case WITH:
+							parseWith(elseListNode, lexer, state);
+							break;
+						default:
+							parseRange(elseListNode, lexer, state);
+							break;
+					}
 					branchNode.setElseListNode(elseListNode);
 
 					return;

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
@@ -42,8 +42,6 @@ class TvalConformanceTest {
 			"printf function", "range count", "range nil count", "bug16g", "bug16i",
 			// #433 parens around a function/pipeline not parsed.
 			"parens in pipeline", "parens: $ in paren in pipe", "parens: spaces and args",
-			// #434 {{else with}} chains not parsed.
-			"with else with", "with else with chain",
 			// #441 octal integer literal (0377) lexed as decimal.
 			"octal0",
 			// #438 range '=' assignment does not update the outer variable.
@@ -137,7 +135,7 @@ class TvalConformanceTest {
 			}
 		}
 		assertTrue(unexpected.isEmpty(), () -> "unexpected text/template field-access divergences (regressions):\n"
-				+ String.join("\n", unexpected) + "\n(known divergences: #431, #433, #434, #438, #441)");
+				+ String.join("\n", unexpected) + "\n(known divergences: #431, #433, #438, #441)");
 	}
 
 	private static String decode(String b64) {


### PR DESCRIPTION
Closes #434. Only `{{else if}}` chains parsed; `{{with}}…{{else with}}…{{end}}` and `{{range}}…{{else range}}…{{end}}` threw a parse error.

**Fix:** `parseElse` now pushes back a `WITH`/`RANGE` keyword after `else` (as it already did for `IF`), and `parseBranch` dispatches an else-branch to `parseIf`/`parseWith`/`parseRange` — all sharing the **outer `{{end}}`**, as Go does. `parseWith` now allows else-branch chains too, so cross forms like `{{if}}…{{else with}}…{{end}}` also work.

Verified: `else with`, `else with` chains, `else range`, `else if` (unchanged), plain `with`/`else` (unchanged), and cross `if`/`else with`.

## jhelm keeps working
**346/346 charts pass** (full `parity-run.sh`) — important for a parser change. Engine builds green incl. the 0.75 jacoco gate. Found via the exec_test.go field-access conformance (#439).

🤖 Generated with [Claude Code](https://claude.com/claude-code)