### PR TITLE
fix(gotemplate-helm): toToml emits Go BurntSushi-style tables (#490 bucket 3)

### DIFF
--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -710,7 +710,9 @@ public final class ConversionFunctions {
 				return "";
 			}
 			try {
-				return tomlToGoStyle(TOML_MAPPER.get().writeValueAsString(args[0]));
+				// Match Helm's toToml, which encodes via Go's BurntSushi/toml (table
+				// headers, sorted keys), not Jackson's dotted-key output.
+				return TomlWriter.write(args[0]);
 			}
 			catch (Exception ex) {
 				log.debug("toToml failed: {}", ex.getMessage());
@@ -725,34 +727,12 @@ public final class ConversionFunctions {
 				throw new FunctionExecutionException("mustToToml: no value provided");
 			}
 			try {
-				return tomlToGoStyle(TOML_MAPPER.get().writeValueAsString(args[0]));
+				return TomlWriter.write(args[0]);
 			}
 			catch (Exception ex) {
 				throw new FunctionExecutionException("mustToToml: failed to convert to TOML: " + ex.getMessage(), ex);
 			}
 		};
-	}
-
-	/**
-	 * Matches a {@code key = 'literal'} TOML line whose value is a single-quoted literal
-	 * string (no embedded single quote, since TOML literal strings can't escape one).
-	 */
-	private static final Pattern TOML_LITERAL_STRING = Pattern.compile("(?m)^(\\h*[^=\\n]*?= )'([^'\\n]*)'(\\h*)$");
-
-	/**
-	 * Rewrites Jackson's single-quoted literal strings to double-quoted basic strings,
-	 * since Go's TOML encoder (what Helm uses) always emits {@code key = "value"}.
-	 * Escapes backslashes and double quotes so the result is a valid basic string.
-	 */
-	private static String tomlToGoStyle(String toml) {
-		Matcher m = TOML_LITERAL_STRING.matcher(toml);
-		StringBuilder sb = new StringBuilder(toml.length());
-		while (m.find()) {
-			String value = m.group(2).replace("\\", "\\\\").replace("\"", "\\\"");
-			m.appendReplacement(sb, Matcher.quoteReplacement(m.group(1) + '"' + value + '"' + m.group(3)));
-		}
-		m.appendTail(sb);
-		return sb.toString();
 	}
 
 	private static Function fromToml() {

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TomlWriter.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TomlWriter.java
@@ -1,0 +1,193 @@
+package org.alexmond.jhelm.gotemplate.helm.functions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Serializes a value to TOML the way Helm's {@code toToml} does, i.e. matching Go's
+ * {@code github.com/BurntSushi/toml} encoder rather than Jackson's dotted-key output.
+ * <p>
+ * The encoder reproduces BurntSushi's structural choices observed against the
+ * {@code helm} binary:
+ * <ul>
+ * <li>keys are sorted alphabetically, with scalar/inline-array fields emitted before
+ * sub-tables;</li>
+ * <li>a table's key/value pairs are indented {@code depth * 2} spaces and its
+ * {@code [header]} by {@code (depth - 1) * 2};</li>
+ * <li>a blank line precedes every <em>top-level</em> table and every array-of-tables
+ * element (but never the first line of output);</li>
+ * <li>strings are basic (double-quoted) strings, floats always carry a decimal
+ * point.</li>
+ * </ul>
+ * A non-table top-level value yields an empty string, matching Helm (BurntSushi errors
+ * and Helm discards the error).
+ */
+final class TomlWriter {
+
+	private static final Pattern BARE_KEY = Pattern.compile("[A-Za-z0-9_-]+");
+
+	private TomlWriter() {
+	}
+
+	/**
+	 * Serialize a value to a TOML document.
+	 * @param root the value to serialize (only a map produces output)
+	 * @return the TOML text, or {@code ""} if {@code root} is not a map
+	 */
+	static String write(Object root) {
+		if (!(root instanceof Map<?, ?> map)) {
+			return "";
+		}
+		StringBuilder sb = new StringBuilder();
+		writeTable(sb, new ArrayList<>(), map);
+		return sb.toString();
+	}
+
+	private static void writeTable(StringBuilder sb, List<String> key, Map<?, ?> map) {
+		List<String> directKeys = new ArrayList<>();
+		List<String> tableKeys = new ArrayList<>();
+		for (Object rawKey : map.keySet()) {
+			String name = String.valueOf(rawKey);
+			if (isTable(map.get(rawKey))) {
+				tableKeys.add(name);
+			}
+			else {
+				directKeys.add(name);
+			}
+		}
+		Collections.sort(directKeys);
+		Collections.sort(tableKeys);
+
+		String indent = "  ".repeat(key.size());
+		for (String name : directKeys) {
+			sb.append(indent).append(formatKey(name)).append(" = ").append(formatValue(map.get(name))).append('\n');
+		}
+		for (String name : tableKeys) {
+			Object value = map.get(name);
+			List<String> childKey = new ArrayList<>(key);
+			childKey.add(name);
+			String header = "  ".repeat(childKey.size() - 1);
+			if (isArrayOfTables(value)) {
+				for (Object element : (List<?>) value) {
+					separator(sb);
+					sb.append(header).append("[[").append(joinKey(childKey)).append("]]\n");
+					writeTable(sb, childKey, (Map<?, ?>) element);
+				}
+			}
+			else {
+				if (childKey.size() == 1) {
+					separator(sb);
+				}
+				sb.append(header).append('[').append(joinKey(childKey)).append("]\n");
+				writeTable(sb, childKey, (Map<?, ?>) value);
+			}
+		}
+	}
+
+	/** Write a blank-line separator, unless nothing has been written yet. */
+	private static void separator(StringBuilder sb) {
+		if (sb.length() > 0) {
+			sb.append('\n');
+		}
+	}
+
+	private static boolean isTable(Object value) {
+		return value instanceof Map || isArrayOfTables(value);
+	}
+
+	private static boolean isArrayOfTables(Object value) {
+		if (!(value instanceof List<?> list) || list.isEmpty()) {
+			return false;
+		}
+		for (Object element : list) {
+			if (!(element instanceof Map)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static String joinKey(List<String> key) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < key.size(); i++) {
+			if (i > 0) {
+				sb.append('.');
+			}
+			sb.append(formatKey(key.get(i)));
+		}
+		return sb.toString();
+	}
+
+	private static String formatKey(String key) {
+		return BARE_KEY.matcher(key).matches() ? key : quote(key);
+	}
+
+	private static String formatValue(Object value) {
+		if (value instanceof String str) {
+			return quote(str);
+		}
+		if (value instanceof Boolean bool) {
+			return bool.toString();
+		}
+		if (value instanceof Double || value instanceof Float) {
+			return formatFloat(((Number) value).doubleValue());
+		}
+		if (value instanceof Number number) {
+			return number.toString();
+		}
+		if (value instanceof List<?> list) {
+			StringBuilder sb = new StringBuilder("[");
+			for (int i = 0; i < list.size(); i++) {
+				if (i > 0) {
+					sb.append(", ");
+				}
+				sb.append(formatValue(list.get(i)));
+			}
+			return sb.append(']').toString();
+		}
+		return quote(String.valueOf(value));
+	}
+
+	private static String formatFloat(double value) {
+		if (Double.isNaN(value)) {
+			return "nan";
+		}
+		if (Double.isInfinite(value)) {
+			return (value > 0) ? "inf" : "-inf";
+		}
+		if (value == Math.floor(value) && Math.abs(value) < 1e15) {
+			return (long) value + ".0";
+		}
+		return Double.toString(value);
+	}
+
+	private static String quote(String str) {
+		StringBuilder sb = new StringBuilder(str.length() + 2);
+		sb.append('"');
+		for (int i = 0; i < str.length(); i++) {
+			char c = str.charAt(i);
+			switch (c) {
+				case '"' -> sb.append("\\\"");
+				case '\\' -> sb.append("\\\\");
+				case '\n' -> sb.append("\\n");
+				case '\t' -> sb.append("\\t");
+				case '\r' -> sb.append("\\r");
+				case '\b' -> sb.append("\\b");
+				case '\f' -> sb.append("\\f");
+				default -> {
+					if (c < 0x20) {
+						sb.append(String.format("\\u%04X", (int) c));
+					}
+					else {
+						sb.append(c);
+					}
+				}
+			}
+		}
+		return sb.append('"').toString();
+	}
+
+}

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -716,4 +716,35 @@ class ConversionFunctionsTest {
 		assertEquals(42, ((Number) parsed.get("count")).intValue());
 	}
 
+	@Test
+	void testToTomlNestedTablesUseHeaders() {
+		// Helm's toToml (Go BurntSushi) emits [table] headers with 2-space-per-depth
+		// indentation, not Jackson's dotted keys (mast.sail = ...). Verified against the
+		// helm binary.
+		Function fn = functions().get("toToml");
+		Map<String, Object> inner = new LinkedHashMap<>();
+		inner.put("cc", "deepval");
+		Map<String, Object> a = new LinkedHashMap<>();
+		a.put("xx", "v");
+		a.put("bb", inner);
+		Map<String, Object> root = new LinkedHashMap<>();
+		root.put("a", a);
+		assertEquals("[a]\n  xx = \"v\"\n  [a.bb]\n    cc = \"deepval\"\n", fn.invoke(new Object[] { root }));
+	}
+
+	@Test
+	void testToTomlArrayOfTables() {
+		// An array of maps renders as repeated [[key]] sections, each preceded by a blank
+		// line (except when it is the first line of output). Verified against the helm
+		// binary.
+		Function fn = functions().get("toToml");
+		Map<String, Object> first = new LinkedHashMap<>();
+		first.put("srv", "alpha");
+		Map<String, Object> second = new LinkedHashMap<>();
+		second.put("srv", "beta");
+		Map<String, Object> root = new LinkedHashMap<>();
+		root.put("list", List.of(first, second));
+		assertEquals("[[list]]\n  srv = \"alpha\"\n\n[[list]]\n  srv = \"beta\"\n", fn.invoke(new Object[] { root }));
+	}
+
 }

--- a/jhelm-gotemplate-helm/src/test/resources/conformance/helm_known_divergences.txt
+++ b/jhelm-gotemplate-helm/src/test/resources/conformance/helm_known_divergences.txt
@@ -2,20 +2,15 @@
 # excluded from HelmConformanceTest. Each line is a base64(template)\tbase64(data) key
 # (keyed on data too, since e.g. fromYaml passes on valid input and diverges on bad input).
 #
-# Three buckets, all tracked for incremental fixing:
+# Backlog status (started at 37 divergences):
 #  1. (fixed) Helm-4 duration helpers (durationSeconds/Days/.../RoundTo/TruncateTo,
-#     mustToDuration) are now implemented in DurationFunctions.
-#  2. (mostly fixed) from* now return Helm's map[Error:<go message>] / [<error>] on
-#     wrong-shape input (the deterministic json.Unmarshal type-mismatch messages). The one
-#     case left is a true parser *syntax* error — fromToml "one" -> BurntSushi's
-#     "toml: line 1: unexpected EOF; expected key separator '='" — whose exact wording a
-#     Jackson-based parser can't reproduce without overfitting.
-#  3. toToml nested maps: Jackson emits dotted keys (mast.sail=...) vs Helm's [mast] tables.
-#     (Flat-map single-quote vs double-quote was fixed; nested-table structure remains.)
+#     mustToDuration) implemented in DurationFunctions.
+#  2. (fixed) from* return Helm's map[Error:<go message>] / [<error>] on wrong-shape input
+#     (deterministic json.Unmarshal type-mismatch messages).
+#  3. (fixed) toToml emits Go BurntSushi-style [table] headers via TomlWriter, not Jackson's
+#     dotted keys.
 #
-#
-# --- bucket 2: from* error format (only the fromToml syntax-error case remains) ---
+# Only one case remains: a true parser *syntax* error — fromToml "one" -> BurntSushi's
+# "toml: line 1: unexpected EOF; expected key separator '='" — whose exact wording a
+# Jackson-based TOML parser can't reproduce without overfitting to the one input.
 e3sgZnJvbVRvbWwgLiB9fQ==	Im9uZSI=
-#
-# --- bucket 3: toToml nested tables ---
-e3sgdG9Ub21sIC4gfX0=	eyJtYXN0Ijp7InNhaWwiOiJ3aGl0ZSJ9fQ==


### PR DESCRIPTION
Closes **bucket 3 of #490**. `HelmConformanceTest` backlog now **37 → 1**.

`toToml` serialised via Jackson's `TomlMapper`, which writes nested maps as dotted keys (`mast.sail = "white"`), whereas Helm's Go BurntSushi encoder emits `[table]` headers. New `TomlWriter` reproduces BurntSushi's output, reverse-engineered from the `helm` binary:

- keys sorted alphabetically; scalar / inline-array fields before sub-tables
- table key/values indented `depth*2`, `[header]` indented `(depth-1)*2`
- a blank line before every **top-level** table and every **array-of-tables** element (never before the first output line)
- basic (double-quoted) strings; floats always carry a decimal point

```
{mast: {sail: white}}              ->  [mast]
                                         sail = "white"

{a: {xx: v, bb: {cc: deepval}}}    ->  [a]
                                         xx = "v"
                                         [a.bb]
                                           cc = "deepval"
```

Replaces the Jackson serialisation and the now-dead `tomlToGoStyle` single→double-quote post-process for both `toToml` and `mustToToml`; `fromToml` still parses via `TomlMapper`. Adds nested-table + array-of-tables unit tests asserting the exact helm output.

## Remaining (1 divergence)
Only `fromToml "one"` stays pinned — a true TOML *syntax* error whose exact BurntSushi wording (`toml: line 1: unexpected EOF; expected key separator '='`) a Jackson parser can't reproduce without overfitting.

## Verification
- `jhelm-gotemplate-helm` verify green — 131 tests, spring-javaformat / PMD / Checkstyle
- **346/346** chart byte-parity unchanged (no chart uses `toToml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)