### PR TITLE
docs(gotmpl4j-core): clarify #431 missing-key behavior is Helm-intended

### DIFF
--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/TvalConformanceTest.java
@@ -31,7 +31,12 @@ class TvalConformanceTest {
 	// Known divergences (each tracked by a ticket); a failure NOT in this set is a
 	// regression and fails the test.
 	private static final Set<String> EXPECTED_DIVERGENCES = Set.of(
-			// Undefined field/key -> "" vs Go "<no value>"/"<nil>" (#431).
+			// Undefined field/key -> "" (Helm's missingkey=zero) vs Go's default option,
+			// which renders "<no value>"/"<nil>". Intended, not a bug: jhelm targets Helm
+			// semantics (verified `helm template` renders a missing key empty), #431
+			// closed.
+			// A configurable Go-default missingkey mode would be future general-engine
+			// work.
 			"map .NO", "empty nil", "html untyped nil", "NIL", "html typed nil",
 			// Go struct fmt / zero-value map index / slice-cap — not expressible with Map
 			// data.


### PR DESCRIPTION
Closes #431 (as **intended behavior, not a bug**).

Verified with the real `helm template`: a missing map key renders **empty** (`[]`), not Go's default `<no value>`.

```
missing-top: []
missing-nested: []
present: [hello]
```

Helm and jhelm use `missingkey=zero` (a missing `interface{}` key → nil → `""`); the Go text/template conformance test uses Go's *default* option which renders `<no value>`. jhelm's `""` is correct for the Helm target — and is exactly what keeps the 346-chart parity. (Aside: `.Values.a.b.c` where an intermediate is nil errors in Helm — `nil pointer evaluating interface {}.c` — a separate behavior.)

Test-comment only; expands the divergence-ledger note and points at a future configurable Go-default `missingkey` mode for general-engine use. Conformance suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)