### PR TITLE
fix(gotmpl4j-sprig): graceful must*/slice + variadic keys (#474)

### DIFF
--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/DictFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/DictFunctions.java
@@ -305,8 +305,16 @@ public final class DictFunctions {
 	}
 
 	private static Function keys() {
-		return (args) -> (args.length > 0 && args[0] instanceof Map) ? new ArrayList<>(((Map<?, ?>) args[0]).keySet())
-				: Collections.emptyList();
+		// Sprig's keys is variadic: it returns the keys of all supplied dicts.
+		return (args) -> {
+			List<Object> result = new ArrayList<>();
+			for (Object arg : args) {
+				if (arg instanceof Map) {
+					result.addAll(((Map<?, ?>) arg).keySet());
+				}
+			}
+			return result;
+		};
 	}
 
 	private static Function mustKeys() {

--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/ListFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/ListFunctions.java
@@ -107,13 +107,8 @@ public final class ListFunctions {
 	}
 
 	private static Function mustFirst() {
-		return (args) -> {
-			Object result = first().invoke(args);
-			if (result == null) {
-				throw new FunctionExecutionException("mustFirst: list is empty");
-			}
-			return result;
-		};
+		// Sprig's mustFirst returns nil for an empty list (only type errors fail).
+		return (args) -> first().invoke(args);
 	}
 
 	private static Function rest() {
@@ -167,13 +162,8 @@ public final class ListFunctions {
 	}
 
 	private static Function mustLast() {
-		return (args) -> {
-			Object result = last().invoke(args);
-			if (result == null) {
-				throw new FunctionExecutionException("mustLast: list is empty");
-			}
-			return result;
-		};
+		// Sprig's mustLast returns nil for an empty list (only type errors fail).
+		return (args) -> last().invoke(args);
 	}
 
 	private static Function initial() {
@@ -344,8 +334,8 @@ public final class ListFunctions {
 
 	private static Function mustWithout() {
 		return (args) -> {
-			if (args.length < 2) {
-				throw new FunctionExecutionException("mustWithout: insufficient arguments");
+			if (args.length < 1) {
+				throw new FunctionExecutionException("mustWithout: a list is required");
 			}
 			return without().invoke(args);
 		};
@@ -378,7 +368,8 @@ public final class ListFunctions {
 
 	private static Function slice() {
 		return (args) -> {
-			if (args.length < 2) {
+			// Sprig's slice with only the list returns the whole list (list[0:]).
+			if (args.length == 0) {
 				return Collections.emptyList();
 			}
 			Object list = args[0];
@@ -397,8 +388,8 @@ public final class ListFunctions {
 
 	private static Function mustSlice() {
 		return (args) -> {
-			if (args.length < 2) {
-				throw new FunctionExecutionException("mustSlice: insufficient arguments");
+			if (args.length < 1) {
+				throw new FunctionExecutionException("mustSlice: a list is required");
 			}
 			return slice().invoke(args);
 		};

--- a/jhelm-gotemplate-sprig/src/test/resources/conformance/sprig_known_divergences.txt
+++ b/jhelm-gotemplate-sprig/src/test/resources/conformance/sprig_known_divergences.txt
@@ -7,17 +7,6 @@
 # untitle: lowercase the first letter of EVERY word, not just the first.
 # compact / mustCompact: drop all empty values (0, "", nil, false), not just "".
 # mustHas: return false when the element is absent / list is nil, not an error.
-# mustWithout / mustSlice with only the list: return the list unchanged, not an error.
-e3sgbXVzdFdpdGhvdXQgbGlzdCB9fQ==  // {{ mustWithout list }} want=[] got=throws
-e3sgbXVzdFdpdGhvdXQgKGxpc3QgMSAyIDMpIH19  // {{ mustWithout (list 1 2 3) }} want=[1 2 3] got=throws
-e3sgbXVzdFNsaWNlIChsaXN0IDEgMiAzKSB9fQ==  // {{ mustSlice (list 1 2 3) }} want=[1 2 3] got=throws
-# slice with only the list (no indices): return the whole list.
-e3sgc2xpY2UgKGxpc3QgMSAyIDMpIH19  // {{ slice (list 1 2 3) }} want=[1 2 3] got=[]
-# mustFirst / mustLast on an empty list: return nil, not an error.
-e3sgbGlzdCB8IG11c3RGaXJzdCB9fQ==  // {{ list | mustFirst }} want=<no value> got=throws
-e3sgbGlzdCB8IG11c3RMYXN0IH19  // {{ list | mustLast }} want=<no value> got=throws
-# keys: accept multiple dicts and return the keys of all of them.
-e3sga2V5cyAoZGljdCAiZm9vIiAxKSAoZGljdCAiYmFyIiAyKSAoZGljdCAiYmFyIiAzKSB8IHVuaXEgfCBzb3J0QWxwaGEgfX0=  // {{ keys (dict ...) (dict ...) ... }} want=[bar foo] got=[foo]
 # seq: return a space-joined sequence string; handle 1/2/3 args and negative steps.
 e3tzZXF9fQ==  // {{seq}} want= got=[]
 e3tzZXEgNX19  // {{seq 5}} want=1 2 3 4 5 got=[1 2 3 4 5]
@@ -47,8 +36,11 @@ e3tkZXJpdmVQYXNzd29yZCAyICJsb25nIiAicGFzc3dvcmQiICJ1c2VyIiAiZXhhbXBsZS5jb20ifX0=
 #
 # --- INTENDED (Helm semantics / float edge; not bugs) ---
 # Helm renders a nil/absent value as "" (missingkey=zero), not Go's "<no value>" (cf. #431).
+# (first/last/mustFirst/mustLast on an empty list, and coalesce of nothing, all return nil.)
 e3sgbGlzdCB8IGZpcnN0IH19  // {{ list | first }} want=<no value> got=  (empty list -> nil -> "")
 e3sgbGlzdCB8IGxhc3QgfX0=  // {{ list | last }} want=<no value> got=
+e3sgbGlzdCB8IG11c3RGaXJzdCB9fQ==  // {{ list | mustFirst }} want=<no value> got=  (now returns nil, not an error)
+e3sgbGlzdCB8IG11c3RMYXN0IH19  // {{ list | mustLast }} want=<no value> got=
 e3sgY29hbGVzY2UgfX0=  // {{ coalesce }} want=<no value> got=
 # Sub-ulp float-accumulation: 2.4*10*4*1.2 = 115.19999999999999 (Java shortest); Go prints 115.2.
 e3sgMS4yIHwgbXVsZiAiMi40IiAxMCAiNCJ9fQ==  // {{ 1.2 | mulf "2.4" 10 "4"}} want=115.2 got=115.19999999999999


### PR DESCRIPTION
More fixes from the Sprig conformance backlog (#474):

- **`slice`/`mustSlice`** with only the list (no indices) → return the whole list (was `[]` / "insufficient arguments").
- **`mustWithout`** with only the list → return it unchanged, not an error.
- **`mustFirst`/`mustLast`** on an empty list → return nil (Sprig only errors on type mismatch). These then render `""` vs Go's `<no value>` — reclassified as the intended Helm nil-rendering pin (cf. #431).
- **`keys`** → variadic: return the keys of *all* supplied dicts, not just the first.

Backlog now down to `seq`, `until`, `abbrevboth`, `wrapWith`, `derivePassword`. All **535** sprig tests + full **346-chart** parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)