### PR TITLE
test(gotmpl4j-core): conformance ledger cleanup after #433/#434

### DIFF
--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
@@ -40,7 +40,9 @@ class TvalConformanceTest {
 			"if 1.5i", "with 1.5i", "printf complex", "bug16j",
 			// exec_test-only funcs (count/zeroArgs/twoArgs/oneArg) — harness, not engine.
 			"printf function", "range count", "range nil count", "bug16g", "bug16i",
-			// #433 parens around a function/pipeline not parsed.
+			// Sprig (add) / exec_test-only (echo, makemap) funcs are not on the
+			// gotmpl4j-core test classpath; parens themselves work (verified, #433
+			// closed).
 			"parens in pipeline", "parens: $ in paren in pipe", "parens: spaces and args",
 			// #441 octal integer literal (0377) lexed as decimal.
 			"octal0",
@@ -135,7 +137,7 @@ class TvalConformanceTest {
 			}
 		}
 		assertTrue(unexpected.isEmpty(), () -> "unexpected text/template field-access divergences (regressions):\n"
-				+ String.join("\n", unexpected) + "\n(known divergences: #431, #433, #438, #441)");
+				+ String.join("\n", unexpected) + "\n(known divergences: #431, #438, #441)");
 	}
 
 	private static String decode(String b64) {


### PR DESCRIPTION
Follow-up to the field-access conformance findings.

- **#434** (`{{else with}}`/`{{else range}}`) — fixed (#444).
- **#433** (parens) — closed as a **false finding**: parens around functions/pipelines work (`{{(printf "%d" 5)}}`→`5`, `{{printf "n=%d" (len .L)}}`→`n=2`); the cases only failed because they use `add` (Sprig) and `echo`/`makemap` (exec_test-only funcs) absent from the gotmpl4j-core test classpath. Re-attributed in the ledger.

Remaining documented divergences — all niche and parity-risky, deferred (tickets stay open):
- **#431** undefined field → `""` vs Go `<no value>` (changing it risks the 346-chart parity)
- **#438** `range $existing = …` outer-var assignment (delicate range-executor scoping for a zero-chart-impact edge)
- **#441** octal integer literal lexing

Test-only change. Engine unaffected; conformance suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)