### PR TITLE
feat(gotmpl4j-starter): WebFlux reactive ViewResolver/View (#42, slice 2)

### DIFF
--- a/gotmpl4j-spring-boot-starter/pom.xml
+++ b/gotmpl4j-spring-boot-starter/pom.xml
@@ -39,6 +39,12 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- Optional WebFlux view layer: only active when the app brings spring-webflux -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -53,6 +59,21 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webflux-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webtestclient</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/GoTemplateReactiveWebConfiguration.java
+++ b/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/GoTemplateReactiveWebConfiguration.java
@@ -1,0 +1,45 @@
+package org.alexmond.gotmpl4j.spring;
+
+import org.alexmond.gotmpl4j.spring.view.GoTemplateReactiveViewResolver;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+/**
+ * Registers a {@link GoTemplateReactiveViewResolver} when the application is a reactive
+ * (WebFlux) web application and the WebFlux view types are on the classpath. Mirrors
+ * Spring Boot's {@code MustacheReactiveWebConfiguration}.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnWebApplication(type = Type.REACTIVE)
+@ConditionalOnClass(GoTemplateReactiveViewResolver.class)
+class GoTemplateReactiveWebConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	GoTemplateReactiveViewResolver goTemplateReactiveViewResolver(GoTemplateService service,
+			Gotmpl4jProperties properties) {
+		GoTemplateReactiveViewResolver resolver = new GoTemplateReactiveViewResolver(service);
+		// Only override the resolver's defaults when the property is set.
+		if (properties.getViewNames() != null) {
+			resolver.setViewNames(properties.getViewNames());
+		}
+		if (properties.getRequestContextAttribute() != null) {
+			resolver.setRequestContextAttribute(properties.getRequestContextAttribute());
+		}
+		if (properties.getCharset() != null) {
+			resolver.setCharset(properties.getCharset());
+		}
+		if (properties.getReactive().getMediaTypes() != null) {
+			resolver.setSupportedMediaTypes(properties.getReactive().getMediaTypes());
+		}
+		resolver.setOrder(Ordered.LOWEST_PRECEDENCE - 10);
+		return resolver;
+	}
+
+}

--- a/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/Gotmpl4jAutoConfiguration.java
+++ b/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/Gotmpl4jAutoConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.core.io.ResourceLoader;
 @AutoConfiguration
 @EnableConfigurationProperties(Gotmpl4jProperties.class)
 @ConditionalOnProperty(prefix = "gotmpl4j", name = "enabled", matchIfMissing = true)
-@Import(GoTemplateServletWebConfiguration.class)
+@Import({ GoTemplateServletWebConfiguration.class, GoTemplateReactiveWebConfiguration.class })
 public class Gotmpl4jAutoConfiguration {
 
 	@Bean

--- a/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/Gotmpl4jProperties.java
+++ b/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/Gotmpl4jProperties.java
@@ -2,9 +2,11 @@ package org.alexmond.gotmpl4j.spring;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
+import org.springframework.http.MediaType;
 
 /**
  * Configuration for the gotmpl4j Spring Boot starter, mirroring the conventions of
@@ -45,6 +47,9 @@ public class Gotmpl4jProperties {
 
 	/** Servlet-specific (Spring MVC) view settings. */
 	private final Servlet servlet = new Servlet();
+
+	/** Reactive-specific (Spring WebFlux) view settings. */
+	private final Reactive reactive = new Reactive();
 
 	public boolean isEnabled() {
 		return this.enabled;
@@ -139,6 +144,10 @@ public class Gotmpl4jProperties {
 		return this.servlet;
 	}
 
+	public Reactive getReactive() {
+		return this.reactive;
+	}
+
 	/**
 	 * Servlet (Spring MVC) view-resolver settings, mirroring
 	 * {@code spring.mustache.servlet}.
@@ -202,6 +211,27 @@ public class Gotmpl4jProperties {
 
 		public void setAllowSessionOverride(boolean allowSessionOverride) {
 			this.allowSessionOverride = allowSessionOverride;
+		}
+
+	}
+
+	/**
+	 * Reactive (Spring WebFlux) view-resolver settings, mirroring
+	 * {@code spring.mustache.reactive}.
+	 */
+	public static class Reactive {
+
+		/**
+		 * Media types supported by the view technology (null uses the resolver default).
+		 */
+		private List<MediaType> mediaTypes;
+
+		public List<MediaType> getMediaTypes() {
+			return this.mediaTypes;
+		}
+
+		public void setMediaTypes(List<MediaType> mediaTypes) {
+			this.mediaTypes = mediaTypes;
 		}
 
 	}

--- a/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/view/GoTemplateReactiveView.java
+++ b/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/view/GoTemplateReactiveView.java
@@ -1,0 +1,57 @@
+package org.alexmond.gotmpl4j.spring.view;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Map;
+
+import reactor.core.publisher.Mono;
+
+import org.alexmond.gotmpl4j.spring.GoTemplateService;
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.result.view.AbstractUrlBasedView;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * Spring WebFlux {@link org.springframework.web.reactive.result.view.View View} that
+ * renders a gotmpl4j template by name. Like the servlet {@link GoTemplateView}, the
+ * view's URL is the template name, so rendering delegates to
+ * {@link GoTemplateService#render(String, Object)} and writes the result to the response.
+ */
+public class GoTemplateReactiveView extends AbstractUrlBasedView {
+
+	private GoTemplateService service;
+
+	private Charset charset = StandardCharsets.UTF_8;
+
+	public void setService(GoTemplateService service) {
+		this.service = service;
+	}
+
+	public void setCharset(Charset charset) {
+		this.charset = charset;
+	}
+
+	@Override
+	public boolean checkResourceExists(Locale locale) {
+		return true;
+	}
+
+	@Override
+	protected Mono<Void> renderInternal(Map<String, Object> model, MediaType contentType, ServerWebExchange exchange) {
+		String body;
+		try {
+			body = this.service.render(getUrl(), model);
+		}
+		catch (RuntimeException ex) {
+			return Mono.error(ex);
+		}
+		Charset cs = (contentType != null && contentType.getCharset() != null) ? contentType.getCharset()
+				: this.charset;
+		DataBuffer buffer = exchange.getResponse().bufferFactory().wrap(body.getBytes(cs));
+		return exchange.getResponse().writeWith(Mono.just(buffer));
+	}
+
+}

--- a/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/view/GoTemplateReactiveViewResolver.java
+++ b/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/view/GoTemplateReactiveViewResolver.java
@@ -1,0 +1,48 @@
+package org.alexmond.gotmpl4j.spring.view;
+
+import java.nio.charset.Charset;
+
+import org.alexmond.gotmpl4j.spring.GoTemplateService;
+
+import org.springframework.web.reactive.result.view.AbstractUrlBasedView;
+import org.springframework.web.reactive.result.view.UrlBasedViewResolver;
+
+/**
+ * Spring WebFlux {@link org.springframework.web.reactive.result.view.ViewResolver
+ * ViewResolver} that resolves a view name to a {@link GoTemplateReactiveView}. As with
+ * the servlet resolver the view name is the template name, so the empty prefix/suffix
+ * defaults are kept; {@link #getViewClass()} is overridden so no overridable setter is
+ * called from the constructor.
+ */
+public class GoTemplateReactiveViewResolver extends UrlBasedViewResolver {
+
+	private final GoTemplateService service;
+
+	private Charset charset;
+
+	public GoTemplateReactiveViewResolver(GoTemplateService service) {
+		this.service = service;
+	}
+
+	public void setCharset(Charset charset) {
+		this.charset = charset;
+	}
+
+	@Override
+	protected Class<?> getViewClass() {
+		return GoTemplateReactiveView.class;
+	}
+
+	@Override
+	protected AbstractUrlBasedView createView(String viewName) {
+		AbstractUrlBasedView view = super.createView(viewName);
+		if (view instanceof GoTemplateReactiveView goView) {
+			goView.setService(this.service);
+			if (this.charset != null) {
+				goView.setCharset(this.charset);
+			}
+		}
+		return view;
+	}
+
+}

--- a/gotmpl4j-spring-boot-starter/src/test/java/org/alexmond/gotmpl4j/spring/GoTemplateReactiveWebConfigurationTest.java
+++ b/gotmpl4j-spring-boot-starter/src/test/java/org/alexmond/gotmpl4j/spring/GoTemplateReactiveWebConfigurationTest.java
@@ -1,0 +1,53 @@
+package org.alexmond.gotmpl4j.spring;
+
+import org.alexmond.gotmpl4j.spring.view.GoTemplateReactiveViewResolver;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.core.Ordered;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Bean-wiring scenarios for the reactive (WebFlux) view layer, mirroring Spring Boot's
+ * {@code MustacheAutoConfigurationReactiveIntegrationTests}: the
+ * {@link GoTemplateReactiveViewResolver} is registered in a reactive web context, absent
+ * off-web, and backs off to a user-defined resolver.
+ */
+class GoTemplateReactiveWebConfigurationTest {
+
+	private final ReactiveWebApplicationContextRunner reactive = new ReactiveWebApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(Gotmpl4jAutoConfiguration.class));
+
+	private final ApplicationContextRunner nonWeb = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(Gotmpl4jAutoConfiguration.class));
+
+	@Test
+	void registersViewResolverInReactiveWebApp() {
+		this.reactive.run((context) -> {
+			GoTemplateReactiveViewResolver resolver = context.getBean(GoTemplateReactiveViewResolver.class);
+			assertEquals(Ordered.LOWEST_PRECEDENCE - 10, resolver.getOrder());
+		});
+	}
+
+	@Test
+	void noViewResolverInNonWebApp() {
+		this.nonWeb.run(
+				(context) -> assertEquals(0, context.getBeanNamesForType(GoTemplateReactiveViewResolver.class).length));
+	}
+
+	@Test
+	void backsOffWhenUserDefinesResolver() {
+		this.reactive
+			.withBean("myResolver", GoTemplateReactiveViewResolver.class,
+					() -> new GoTemplateReactiveViewResolver(null))
+			.run((context) -> {
+				assertEquals(1, context.getBeanNamesForType(GoTemplateReactiveViewResolver.class).length);
+				assertTrue(context.containsBean("myResolver"));
+			});
+	}
+
+}

--- a/gotmpl4j-spring-boot-starter/src/test/java/org/alexmond/gotmpl4j/spring/GoTemplateReactiveWebIntegrationTest.java
+++ b/gotmpl4j-spring-boot-starter/src/test/java/org/alexmond/gotmpl4j/spring/GoTemplateReactiveWebIntegrationTest.java
@@ -1,0 +1,66 @@
+package org.alexmond.gotmpl4j.spring;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * End-to-end reactive rendering, mirroring Spring Boot's
+ * {@code MustacheAutoConfigurationReactiveIntegrationTests}: a controller returns a view
+ * name and the autoconfigured
+ * {@link org.alexmond.gotmpl4j.spring.view.GoTemplateReactiveViewResolver} renders the
+ * gotmpl4j template through WebFlux. The application type is forced to reactive because
+ * the test classpath also carries Spring MVC.
+ */
+@SpringBootTest(classes = GoTemplateReactiveWebIntegrationTest.TestApp.class,
+		properties = "spring.main.web-application-type=reactive")
+@AutoConfigureWebTestClient
+class GoTemplateReactiveWebIntegrationTest {
+
+	@Autowired
+	private WebTestClient webTestClient;
+
+	@Test
+	void rendersGoTemplateViewThroughWebFlux() {
+		this.webTestClient.get()
+			.uri("/hello")
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody(String.class)
+			.isEqualTo("Hi WORLD from gotmpl4j");
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableAutoConfiguration
+	static class TestApp {
+
+		@Bean
+		HelloController helloController() {
+			return new HelloController();
+		}
+
+	}
+
+	@Controller
+	static class HelloController {
+
+		@GetMapping("/hello")
+		String hello(Model model) {
+			model.addAttribute("Name", "world");
+			model.addAttribute("Site", "gotmpl4j");
+			return "hello";
+		}
+
+	}
+
+}


### PR DESCRIPTION
Slice 2 of #42 — the reactive (WebFlux) counterpart to the servlet view layer (#458), mirroring Spring Boot's `MustacheReactiveWebConfiguration`.

## What's added
- **`GoTemplateReactiveView`** (`extends` reactive `AbstractUrlBasedView`) — `renderInternal` delegates to `GoTemplateService.render(viewName, model)` and writes the bytes to the `ServerWebExchange` response (charset from the negotiated content type, else the configured charset).
- **`GoTemplateReactiveViewResolver`** (`extends` reactive `UrlBasedViewResolver`) — resolves a view name straight to the template name; overrides `getViewClass()`/`createView()` (no overridable setter in the constructor).
- **`GoTemplateReactiveWebConfiguration`** — `@ConditionalOnWebApplication(REACTIVE)` + `@ConditionalOnClass` + `@ConditionalOnMissingBean`, `@Import`'d alongside the servlet config (the two are mutually exclusive by web type).
- **`Gotmpl4jProperties`** — nested `reactive.media-types` (mirrors `spring.mustache.reactive`).
- **pom** — `spring-webflux` *optional*; tests add `spring-boot-starter-webflux` + `spring-boot-webflux-test` + `spring-boot-webtestclient`.

## Tests (ported, adapted)
- resolver registered in a reactive web context; **absent** off-web; **backs off** to a user bean
- **end-to-end WebTestClient**: a `@Controller` returns `"hello"` → reactive resolver → `Hi WORLD from gotmpl4j` (`web-application-type` forced to `reactive` since the test classpath also carries Spring MVC)

## Scope / safety
Starter-only leaf module — **not on the chart path, jhelm 346-chart parity unaffected**. All **17** starter tests green with full gates (servlet + reactive coexist).

**Remaining (#42):** slice 3 — `TemplateAvailabilityProvider` + autoconfig-level tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)