### PR TITLE
fix(gotmpl4j-core): js builtin escapes non-printable characters (#455)

### DIFF
--- a/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/Functions.java
+++ b/jhelm-gotemplate/src/main/java/org/alexmond/gotmpl4j/Functions.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.IllegalFormatException;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -340,10 +341,27 @@ public final class Functions {
 					case '>' -> sb.append("\\u003E");
 					case '&' -> sb.append("\\u0026");
 					case '=' -> sb.append("\\u003D");
-					default -> sb.append(c);
+					// Go's JSEscapeString escapes any non-printable rune to \\uXXXX;
+					// surrogates pass through so astral chars (e.g. emoji) stay intact.
+					default -> sb.append((!Character.isSurrogate(c) && !isPrintableForJs(c))
+							? String.format(Locale.ROOT, "\\u%04X", (int) c) : String.valueOf(c));
 				}
 			}
 			return sb.toString();
+		};
+	}
+
+	// Mirror Go's unicode.IsPrint: only the ASCII space is printable among separators;
+	// control/format/surrogate/private-use/unassigned code points are not.
+	private static boolean isPrintableForJs(char c) {
+		if (c == ' ') {
+			return true;
+		}
+		return switch (Character.getType(c)) {
+			case Character.CONTROL, Character.FORMAT, Character.SURROGATE, Character.PRIVATE_USE, Character.UNASSIGNED,
+					Character.LINE_SEPARATOR, Character.PARAGRAPH_SEPARATOR, Character.SPACE_SEPARATOR ->
+				false;
+			default -> true;
 		};
 	}
 

--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/BuiltinConformanceTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/BuiltinConformanceTest.java
@@ -1,0 +1,65 @@
+package org.alexmond.gotmpl4j;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Conformance for two more Go text/template exec_test.go tables: {@code TestJSEscaping}
+ * (the {@code js} builtin) and the portable subset of {@code TestIsTrue} (truthiness).
+ *
+ * <p>
+ * TestIsTrue cases using Go-only kinds (uint8, complex64, channels, unsafe.Pointer, fixed
+ * arrays) are omitted — the JVM has no equivalent; the value-bearing kinds (int, float,
+ * bool, slice, map, nil, non-nil pointer) are covered.
+ */
+class BuiltinConformanceTest {
+
+	private String js(String literal) throws Exception {
+		GoTemplate t = new GoTemplate();
+		// Pass the raw string through a backtick literal so no parser unescaping occurs.
+		t.parse("p", "{{js `" + literal + "`}}");
+		return t.render("p", Map.of());
+	}
+
+	@Test
+	void jsEscaping() throws Exception {
+		// Go JSEscapeString: escapes ' " \ and the HTML-sensitive < > & = to \\uXXXX,
+		// escapes unprintables, and passes printable Unicode through unchanged.
+		assertEquals("a", js("a"));
+		assertEquals("\\'foo", js("'foo"));
+		assertEquals("Go \\\"jump\\\" \\\\", js("Go \"jump\" \\"));
+		assertEquals("Yukihiro says \\\"今日は世界\\\"", js("Yukihiro says \"今日は世界\""));
+		assertEquals("unprintable \\uFFFE", js("unprintable ￾"));
+		assertEquals("\\u003Chtml\\u003E", js("<html>"));
+		assertEquals("no \\u003D in attributes", js("no = in attributes"));
+		assertEquals("\\u0026#x27; does not become HTML entity", js("&#x27; does not become HTML entity"));
+	}
+
+	@Test
+	void isTrue() {
+		// int / float / bool
+		assertTrue(Functions.isTrue(1L));
+		assertFalse(Functions.isTrue(0L));
+		assertTrue(Functions.isTrue(1.0));
+		assertFalse(Functions.isTrue(0.0));
+		assertTrue(Functions.isTrue(true));
+		assertFalse(Functions.isTrue(false));
+		// slice (non-empty / empty)
+		assertTrue(Functions.isTrue(List.of(1L, 2L)));
+		assertFalse(Functions.isTrue(List.of()));
+		// map (non-empty / empty)
+		assertTrue(Functions.isTrue(Map.of("a", 1L, "b", 2L)));
+		assertFalse(Functions.isTrue(Map.of()));
+		// nil
+		assertFalse(Functions.isTrue(null));
+		// non-nil object (Go: new(int) is true even though it points at zero)
+		assertTrue(Functions.isTrue(new Object()));
+	}
+
+}


### PR DESCRIPTION
Closes #455. Found by porting two more Go text/template `exec_test.go` tables.

## Bug
Go's `JSEscapeString` escapes any non-printable rune to `\uXXXX`. jhelm's `jsEscape` only handled `\ ' " \n \r \t < > & =` and passed everything else through, so control/format/non-character code points were emitted raw:

| | jhelm (before) | Go |
|---|---|---|
| `{{ js "unprintable U+FFFE" }}` | raw `￾` | `￾` |

**Fix:** escape non-printable BMP chars in the `default` branch (mirroring Go's `unicode.IsPrint`); surrogates pass through so astral chars like emoji stay intact.

## New conformance net — `BuiltinConformanceTest`
- **`TestJSEscaping`** (Go's table) — now fully matches Go (all 8 cases: quotes, backslash, `< > & =` → `\uXXXX`, printable Unicode passthrough, non-printable escaped)
- **`TestIsTrue`** (portable subset) — `int/float/bool/slice/map/nil/non-nil object` truthiness; **already conformant**, locked in. Go-only kinds (`uint8`, `complex64`, channels, `unsafe.Pointer`, fixed arrays) omitted.

## Verification
- all **559** gotmpl4j tests + full **346-chart** `helm template` byte-parity green

🤖 Generated with [Claude Code](https://claude.com/claude-code)