### PR TITLE
fix(gotmpl4j-core): lex Go legacy octal integer literals (0377 == 255) (#441)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/parse/NumberParser.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/parse/NumberParser.java
@@ -137,7 +137,28 @@ final class NumberParser {
 			return Long.parseLong(trimmed.substring(offset + 2), 16);
 		}
 
-		return Long.parseLong(trimmed.substring(offset), 10);
+		String body = trimmed.substring(offset);
+		// Go's legacy octal form: a leading 0 followed only by octal digits (0377 ==
+		// 255).
+		// The 0b/0o/0x prefixes above are handled first; a lone "0" stays decimal.
+		if (isLegacyOctal(body)) {
+			return Long.parseLong(body, 8);
+		}
+
+		return Long.parseLong(body, 10);
+	}
+
+	private static boolean isLegacyOctal(String body) {
+		if (body.length() < 2 || body.charAt(0) != '0') {
+			return false;
+		}
+		for (int i = 1; i < body.length(); i++) {
+			char c = body.charAt(i);
+			if (c < '0' || c > '7') {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private static double parseFloatValue(String text) {

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
@@ -43,9 +43,7 @@ class TvalConformanceTest {
 			// Sprig (add) / exec_test-only (echo, makemap) funcs are not on the
 			// gotmpl4j-core test classpath; parens themselves work (verified, #433
 			// closed).
-			"parens in pipeline", "parens: $ in paren in pipe", "parens: spaces and args",
-			// #441 octal integer literal (0377) lexed as decimal.
-			"octal0");
+			"parens in pipeline", "parens: $ in paren in pipe", "parens: spaces and args");
 
 	// Tokens that indicate a Go-only feature gotmpl4j's Map data model cannot express.
 	private static final List<String> UNSUPPORTED = List.of(".Method", ".MAdd", ".Copy", ".GetU", ".MyError",
@@ -135,7 +133,7 @@ class TvalConformanceTest {
 			}
 		}
 		assertTrue(unexpected.isEmpty(), () -> "unexpected text/template field-access divergences (regressions):\n"
-				+ String.join("\n", unexpected) + "\n(known divergences: #431, #441)");
+				+ String.join("\n", unexpected) + "\n(known divergences: #431)");
 	}
 
 	private static String decode(String b64) {


### PR DESCRIPTION
Closes #441.

`NumberParser` handled the modern `0b`/`0o`/`0x` prefixes but not Go's **legacy octal** form — a leading `0` followed only by octal digits. So `{{print 0377}}` fell through to base-10 and rendered `377` instead of Go's `255`.

**Fix:** add an `isLegacyOctal(body)` check before the decimal fallback. A lone `"0"` stays decimal; the `0x`/`0b`/`0o` prefixes are still handled first; non-octal sequences like `08` or `0.5` fall through unchanged to decimal/float.

**Verified**
- conformance `octal0` (`{{print 0377}}` → `255`) now passes → removed from the ledger (only #431 remains there)
- all 555 gotmpl4j tests + full 346-chart `helm template` byte-parity green (octal literals can appear in chart templates as file modes, so the gate matters here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)