### PR TITLE
fix(gotmpl4j-core): range `=` assignment updates the outer variable (#438)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/exec/Executor.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/exec/Executor.java
@@ -222,19 +222,26 @@ public class Executor {
 			throws IOException, TemplateExecutionException, TemplateNotFoundException {
 		PipeNode pipeNode = rangeNode.getPipeNode();
 		List<VariableNode> rangeVars = pipeNode.getVariables();
+		// `range $i := x` declares loop-local variables (saved/restored around the loop);
+		// `range $i = x` ASSIGNS an existing outer variable, which keeps the last
+		// iterated
+		// value after the loop (and is unchanged for an empty range), so it is not
+		// saved/restored.
+		boolean declare = rangeVars.isEmpty() || pipeNode.isDeclare();
 
-		// Save current variable values to restore later
+		// Save current variable values to restore later (declarations only).
 		Map<String, Object> savedVars = new HashMap<>();
-		for (VariableNode varNode : rangeVars) {
-			String varName = varNode.getIdentifier(0);
-			if (variables.containsKey(varName)) {
-				savedVars.put(varName, variables.get(varName));
+		if (declare) {
+			for (VariableNode varNode : rangeVars) {
+				String varName = varNode.getIdentifier(0);
+				if (variables.containsKey(varName)) {
+					savedVars.put(varName, variables.get(varName));
+				}
 			}
-		}
-
-		// Initialize range variables to null in case the range is empty
-		for (VariableNode varNode : rangeVars) {
-			variables.put(varNode.getIdentifier(0), null);
+			// Initialize range variables to null in case the range is empty
+			for (VariableNode varNode : rangeVars) {
+				variables.put(varNode.getIdentifier(0), null);
+			}
 		}
 
 		// Execute pipe but don't set variables yet - we'll set them per iteration
@@ -244,24 +251,30 @@ public class Executor {
 			if (rangeNode.getElseListNode() != null) {
 				writeNode(writer, rangeNode.getElseListNode(), data, beanInfo);
 			}
-			restoreVariables(rangeVars, savedVars);
+			if (declare) {
+				restoreVariables(rangeVars, savedVars);
+			}
 			return;
 		}
 
-		iterateRange(writer, rangeNode, rangeVars, arrayOrList, data, beanInfo, savedVars);
+		iterateRange(writer, rangeNode, rangeVars, arrayOrList, data, beanInfo, savedVars, declare);
 
-		// Restore variables after range
-		restoreVariables(rangeVars, savedVars);
+		// Restore declared variables after range (assignments keep their last value).
+		if (declare) {
+			restoreVariables(rangeVars, savedVars);
+		}
 	}
 
 	private void iterateRange(Writer writer, RangeNode rangeNode, List<VariableNode> rangeVars, Object arrayOrList,
-			Object data, BeanInfo beanInfo, Map<String, Object> savedVars)
+			Object data, BeanInfo beanInfo, Map<String, Object> savedVars, boolean declare)
 			throws IOException, TemplateExecutionException, TemplateNotFoundException {
 		if (arrayOrList.getClass().isArray()) {
 			int length = Array.getLength(arrayOrList);
 			if (length == 0 && rangeNode.getElseListNode() != null) {
 				writeNode(writer, rangeNode.getElseListNode(), data, beanInfo);
-				restoreVariables(rangeVars, savedVars);
+				if (declare) {
+					restoreVariables(rangeVars, savedVars);
+				}
 				return;
 			}
 			for (int i = 0; i < length; i++) {
@@ -273,24 +286,28 @@ public class Executor {
 			}
 		}
 		else if (arrayOrList instanceof Collection<?> collection) {
-			iterateCollection(writer, rangeNode, rangeVars, collection, data, beanInfo, savedVars);
+			iterateCollection(writer, rangeNode, rangeVars, collection, data, beanInfo, savedVars, declare);
 		}
 		else if (arrayOrList instanceof Map<?, ?> map) {
-			iterateMap(writer, rangeNode, rangeVars, map, data, beanInfo, savedVars);
+			iterateMap(writer, rangeNode, rangeVars, map, data, beanInfo, savedVars, declare);
 		}
 		else {
-			restoreVariables(rangeVars, savedVars);
+			if (declare) {
+				restoreVariables(rangeVars, savedVars);
+			}
 			throw new TemplateExecutionException(
 					String.format("can't iterate over %s", arrayOrList.getClass().getName()));
 		}
 	}
 
 	private void iterateCollection(Writer writer, RangeNode rangeNode, List<VariableNode> rangeVars,
-			Collection<?> collection, Object data, BeanInfo beanInfo, Map<String, Object> savedVars)
+			Collection<?> collection, Object data, BeanInfo beanInfo, Map<String, Object> savedVars, boolean declare)
 			throws IOException, TemplateExecutionException, TemplateNotFoundException {
 		if (collection.isEmpty() && rangeNode.getElseListNode() != null) {
 			writeNode(writer, rangeNode.getElseListNode(), data, beanInfo);
-			restoreVariables(rangeVars, savedVars);
+			if (declare) {
+				restoreVariables(rangeVars, savedVars);
+			}
 			return;
 		}
 		int index = 0;
@@ -303,11 +320,13 @@ public class Executor {
 	}
 
 	private void iterateMap(Writer writer, RangeNode rangeNode, List<VariableNode> rangeVars, Map<?, ?> map,
-			Object data, BeanInfo beanInfo, Map<String, Object> savedVars)
+			Object data, BeanInfo beanInfo, Map<String, Object> savedVars, boolean declare)
 			throws IOException, TemplateExecutionException, TemplateNotFoundException {
 		if (map.isEmpty() && rangeNode.getElseListNode() != null) {
 			writeNode(writer, rangeNode.getElseListNode(), data, beanInfo);
-			restoreVariables(rangeVars, savedVars);
+			if (declare) {
+				restoreVariables(rangeVars, savedVars);
+			}
 			return;
 		}
 		// Go text/template guarantees sorted-key iteration for maps with

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
@@ -45,9 +45,7 @@ class TvalConformanceTest {
 			// closed).
 			"parens in pipeline", "parens: $ in paren in pipe", "parens: spaces and args",
 			// #441 octal integer literal (0377) lexed as decimal.
-			"octal0",
-			// #438 range '=' assignment does not update the outer variable.
-			"issue56490");
+			"octal0");
 
 	// Tokens that indicate a Go-only feature gotmpl4j's Map data model cannot express.
 	private static final List<String> UNSUPPORTED = List.of(".Method", ".MAdd", ".Copy", ".GetU", ".MyError",
@@ -137,7 +135,7 @@ class TvalConformanceTest {
 			}
 		}
 		assertTrue(unexpected.isEmpty(), () -> "unexpected text/template field-access divergences (regressions):\n"
-				+ String.join("\n", unexpected) + "\n(known divergences: #431, #438, #441)");
+				+ String.join("\n", unexpected) + "\n(known divergences: #431, #441)");
 	}
 
 	private static String decode(String b64) {


### PR DESCRIPTION
Closes #438.

`{{range $i = .Coll}}` **assigns** an existing outer variable each iteration — after the loop `$i` holds the last value (and is unchanged for an empty range). `{{range $i := .Coll}}` **declares** a loop-local that reverts on exit. The range executor previously treated both identically: it saved, null-initialised, and restored the range vars unconditionally, clobbering the outer variable in the `=` case.

**Fix:** gate the save / null-init / final-restore (and the empty-range else-branch restores) on `pipeNode.isDeclare()` — the parser already sets this `false` for `$x = …`. The flag is threaded through `iterateRange`/`iterateCollection`/`iterateMap`. Declaration semantics are untouched.

**Verified**
- `{{$i:=0}}{{range $i = .AI}}{{$i}}{{end}}{{$i}}` → `3455` (was `345`)
- empty range (`$i = .Empty`) leaves the outer var unchanged
- 2-var `{{range $k, $v = .AI}}` assigns both key and value
- declare path (`$i := .AI`) still reverts after the loop
- conformance `issue56490` now passes → removed from the divergence ledger (remaining: #431, #441)
- **all 554 gotmpl4j tests + full 346-chart `helm template` byte-parity green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)