### PR TITLE
Migrate to gotmpl4j 0.3.0 with missingkey=zero (Helm nil rendering)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -167,8 +167,9 @@ public class Engine {
 	private String doRender(Chart chart, Map<String, Object> values, Map<String, Object> releaseInfo) {
 		namedTemplates.clear();
 		templateVersions.clear();
-		// Create a new template for each render to avoid accumulation
-		this.factory = new GoTemplate();
+		// Create a new template for each render to avoid accumulation. Helm renders a
+		// nil/absent value as "" (missingkey=zero), not Go's "<no value>".
+		this.factory = new GoTemplate().option("missingkey=zero");
 
 		// Apply aliases from dependency metadata before collecting templates, so that
 		// subchart .Chart.Name and template registration keys use the alias consistently.

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctions.java
@@ -119,7 +119,8 @@ public final class TemplateFunctions {
 	 * @return the rendered output
 	 */
 	private static String renderInline(GoTemplate factory, String text, Object data) throws Exception {
-		GoTemplate tplTemplate = new GoTemplate(factory.getFunctions());
+		// Match Helm's missingkey=zero: a nil/absent value renders "" inside tpl too.
+		GoTemplate tplTemplate = new GoTemplate(factory.getFunctions()).option("missingkey=zero");
 		tplTemplate.getRootNodes().putAll(factory.getRootNodes());
 		tplTemplate.parse("inline", text);
 		for (var entry : tplTemplate.getRootNodes().entrySet()) {

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
              dedicated CI job (see .github/workflows/parity.yml). Override with
              -Dsurefire.excludedGroups= -Dgroups=comparison to run only the parity suite. -->
         <surefire.excludedGroups>comparison</surefire.excludedGroups>
-        <gotmpl4j.version>0.1.0</gotmpl4j.version>
+        <gotmpl4j.version>0.3.0</gotmpl4j.version>
         <kubernetes-client.version>25.0.0</kubernetes-client.version>
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>


### PR DESCRIPTION
gotmpl4j **0.3.0** adds a `MissingKeyMode` option (resolves gotmpl4j#37): nil/absent values render Go's `<no value>` by default, or `""` with `missingkey=zero`. jhelm sets **`option("missingkey=zero")`** on both the render engine (`Engine`) and the `tpl` function (`TemplateFunctions`) so a nil/missing value renders `""` exactly as Helm does — the behavior 0.1.0 had, which 0.2.0's unconditional `<no value>` change (gotmpl4j#13) had broken.

## Free correctness fixes from 0.3.0
The closed-issue sweep verified each of these matches Helm v3.19, so migrating *improves* parity:
- `and`/`or` short-circuit evaluation (#11)
- map-range key ordering (#12)
- char / large-integer literal parsing (#14)
- `trimAll` character-class (#16)
- `replace` backslash handling (#17)

(The crypto / HTML-mode / recursion-guard / starter / CI fixes have no jhelm rendering impact.)

## Verification
- `helm: x: []` and `jhelm: x: []` for `{{ .Values.missing }}` (nil restored).
- **346/346 chart parity** passes; 499 jhelm-core tests green; 0 PMD/Checkstyle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)