### PR TITLE
feat(gotmpl4j-starter): Spring MVC ViewResolver/View for Go templates (#42, slice 1)

### DIFF
--- a/gotmpl4j-spring-boot-starter/pom.xml
+++ b/gotmpl4j-spring-boot-starter/pom.xml
@@ -28,9 +28,31 @@
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
 
+        <!-- Optional Spring MVC view layer: only active when the app brings spring-webmvc -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/GoTemplateLoader.java
+++ b/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/GoTemplateLoader.java
@@ -44,7 +44,7 @@ public class GoTemplateLoader {
 	 * @throws GoTemplateException if a template cannot be read or parsed
 	 */
 	public GoTemplate load() {
-		String location = withTrailingSlash(this.properties.getTemplateLocation());
+		String location = withTrailingSlash(this.properties.getPrefix());
 		String pattern = toPatternPrefix(location) + "**/*" + this.properties.getSuffix();
 		try {
 			GoTemplate goTemplate = this.factory.create();

--- a/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/GoTemplateServletWebConfiguration.java
+++ b/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/GoTemplateServletWebConfiguration.java
@@ -1,0 +1,40 @@
+package org.alexmond.gotmpl4j.spring;
+
+import org.alexmond.gotmpl4j.spring.view.GoTemplateViewResolver;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+/**
+ * Registers a {@link GoTemplateViewResolver} when the application is a servlet web
+ * application and Spring MVC's view types are on the classpath. Mirrors Spring Boot's
+ * {@code MustacheServletWebConfiguration}.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnWebApplication(type = Type.SERVLET)
+@ConditionalOnClass(GoTemplateViewResolver.class)
+class GoTemplateServletWebConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	GoTemplateViewResolver goTemplateViewResolver(GoTemplateService service, Gotmpl4jProperties properties) {
+		Gotmpl4jProperties.Servlet servlet = properties.getServlet();
+		GoTemplateViewResolver resolver = new GoTemplateViewResolver(service);
+		resolver.setContentType(servlet.getContentType());
+		resolver.setViewNames(properties.getViewNames());
+		resolver.setRequestContextAttribute(properties.getRequestContextAttribute());
+		resolver.setExposeRequestAttributes(servlet.isExposeRequestAttributes());
+		resolver.setExposeSessionAttributes(servlet.isExposeSessionAttributes());
+		resolver.setAllowRequestOverride(servlet.isAllowRequestOverride());
+		resolver.setAllowSessionOverride(servlet.isAllowSessionOverride());
+		resolver.setCache(properties.isCache());
+		resolver.setOrder(Ordered.LOWEST_PRECEDENCE - 10);
+		return resolver;
+	}
+
+}

--- a/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/Gotmpl4jAutoConfiguration.java
+++ b/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/Gotmpl4jAutoConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ResourceLoader;
 
 /**
@@ -33,6 +34,7 @@ import org.springframework.core.io.ResourceLoader;
 @AutoConfiguration
 @EnableConfigurationProperties(Gotmpl4jProperties.class)
 @ConditionalOnProperty(prefix = "gotmpl4j", name = "enabled", matchIfMissing = true)
+@Import(GoTemplateServletWebConfiguration.class)
 public class Gotmpl4jAutoConfiguration {
 
 	@Bean

--- a/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/Gotmpl4jProperties.java
+++ b/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/Gotmpl4jProperties.java
@@ -4,10 +4,11 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 /**
  * Configuration for the gotmpl4j Spring Boot starter, mirroring the conventions of
- * {@code spring.thymeleaf.*} / {@code spring.freemarker.*}.
+ * {@code spring.mustache.*} / {@code spring.freemarker.*}.
  */
 @ConfigurationProperties("gotmpl4j")
 public class Gotmpl4jProperties {
@@ -16,22 +17,34 @@ public class Gotmpl4jProperties {
 	private boolean enabled = true;
 
 	/**
-	 * Location templates are loaded from (a Spring resource location). Default
+	 * Prefix (a Spring resource location) templates are loaded from. Default
 	 * {@code classpath:/templates/}.
 	 */
-	private String templateLocation = "classpath:/templates/";
+	private String prefix = "classpath:/templates/";
 
-	/** File-name suffix of templates under {@link #templateLocation}. */
+	/** File-name suffix of templates under {@link #prefix}. */
 	private String suffix = ".gotmpl";
 
-	/** Charset used to read template files. */
+	/** Charset used to read template files and render views. */
 	private Charset charset = StandardCharsets.UTF_8;
+
+	/** Whether to check that the templates location exists. */
+	private boolean checkTemplateLocation = true;
 
 	/**
 	 * Whether to cache the compiled template set. Disable during development so template
 	 * edits are picked up without a restart.
 	 */
 	private boolean cache = true;
+
+	/** View names that can be resolved (null means all). */
+	private String[] viewNames;
+
+	/** Name of the RequestContext attribute for all views, or null to use the default. */
+	private String requestContextAttribute;
+
+	/** Servlet-specific (Spring MVC) view settings. */
+	private final Servlet servlet = new Servlet();
 
 	public boolean isEnabled() {
 		return this.enabled;
@@ -41,12 +54,33 @@ public class Gotmpl4jProperties {
 		this.enabled = enabled;
 	}
 
-	public String getTemplateLocation() {
-		return this.templateLocation;
+	public String getPrefix() {
+		return this.prefix;
 	}
 
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	/**
+	 * Deprecated alias for {@link #getPrefix()}.
+	 * @return the template location (the prefix)
+	 * @deprecated use {@link #getPrefix()} / {@code gotmpl4j.prefix} instead
+	 */
+	@Deprecated(since = "0.1.0")
+	@DeprecatedConfigurationProperty(replacement = "gotmpl4j.prefix")
+	public String getTemplateLocation() {
+		return this.prefix;
+	}
+
+	/**
+	 * Deprecated alias for {@link #setPrefix(String)}.
+	 * @param templateLocation the template location (the prefix)
+	 * @deprecated use {@link #setPrefix(String)} / {@code gotmpl4j.prefix} instead
+	 */
+	@Deprecated(since = "0.1.0")
 	public void setTemplateLocation(String templateLocation) {
-		this.templateLocation = templateLocation;
+		this.prefix = templateLocation;
 	}
 
 	public String getSuffix() {
@@ -61,8 +95,20 @@ public class Gotmpl4jProperties {
 		return this.charset;
 	}
 
+	public String getCharsetName() {
+		return (this.charset != null) ? this.charset.name() : null;
+	}
+
 	public void setCharset(Charset charset) {
 		this.charset = charset;
+	}
+
+	public boolean isCheckTemplateLocation() {
+		return this.checkTemplateLocation;
+	}
+
+	public void setCheckTemplateLocation(boolean checkTemplateLocation) {
+		this.checkTemplateLocation = checkTemplateLocation;
 	}
 
 	public boolean isCache() {
@@ -71,6 +117,93 @@ public class Gotmpl4jProperties {
 
 	public void setCache(boolean cache) {
 		this.cache = cache;
+	}
+
+	public String[] getViewNames() {
+		return (this.viewNames != null) ? this.viewNames.clone() : null;
+	}
+
+	public void setViewNames(String[] viewNames) {
+		this.viewNames = (viewNames != null) ? viewNames.clone() : null;
+	}
+
+	public String getRequestContextAttribute() {
+		return this.requestContextAttribute;
+	}
+
+	public void setRequestContextAttribute(String requestContextAttribute) {
+		this.requestContextAttribute = requestContextAttribute;
+	}
+
+	public Servlet getServlet() {
+		return this.servlet;
+	}
+
+	/**
+	 * Servlet (Spring MVC) view-resolver settings, mirroring
+	 * {@code spring.mustache.servlet}.
+	 */
+	public static class Servlet {
+
+		/** Content-Type value written for resolved views. */
+		private String contentType = "text/html";
+
+		/** Whether HttpServletRequest attributes are allowed to merge into the model. */
+		private boolean exposeRequestAttributes;
+
+		/** Whether HttpSession attributes are allowed to merge into the model. */
+		private boolean exposeSessionAttributes;
+
+		/**
+		 * Whether a request attribute may override a model attribute of the same name.
+		 */
+		private boolean allowRequestOverride;
+
+		/**
+		 * Whether a session attribute may override a model attribute of the same name.
+		 */
+		private boolean allowSessionOverride;
+
+		public String getContentType() {
+			return this.contentType;
+		}
+
+		public void setContentType(String contentType) {
+			this.contentType = contentType;
+		}
+
+		public boolean isExposeRequestAttributes() {
+			return this.exposeRequestAttributes;
+		}
+
+		public void setExposeRequestAttributes(boolean exposeRequestAttributes) {
+			this.exposeRequestAttributes = exposeRequestAttributes;
+		}
+
+		public boolean isExposeSessionAttributes() {
+			return this.exposeSessionAttributes;
+		}
+
+		public void setExposeSessionAttributes(boolean exposeSessionAttributes) {
+			this.exposeSessionAttributes = exposeSessionAttributes;
+		}
+
+		public boolean isAllowRequestOverride() {
+			return this.allowRequestOverride;
+		}
+
+		public void setAllowRequestOverride(boolean allowRequestOverride) {
+			this.allowRequestOverride = allowRequestOverride;
+		}
+
+		public boolean isAllowSessionOverride() {
+			return this.allowSessionOverride;
+		}
+
+		public void setAllowSessionOverride(boolean allowSessionOverride) {
+			this.allowSessionOverride = allowSessionOverride;
+		}
+
 	}
 
 }

--- a/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/view/GoTemplateView.java
+++ b/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/view/GoTemplateView.java
@@ -1,0 +1,42 @@
+package org.alexmond.gotmpl4j.spring.view;
+
+import java.io.Writer;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.alexmond.gotmpl4j.spring.GoTemplateService;
+
+import org.springframework.web.servlet.view.AbstractTemplateView;
+
+/**
+ * Spring MVC {@link org.springframework.web.servlet.View View} that renders a gotmpl4j
+ * template by name. The view's URL is the template name (the loader already keys
+ * templates by their suffix-stripped relative path), so rendering delegates straight to
+ * {@link GoTemplateService#render(String, Object)} with the merged model.
+ */
+public class GoTemplateView extends AbstractTemplateView {
+
+	private GoTemplateService service;
+
+	/**
+	 * Set the rendering service. Injected by {@link GoTemplateViewResolver} when it
+	 * builds the view.
+	 * @param service the gotmpl4j service
+	 */
+	public void setService(GoTemplateService service) {
+		this.service = service;
+	}
+
+	@Override
+	protected void renderMergedTemplateModel(Map<String, Object> model, HttpServletRequest request,
+			HttpServletResponse response) throws Exception {
+		String body = this.service.render(getUrl(), model);
+		response.setContentType(getContentType());
+		try (Writer writer = response.getWriter()) {
+			writer.write(body);
+		}
+	}
+
+}

--- a/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/view/GoTemplateViewResolver.java
+++ b/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/view/GoTemplateViewResolver.java
@@ -1,0 +1,34 @@
+package org.alexmond.gotmpl4j.spring.view;
+
+import org.alexmond.gotmpl4j.spring.GoTemplateService;
+
+import org.springframework.web.servlet.view.AbstractTemplateViewResolver;
+import org.springframework.web.servlet.view.AbstractUrlBasedView;
+
+/**
+ * Spring MVC {@link org.springframework.web.servlet.ViewResolver ViewResolver} that
+ * resolves a view name to a {@link GoTemplateView}. The view name is used as the template
+ * name directly (the loader already applies the prefix/suffix), so this resolver keeps
+ * {@code UrlBasedViewResolver}'s empty prefix/suffix defaults.
+ */
+public class GoTemplateViewResolver extends AbstractTemplateViewResolver {
+
+	private final GoTemplateService service;
+
+	public GoTemplateViewResolver(GoTemplateService service) {
+		this.service = service;
+	}
+
+	@Override
+	protected Class<?> getViewClass() {
+		return GoTemplateView.class;
+	}
+
+	@Override
+	protected AbstractUrlBasedView buildView(String viewName) throws Exception {
+		GoTemplateView view = (GoTemplateView) super.buildView(viewName);
+		view.setService(this.service);
+		return view;
+	}
+
+}

--- a/gotmpl4j-spring-boot-starter/src/test/java/org/alexmond/gotmpl4j/spring/GoTemplateServletWebConfigurationTest.java
+++ b/gotmpl4j-spring-boot-starter/src/test/java/org/alexmond/gotmpl4j/spring/GoTemplateServletWebConfigurationTest.java
@@ -1,0 +1,50 @@
+package org.alexmond.gotmpl4j.spring;
+
+import org.alexmond.gotmpl4j.spring.view.GoTemplateViewResolver;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.core.Ordered;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Bean-wiring scenarios for the servlet view layer, mirroring Spring Boot's
+ * {@code MustacheAutoConfigurationTests}: the {@link GoTemplateViewResolver} is
+ * registered in a servlet web context, absent off-web, and backs off to a user-defined
+ * resolver.
+ */
+class GoTemplateServletWebConfigurationTest {
+
+	private final WebApplicationContextRunner web = new WebApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(Gotmpl4jAutoConfiguration.class));
+
+	private final ApplicationContextRunner nonWeb = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(Gotmpl4jAutoConfiguration.class));
+
+	@Test
+	void registersViewResolverInServletWebApp() {
+		this.web.run((context) -> {
+			GoTemplateViewResolver resolver = context.getBean(GoTemplateViewResolver.class);
+			assertEquals(Ordered.LOWEST_PRECEDENCE - 10, resolver.getOrder());
+		});
+	}
+
+	@Test
+	void noViewResolverInNonWebApp() {
+		this.nonWeb.run((context) -> assertEquals(0, context.getBeanNamesForType(GoTemplateViewResolver.class).length));
+	}
+
+	@Test
+	void backsOffWhenUserDefinesResolver() {
+		this.web.withBean("myResolver", GoTemplateViewResolver.class, () -> new GoTemplateViewResolver(null))
+			.run((context) -> {
+				assertEquals(1, context.getBeanNamesForType(GoTemplateViewResolver.class).length);
+				assertTrue(context.containsBean("myResolver"));
+			});
+	}
+
+}

--- a/gotmpl4j-spring-boot-starter/src/test/java/org/alexmond/gotmpl4j/spring/GoTemplateServletWebIntegrationTest.java
+++ b/gotmpl4j-spring-boot-starter/src/test/java/org/alexmond/gotmpl4j/spring/GoTemplateServletWebIntegrationTest.java
@@ -1,0 +1,64 @@
+package org.alexmond.gotmpl4j.spring;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end servlet rendering, mirroring Spring Boot's
+ * {@code MustacheAutoConfigurationServletIntegrationTests}: a controller returns a view
+ * name, the autoconfigured
+ * {@link org.alexmond.gotmpl4j.spring.view.GoTemplateViewResolver} resolves it, and the
+ * gotmpl4j template is rendered to the response.
+ */
+@SpringBootTest(classes = GoTemplateServletWebIntegrationTest.TestApp.class)
+@AutoConfigureMockMvc
+class GoTemplateServletWebIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void rendersGoTemplateViewThroughMvc() throws Exception {
+		this.mockMvc.perform(get("/hello"))
+			.andExpect(status().isOk())
+			.andExpect(content().string("Hi WORLD from gotmpl4j"));
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableAutoConfiguration
+	static class TestApp {
+
+		@Bean
+		HelloController helloController() {
+			return new HelloController();
+		}
+
+	}
+
+	@Controller
+	static class HelloController {
+
+		@GetMapping("/hello")
+		String hello(Model model) {
+			model.addAttribute("Name", "world");
+			model.addAttribute("Site", "gotmpl4j");
+			return "hello";
+		}
+
+	}
+
+}


### PR DESCRIPTION
First slice of #42 — makes `gotmpl4j-spring-boot-starter` a first-class Spring **view technology**, mirroring Spring Boot's Mustache/FreeMarker servlet integration contract. A controller returning a view name now renders a gotmpl4j template.

> Context: investigated against Spring Boot 4.0.6 `spring-boot-mustache` (the closest analog). The starter is extraction-clean (no jhelm coupling) and ships with gotmpl4j on the #25 split. Spring's engine tests are a **convention reference, not an output oracle** (Mustache ≠ Go templates), so the ported tests mirror *integration scenarios*, not byte output.

## What's added
- **`GoTemplateView`** (`extends AbstractTemplateView`) — renders a template by name via `GoTemplateService` to the response with the configured content type.
- **`GoTemplateViewResolver`** (`extends AbstractTemplateViewResolver`) — resolves a view name straight to the template name (the loader already applies prefix/suffix); overrides `getViewClass()`/`buildView()`, no overridable calls in the constructor.
- **`GoTemplateServletWebConfiguration`** — `@ConditionalOnWebApplication(SERVLET)` + `@ConditionalOnClass` + `@ConditionalOnMissingBean`, imported by the autoconfig (only active when the app brings Spring MVC).
- **`Gotmpl4jProperties`** — Spring-convention fields: canonical **`prefix`** (with **`template-location`** kept as a deprecated alias), `check-template-location`, `view-names`, `request-context-attribute`, and a nested **`servlet`** group (`content-type`, `expose-request/session-attributes`, `allow-*-override`).
- **pom** — `spring-webmvc` *optional* + `jakarta.servlet-api` *provided*.

## Tests (ported, adapted)
- resolver registered in a servlet web context; **absent** off-web; **backs off** to a user-defined resolver (`MustacheAutoConfigurationTests` scenarios)
- **end-to-end MockMvc**: a `@Controller` returns `"hello"` → autoconfigured resolver → `Hi WORLD from gotmpl4j` (`MustacheAutoConfigurationServletIntegrationTests`)

## Scope / safety
Starter-only leaf module — **not on the chart path, jhelm 346-chart parity unaffected**. All **13** starter tests green with full gates (PMD + Checkstyle + format).

**Next slices:** WebFlux reactive `ViewResolver` (slice 2), `TemplateAvailabilityProvider` (slice 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)