### PR TITLE
feat(gotemplate-helm): Helm funcs conformance — duration helpers + from* errors (#490 buckets 1–2)

### DIFF
--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/HelmFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/HelmFunctions.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.alexmond.gotmpl4j.Function;
 import org.alexmond.gotmpl4j.GoTemplate;
 import org.alexmond.jhelm.gotemplate.helm.functions.ConversionFunctions;
+import org.alexmond.jhelm.gotemplate.helm.functions.DurationFunctions;
 import org.alexmond.jhelm.gotemplate.helm.functions.KubernetesFunctions;
 import org.alexmond.jhelm.gotemplate.helm.functions.KubernetesProvider;
 import org.alexmond.jhelm.gotemplate.helm.functions.TemplateFunctions;
@@ -39,6 +40,9 @@ public final class HelmFunctions {
 		// YAML/JSON conversion (toYaml, toJson, fromYaml, fromJson, and must* variants)
 		functions.putAll(ConversionFunctions.getFunctions());
 
+		// Helm 4 duration helpers (durationSeconds, durationRoundTo, mustToDuration, …)
+		functions.putAll(DurationFunctions.getFunctions());
+
 		// Kubernetes operations (lookup, kubeVersion) - with provider
 		functions.putAll(KubernetesFunctions.getFunctions(kubernetesProvider));
 
@@ -66,6 +70,11 @@ public final class HelmFunctions {
 
 		categories.put("Conversion", List.of("toYaml", "toJson", "fromYaml", "fromJson", "fromYamlArray", "toToml",
 				"fromToml", "mustToYaml", "mustToJson", "mustFromYaml", "mustFromJson", "mustToToml", "mustFromToml"));
+
+		categories.put("Duration",
+				List.of("mustToDuration", "durationSeconds", "durationMinutes", "durationHours", "durationDays",
+						"durationWeeks", "durationMilliseconds", "durationMicroseconds", "durationNanoseconds",
+						"durationRoundTo", "durationTruncateTo"));
 
 		categories.put("Kubernetes", List.of("lookup", "kubeVersion"));
 

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -279,6 +279,64 @@ public final class ConversionFunctions {
 	}
 
 	/**
+	 * Wrap an error message the way Helm's {@code from*} map functions do: a single-entry
+	 * map under the {@code Error} key, which renders as {@code map[Error:<message>]}.
+	 */
+	private static Map<String, Object> errorMap(String message) {
+		Map<String, Object> error = new LinkedHashMap<>();
+		error.put("Error", message);
+		return error;
+	}
+
+	/**
+	 * Wrap an error message the way Helm's {@code from*Array} functions do: a
+	 * single-element list, which renders as {@code [<message>]}.
+	 */
+	private static List<Object> errorList(String message) {
+		return List.of(message);
+	}
+
+	/**
+	 * Build the Go {@code json.Unmarshal} type-mismatch message Helm surfaces when a
+	 * {@code from*} function is handed valid input of the wrong shape. The JSON variant
+	 * is the bare {@code encoding/json} message; the YAML variant carries the
+	 * {@code sigs.k8s.io/yaml} wrapper ({@code "error unmarshaling JSON: while decoding
+	 * JSON: ..."}) because Helm's {@code fromYaml}/{@code fromYamlArray} round-trip YAML
+	 * through JSON.
+	 * @param value the value that was actually parsed (its kind drives the message)
+	 * @param yaml {@code true} for the YAML functions, {@code false} for the JSON
+	 * functions
+	 * @param wantMap {@code true} when a map was expected, {@code false} for a list
+	 * @return the Go error string
+	 */
+	private static String goUnmarshalMessage(Object value, boolean yaml, boolean wantMap) {
+		String wantType = wantMap ? "map[string]interface {}" : "[]interface {}";
+		String base = "json: cannot unmarshal " + goJsonKind(value) + " into Go value of type " + wantType;
+		return yaml ? "error unmarshaling JSON: while decoding JSON: " + base : base;
+	}
+
+	/**
+	 * The Go {@code encoding/json} name for a decoded value's kind, as it appears in an
+	 * unmarshal error ({@code array}, {@code object}, {@code string}, {@code number},
+	 * {@code bool}).
+	 */
+	private static String goJsonKind(Object value) {
+		if (value instanceof List) {
+			return "array";
+		}
+		if (value instanceof Map) {
+			return "object";
+		}
+		if (value instanceof Boolean) {
+			return "bool";
+		}
+		if (value instanceof Number) {
+			return "number";
+		}
+		return "string";
+	}
+
+	/**
 	 * fromYaml parses YAML string to object Returns empty map on error
 	 */
 	private static Function fromYaml() {
@@ -292,7 +350,18 @@ public final class ConversionFunctions {
 					return new LinkedHashMap<>();
 				}
 				Object result = loadFirstYamlDocument(yaml);
-				return (result instanceof Map<?, ?> map) ? map : new LinkedHashMap<>();
+				if (result == null) {
+					return new LinkedHashMap<>();
+				}
+				if (result instanceof Map<?, ?> map) {
+					return map;
+				}
+				// Valid YAML of the wrong shape (e.g. a sequence): Helm's fromYaml runs
+				// it
+				// through sigs.k8s.io/yaml (YAML -> JSON -> json.Unmarshal into a map)
+				// and
+				// returns map[Error:<the JSON unmarshal error>], not an empty map.
+				return errorMap(goUnmarshalMessage(result, true, true));
 			}
 			catch (Exception ex) {
 				// Match Helm's fromYaml, which surfaces a parse failure under an "Error"
@@ -302,9 +371,7 @@ public final class ConversionFunctions {
 				// empty map hides real bugs (it wiped bitnami/grafana-mimir's whole
 				// config).
 				log.debug("fromYaml failed: {}", ex.getMessage());
-				Map<String, Object> error = new LinkedHashMap<>();
-				error.put("Error", ex.getMessage());
-				return error;
+				return errorMap(ex.getMessage());
 			}
 		};
 	}
@@ -352,7 +419,15 @@ public final class ConversionFunctions {
 					return Collections.emptyList();
 				}
 				Object result = loadFirstYamlDocument(yaml);
-				return (result instanceof List<?> list) ? list : Collections.emptyList();
+				if (result == null) {
+					return Collections.emptyList();
+				}
+				if (result instanceof List<?> list) {
+					return list;
+				}
+				// Valid YAML of the wrong shape (e.g. a mapping): Helm returns
+				// [<the JSON unmarshal error>], not an empty list.
+				return errorList(goUnmarshalMessage(result, true, false));
 			}
 			catch (Exception ex) {
 				// Match Helm's fromYamlArray, which returns [err.Error()] on a parse
@@ -534,7 +609,13 @@ public final class ConversionFunctions {
 				if (json.isBlank() || "null".equals(json)) {
 					return Map.of();
 				}
-				return JSON_MAPPER.get().readValue(json, Map.class);
+				Object result = JSON_MAPPER.get().readValue(json, Object.class);
+				if (result instanceof Map<?, ?> map) {
+					return map;
+				}
+				// Valid JSON of the wrong shape (e.g. an array): Helm returns
+				// map[Error:<the json.Unmarshal error>], not an empty map.
+				return errorMap(goUnmarshalMessage(result, false, true));
 			}
 			catch (Exception ex) {
 				log.debug("fromJson failed: {}", ex.getMessage());
@@ -581,7 +662,13 @@ public final class ConversionFunctions {
 				if (json.isBlank() || "null".equals(json)) {
 					return Collections.emptyList();
 				}
-				return JSON_MAPPER.get().readValue(json, List.class);
+				Object result = JSON_MAPPER.get().readValue(json, Object.class);
+				if (result instanceof List<?> list) {
+					return list;
+				}
+				// Valid JSON of the wrong shape (e.g. an object): Helm returns
+				// [<the json.Unmarshal error>], not an empty list.
+				return errorList(goUnmarshalMessage(result, false, false));
 			}
 			catch (Exception ex) {
 				log.debug("fromJsonArray failed: {}", ex.getMessage());

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/DurationFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/DurationFunctions.java
@@ -1,0 +1,277 @@
+package org.alexmond.jhelm.gotemplate.helm.functions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.alexmond.gotmpl4j.Function;
+import org.alexmond.gotmpl4j.FunctionExecutionException;
+
+/**
+ * Helm 4 duration helper functions, ported from {@code pkg/engine/funcs.go}.
+ * <p>
+ * Every helper coerces its argument to a {@code time.Duration} (nanoseconds) the way Helm
+ * does: a number is taken as <em>seconds</em>; a string is parsed first as a Go duration
+ * ({@code "1m30s"}, {@code "90s"}, {@code "36h"}) and, failing that, as a floating-point
+ * number of seconds ({@code "2.5"}); anything unparseable becomes the zero duration (the
+ * {@code must} variant errors instead). The component accessors ({@code durationSeconds},
+ * {@code durationMinutes}, …) return Go's {@code float64}/{@code int64} component values,
+ * and {@code mustToDuration}/{@code durationRoundTo}/{@code durationTruncateTo} render
+ * Go's {@code time.Duration.String()} form.
+ */
+public final class DurationFunctions {
+
+	private static final long NANOS_PER_SECOND = 1_000_000_000L;
+
+	private static final long NANOS_PER_MINUTE = 60L * NANOS_PER_SECOND;
+
+	private static final long NANOS_PER_HOUR = 60L * NANOS_PER_MINUTE;
+
+	private static final Map<String, Long> UNIT_NANOS = Map.of("ns", 1L, "us", 1_000L, "µs", 1_000L, "ms", 1_000_000L,
+			"s", NANOS_PER_SECOND, "m", NANOS_PER_MINUTE, "h", NANOS_PER_HOUR);
+
+	private DurationFunctions() {
+	}
+
+	/**
+	 * Get the Helm 4 duration helper functions.
+	 * @return map of function name to implementation
+	 */
+	public static Map<String, Function> getFunctions() {
+		Map<String, Function> functions = new HashMap<>();
+
+		functions.put("mustToDuration", (args) -> goDurationString(toDurationStrict(arg(args, 0))));
+
+		functions.put("durationSeconds", (args) -> (double) toDurationLenient(arg(args, 0)) / NANOS_PER_SECOND);
+		functions.put("durationMinutes", (args) -> (double) toDurationLenient(arg(args, 0)) / NANOS_PER_MINUTE);
+		functions.put("durationHours", (args) -> (double) toDurationLenient(arg(args, 0)) / NANOS_PER_HOUR);
+		functions.put("durationDays", (args) -> (double) toDurationLenient(arg(args, 0)) / (24L * NANOS_PER_HOUR));
+		functions.put("durationWeeks",
+				(args) -> (double) toDurationLenient(arg(args, 0)) / (7L * 24L * NANOS_PER_HOUR));
+
+		functions.put("durationMilliseconds", (args) -> toDurationLenient(arg(args, 0)) / 1_000_000L);
+		functions.put("durationMicroseconds", (args) -> toDurationLenient(arg(args, 0)) / 1_000L);
+		functions.put("durationNanoseconds", (args) -> toDurationLenient(arg(args, 0)));
+
+		functions.put("durationRoundTo", (args) -> goDurationString(
+				roundDuration(toDurationLenient(arg(args, 0)), toDurationLenient(arg(args, 1)))));
+		functions.put("durationTruncateTo", (args) -> goDurationString(
+				truncateDuration(toDurationLenient(arg(args, 0)), toDurationLenient(arg(args, 1)))));
+
+		return functions;
+	}
+
+	private static Object arg(Object[] args, int index) {
+		return (args != null && args.length > index) ? args[index] : null;
+	}
+
+	/**
+	 * Coerce to nanoseconds, returning the zero duration on any parse failure (the
+	 * lenient {@code duration*} accessors).
+	 */
+	private static long toDurationLenient(Object value) {
+		Long nanos = toDurationOrNull(value);
+		return (nanos != null) ? nanos : 0L;
+	}
+
+	/**
+	 * Coerce to nanoseconds, throwing on a parse failure ({@code mustToDuration}).
+	 */
+	private static long toDurationStrict(Object value) {
+		Long nanos = toDurationOrNull(value);
+		if (nanos == null) {
+			throw new FunctionExecutionException("mustToDuration: cannot parse duration: " + value);
+		}
+		return nanos;
+	}
+
+	private static Long toDurationOrNull(Object value) {
+		if (value instanceof Number num) {
+			return Math.round(num.doubleValue() * NANOS_PER_SECOND);
+		}
+		if (value instanceof String str) {
+			String trimmed = str.trim();
+			Long parsed = parseGoDuration(trimmed);
+			if (parsed != null) {
+				return parsed;
+			}
+			try {
+				return Math.round(Double.parseDouble(trimmed) * NANOS_PER_SECOND);
+			}
+			catch (NumberFormatException ex) {
+				return null;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Parse a Go {@code time.ParseDuration} string (e.g. {@code "1m30s"}). Returns the
+	 * duration in nanoseconds, or {@code null} if the input is not a valid Go duration (a
+	 * bare number such as {@code "2.5"} has no unit and so returns {@code null}, leaving
+	 * the caller to try a float-seconds parse).
+	 */
+	private static Long parseGoDuration(String s) {
+		if (s.isEmpty()) {
+			return null;
+		}
+		boolean negative = false;
+		int i = 0;
+		char first = s.charAt(0);
+		if (first == '+' || first == '-') {
+			negative = first == '-';
+			i = 1;
+		}
+		if (s.substring(i).equals("0")) {
+			return 0L;
+		}
+		double nanos = 0;
+		boolean sawUnit = false;
+		while (i < s.length()) {
+			int numStart = i;
+			while (i < s.length() && (Character.isDigit(s.charAt(i)) || s.charAt(i) == '.')) {
+				i++;
+			}
+			if (i == numStart) {
+				return null;
+			}
+			double magnitude;
+			try {
+				magnitude = Double.parseDouble(s.substring(numStart, i));
+			}
+			catch (NumberFormatException ex) {
+				return null;
+			}
+			int unitStart = i;
+			while (i < s.length() && !Character.isDigit(s.charAt(i)) && s.charAt(i) != '.') {
+				i++;
+			}
+			if (i == unitStart) {
+				return null;
+			}
+			Long unit = UNIT_NANOS.get(s.substring(unitStart, i));
+			if (unit == null) {
+				return null;
+			}
+			nanos += magnitude * unit;
+			sawUnit = true;
+		}
+		if (!sawUnit) {
+			return null;
+		}
+		long result = Math.round(nanos);
+		return negative ? -result : result;
+	}
+
+	/**
+	 * Round to the nearest multiple of {@code m}, matching Go's {@code Duration.Round}
+	 * (ties away from zero; a non-positive {@code m} returns {@code d} unchanged).
+	 */
+	static long roundDuration(long d, long m) {
+		if (m <= 0) {
+			return d;
+		}
+		long r = d % m;
+		if (r + r < m) {
+			return d - r;
+		}
+		return d + m - r;
+	}
+
+	/**
+	 * Truncate toward zero to a multiple of {@code m}, matching Go's
+	 * {@code Duration.Truncate} (a non-positive {@code m} returns {@code d} unchanged).
+	 */
+	static long truncateDuration(long d, long m) {
+		if (m <= 0) {
+			return d;
+		}
+		return d - d % m;
+	}
+
+	/**
+	 * Render nanoseconds the way Go's {@code time.Duration.String()} does (e.g.
+	 * {@code 90s ->
+	 * "1m30s"}, {@code 0 -> "0s"}). Ported from the Go runtime.
+	 */
+	static String goDurationString(long d) {
+		char[] buf = new char[32];
+		int w = buf.length;
+		boolean negative = d < 0;
+		long u = negative ? -d : d;
+		if (u < NANOS_PER_SECOND) {
+			buf[--w] = 's';
+			w--;
+			if (u == 0) {
+				return "0s";
+			}
+			int prec;
+			if (u < 1_000L) {
+				prec = 0;
+				buf[w] = 'n';
+			}
+			else if (u < 1_000_000L) {
+				prec = 3;
+				buf[w] = 'µ';
+			}
+			else {
+				prec = 6;
+				buf[w] = 'm';
+			}
+			long[] holder = { u };
+			w = fmtFrac(buf, w, holder, prec);
+			w = fmtInt(buf, w, holder[0]);
+		}
+		else {
+			buf[--w] = 's';
+			long[] holder = { u };
+			w = fmtFrac(buf, w, holder, 9);
+			w = fmtInt(buf, w, holder[0] % 60);
+			long rem = holder[0] / 60;
+			if (rem > 0) {
+				buf[--w] = 'm';
+				w = fmtInt(buf, w, rem % 60);
+				rem /= 60;
+				if (rem > 0) {
+					buf[--w] = 'h';
+					w = fmtInt(buf, w, rem);
+				}
+			}
+		}
+		if (negative) {
+			buf[--w] = '-';
+		}
+		return new String(buf, w, buf.length - w);
+	}
+
+	private static int fmtFrac(char[] buf, int w, long[] holder, int prec) {
+		long v = holder[0];
+		boolean print = false;
+		for (int i = 0; i < prec; i++) {
+			long digit = v % 10;
+			print = print || digit != 0;
+			if (print) {
+				buf[--w] = (char) ('0' + digit);
+			}
+			v /= 10;
+		}
+		if (print) {
+			buf[--w] = '.';
+		}
+		holder[0] = v;
+		return w;
+	}
+
+	private static int fmtInt(char[] buf, int w, long v) {
+		if (v == 0) {
+			buf[--w] = '0';
+		}
+		else {
+			while (v > 0) {
+				buf[--w] = (char) ('0' + v % 10);
+				v /= 10;
+			}
+		}
+		return w;
+	}
+
+}

--- a/jhelm-gotemplate-helm/src/test/resources/conformance/helm_known_divergences.txt
+++ b/jhelm-gotemplate-helm/src/test/resources/conformance/helm_known_divergences.txt
@@ -3,43 +3,12 @@
 # (keyed on data too, since e.g. fromYaml passes on valid input and diverges on bad input).
 #
 # Three buckets, all tracked for incremental fixing:
-#  1. Helm-4 duration helpers not yet implemented (durationSeconds/Days/.../RoundTo/
-#     TruncateTo, mustToDuration) -> parser errors on the unknown functions.
+#  1. (fixed) Helm-4 duration helpers (durationSeconds/Days/.../RoundTo/TruncateTo,
+#     mustToDuration) are now implemented in DurationFunctions.
 #  2. from* return empty on bad input; Helm returns map[Error:<go message>] / [<error>].
 #  3. toToml nested maps: Jackson emits dotted keys (mast.sail=...) vs Helm's [mast] tables.
 #     (Flat-map single-quote vs double-quote was fixed; nested-table structure remains.)
 #
-# --- bucket 1: duration helpers (unimplemented) ---
-e3sgbXVzdFRvRHVyYXRpb24gMzAgfX0=	bnVsbA==
-e3sgbXVzdFRvRHVyYXRpb24gIjFtMzBzIiB9fQ==	bnVsbA==
-e3sgZHVyYXRpb25TZWNvbmRzICIxbTMwcyIgfX0=	bnVsbA==
-e3sgZHVyYXRpb25TZWNvbmRzICIyLjUiIH19	bnVsbA==
-e3sgZHVyYXRpb25TZWNvbmRzICIgIDIuNSAgIiB9fQ==	bnVsbA==
-e3sgZHVyYXRpb25TZWNvbmRzIDIgfX0=	bnVsbA==
-e3sgZHVyYXRpb25TZWNvbmRzIDIuNSB9fQ==	bnVsbA==
-e3sgZHVyYXRpb25TZWNvbmRzIC4gfX0=	Mg==
-e3sgZHVyYXRpb25TZWNvbmRzICJub3BlIiB9fQ==	bnVsbA==
-e3sgZHVyYXRpb25TZWNvbmRzICIiIH19	bnVsbA==
-e3sgZHVyYXRpb25TZWNvbmRzICIgICAiIH19	bnVsbA==
-e3sgZHVyYXRpb25TZWNvbmRzIC4gfX0=	bnVsbA==
-e3sgZHVyYXRpb25NaWxsaXNlY29uZHMgMiB9fQ==	bnVsbA==
-e3sgZHVyYXRpb25NaWxsaXNlY29uZHMgMS41IH19	bnVsbA==
-e3sgZHVyYXRpb25NaWNyb3NlY29uZHMgMiB9fQ==	bnVsbA==
-e3sgZHVyYXRpb25OYW5vc2Vjb25kcyAyIH19	bnVsbA==
-e3sgZHVyYXRpb25NaW51dGVzICI5MHMiIH19	bnVsbA==
-e3sgZHVyYXRpb25Ib3VycyAiOTBtIiB9fQ==	bnVsbA==
-e3sgZHVyYXRpb25EYXlzICIzNmgiIH19	bnVsbA==
-e3sgZHVyYXRpb25EYXlzIDg2NDAwIH19	bnVsbA==
-e3sgZHVyYXRpb25XZWVrcyAiMTY4aCIgfX0=	bnVsbA==
-e3sgZHVyYXRpb25XZWVrcyAiMjUyaCIgfX0=	bnVsbA==
-e3sgZHVyYXRpb25Sb3VuZFRvIDkzIDYwIH19	bnVsbA==
-e3sgZHVyYXRpb25UcnVuY2F0ZVRvIDkzIDYwIH19	bnVsbA==
-e3sgZHVyYXRpb25Sb3VuZFRvICI5M3MiICIxbSIgfX0=	bnVsbA==
-e3sgZHVyYXRpb25UcnVuY2F0ZVRvICI5M3MiICIxbSIgfX0=	bnVsbA==
-e3sgZHVyYXRpb25Sb3VuZFRvICI5M3MiICJub3BlIiB9fQ==	bnVsbA==
-e3sgZHVyYXRpb25UcnVuY2F0ZVRvICI5M3MiICJub3BlIiB9fQ==	bnVsbA==
-e3sgZHVyYXRpb25Sb3VuZFRvICI5M3MiIDAgfX0=	bnVsbA==
-e3sgZHVyYXRpb25UcnVuY2F0ZVRvICI5M3MiIC0xIH19	bnVsbA==
 #
 # --- bucket 2: from* error format ---
 e3sgZnJvbVRvbWwgLiB9fQ==	Im9uZSI=

--- a/jhelm-gotemplate-helm/src/test/resources/conformance/helm_known_divergences.txt
+++ b/jhelm-gotemplate-helm/src/test/resources/conformance/helm_known_divergences.txt
@@ -5,18 +5,17 @@
 # Three buckets, all tracked for incremental fixing:
 #  1. (fixed) Helm-4 duration helpers (durationSeconds/Days/.../RoundTo/TruncateTo,
 #     mustToDuration) are now implemented in DurationFunctions.
-#  2. from* return empty on bad input; Helm returns map[Error:<go message>] / [<error>].
+#  2. (mostly fixed) from* now return Helm's map[Error:<go message>] / [<error>] on
+#     wrong-shape input (the deterministic json.Unmarshal type-mismatch messages). The one
+#     case left is a true parser *syntax* error — fromToml "one" -> BurntSushi's
+#     "toml: line 1: unexpected EOF; expected key separator '='" — whose exact wording a
+#     Jackson-based parser can't reproduce without overfitting.
 #  3. toToml nested maps: Jackson emits dotted keys (mast.sail=...) vs Helm's [mast] tables.
 #     (Flat-map single-quote vs double-quote was fixed; nested-table structure remains.)
 #
 #
-# --- bucket 2: from* error format ---
+# --- bucket 2: from* error format (only the fromToml syntax-error case remains) ---
 e3sgZnJvbVRvbWwgLiB9fQ==	Im9uZSI=
-e3sgZnJvbVlhbWwgLiB9fQ==	Ii0gb25lXG4tIHR3b1xuIg==
-e3sgZnJvbUpzb24gLiB9fQ==	IltcIm9uZVwiLCBcInR3b1wiXSI=
-e3sgZnJvbUpzb25BcnJheSAuIH19	IntcImhlbGxvXCI6IFwid29ybGRcIn0i
-e3sgZnJvbVlhbWwgLiB9fQ==	IltcIm9uZVwiLCBcInR3b1wiXSI=
-e3sgZnJvbVlhbWxBcnJheSAuIH19	ImhlbGxvOiB3b3JsZCI=
 #
 # --- bucket 3: toToml nested tables ---
 e3sgdG9Ub21sIC4gfX0=	eyJtYXN0Ijp7InNhaWwiOiJ3aGl0ZSJ9fQ==


### PR DESCRIPTION
Closes the bulk of **#490** — the `HelmConformanceTest` (ported from Helm's `pkg/engine/funcs_test.go`) backlog drops from **37 divergences to 2**.

## Bucket 1 — Helm 4 duration helpers (30 cases)
New `DurationFunctions` registering 11 helpers: `mustToDuration`, `durationSeconds`/`Minutes`/`Hours`/`Days`/`Weeks`, `durationMilliseconds`/`Microseconds`/`Nanoseconds`, `durationRoundTo`, `durationTruncateTo`. Faithful ports of Go's `funcs.go` + `time.Duration`:
- arg coercion — number → seconds; string → Go duration (`"1m30s"`) then float-seconds (`"2.5"`); unparseable → zero (`must*` errors)
- `Duration.Round` / `Duration.Truncate` (ties away from zero; non-positive modulus is a no-op)
- `Duration.String()` port (`90s → "1m30s"`, `0 → "0s"`)

## Bucket 2 — `from*` error format (5 cases)
`fromJson`/`fromYaml` (map) and `fromJsonArray`/`fromYamlArray` (list) silently returned an empty container on valid input of the wrong shape. Helm returns Go's `json.Unmarshal` type-mismatch error: `map[Error:<msg>]` / `[<msg>]`. These messages are deterministic in (got-kind, want-kind) — the JSON functions use the bare `encoding/json` message, the YAML functions carry the `sigs.k8s.io/yaml` wrapper since Helm round-trips YAML through JSON.

## Remaining (2 divergences, documented in `helm_known_divergences.txt`)
- `fromToml "one"` — a true parser *syntax* error; BurntSushi's exact wording isn't reproducible from Jackson without overfitting.
- `toToml` nested maps — Jackson emits dotted keys vs Helm's `[table]` headers; needs a custom TOML emitter (deferred — risky to the working flat-map path).

## Verification
- `jhelm-gotemplate-helm` verify green — 129 tests, spring-javaformat / PMD / Checkstyle
- **346/346** chart byte-parity unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)