### PR TITLE
feat(gotmpl4j-starter): TemplateAvailabilityProvider (#42, slice 3) — closes #42

### DIFF
--- a/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/GoTemplateAvailabilityProvider.java
+++ b/gotmpl4j-spring-boot-starter/src/main/java/org/alexmond/gotmpl4j/spring/GoTemplateAvailabilityProvider.java
@@ -1,0 +1,32 @@
+package org.alexmond.gotmpl4j.spring;
+
+import org.springframework.boot.autoconfigure.template.TemplateAvailabilityProvider;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.util.ClassUtils;
+
+/**
+ * {@link TemplateAvailabilityProvider} that reports whether a gotmpl4j view template
+ * exists, mirroring Spring Boot's {@code MustacheTemplateAvailabilityProvider}. Spring
+ * Boot uses this to decide whether a view name is backed by a template (e.g. for error
+ * views).
+ */
+public class GoTemplateAvailabilityProvider implements TemplateAvailabilityProvider {
+
+	@Override
+	public boolean isTemplateAvailable(String view, Environment environment, ClassLoader classLoader,
+			ResourceLoader resourceLoader) {
+		if (ClassUtils.isPresent("org.alexmond.gotmpl4j.GoTemplate", classLoader)) {
+			// Mirror Gotmpl4jProperties defaults; honour the deprecated
+			// template-location.
+			String prefix = environment.getProperty("gotmpl4j.prefix");
+			if (prefix == null) {
+				prefix = environment.getProperty("gotmpl4j.template-location", "classpath:/templates/");
+			}
+			String suffix = environment.getProperty("gotmpl4j.suffix", ".gotmpl");
+			return resourceLoader.getResource(prefix + view + suffix).exists();
+		}
+		return false;
+	}
+
+}

--- a/gotmpl4j-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/gotmpl4j-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.template.TemplateAvailabilityProvider=\
+org.alexmond.gotmpl4j.spring.GoTemplateAvailabilityProvider

--- a/gotmpl4j-spring-boot-starter/src/test/java/org/alexmond/gotmpl4j/spring/GoTemplateAvailabilityProviderTest.java
+++ b/gotmpl4j-spring-boot-starter/src/test/java/org/alexmond/gotmpl4j/spring/GoTemplateAvailabilityProviderTest.java
@@ -1,0 +1,58 @@
+package org.alexmond.gotmpl4j.spring;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link GoTemplateAvailabilityProvider}, ported from Spring Boot's
+ * {@code MustacheTemplateAvailabilityProviderTests}: an existing template is reported
+ * available, a missing one is not, and custom prefix/suffix (incl. the deprecated
+ * {@code template-location}) are honoured.
+ */
+class GoTemplateAvailabilityProviderTest {
+
+	private final GoTemplateAvailabilityProvider provider = new GoTemplateAvailabilityProvider();
+
+	private final ResourceLoader resourceLoader = new DefaultResourceLoader();
+
+	private final MockEnvironment environment = new MockEnvironment();
+
+	@Test
+	void availableTemplate() {
+		assertTrue(isAvailable("hello"));
+	}
+
+	@Test
+	void unavailableTemplate() {
+		assertFalse(isAvailable("does-not-exist"));
+	}
+
+	@Test
+	void nestedTemplateIsAvailable() {
+		assertTrue(isAvailable("layouts/footer"));
+	}
+
+	@Test
+	void honoursDeprecatedTemplateLocationAlias() {
+		this.environment.setProperty("gotmpl4j.template-location", "classpath:/templates/");
+		assertTrue(isAvailable("hello"));
+	}
+
+	@Test
+	void customSuffixThatDoesNotMatchIsUnavailable() {
+		this.environment.setProperty("gotmpl4j.suffix", ".nope");
+		assertFalse(isAvailable("hello"));
+	}
+
+	private boolean isAvailable(String view) {
+		return this.provider.isTemplateAvailable(view, this.environment, getClass().getClassLoader(),
+				this.resourceLoader);
+	}
+
+}


### PR DESCRIPTION
Final slice of #42, mirroring Spring Boot's `MustacheTemplateAvailabilityProvider`.

## What's added
- **`GoTemplateAvailabilityProvider`** (implements `TemplateAvailabilityProvider`) — reports whether a view name is backed by a gotmpl4j template by checking `prefix + view + suffix` exists (honouring the deprecated `template-location` alias), guarded by the engine class being present.
- **`META-INF/spring.factories`** registers it so Spring Boot discovers it (used e.g. to decide whether a view name maps to a template, error-view resolution).

## Tests (ported from `MustacheTemplateAvailabilityProviderTests`)
existing template available · missing one not · nested template available · deprecated `template-location` alias honoured · non-matching suffix unavailable.

## #42 complete
`gotmpl4j-spring-boot-starter` is now a **full Spring view technology**:
- servlet `ViewResolver`/`View` (#458)
- WebFlux reactive `ViewResolver`/`View` (#459)
- `TemplateAvailabilityProvider` (this)

All **22** starter tests green with full gates. Starter-only leaf module — jhelm 346-chart parity unaffected.

Closes #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)