### PR TITLE
test(gotmpl4j-core): port Go isCSSNmchar + endsWithCSSKeyword

### DIFF
--- a/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/CssLexConformanceTest.java
+++ b/jhelm-gotemplate/src/test/java/org/alexmond/gotmpl4j/html/CssLexConformanceTest.java
@@ -9,6 +9,7 @@ import java.util.TreeSet;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -49,6 +50,33 @@ class CssLexConformanceTest {
 
 	private static String decode(String b64) {
 		return new String(Base64.getDecoder().decode(b64), StandardCharsets.UTF_8);
+	}
+
+	/** Ported from Go css_test.go TestIsCSSNmchar — a CSS identifier character. */
+	@Test
+	void isCssNmcharConformance() {
+		int[][] cases = { { 0, 0 }, { '0', 1 }, { '9', 1 }, { 'A', 1 }, { 'Z', 1 }, { 'a', 1 }, { 'z', 1 }, { '_', 1 },
+				{ '-', 1 }, { ':', 0 }, { ';', 0 }, { ' ', 0 }, { 0x7f, 0 }, { 0x80, 1 }, { 0x1234, 1 }, { 0xd800, 0 },
+				{ 0xdc00, 0 }, { 0xfffe, 0 }, { 0x10000, 1 }, { 0x110000, 0 } };
+		for (int[] c : cases) {
+			assertEquals(c[1] == 1, CssLex.isCSSNmchar(c[0]), () -> "isCSSNmchar(0x" + Integer.toHexString(c[0]) + ")");
+		}
+	}
+
+	/**
+	 * Ported from Go css_test.go TestEndsWithCSSKeyword — case-insensitive keyword
+	 * suffix.
+	 */
+	@Test
+	void endsWithCssKeywordConformance() {
+		Object[][] cases = { { "", "url", false }, { "url", "url", true }, { "URL", "url", true },
+				{ "Url", "url", true }, { "url", "important", false }, { "important", "important", true },
+				{ "image-url", "url", false }, { "imageurl", "url", false }, { "image url", "url", true } };
+		for (Object[] c : cases) {
+			byte[] b = ((String) c[0]).getBytes(StandardCharsets.UTF_8);
+			assertEquals(c[2], CssLex.endsWithCSSKeyword(b, b.length, (String) c[1]),
+					() -> "endsWithCSSKeyword(" + c[0] + ", " + c[1] + ")");
+		}
 	}
 
 }


### PR DESCRIPTION
Adds two boolean-helper conformance methods to `CssLexConformanceTest`, ported from Go `css_test.go`:

- **`isCSSNmchar`** (20 cases) — CSS identifier chars plus the non-ASCII ranges; verifies surrogates (`0xd800`/`0xdc00`), the `0xfffe` noncharacter, and out-of-range `0x110000` are excluded while `0x80`/`0x1234`/`0x10000` are included.
- **`endsWithCSSKeyword`** (9 cases) — case-insensitive keyword suffix (`url`/`URL`/`Url`, `image url` vs `image-url`/`imageurl`).

Both **fully Go-conformant**. Test-only; html escaping is opt-in so text-mode chart parity is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)