### PR TITLE
Implement sprig derivePassword (Master Password / MPW algorithm)

### DIFF
--- a/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/CryptoFunctions.java
+++ b/jhelm-gotemplate-sprig/src/main/java/org/alexmond/gotmpl4j/sprig/functions/CryptoFunctions.java
@@ -1,5 +1,6 @@
 package org.alexmond.gotmpl4j.sprig.functions;
 
+import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -26,6 +27,7 @@ import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
+import org.bouncycastle.crypto.generators.SCrypt;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import java.nio.charset.StandardCharsets;
@@ -34,7 +36,6 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
-import org.apache.commons.codec.binary.Hex;
 
 /**
  * Cryptographic and random generation functions from Sprig library. Includes password
@@ -184,31 +185,85 @@ public final class CryptoFunctions {
 		};
 	}
 
+	private static final String MASTER_PASSWORD_SEED = "com.lyndir.masterpassword";
+
+	// Master Password (MPW) password-type templates and character classes, ported
+	// verbatim
+	// from Masterminds/sprig (which ports Maarten Billemont's algorithm).
+	private static final Map<String, String[]> PASSWORD_TYPE_TEMPLATES = Map.of("maximum",
+			new String[] { "anoxxxxxxxxxxxxxxxxx", "axxxxxxxxxxxxxxxxxno" }, "long",
+			new String[] { "CvcvnoCvcvCvcv", "CvcvCvcvnoCvcv", "CvcvCvcvCvcvno", "CvccnoCvcvCvcv", "CvccCvcvnoCvcv",
+					"CvccCvcvCvcvno", "CvcvnoCvccCvcv", "CvcvCvccnoCvcv", "CvcvCvccCvcvno", "CvcvnoCvcvCvcc",
+					"CvcvCvcvnoCvcc", "CvcvCvcvCvccno", "CvccnoCvccCvcv", "CvccCvccnoCvcv", "CvccCvccCvcvno",
+					"CvcvnoCvccCvcc", "CvcvCvccnoCvcc", "CvcvCvccCvccno", "CvccnoCvcvCvcc", "CvccCvcvnoCvcc",
+					"CvccCvcvCvccno" },
+			"medium", new String[] { "CvcnoCvc", "CvcCvcno" }, "short", new String[] { "Cvcn" }, "basic",
+			new String[] { "aaanaaan", "aannaaan", "aaannaaa" }, "pin", new String[] { "nnnn" });
+
+	private static final Map<Character, String> TEMPLATE_CHARACTERS = Map.of('V', "AEIOU", 'C', "BCDFGHJKLMNPQRSTVWXYZ",
+			'v', "aeiou", 'c', "bcdfghjklmnpqrstvwxyz", 'A', "AEIOUBCDFGHJKLMNPQRSTVWXYZ", 'a',
+			"AEIOUaeiouBCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz", 'n', "0123456789", 'o', "@&%?,=[]_:-+*$#!'^~;()/.",
+			'x', "AEIOUaeiouBCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz0123456789!@#$%^&*()");
+
 	/**
-	 * Derives a password based on input parameters using a simple HMAC-SHA256 approach.
+	 * Derives a site password with the Master Password (MPW) algorithm, matching Sprig:
+	 * scrypt(masterPassword, seed+len(user)+user) -&gt; key, then HMAC-SHA256 over
+	 * seed+len(site)+site+counter selects a template and fills each class slot.
 	 */
 	private static Function derivePassword() {
 		return (args) -> {
-			if (args.length < 4) {
+			if (args.length < 5) {
 				return "";
 			}
-			long counter = (args[0] instanceof Number) ? ((Number) args[0]).longValue() : 1;
-			String context = String.valueOf(args[1]);
-			String masterPassword = String.valueOf(args[2]);
+			long counter = (args[0] instanceof Number) ? ((Number) args[0]).longValue() : 1L;
+			String passwordType = String.valueOf(args[1]);
+			String[] templates = PASSWORD_TYPE_TEMPLATES.get(passwordType);
+			if (templates == null) {
+				return "cannot find password template " + passwordType;
+			}
+			String password = String.valueOf(args[2]);
 			String user = String.valueOf(args[3]);
+			String site = String.valueOf(args[4]);
 			try {
-				String combined = counter + context + masterPassword + user;
+				byte[] seedBytes = MASTER_PASSWORD_SEED.getBytes(StandardCharsets.UTF_8);
+				byte[] userBytes = user.getBytes(StandardCharsets.UTF_8);
+				ByteArrayOutputStream salt = new ByteArrayOutputStream();
+				salt.writeBytes(seedBytes);
+				salt.writeBytes(beUint32(userBytes.length));
+				salt.writeBytes(userBytes);
+				byte[] key = SCrypt.generate(password.getBytes(StandardCharsets.UTF_8), salt.toByteArray(), 32768, 8, 2,
+						64);
+
+				byte[] siteBytes = site.getBytes(StandardCharsets.UTF_8);
+				ByteArrayOutputStream message = new ByteArrayOutputStream();
+				message.writeBytes(seedBytes);
+				message.writeBytes(beUint32(siteBytes.length));
+				message.writeBytes(siteBytes);
+				message.writeBytes(beUint32(counter));
+
 				Mac mac = Mac.getInstance("HmacSHA256");
-				SecretKeySpec key = new SecretKeySpec(masterPassword.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
-				mac.init(key);
-				byte[] raw = mac.doFinal(combined.getBytes(StandardCharsets.UTF_8));
-				return Hex.encodeHexString(raw).substring(0, 20);
+				mac.init(new SecretKeySpec(key, "HmacSHA256"));
+				byte[] seed = mac.doFinal(message.toByteArray());
+
+				// Go treats the HMAC bytes as unsigned when indexing (int(seed[i])).
+				String template = templates[(seed[0] & 0xFF) % templates.length];
+				StringBuilder out = new StringBuilder(template.length());
+				for (int i = 0; i < template.length(); i++) {
+					String passChars = TEMPLATE_CHARACTERS.get(template.charAt(i));
+					out.append(passChars.charAt((seed[i + 1] & 0xFF) % passChars.length()));
+				}
+				return out.toString();
 			}
 			catch (Exception ex) {
 				log.debug("derivePassword failed: {}", ex.getMessage());
 				return "";
 			}
 		};
+	}
+
+	// 4-byte big-endian encoding, matching Go's binary.Write(BigEndian, uint32(v)).
+	private static byte[] beUint32(long v) {
+		return new byte[] { (byte) (v >>> 24), (byte) (v >>> 16), (byte) (v >>> 8), (byte) v };
 	}
 
 	// ========== Key Generation ==========

--- a/jhelm-gotemplate-sprig/src/test/java/org/alexmond/gotmpl4j/sprig/functions/CryptoFunctionsTest.java
+++ b/jhelm-gotemplate-sprig/src/test/java/org/alexmond/gotmpl4j/sprig/functions/CryptoFunctionsTest.java
@@ -69,16 +69,17 @@ class CryptoFunctionsTest {
 
 	@Test
 	void testDerivePassword() throws IOException, TemplateException {
-		String result = exec("{{ derivePassword 1 \"long\" \"masterpass\" \"user\" }}");
-		assertNotNull(result);
-		assertFalse(result.isEmpty());
-		assertEquals(20, result.length());
+		// Master Password (MPW) algorithm: exact values match Sprig/upstream.
+		assertEquals("ZedaFaxcZaso9*", exec("{{ derivePassword 1 \"long\" \"password\" \"user\" \"example.com\" }}"));
+		assertEquals("pf4zS1LjCg&LjhsZ7T2~",
+				exec("{{ derivePassword 1 \"maximum\" \"password\" \"user\" \"example.com\" }}"));
+		assertEquals("6685", exec("{{ derivePassword 1 \"pin\" \"password\" \"user\" \"example.com\" }}"));
 	}
 
 	@Test
 	void testDerivePasswordDeterministic() throws IOException, TemplateException {
-		String result1 = exec("{{ derivePassword 1 \"long\" \"master\" \"user1\" }}");
-		String result2 = exec("{{ derivePassword 1 \"long\" \"master\" \"user1\" }}");
+		String result1 = exec("{{ derivePassword 1 \"long\" \"master\" \"user1\" \"site.example\" }}");
+		String result2 = exec("{{ derivePassword 1 \"long\" \"master\" \"user1\" \"site.example\" }}");
 		assertEquals(result1, result2);
 	}
 

--- a/jhelm-gotemplate-sprig/src/test/resources/conformance/sprig_known_divergences.txt
+++ b/jhelm-gotemplate-sprig/src/test/resources/conformance/sprig_known_divergences.txt
@@ -7,14 +7,6 @@
 # untitle: lowercase the first letter of EVERY word, not just the first.
 # compact / mustCompact: drop all empty values (0, "", nil, false), not just "".
 # mustHas: return false when the element is absent / list is nil, not an error.
-# derivePassword: implement the Master Password (MPW) algorithm, not a hash hex dump.
-e3tkZXJpdmVQYXNzd29yZCAxICJiYXNpYyIgInBhc3N3b3JkIiAidXNlciIgImV4YW1wbGUuY29tIn19  // derivePassword basic
-e3tkZXJpdmVQYXNzd29yZCAxICJsb25nIiAicGFzc3dvcmQiICJ1c2VyIiAiZXhhbXBsZS5jb20ifX0=  // derivePassword long
-e3tkZXJpdmVQYXNzd29yZCAxICJtYXhpbXVtIiAicGFzc3dvcmQiICJ1c2VyIiAiZXhhbXBsZS5jb20ifX0=  // derivePassword maximum
-e3tkZXJpdmVQYXNzd29yZCAxICJtZWRpdW0iICJwYXNzd29yZCIgInVzZXIiICJleGFtcGxlLmNvbSJ9fQ==  // derivePassword medium
-e3tkZXJpdmVQYXNzd29yZCAxICJwaW4iICJwYXNzd29yZCIgInVzZXIiICJleGFtcGxlLmNvbSJ9fQ==  // derivePassword pin
-e3tkZXJpdmVQYXNzd29yZCAxICJzaG9ydCIgInBhc3N3b3JkIiAidXNlciIgImV4YW1wbGUuY29tIn19  // derivePassword short
-e3tkZXJpdmVQYXNzd29yZCAyICJsb25nIiAicGFzc3dvcmQiICJ1c2VyIiAiZXhhbXBsZS5jb20ifX0=  // derivePassword long seed 2
 #
 # semver: (semver X).Compare piped needs a bound-method value. Our semver returns a
 # plain Map (keys Major/Minor/Patch/Prerelease/...), so `.Compare` resolves to a missing


### PR DESCRIPTION
## Summary

`derivePassword` was a placeholder that HMAC'd the inputs and hex-dumped 20 chars — it neither matched Sprig nor took the `site` argument. Replaced it with a faithful port of [Masterminds/sprig](https://github.com/Masterminds/sprig)'s **Master Password (MPW)** algorithm (Maarten Billemont's spec):

- `masterKey = scrypt(password, "com.lyndir.masterpassword" + BE32(len user) + user, N=32768, r=8, p=2, dkLen=64)` — via BouncyCastle `SCrypt` (already on the classpath through `bcprov`);
- `seed = HMAC-SHA256(masterKey, "com.lyndir.masterpassword" + BE32(len site) + site + BE32(counter))`;
- `template = passwordTypeTemplates[type][seed[0] % n]`, then each class char `c` maps via `templateCharacters[c][seed[i+1] % len]`.

HMAC bytes are masked `& 0xFF` before the modulo to match Go's unsigned `int(seed[i])` indexing. The full template and character-class tables are ported verbatim, and the signature is now the Sprig 5-arg form `(counter, type, password, user, site)`.

## Verified against Sprig's own `crypto_test.go`

| call | output |
|---|---|
| `derivePassword 1 "long" "password" "user" "example.com"` | `ZedaFaxcZaso9*` |
| `derivePassword 2 "long" …` | `Fovi2@JifpTupx` |
| `derivePassword 1 "maximum" …` | `pf4zS1LjCg&LjhsZ7T2~` |
| `derivePassword 1 "medium" …` | `ZedJuz8$` |
| `derivePassword 1 "basic" …` | `pIS54PLs` |
| `derivePassword 1 "short" …` | `Zed5` |
| `derivePassword 1 "pin" …` | `6685` |

## Tests

- Unpins the seven `derivePassword` cases from `sprig_known_divergences.txt` — **clearing the last #474 bug-backlog item**.
- Updated `CryptoFunctionsTest` (had asserted the old 4-arg hex-dump shape) to the real 5-arg values.
- **545 sprig tests green**; **346/346 chart parity gate green**; 0 PMD/Checkstyle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)