### PR TITLE
Recategorize conformance divergences: only engine-level pins remain

### DIFF
--- a/jhelm-gotemplate-sprig/src/test/resources/conformance/sprig_known_divergences.txt
+++ b/jhelm-gotemplate-sprig/src/test/resources/conformance/sprig_known_divergences.txt
@@ -1,28 +1,30 @@
-# Known gotmpl4j-sprig divergences from Masterminds/sprig, found by SprigConformanceTest.
-# Format: <base64 template>  // <description>.  Each line is excluded from the conformance
-# assertion. Most are real gotmpl4j-sprig bugs to fix incrementally (tracking issue #474);
-# a few are intended (Helm nil-rendering "" vs Go "<no value>", and a float-ulp edge).
+# Known divergences from Masterminds/sprig, excluded from the SprigConformanceTest assertion.
+# Format: <base64 template>  // <description>. Each base64 line is excluded.
 #
-# --- BUGS (to fix) ---
-# untitle: lowercase the first letter of EVERY word, not just the first.
-# compact / mustCompact: drop all empty values (0, "", nil, false), not just "".
-# mustHas: return false when the element is absent / list is nil, not an error.
+# STATUS: every Sprig *function* divergence from the conformance grind is fixed (958/967
+# cases assert clean). The 9 pins below are NOT function bugs — they are gotmpl4j-core
+# ENGINE behaviors that merely surface through Sprig cases, tracked in the gotmpl4j repo.
 #
-# semver: (semver X).Compare piped needs a bound-method value. Our semver returns a
-# plain Map (keys Major/Minor/Patch/Prerelease/...), so `.Compare` resolves to a missing
-# key -> nil -> "". Supporting it needs an object wrapper exposing a reflective
-# Compare(other) plus engine method-value support; no chart uses this form.
+# --- ENGINE: nil renders as "" instead of Go's "<no value>" (gotmpl4j#13) ---
+# Helm renders a nil/absent value as "" (missingkey=zero); Go's text/template renders
+# "<no value>". first/last/mustFirst/mustLast on an empty list, and coalesce of nothing,
+# all yield nil. The faithful fix is an engine missingkey mode (Go "<no value>" default +
+# an opt-in empty-on-nil mode for Helm) — flipping it unconditionally would break Helm's
+# 346-chart byte-parity, so it is an engine-design change, not a sprig fix.
+e3sgbGlzdCB8IGZpcnN0IH19  // {{ list | first }} want=<no value> got=  (empty list -> nil -> "")
+e3sgbGlzdCB8IGxhc3QgfX0=  // {{ list | last }} want=<no value> got=
+e3sgbGlzdCB8IG11c3RGaXJzdCB9fQ==  // {{ list | mustFirst }} want=<no value> got=  (returns nil, not an error)
+e3sgbGlzdCB8IG11c3RMYXN0IH19  // {{ list | mustLast }} want=<no value> got=
+e3sgY29hbGVzY2UgfX0=  // {{ coalesce }} want=<no value> got=
+#
+# --- ENGINE: no bound-method values in pipelines (gotmpl4j#1) ---
+# `(semver X).Compare` piped needs a bound-method value; our semver returns a plain Map, so
+# `.Compare` resolves to a missing key -> nil -> "". No chart uses this form.
 e3sgc2VtdmVyICIxLjIuMyIgfCAoc2VtdmVyICIxLjIuMyIpLkNvbXBhcmUgfX0=  // {{ semver "1.2.3" | (semver "1.2.3").Compare }} want=0 got=
 e3sgc2VtdmVyICIxLjIuMyIgfCAoc2VtdmVyICIxLjMuMyIpLkNvbXBhcmUgfX0=  // {{ semver "1.2.3" | (semver "1.3.3").Compare }} want=1 got=
 e3sgc2VtdmVyICIxLjQuMyIgfCAoc2VtdmVyICIxLjIuMyIpLkNvbXBhcmUgfX0=  // {{ semver "1.4.3" | (semver "1.2.3").Compare }} want=-1 got=
 #
-# --- INTENDED (Helm semantics / float edge; not bugs) ---
-# Helm renders a nil/absent value as "" (missingkey=zero), not Go's "<no value>" (cf. #431).
-# (first/last/mustFirst/mustLast on an empty list, and coalesce of nothing, all return nil.)
-e3sgbGlzdCB8IGZpcnN0IH19  // {{ list | first }} want=<no value> got=  (empty list -> nil -> "")
-e3sgbGlzdCB8IGxhc3QgfX0=  // {{ list | last }} want=<no value> got=
-e3sgbGlzdCB8IG11c3RGaXJzdCB9fQ==  // {{ list | mustFirst }} want=<no value> got=  (now returns nil, not an error)
-e3sgbGlzdCB8IG11c3RMYXN0IH19  // {{ list | mustLast }} want=<no value> got=
-e3sgY29hbGVzY2UgfX0=  // {{ coalesce }} want=<no value> got=
-# Sub-ulp float-accumulation: 2.4*10*4*1.2 = 115.19999999999999 (Java shortest); Go prints 115.2.
+# --- ENGINE: float compute-order ulp (wontfix edge) ---
+# 2.4*10*4*1.2 lands on a different IEEE-754 double in the JVM (115.19999999999999, Java's
+# shortest round-trip) than in Go (115.2). A single arithmetic-ordering edge.
 e3sgMS4yIHwgbXVsZiAiMi40IiAxMCAiNCJ9fQ==  // {{ 1.2 | mulf "2.4" 10 "4"}} want=115.2 got=115.19999999999999


### PR DESCRIPTION
Sprig-function conformance is complete (958/967 assert clean). The 9 remaining pins are gotmpl4j-core **engine** behaviors, not function bugs: nil→`""` vs `<no value>` (gotmpl4j#13, 5), bound-method values (gotmpl4j#1, 3), float ulp (1). Rewrote the divergences file to group them by root cause and dropped the stale untitle/compact/mustHas comments. Conformance stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)