### PR TITLE
Fix sprig seq/until/untilStep to match Masterminds/sprig semantics

### DIFF
--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/ListFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/ListFunctions.java
@@ -400,72 +400,62 @@ public final class ListFunctions {
 			if (args.length == 0) {
 				return Collections.emptyList();
 			}
-			int n = ((Number) args[0]).intValue();
-			List<Integer> res = new ArrayList<>();
-			for (int i = 0; i < n; i++) {
-				res.add(i);
-			}
-			return res;
+			int count = ((Number) args[0]).intValue();
+			return untilStepList(0, count, (count < 0) ? -1 : 1);
 		};
+	}
+
+	// Sprig's untilStep core: [start, stop) by step, honouring direction.
+	private static List<Integer> untilStepList(int start, int stop, int step) {
+		List<Integer> v = new ArrayList<>();
+		if (stop < start) {
+			for (int i = start; step < 0 && i > stop; i += step) {
+				v.add(i);
+			}
+			return v;
+		}
+		for (int i = start; step > 0 && i < stop; i += step) {
+			v.add(i);
+		}
+		return v;
 	}
 
 	private static Function untilStep() {
-		return (args) -> {
-			if (args.length < 3) {
-				return Collections.emptyList();
-			}
-			int start = ((Number) args[0]).intValue();
-			int stop = ((Number) args[1]).intValue();
-			int step = ((Number) args[2]).intValue();
-			if (step == 0) {
-				return Collections.emptyList();
-			}
+		return (args) -> (args.length < 3) ? Collections.emptyList() : untilStepList(((Number) args[0]).intValue(),
+				((Number) args[1]).intValue(), ((Number) args[2]).intValue());
+	}
 
-			List<Integer> res = new ArrayList<>();
-			if (step > 0) {
-				for (int i = start; i < stop; i += step) {
-					res.add(i);
-				}
+	// Sprig's seq returns a space-joined sequence string (numeric.go): 1/2/3 int args,
+	// auto-direction for 1/2-arg forms, explicit step for the 3-arg form.
+	private static Function seq() {
+		return (args) -> {
+			int n = args.length;
+			if (n < 1 || n > 3) {
+				return "";
 			}
-			else {
-				for (int i = start; i > stop; i += step) {
-					res.add(i);
-				}
+			int start = (n == 1) ? 1 : ((Number) args[0]).intValue();
+			int end = ((Number) args[n - 1]).intValue();
+			int explicitStep = (n == 3) ? ((Number) args[1]).intValue() : 0;
+			// 1/2-arg forms step by the auto-direction; the 3-arg form uses its explicit
+			// step but bails when the explicit step runs the wrong way.
+			if (n == 3 && end < start && explicitStep > 0) {
+				return "";
 			}
-			return res;
+			int dir = (end < start) ? -1 : 1;
+			int step = (n == 3) ? explicitStep : dir;
+			return joinInts(untilStepList(start, end + dir, step));
 		};
 	}
 
-	private static Function seq() {
-		return (args) -> {
-			if (args.length == 0) {
-				return Collections.emptyList();
+	private static String joinInts(List<Integer> v) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < v.size(); i++) {
+			if (i > 0) {
+				sb.append(' ');
 			}
-			int start = 1;
-			int end = ((Number) args[0]).intValue();
-			int step = 1;
-
-			if (args.length >= 2) {
-				start = ((Number) args[0]).intValue();
-				end = ((Number) args[1]).intValue();
-			}
-			if (args.length >= 3) {
-				step = ((Number) args[2]).intValue();
-			}
-
-			List<Integer> res = new ArrayList<>();
-			if (step > 0) {
-				for (int i = start; i <= end; i += step) {
-					res.add(i);
-				}
-			}
-			else {
-				for (int i = start; i >= end; i += step) {
-					res.add(i);
-				}
-			}
-			return res;
-		};
+			sb.append((int) v.get(i));
+		}
+		return sb.toString();
 	}
 
 	private static Function compact() {

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/gotmpl4j/sprig/functions/CollectionFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/gotmpl4j/sprig/functions/CollectionFunctionsTest.java
@@ -488,7 +488,7 @@ class CollectionFunctionsTest {
 
 	@ParameterizedTest
 	@CsvSource(delimiter = '|',
-			value = { "{{ $s := seq 1 5 }}{{ join \",\" $s }}                    | 1,2,3,4,5",
+			value = { "{{ seq 1 5 }}                                          | 1 2 3 4 5",
 					"{{ $u := until 5 }}{{ join \",\" $u }}                    | 0,1,2,3,4",
 					"{{ $u := untilStep 0 10 2 }}{{ join \",\" $u }}           | 0,2,4,6,8" })
 	void testSequences(String template, String expected) throws IOException, TemplateException {

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/gotmpl4j/sprig/functions/MathFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/gotmpl4j/sprig/functions/MathFunctionsTest.java
@@ -55,7 +55,7 @@ class MathFunctionsTest {
 	}
 
 	@ParameterizedTest
-	@CsvSource(delimiter = '|', value = { "{{ $s := seq 1 3 }}{{ len $s }}              | 3",
+	@CsvSource(delimiter = '|', value = { "{{ seq 1 3 }}                                | 1 2 3",
 			"{{ $u := until 3 }}{{ len $u }}              | 3", "{{ $u := untilStep 0 10 2 }}{{ len $u }}     | 5" })
 	void testSequenceFunction(String template, String expected) throws IOException, TemplateException {
 		assertEquals(expected, exec(template));

--- a/jhelm-gotemplate-sprig/src/test/resources/conformance/sprig_known_divergences.txt
+++ b/jhelm-gotemplate-sprig/src/test/resources/conformance/sprig_known_divergences.txt
@@ -7,20 +7,6 @@
 # untitle: lowercase the first letter of EVERY word, not just the first.
 # compact / mustCompact: drop all empty values (0, "", nil, false), not just "".
 # mustHas: return false when the element is absent / list is nil, not an error.
-# seq: return a space-joined sequence string; handle 1/2/3 args and negative steps.
-e3tzZXF9fQ==  // {{seq}} want= got=[]
-e3tzZXEgNX19  // {{seq 5}} want=1 2 3 4 5 got=[1 2 3 4 5]
-e3tzZXEgMH19  // {{seq 0}} want=1 0 got=[]
-e3tzZXEgLTV9fQ==  // {{seq -5}} want=1 0 -1 -2 -3 -4 -5 got=[]
-e3tzZXEgMCA0fX0=  // {{seq 0 4}} want=0 1 2 3 4 got=[0 1 2 3 4]
-e3tzZXEgMCAtNH19  // {{seq 0 -4}} want=0 -1 -2 -3 -4 got=[]
-e3tzZXEgMCAxIDN9fQ==  // {{seq 0 1 3}} want=0 1 2 3 got=[0]
-e3tzZXEgMCAzIDEwfX0=  // {{seq 0 3 10}} want=0 3 6 9 got=[0]
-e3tzZXEgMyAtMyAyfX0=  // {{seq 3 -3 2}} want=3 got=[]
-e3tzZXEgMyAzIDJ9fQ==  // {{seq 3 3 2}} want= got=[3]
-e3tzZXEgMCAxIDIgM319  // {{seq 0 1 2 3}} want= got=[0]
-# until: a negative argument counts down (0 -1 -2 ...).
-e3tyYW5nZSAkaSwgJGUgOj0gdW50aWwgLTV9fXt7JGl9fXt7JGV9fSB7e2VuZH19  // {{range until -5}}... want=00 1-1 2-2 3-3 4-4 got=
 # abbrevboth: abbreviate with leading+trailing ellipsis around a window.
 e3thYmJyZXZib3RoIDUgMTAgIjEyMzQgNTY3OCA5MTIzIn19  // {{abbrevboth 5 10 "1234 5678 9123"}} want=...5678... got=1234 5678 9123
 # wrapWith: wrap at the width using the separator, not a leading newline.


### PR DESCRIPTION
## Summary

Grinding `gotmpl4j-sprig` against [Masterminds/sprig](https://github.com/Masterminds/sprig)'s upstream Go test suite surfaced three divergences in the numeric sequence builders, now fixed to match `sprig_numeric.go` exactly.

- **`seq`** — Sprig's `seq` returns a **space-joined string** (e.g. `"1 2 3 4 5"`), not a list. Supports 1-arg (`seq N` → `1..N`), 2-arg (`seq start end`), and 3-arg (`seq start step end`) forms, including descending ranges and the empty case when an explicit positive step can't reach a lower end.
- **`until`** — now handles negative counts by counting down (`until -3` → `0 -1 -2`), matching `untilStep(0, count, count<0 ? -1 : 1)`.
- **`untilStep`** — shares the `untilStepList` helper with Sprig-exact direction/guard logic (empty when the step direction can't reach `stop`).

All three are factored around a single `untilStepList(start, stop, step)` helper mirroring the Go source.

## Tests

- Two existing tests (`CollectionFunctionsTest.testSequences`, `MathFunctionsTest.testSequenceFunction`) had codified the old buggy *seq-returns-a-list* behavior; updated to the Sprig-correct space-joined output.
- Removed `seq`/`until` entries from `sprig_known_divergences.txt`.
- **535 sprig tests green**; **346/346 chart parity gate green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)