### PR TITLE
test(gotmpl4j-core): port Go html/template TestJSValEscaper

### DIFF
--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/JsEscaperConformanceTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/JsEscaperConformanceTest.java
@@ -1,5 +1,10 @@
 package org.alexmond.gotmpl4j.html;
 
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,6 +42,34 @@ class JsEscaperConformanceTest {
 		for (String[] c : cases) {
 			assertEquals(c[1], JsEscapers.jsRegexpEscaper(c[0]), () -> "jsRegexpEscaper(" + c[0] + ")");
 		}
+	}
+
+	@Test
+	void jsValEscaper() {
+		// Numbers are wrapped in spaces to prevent token-merging; floats use shortest
+		// form.
+		assertEquals(" 42 ", JsEscapers.jsValEscaper(42L));
+		assertEquals(" -42 ", JsEscapers.jsValEscaper(-42L));
+		assertEquals(" 0 ", JsEscapers.jsValEscaper(0L));
+		assertEquals(" 1 ", JsEscapers.jsValEscaper(1.0));
+		assertEquals(" 0.5 ", JsEscapers.jsValEscaper(0.5));
+		assertEquals(" -0.5 ", JsEscapers.jsValEscaper(-0.5));
+		// Strings render as JSON string literals with the html/template JS escapes.
+		assertEquals("\"\"", JsEscapers.jsValEscaper(""));
+		assertEquals("\"foo\"", JsEscapers.jsValEscaper("foo"));
+		assertEquals("\"\\r\\n\\u2028\\u2029\"", JsEscapers.jsValEscaper("\r\n\u2028\u2029"));
+		assertEquals("\"\\t\\u000b\"", JsEscapers.jsValEscaper("\t"));
+		assertEquals("\"\\u003c!--\"", JsEscapers.jsValEscaper("<!--"));
+		assertEquals("\"--\\u003e\"", JsEscapers.jsValEscaper("-->"));
+		// Slices and maps marshal to JSON arrays/objects.
+		assertEquals("[]", JsEscapers.jsValEscaper(List.of()));
+		assertEquals("[42,\"foo\",null]", JsEscapers.jsValEscaper(Arrays.asList(42L, "foo", null)));
+		assertEquals("[\"\\u003c!--\",\"\\u003c/script\\u003e\",\"--\\u003e\"]",
+				JsEscapers.jsValEscaper(List.of("<!--", "</script>", "-->")));
+		Map<String, Object> struct = new LinkedHashMap<>();
+		struct.put("X", 1L);
+		struct.put("Y", 2L);
+		assertEquals("{\"X\":1,\"Y\":2}", JsEscapers.jsValEscaper(struct));
 	}
 
 }


### PR DESCRIPTION
Adds a `jsValEscaper` conformance method to `JsEscaperConformanceTest`, ported from Go `html/template` `js_test.go` `TestJSValEscaper` — the value→JS-literal path (over `JsonMarshal`).

**16 cases**: numbers wrapped in spaces (`" 42 "`, `" -0.5 "`, float shortest-form `1.0`→`" 1 "`), JSON string literals with the JS escapes (`"<!--"`, ` `/` `, ``), and slice/map marshaling to JSON arrays/objects (`[42,"foo",null]`, `{"X":1,"Y":2}`).

**Result: all pass — fully Go-conformant.** Go-only numeric edges (negative zero, ulp-of-2^53 precision, `uint64`) are omitted as not JVM-expressible.

Test-only; html escaping is opt-in so text-mode chart parity is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)