### PR TITLE
fix(gotmpl4j-sprig): untitle / compact / mustHas Sprig parity (#474)

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -53,6 +53,9 @@
          plus the Go-faithful serialization post-processing — long by nature -->
     <suppress checks="FileLength" files="ConversionFunctions\.java"/>
 
+    <!-- StringFunctions is a flat registry of the ~80 Sprig string functions — long by nature -->
+    <suppress checks="FileLength" files="StringFunctions\.java"/>
+
     <!-- Test files are exempt from size limits: test methods are short but files accumulate many of them -->
     <suppress checks="MethodLength" files=".*Test\.java"/>
     <suppress checks="FileLength" files=".*Test\.java"/>

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/ListFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/ListFunctions.java
@@ -370,11 +370,9 @@ public final class ListFunctions {
 			if (args.length < 2) {
 				throw new FunctionExecutionException("mustHas: insufficient arguments");
 			}
-			boolean result = (boolean) has().invoke(args);
-			if (!result) {
-				throw new FunctionExecutionException("mustHas: element not found");
-			}
-			return result;
+			// Sprig's mustHas returns false when the element is absent (only type errors
+			// fail), so a not-found result is not an exception.
+			return has().invoke(args);
 		};
 	}
 
@@ -486,12 +484,35 @@ public final class ListFunctions {
 			}
 			List<Object> result = new ArrayList<>();
 			for (Object item : (Collection<?>) args[0]) {
-				if (item != null && !"".equals(item) && !Boolean.FALSE.equals(item)) {
+				if (!isSprigEmpty(item)) {
 					result.add(item);
 				}
 			}
 			return result;
 		};
+	}
+
+	// Sprig's empty(): nil, false, a zero number, "", or an empty collection/map.
+	private static boolean isSprigEmpty(Object o) {
+		if (o == null) {
+			return true;
+		}
+		if (o instanceof Boolean b) {
+			return !b;
+		}
+		if (o instanceof String s) {
+			return s.isEmpty();
+		}
+		if (o instanceof Number n) {
+			return n.doubleValue() == 0.0;
+		}
+		if (o instanceof Collection<?> c) {
+			return c.isEmpty();
+		}
+		if (o instanceof Map<?, ?> m) {
+			return m.isEmpty();
+		}
+		return false;
 	}
 
 	private static Function mustCompact() {

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/StringFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/StringFunctions.java
@@ -143,17 +143,23 @@ public final class StringFunctions {
 			// Mirror Go's strings.Title (used by sprig's `title`): title-case the letter
 			// after a separator, leaving everything else untouched. So mixed-case
 			// "xtrabackupSidecar" -> "XtrabackupSidecar", not "Xtrabackupsidecar".
-			StringBuilder sb = new StringBuilder(s.length());
-			int prev = ' ';
-			int i = 0;
-			while (i < s.length()) {
-				int cp = s.codePointAt(i);
-				sb.appendCodePoint(isTitleSeparator(prev) ? Character.toTitleCase(cp) : cp);
-				prev = cp;
-				i += Character.charCount(cp);
-			}
-			return sb.toString();
+			return mapWordStarts(s, Character::toTitleCase);
 		};
+	}
+
+	// Apply {@code first} to the first letter after each title-separator (used by
+	// title/untitle), leaving the rest of each word untouched.
+	private static String mapWordStarts(String s, java.util.function.IntUnaryOperator first) {
+		StringBuilder sb = new StringBuilder(s.length());
+		int prev = ' ';
+		int i = 0;
+		while (i < s.length()) {
+			int cp = s.codePointAt(i);
+			sb.appendCodePoint(isTitleSeparator(prev) ? first.applyAsInt(cp) : cp);
+			prev = cp;
+			i += Character.charCount(cp);
+		}
+		return sb.toString();
 	}
 
 	// Mirrors Go's strings.isSeparator: letters, digits and '_' are part of a word; any
@@ -174,7 +180,9 @@ public final class StringFunctions {
 			if (s.isEmpty()) {
 				return s;
 			}
-			return Character.toLowerCase(s.charAt(0)) + s.substring(1);
+			// Inverse of title(): lower-case the first letter after each separator, so
+			// "First Try" -> "first try" (not just the first word).
+			return mapWordStarts(s, Character::toLowerCase);
 		};
 	}
 

--- a/jhelm-gotemplate-sprig/src/test/resources/conformance/sprig_known_divergences.txt
+++ b/jhelm-gotemplate-sprig/src/test/resources/conformance/sprig_known_divergences.txt
@@ -5,13 +5,8 @@
 #
 # --- BUGS (to fix) ---
 # untitle: lowercase the first letter of EVERY word, not just the first.
-e3t1bnRpdGxlICJGaXJzdCBUcnkifX0=  // {{untitle "First Try"}} want=first try got=first Try
 # compact / mustCompact: drop all empty values (0, "", nil, false), not just "".
-e3sgbGlzdCAxIDAgIiIgImhlbGxvIiB8IGNvbXBhY3QgfX0=  // {{ list 1 0 "" "hello" | compact }} want=[1 hello] got=[1 0 hello]
-e3sgbGlzdCAxIDAgIiIgImhlbGxvIiB8IG11c3RDb21wYWN0IH19  // {{ list 1 0 "" "hello" | mustCompact }} want=[1 hello] got=[1 0 hello]
 # mustHas: return false when the element is absent / list is nil, not an error.
-e3sgbGlzdCAxIDIgMyB8IG11c3RIYXMgNCB9fQ==  // {{ list 1 2 3 | mustHas 4 }} want=false got=throws
-e3sgbXVzdEhhcyAiYmFyIiBuaWwgfX0=  // {{ mustHas "bar" nil }} want=false got=throws
 # mustWithout / mustSlice with only the list: return the list unchanged, not an error.
 e3sgbXVzdFdpdGhvdXQgbGlzdCB9fQ==  // {{ mustWithout list }} want=[] got=throws
 e3sgbXVzdFdpdGhvdXQgKGxpc3QgMSAyIDMpIH19  // {{ mustWithout (list 1 2 3) }} want=[1 2 3] got=throws


### PR DESCRIPTION
Three fixes from the Sprig conformance backlog (#474):

- **`untitle`** — lower-case the first letter of *every* word, not just the first (`"First Try"`→`first try`). Extracted the shared separator-walk into `mapWordStarts()`, reused by `title()`/`untitle()`.
- **`compact`/`mustCompact`** — drop all Sprig-"empty" values (nil, false, a zero number, `""`, empty collection/map), not only `""` (`list 1 0 "" "hello"`→`[1 hello]`). Added `isSprigEmpty()`.
- **`mustHas`** — return `false` when the element is absent (Sprig only errors on type mismatch), instead of throwing.

4 entries cleared from `sprig_known_divergences.txt`. `FileLength` suppressed for `StringFunctions.java` (a flat ~80-function registry, like the already-suppressed `ConversionFunctions`).

All **535** sprig tests + full **346-chart** parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)