### PR TITLE
Fix sprig abbrev/abbrevboth/wrap/wrapWith to match goutils

### DIFF
--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/StringFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/StringFunctions.java
@@ -236,9 +236,10 @@ public final class StringFunctions {
 			if (args.length < 2) {
 				return "";
 			}
-			int max = ((Number) args[0]).intValue();
+			int width = ((Number) args[0]).intValue();
 			String s = String.valueOf(args[1]);
-			return (s.length() <= max) ? s : s.substring(0, max - 3) + "...";
+			// Mirrors Sprig: width < 4 returns the string unchanged.
+			return (width < 4) ? s : abbreviateFull(s, 0, width);
 		};
 	}
 
@@ -250,11 +251,34 @@ public final class StringFunctions {
 			int left = ((Number) args[0]).intValue();
 			int right = ((Number) args[1]).intValue();
 			String s = String.valueOf(args[2]);
-			if (s.length() <= left + right) {
+			// Mirrors Sprig: right<4, or (left>0 and right<7), returns unchanged.
+			if (right < 4 || (left > 0 && right < 7)) {
 				return s;
 			}
-			return "..." + s.substring(s.length() - right);
+			return abbreviateFull(s, left, right);
 		};
+	}
+
+	// Port of Masterminds/goutils AbbreviateFull (used by Sprig's abbrev/abbrevboth).
+	private static String abbreviateFull(String str, int offset, int maxWidth) {
+		if (str.isEmpty() || maxWidth < 4 || str.length() <= maxWidth) {
+			return str;
+		}
+		int off = Math.min(offset, str.length());
+		if (str.length() - off < (maxWidth - 3)) {
+			off = str.length() - (maxWidth - 3);
+		}
+		String marker = "...";
+		if (off <= 4) {
+			return str.substring(0, maxWidth - 3) + marker;
+		}
+		if (maxWidth < 7) {
+			return str;
+		}
+		if ((off + maxWidth - 3) < str.length()) {
+			return marker + abbreviateFull(str.substring(off), 0, maxWidth - 3);
+		}
+		return marker + str.substring(str.length() - (maxWidth - 3));
 	}
 
 	private static Function initials() {
@@ -277,7 +301,8 @@ public final class StringFunctions {
 			}
 			int col = ((Number) args[0]).intValue();
 			String s = String.valueOf(args[1]);
-			return wrapText(s, col, "");
+			// Sprig's wrap == goutils Wrap == WrapCustom(s, col, "\n", false).
+			return wrapCustom(s, col, "", false);
 		};
 	}
 
@@ -287,31 +312,50 @@ public final class StringFunctions {
 				return "";
 			}
 			int col = ((Number) args[0]).intValue();
-			String indent = String.valueOf(args[1]);
+			String sep = String.valueOf(args[1]);
 			String s = String.valueOf(args[2]);
-			return wrapText(s, col, indent);
+			// Sprig's wrapWith == goutils WrapCustom(s, col, sep, true).
+			return wrapCustom(s, col, sep, true);
 		};
 	}
 
-	private static String wrapText(String text, int col, String indent) {
-		String[] words = text.split("\\s+");
-		StringBuilder result = new StringBuilder();
-		StringBuilder line = new StringBuilder(indent);
-
-		for (String word : words) {
-			if (line.length() + word.length() + 1 > col && line.length() > indent.length()) {
-				result.append(line).append('\n');
-				line = new StringBuilder(indent);
-			}
-			if (line.length() > indent.length()) {
-				line.append(' ');
-			}
-			line.append(word);
+	// Port of Masterminds/goutils WrapCustom (used by Sprig's wrap/wrapWith).
+	private static String wrapCustom(String str, int wrapLength, String newLineStr, boolean wrapLongWords) {
+		if (str.isEmpty()) {
+			return "";
 		}
-		if (line.length() > indent.length()) {
-			result.append(line);
+		String nl = newLineStr.isEmpty() ? "\n" : newLineStr;
+		int width = Math.max(wrapLength, 1);
+		int inputLineLength = str.length();
+		int offset = 0;
+		StringBuilder wrappedLine = new StringBuilder();
+		while (inputLineLength - offset > width) {
+			if (str.charAt(offset) == ' ') {
+				offset++;
+				continue;
+			}
+			int spaceToWrapAt = str.substring(offset, offset + width).lastIndexOf(' ') + offset;
+			if (spaceToWrapAt >= offset) {
+				wrappedLine.append(str, offset, spaceToWrapAt).append(nl);
+				offset = spaceToWrapAt + 1;
+			}
+			else if (wrapLongWords) {
+				wrappedLine.append(str, offset, width + offset).append(nl);
+				offset += width;
+			}
+			else {
+				spaceToWrapAt = str.indexOf(' ', offset);
+				if (spaceToWrapAt >= 0) {
+					wrappedLine.append(str, offset, spaceToWrapAt).append(nl);
+					offset = spaceToWrapAt + 1;
+				}
+				else {
+					wrappedLine.append(str.substring(offset));
+					offset = inputLineLength;
+				}
+			}
 		}
-		return result.toString();
+		return wrappedLine.append(str.substring(offset)).toString();
 	}
 
 	private static Function contains() {

--- a/jhelm-gotemplate-sprig/src/test/resources/conformance/sprig_known_divergences.txt
+++ b/jhelm-gotemplate-sprig/src/test/resources/conformance/sprig_known_divergences.txt
@@ -7,10 +7,6 @@
 # untitle: lowercase the first letter of EVERY word, not just the first.
 # compact / mustCompact: drop all empty values (0, "", nil, false), not just "".
 # mustHas: return false when the element is absent / list is nil, not an error.
-# abbrevboth: abbreviate with leading+trailing ellipsis around a window.
-e3thYmJyZXZib3RoIDUgMTAgIjEyMzQgNTY3OCA5MTIzIn19  // {{abbrevboth 5 10 "1234 5678 9123"}} want=...5678... got=1234 5678 9123
-# wrapWith: wrap at the width using the separator, not a leading newline.
-e3t3cmFwV2l0aCA1ICJcdCIgIkhlbGxvIFdvcmxkIn19  // {{wrapWith 5 "\t" "Hello World"}} want=Hello\tWorld got=\tHello\nWorld
 # derivePassword: implement the Master Password (MPW) algorithm, not a hash hex dump.
 e3tkZXJpdmVQYXNzd29yZCAxICJiYXNpYyIgInBhc3N3b3JkIiAidXNlciIgImV4YW1wbGUuY29tIn19  // derivePassword basic
 e3tkZXJpdmVQYXNzd29yZCAxICJsb25nIiAicGFzc3dvcmQiICJ1c2VyIiAiZXhhbXBsZS5jb20ifX0=  // derivePassword long


### PR DESCRIPTION
## Summary

Grinding `gotmpl4j-sprig` against [Masterminds/sprig](https://github.com/Masterminds/sprig)'s upstream Go test suite found that the abbreviate and wrap functions used ad-hoc logic rather than the [Masterminds/goutils](https://github.com/Masterminds/goutils) algorithms Sprig delegates to. Ported both faithfully.

- **`abbreviateFull`** (goutils `AbbreviateFull`) — backs both `abbrev` and `abbrevboth`. `abbrevboth 5 10 "1234 5678 9123"` now yields `...5678...` (windowed ellipsis on both sides) instead of the verbatim input. Guard semantics match Sprig: `abbrev` returns the string unchanged for `width < 4`; `abbrevboth` for `right < 4` or (`left > 0` and `right < 7`).
- **`wrapCustom`** (goutils `WrapCustom`) — backs both `wrap` (`wrapLongWords=false`) and `wrapWith` (`wrapLongWords=true`). `wrapWith 5 "\t" "Hello World"` now yields `Hello\tWorld` (separator between words at the wrap boundary) instead of a spurious leading `\t` and `\n` break.

## Tests

- Removed `abbrevboth`/`wrapWith` entries from `sprig_known_divergences.txt`; both now pass conformance.
- Existing loose length-bound tests for all four functions still pass.
- **535 sprig tests green**; **346/346 chart parity gate green**; 0 PMD/Checkstyle violations.

Backlog #474 remaining after this: `derivePassword` (full Master Password / MPW algorithm — tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)