### PR TITLE
docs: deep Javadoc review across all modules (pre-release)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/HelmJavaApplication.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/HelmJavaApplication.java
@@ -8,6 +8,13 @@ import picocli.CommandLine;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.IFactory;
 
+/**
+ * Spring Boot entry point for the {@code jhelm} command-line application.
+ * <p>
+ * Bootstraps the Spring context, then hands the command-line arguments to the Picocli
+ * {@link JHelmCommand} for parsing and execution. The process exit code reported back to
+ * the shell is the Picocli execution result.
+ */
 @SpringBootApplication
 public class HelmJavaApplication implements CommandLineRunner, ExitCodeGenerator {
 
@@ -17,15 +24,29 @@ public class HelmJavaApplication implements CommandLineRunner, ExitCodeGenerator
 
 	private int exitCode;
 
+	/**
+	 * Creates the application runner.
+	 * @param factory the Picocli factory used to instantiate Spring-managed commands
+	 * @param jHelmCommand the root {@code jhelm} command
+	 */
 	public HelmJavaApplication(IFactory factory, JHelmCommand jHelmCommand) {
 		this.factory = factory;
 		this.jHelmCommand = jHelmCommand;
 	}
 
+	/**
+	 * Application entry point; runs the Spring context and exits with the command
+	 * execution result.
+	 * @param args the command-line arguments
+	 */
 	public static void main(String[] args) {
 		System.exit(SpringApplication.exit(SpringApplication.run(HelmJavaApplication.class, args)));
 	}
 
+	/**
+	 * Parses and executes the command line via Picocli, capturing the exit code.
+	 * @param args the command-line arguments passed by Spring Boot
+	 */
 	@Override
 	public void run(String... args) {
 		CommandLine cmd = new CommandLine(jHelmCommand, factory);
@@ -34,6 +55,10 @@ public class HelmJavaApplication implements CommandLineRunner, ExitCodeGenerator
 		exitCode = cmd.execute(args);
 	}
 
+	/**
+	 * Returns the exit code produced by the last command execution.
+	 * @return the process exit code
+	 */
 	@Override
 	public int getExitCode() {
 		return exitCode;

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
@@ -26,6 +26,11 @@ import org.alexmond.jhelm.app.output.CliOutput;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+/**
+ * Root {@code jhelm} command. Defines global options and wires up every top-level
+ * subcommand (install, upgrade, template, repo, and so on). Running it with no subcommand
+ * prints the usage help.
+ */
 @Component
 @CommandLine.Command(name = "jhelm", mixinStandardHelpOptions = true, version = "jhelm 0.0.1",
 		header = { "", "The Java Kubernetes package manager", "" },
@@ -42,6 +47,16 @@ import picocli.CommandLine;
 				RepoCommand.class, RegistryCommand.class, PluginCommand.class, SearchCommand.class })
 public class JHelmCommand implements Runnable {
 
+	/** Creates the command. */
+	@SuppressWarnings("PMD.UnnecessaryConstructor")
+	public JHelmCommand() {
+	}
+
+	/**
+	 * Toggles colored CLI output. Bound to the inherited {@code --no-color} option so it
+	 * applies to every subcommand.
+	 * @param noColor {@code true} to disable ANSI colors in output
+	 */
 	@CommandLine.Option(names = { "--no-color" }, description = "Disable colored output",
 			scope = CommandLine.ScopeType.INHERIT)
 	public void setNoColor(boolean noColor) {
@@ -50,6 +65,9 @@ public class JHelmCommand implements Runnable {
 		}
 	}
 
+	/**
+	 * Prints the usage help when {@code jhelm} is invoked without a subcommand.
+	 */
 	@Override
 	public void run() {
 		CommandLine.usage(this, System.out);

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/CreateCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/CreateCommand.java
@@ -10,6 +10,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+/**
+ * Implements {@code jhelm create NAME}, scaffolding a new chart directory with the given
+ * name (optionally from a starter scaffold).
+ */
 @Slf4j
 @Component
 @CommandLine.Command(name = "create", mixinStandardHelpOptions = true,
@@ -25,10 +29,17 @@ public class CreateCommand implements Runnable {
 			description = "The name or absolute path to Helm starter scaffold")
 	private String starter;
 
+	/**
+	 * Creates the command.
+	 * @param createAction the action that scaffolds the new chart
+	 */
 	public CreateCommand(CreateAction createAction) {
 		this.createAction = createAction;
 	}
 
+	/**
+	 * Scaffolds the new chart and reports the result.
+	 */
 	@Override
 	public void run() {
 		try {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/DependencyCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/DependencyCommand.java
@@ -40,6 +40,14 @@ import java.util.List;
 @Slf4j
 public class DependencyCommand implements Runnable {
 
+	/** Creates the command. */
+	@SuppressWarnings("PMD.UnnecessaryConstructor")
+	public DependencyCommand() {
+	}
+
+	/**
+	 * Prints the usage help when {@code dependency} is invoked without a subcommand.
+	 */
 	@Override
 	public void run() {
 		CommandLine.usage(this, System.out);
@@ -59,6 +67,14 @@ public class DependencyCommand implements Runnable {
 		@CommandLine.Parameters(index = "0", description = "chart directory", defaultValue = ".")
 		String chartPath;
 
+		/** Creates the command. */
+		@SuppressWarnings("PMD.UnnecessaryConstructor")
+		public ListCommand() {
+		}
+
+		/**
+		 * Lists the chart's dependencies and their resolution status.
+		 */
 		@Override
 		public void run() {
 			try {
@@ -187,10 +203,18 @@ public class DependencyCommand implements Runnable {
 				description = "Enable dependency tags to include (comma-separated)")
 		List<String> withTags = new ArrayList<>();
 
+		/**
+		 * Creates the command.
+		 * @param repoManager the repository manager used to refresh and resolve
+		 * dependencies
+		 */
 		public UpdateCommand(RepoManager repoManager) {
 			this.repoManager = repoManager;
 		}
 
+		/**
+		 * Resolves dependencies from Chart.yaml, downloads them, and writes Chart.lock.
+		 */
 		@Override
 		public void run() {
 			try {
@@ -286,10 +310,18 @@ public class DependencyCommand implements Runnable {
 		@CommandLine.Option(names = { "--skip-refresh" }, description = "Skip refreshing the local repository cache")
 		boolean skipRefresh;
 
+		/**
+		 * Creates the command.
+		 * @param repoManager the repository manager used to refresh and download
+		 * dependencies
+		 */
 		public BuildCommand(RepoManager repoManager) {
 			this.repoManager = repoManager;
 		}
 
+		/**
+		 * Rebuilds the charts/ directory from the pinned versions in Chart.lock.
+		 */
 		@Override
 		public void run() {
 			try {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/GetCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/GetCommand.java
@@ -10,6 +10,11 @@ import picocli.CommandLine;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * Implements {@code jhelm get}, downloading extended information about a named release.
+ * Delegates to subcommands for values, manifest, notes, hooks, metadata, and the combined
+ * {@code all} view.
+ */
 @Component
 @CommandLine.Command(name = "get", mixinStandardHelpOptions = true,
 		description = "Download extended information of a named release",
@@ -18,6 +23,14 @@ import java.util.Optional;
 @Slf4j
 public class GetCommand implements Runnable {
 
+	/** Creates the command. */
+	@SuppressWarnings("PMD.UnnecessaryConstructor")
+	public GetCommand() {
+	}
+
+	/**
+	 * Prints the usage help when {@code get} is invoked without a subcommand.
+	 */
 	@Override
 	public void run() {
 		CommandLine.usage(this, System.out);
@@ -31,6 +44,10 @@ public class GetCommand implements Runnable {
 		return getAction.getRelease(name, namespace);
 	}
 
+	/**
+	 * Implements {@code get values}: prints the user-supplied or computed values of a
+	 * release.
+	 */
 	@Component
 	@CommandLine.Command(name = "values", mixinStandardHelpOptions = true,
 			description = "Download the values file for a named release")
@@ -56,10 +73,17 @@ public class GetCommand implements Runnable {
 				description = "output format (yaml or json)")
 		String output;
 
+		/**
+		 * Creates the command.
+		 * @param getAction the action that fetches release information
+		 */
 		public ValuesCommand(GetAction getAction) {
 			this.getAction = getAction;
 		}
 
+		/**
+		 * Prints the release values in the requested output format.
+		 */
 		@Override
 		public void run() {
 			try {
@@ -90,6 +114,10 @@ public class GetCommand implements Runnable {
 
 	}
 
+	/**
+	 * Implements {@code get manifest}: prints the rendered Kubernetes manifest of a
+	 * release.
+	 */
 	@Component
 	@CommandLine.Command(name = "manifest", mixinStandardHelpOptions = true,
 			description = "Download the manifest for a named release")
@@ -108,10 +136,17 @@ public class GetCommand implements Runnable {
 				description = "get the named release with revision")
 		int revision;
 
+		/**
+		 * Creates the command.
+		 * @param getAction the action that fetches release information
+		 */
 		public ManifestCommand(GetAction getAction) {
 			this.getAction = getAction;
 		}
 
+		/**
+		 * Prints the release manifest.
+		 */
 		@Override
 		public void run() {
 			try {
@@ -129,6 +164,9 @@ public class GetCommand implements Runnable {
 
 	}
 
+	/**
+	 * Implements {@code get notes}: prints the NOTES.txt output rendered for a release.
+	 */
 	@Component
 	@CommandLine.Command(name = "notes", mixinStandardHelpOptions = true,
 			description = "Download the notes for a named release")
@@ -147,10 +185,17 @@ public class GetCommand implements Runnable {
 				description = "get the named release with revision")
 		int revision;
 
+		/**
+		 * Creates the command.
+		 * @param getAction the action that fetches release information
+		 */
 		public NotesCommand(GetAction getAction) {
 			this.getAction = getAction;
 		}
 
+		/**
+		 * Prints the release notes, or a placeholder when none exist.
+		 */
 		@Override
 		public void run() {
 			try {
@@ -174,6 +219,7 @@ public class GetCommand implements Runnable {
 
 	}
 
+	/** Implements {@code get hooks}: prints the hook manifests defined for a release. */
 	@Component
 	@CommandLine.Command(name = "hooks", mixinStandardHelpOptions = true,
 			description = "Download all hooks for a named release")
@@ -192,10 +238,17 @@ public class GetCommand implements Runnable {
 				description = "get the named release with revision")
 		int revision;
 
+		/**
+		 * Creates the command.
+		 * @param getAction the action that fetches release information
+		 */
 		public HooksCommand(GetAction getAction) {
 			this.getAction = getAction;
 		}
 
+		/**
+		 * Prints the release hooks, or a placeholder when none exist.
+		 */
 		@Override
 		public void run() {
 			try {
@@ -219,6 +272,10 @@ public class GetCommand implements Runnable {
 
 	}
 
+	/**
+	 * Implements {@code get metadata}: prints release metadata such as name, namespace,
+	 * and revision.
+	 */
 	@Component
 	@CommandLine.Command(name = "metadata", mixinStandardHelpOptions = true,
 			description = "Download the metadata for a named release")
@@ -241,10 +298,17 @@ public class GetCommand implements Runnable {
 				description = "output format (yaml or json)")
 		String output;
 
+		/**
+		 * Creates the command.
+		 * @param getAction the action that fetches release information
+		 */
 		public MetadataCommand(GetAction getAction) {
 			this.getAction = getAction;
 		}
 
+		/**
+		 * Prints the release metadata in the requested output format.
+		 */
 		@Override
 		public void run() {
 			try {
@@ -268,6 +332,10 @@ public class GetCommand implements Runnable {
 
 	}
 
+	/**
+	 * Implements {@code get all}: prints the combined values, manifest, notes, and hooks
+	 * of a release.
+	 */
 	@Component
 	@CommandLine.Command(name = "all", mixinStandardHelpOptions = true,
 			description = "Download all information for a named release")
@@ -286,10 +354,17 @@ public class GetCommand implements Runnable {
 				description = "get the named release with revision")
 		int revision;
 
+		/**
+		 * Creates the command.
+		 * @param getAction the action that fetches release information
+		 */
 		public AllCommand(GetAction getAction) {
 			this.getAction = getAction;
 		}
 
+		/**
+		 * Prints all available information for the release.
+		 */
 		@Override
 		public void run() {
 			try {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/HistoryCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/HistoryCommand.java
@@ -9,6 +9,9 @@ import picocli.CommandLine;
 
 import java.util.List;
 
+/**
+ * Implements {@code jhelm history RELEASE}, printing the revision history of a release.
+ */
 @Component
 @CommandLine.Command(name = "history", mixinStandardHelpOptions = true, description = "Fetch release history")
 @Slf4j
@@ -22,10 +25,17 @@ public class HistoryCommand implements Runnable {
 	@CommandLine.Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
 	private String namespace;
 
+	/**
+	 * Creates the command.
+	 * @param historyAction the action that retrieves release history
+	 */
 	public HistoryCommand(HistoryAction historyAction) {
 		this.historyAction = historyAction;
 	}
 
+	/**
+	 * Prints the release revision history as a table.
+	 */
 	@Override
 	public void run() {
 		try {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -19,6 +19,11 @@ import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
+/**
+ * Implements {@code jhelm install RELEASE CHART}, installing a chart into the cluster.
+ * Supports values overrides, dry-run, waiting for readiness, atomic rollback on failure,
+ * and post-renderers.
+ */
 @Component
 @CommandLine.Command(name = "install", mixinStandardHelpOptions = true, description = "Install a chart")
 @Slf4j
@@ -62,6 +67,13 @@ public class InstallCommand implements Runnable {
 	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
 
+	/**
+	 * Creates the command.
+	 * @param installAction the action that performs the install
+	 * @param uninstallAction the action used to roll back when {@code --atomic} is set
+	 * @param kubeService the Kubernetes service used to wait for resource readiness
+	 * @param chartLoader the loader that reads the chart from disk
+	 */
 	public InstallCommand(InstallAction installAction, UninstallAction uninstallAction, KubeService kubeService,
 			ChartLoader chartLoader) {
 		this.installAction = installAction;

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/LintCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/LintCommand.java
@@ -11,6 +11,10 @@ import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
+/**
+ * Implements {@code jhelm lint CHART}, examining a chart for possible issues and
+ * reporting warnings and errors.
+ */
 @Component
 @CommandLine.Command(name = "lint", mixinStandardHelpOptions = true,
 		description = "Examine a chart for possible issues")
@@ -30,6 +34,10 @@ public class LintCommand implements Runnable {
 	@Option(names = { "--strict" }, defaultValue = "false", description = "fail on lint warnings")
 	private boolean strict;
 
+	/**
+	 * Creates the command.
+	 * @param lintAction the action that lints the chart
+	 */
 	public LintCommand(LintAction lintAction) {
 		this.lintAction = lintAction;
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
@@ -10,6 +10,10 @@ import picocli.CommandLine;
 import java.util.List;
 import java.util.Locale;
 
+/**
+ * Implements {@code jhelm list}, printing the releases in a namespace with their
+ * revision, status, and chart.
+ */
 @Component
 @CommandLine.Command(name = "list", mixinStandardHelpOptions = true, description = "List releases")
 @Slf4j
@@ -20,6 +24,10 @@ public class ListCommand implements Runnable {
 	@CommandLine.Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
 	private String namespace;
 
+	/**
+	 * Creates the command.
+	 * @param listAction the action that lists releases
+	 */
 	public ListCommand(ListAction listAction) {
 		this.listAction = listAction;
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PackageCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PackageCommand.java
@@ -10,6 +10,10 @@ import org.alexmond.jhelm.core.action.PackageAction;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+/**
+ * Implements {@code jhelm package CHART}, packaging a chart directory into a {@code .tgz}
+ * archive, optionally signing it with a PGP key.
+ */
 @Component
 @CommandLine.Command(name = "package", mixinStandardHelpOptions = true,
 		description = "Package a chart directory into a chart archive")
@@ -38,6 +42,10 @@ public class PackageCommand implements Runnable {
 			description = "path to a file containing the passphrase for the signing key")
 	private String passphraseFile;
 
+	/**
+	 * Creates the command.
+	 * @param packageAction the action that packages and optionally signs the chart
+	 */
 	public PackageCommand(PackageAction packageAction) {
 		this.packageAction = packageAction;
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PluginCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PluginCommand.java
@@ -10,16 +10,31 @@ import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 import org.alexmond.jhelm.app.output.CliOutput;
 
+/**
+ * Implements {@code jhelm plugin}, managing installed plugins via the {@code install},
+ * {@code uninstall}, and {@code list} subcommands.
+ */
 @Component
 @CommandLine.Command(name = "plugin", mixinStandardHelpOptions = true, description = "Manage plugins",
 		subcommands = { PluginCommand.Install.class, PluginCommand.Uninstall.class, PluginCommand.ListPlugins.class })
 public class PluginCommand implements Runnable {
 
+	/** Creates the command. */
+	@SuppressWarnings("PMD.UnnecessaryConstructor")
+	public PluginCommand() {
+	}
+
+	/**
+	 * Prints the usage help when {@code plugin} is invoked without a subcommand.
+	 */
 	@Override
 	public void run() {
 		CommandLine.usage(this, System.out);
 	}
 
+	/**
+	 * Implements {@code plugin install}: installs a plugin from a {@code .jhp} archive.
+	 */
 	@Component
 	@CommandLine.Command(name = "install", mixinStandardHelpOptions = true,
 			description = "Install a plugin from a .jhp archive")
@@ -30,6 +45,11 @@ public class PluginCommand implements Runnable {
 
 		private final ObjectProvider<PluginManager> pluginManagerProvider;
 
+		/**
+		 * Creates the command.
+		 * @param pluginManagerProvider provider for the plugin manager (may be absent
+		 * when plugins are disabled)
+		 */
 		public Install(ObjectProvider<PluginManager> pluginManagerProvider) {
 			this.pluginManagerProvider = pluginManagerProvider;
 		}
@@ -53,6 +73,7 @@ public class PluginCommand implements Runnable {
 
 	}
 
+	/** Implements {@code plugin uninstall}: removes an installed plugin by name. */
 	@Component
 	@CommandLine.Command(name = "uninstall", mixinStandardHelpOptions = true, description = "Uninstall a plugin")
 	public static class Uninstall implements Runnable {
@@ -62,6 +83,11 @@ public class PluginCommand implements Runnable {
 
 		private final ObjectProvider<PluginManager> pluginManagerProvider;
 
+		/**
+		 * Creates the command.
+		 * @param pluginManagerProvider provider for the plugin manager (may be absent
+		 * when plugins are disabled)
+		 */
 		public Uninstall(ObjectProvider<PluginManager> pluginManagerProvider) {
 			this.pluginManagerProvider = pluginManagerProvider;
 		}
@@ -84,12 +110,18 @@ public class PluginCommand implements Runnable {
 
 	}
 
+	/** Implements {@code plugin list}: prints the installed plugins as a table. */
 	@Component
 	@CommandLine.Command(name = "list", mixinStandardHelpOptions = true, description = "List installed plugins")
 	public static class ListPlugins implements Runnable {
 
 		private final ObjectProvider<PluginManager> pluginManagerProvider;
 
+		/**
+		 * Creates the command.
+		 * @param pluginManagerProvider provider for the plugin manager (may be absent
+		 * when plugins are disabled)
+		 */
 		public ListPlugins(ObjectProvider<PluginManager> pluginManagerProvider) {
 			this.pluginManagerProvider = pluginManagerProvider;
 		}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PullCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PullCommand.java
@@ -6,6 +6,10 @@ import org.alexmond.jhelm.core.service.RepoManager;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+/**
+ * Implements {@code jhelm pull CHART}, downloading a chart from a repository or OCI
+ * registry to a local directory.
+ */
 @Component
 @CommandLine.Command(name = "pull", mixinStandardHelpOptions = true, description = "Download a chart from a repository")
 @Slf4j
@@ -22,6 +26,10 @@ public class PullCommand implements Runnable {
 	@CommandLine.Option(names = { "--dest", "-d" }, defaultValue = ".", description = "destination directory")
 	private String dest;
 
+	/**
+	 * Creates the command.
+	 * @param repoManager the repository manager that downloads the chart
+	 */
 	public PullCommand(RepoManager repoManager) {
 		this.repoManager = repoManager;
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PushCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PushCommand.java
@@ -6,6 +6,10 @@ import org.alexmond.jhelm.core.service.RepoManager;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+/**
+ * Implements {@code jhelm push CHART REMOTE}, uploading a packaged chart archive to a
+ * remote OCI registry.
+ */
 @Component
 @CommandLine.Command(name = "push", mixinStandardHelpOptions = true,
 		description = "Push a chart to a remote OCI registry")
@@ -20,6 +24,10 @@ public class PushCommand implements Runnable {
 	@CommandLine.Parameters(index = "1", description = "OCI registry destination (oci://registry/repo/chart[:tag])")
 	private String remote;
 
+	/**
+	 * Creates the command.
+	 * @param repoManager the repository manager that pushes the chart to the registry
+	 */
 	public PushCommand(RepoManager repoManager) {
 		this.repoManager = repoManager;
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RegistryCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RegistryCommand.java
@@ -8,6 +8,10 @@ import picocli.CommandLine;
 
 import java.io.IOException;
 
+/**
+ * Implements {@code jhelm registry}, managing authentication to OCI registries via the
+ * {@code login} and {@code logout} subcommands.
+ */
 @Component
 @CommandLine.Command(name = "registry", mixinStandardHelpOptions = true,
 		description = "Login to or logout from a registry",
@@ -15,11 +19,20 @@ import java.io.IOException;
 @Slf4j
 public class RegistryCommand implements Runnable {
 
+	/** Creates the command. */
+	@SuppressWarnings("PMD.UnnecessaryConstructor")
+	public RegistryCommand() {
+	}
+
+	/**
+	 * Prints the usage help when {@code registry} is invoked without a subcommand.
+	 */
 	@Override
 	public void run() {
 		CommandLine.usage(this, System.out);
 	}
 
+	/** Implements {@code registry login}: authenticates to an OCI registry. */
 	@Component
 	@CommandLine.Command(name = "login", mixinStandardHelpOptions = true, description = "Login to a registry")
 	@Slf4j
@@ -36,6 +49,10 @@ public class RegistryCommand implements Runnable {
 		@CommandLine.Option(names = { "-p", "--password" }, description = "registry password", required = true)
 		private String password;
 
+		/**
+		 * Creates the command.
+		 * @param registryManager the manager that performs the registry login
+		 */
 		public LoginCommand(RegistryManager registryManager) {
 			this.registryManager = registryManager;
 		}
@@ -53,6 +70,7 @@ public class RegistryCommand implements Runnable {
 
 	}
 
+	/** Implements {@code registry logout}: removes stored credentials for a registry. */
 	@Component
 	@CommandLine.Command(name = "logout", mixinStandardHelpOptions = true, description = "Logout from a registry")
 	@Slf4j
@@ -63,6 +81,10 @@ public class RegistryCommand implements Runnable {
 		@CommandLine.Parameters(index = "0", description = "registry server")
 		private String server;
 
+		/**
+		 * Creates the command.
+		 * @param registryManager the manager that performs the registry logout
+		 */
 		public LogoutCommand(RegistryManager registryManager) {
 			this.registryManager = registryManager;
 		}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoCommand.java
@@ -9,6 +9,10 @@ import picocli.CommandLine;
 
 import java.io.IOException;
 
+/**
+ * Implements {@code jhelm repo}, managing chart repositories via the {@code add},
+ * {@code list}, {@code remove}, and {@code search} subcommands.
+ */
 @Component
 @CommandLine.Command(name = "repo", mixinStandardHelpOptions = true, description = "Manage chart repositories",
 		subcommands = { RepoCommand.AddCommand.class, RepoCommand.ListCommand.class, RepoCommand.RemoveCommand.class,
@@ -16,11 +20,20 @@ import java.io.IOException;
 @Slf4j
 public class RepoCommand implements Runnable {
 
+	/** Creates the command. */
+	@SuppressWarnings("PMD.UnnecessaryConstructor")
+	public RepoCommand() {
+	}
+
+	/**
+	 * Prints the usage help when {@code repo} is invoked without a subcommand.
+	 */
 	@Override
 	public void run() {
 		CommandLine.usage(this, System.out);
 	}
 
+	/** Implements {@code repo add}: registers a chart repository by name and URL. */
 	@Component
 	@CommandLine.Command(name = "add", mixinStandardHelpOptions = true, description = "Add a chart repository")
 	@Slf4j
@@ -34,6 +47,10 @@ public class RepoCommand implements Runnable {
 		@CommandLine.Parameters(index = "1", description = "repository url")
 		private String url;
 
+		/**
+		 * Creates the command.
+		 * @param repoManager the repository manager that stores the repository
+		 */
 		public AddCommand(RepoManager repoManager) {
 			this.repoManager = repoManager;
 		}
@@ -51,6 +68,7 @@ public class RepoCommand implements Runnable {
 
 	}
 
+	/** Implements {@code repo list}: prints the configured chart repositories. */
 	@Component
 	@CommandLine.Command(name = "list", mixinStandardHelpOptions = true, description = "List chart repositories")
 	@Slf4j
@@ -58,6 +76,11 @@ public class RepoCommand implements Runnable {
 
 		private final RepoManager repoManager;
 
+		/**
+		 * Creates the command.
+		 * @param repoManager the repository manager that supplies the configured
+		 * repositories
+		 */
 		public ListCommand(RepoManager repoManager) {
 			this.repoManager = repoManager;
 		}
@@ -78,6 +101,7 @@ public class RepoCommand implements Runnable {
 
 	}
 
+	/** Implements {@code repo remove}: deletes a chart repository by name. */
 	@Component
 	@CommandLine.Command(name = "remove", mixinStandardHelpOptions = true,
 			description = "Remove one or more chart repositories")
@@ -89,6 +113,10 @@ public class RepoCommand implements Runnable {
 		@CommandLine.Parameters(index = "0", description = "repository name")
 		private String name;
 
+		/**
+		 * Creates the command.
+		 * @param repoManager the repository manager that removes the repository
+		 */
 		public RemoveCommand(RepoManager repoManager) {
 			this.repoManager = repoManager;
 		}
@@ -106,6 +134,7 @@ public class RepoCommand implements Runnable {
 
 	}
 
+	/** Implements {@code repo search}: searches the added repositories for a chart. */
 	@Component
 	@CommandLine.Command(name = "search", mixinStandardHelpOptions = true,
 			description = "Search the added repositories for a chart")
@@ -120,6 +149,10 @@ public class RepoCommand implements Runnable {
 		@CommandLine.Option(names = { "--versions" }, description = "show all versions")
 		private boolean showAllVersions;
 
+		/**
+		 * Creates the command.
+		 * @param repoManager the repository manager that resolves chart versions
+		 */
 		public SearchCommand(RepoManager repoManager) {
 			this.repoManager = repoManager;
 		}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
@@ -6,6 +6,10 @@ import org.alexmond.jhelm.core.action.RollbackAction;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+/**
+ * Implements {@code jhelm rollback RELEASE REVISION}, rolling a release back to a
+ * previous revision.
+ */
 @Component
 @CommandLine.Command(name = "rollback", mixinStandardHelpOptions = true,
 		description = "Roll back a release to a previous revision")
@@ -23,6 +27,10 @@ public class RollbackCommand implements Runnable {
 	@CommandLine.Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
 	private String namespace;
 
+	/**
+	 * Creates the command.
+	 * @param rollbackAction the action that performs the rollback
+	 */
 	public RollbackCommand(RollbackAction rollbackAction) {
 		this.rollbackAction = rollbackAction;
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchCommand.java
@@ -3,11 +3,23 @@ package org.alexmond.jhelm.app.command;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+/**
+ * Implements {@code jhelm search}, the parent command for chart search. Delegates to the
+ * {@code hub} subcommand to search Artifact Hub.
+ */
 @Component
 @CommandLine.Command(name = "search", mixinStandardHelpOptions = true, description = "Search for a keyword in charts",
 		subcommands = { SearchHubCommand.class })
 public class SearchCommand implements Runnable {
 
+	/** Creates the command. */
+	@SuppressWarnings("PMD.UnnecessaryConstructor")
+	public SearchCommand() {
+	}
+
+	/**
+	 * Prints the usage help when {@code search} is invoked without a subcommand.
+	 */
 	@Override
 	public void run() {
 		CommandLine.usage(this, System.out);

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchHubCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchHubCommand.java
@@ -7,6 +7,10 @@ import org.alexmond.jhelm.core.action.SearchHubAction;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+/**
+ * Implements {@code jhelm search hub KEYWORD}, searching Artifact Hub for charts matching
+ * a keyword and printing the results as a table.
+ */
 @Component
 @CommandLine.Command(name = "hub", mixinStandardHelpOptions = true, description = "Search for charts in Artifact Hub")
 public class SearchHubCommand implements Runnable {
@@ -24,6 +28,10 @@ public class SearchHubCommand implements Runnable {
 			description = "print charts repository URL")
 	private boolean listRepoUrl;
 
+	/**
+	 * Creates the command.
+	 * @param searchHubAction the action that queries Artifact Hub
+	 */
 	public SearchHubCommand(SearchHubAction searchHubAction) {
 		this.searchHubAction = searchHubAction;
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ShowCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ShowCommand.java
@@ -6,6 +6,11 @@ import org.alexmond.jhelm.core.action.ShowAction;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+/**
+ * Implements {@code jhelm show}, displaying information about a chart via the
+ * {@code chart}, {@code values}, {@code readme}, {@code crds}, and {@code all}
+ * subcommands.
+ */
 @Component
 @CommandLine.Command(name = "show", mixinStandardHelpOptions = true, description = "Show information about a chart",
 		subcommands = { ShowCommand.ChartCommand.class, ShowCommand.ValuesCommand.class,
@@ -13,11 +18,20 @@ import picocli.CommandLine;
 @Slf4j
 public class ShowCommand implements Runnable {
 
+	/** Creates the command. */
+	@SuppressWarnings("PMD.UnnecessaryConstructor")
+	public ShowCommand() {
+	}
+
+	/**
+	 * Prints the usage help when {@code show} is invoked without a subcommand.
+	 */
 	@Override
 	public void run() {
 		CommandLine.usage(this, System.out);
 	}
 
+	/** Implements {@code show chart}: prints the chart's Chart.yaml. */
 	@Component
 	@CommandLine.Command(name = "chart", mixinStandardHelpOptions = true, description = "Show the chart's Chart.yaml")
 	@Slf4j
@@ -28,6 +42,10 @@ public class ShowCommand implements Runnable {
 		@CommandLine.Parameters(index = "0", description = "chart path")
 		String chartPath;
 
+		/**
+		 * Creates the command.
+		 * @param showAction the action that reads chart contents
+		 */
 		public ChartCommand(ShowAction showAction) {
 			this.showAction = showAction;
 		}
@@ -44,6 +62,7 @@ public class ShowCommand implements Runnable {
 
 	}
 
+	/** Implements {@code show values}: prints the chart's values.yaml. */
 	@Component
 	@CommandLine.Command(name = "values", mixinStandardHelpOptions = true, description = "Show the chart's values.yaml")
 	@Slf4j
@@ -54,6 +73,10 @@ public class ShowCommand implements Runnable {
 		@CommandLine.Parameters(index = "0", description = "chart path")
 		String chartPath;
 
+		/**
+		 * Creates the command.
+		 * @param showAction the action that reads chart contents
+		 */
 		public ValuesCommand(ShowAction showAction) {
 			this.showAction = showAction;
 		}
@@ -70,6 +93,7 @@ public class ShowCommand implements Runnable {
 
 	}
 
+	/** Implements {@code show readme}: prints the chart's README. */
 	@Component
 	@CommandLine.Command(name = "readme", mixinStandardHelpOptions = true, description = "Show the chart's README")
 	@Slf4j
@@ -80,6 +104,10 @@ public class ShowCommand implements Runnable {
 		@CommandLine.Parameters(index = "0", description = "chart path")
 		String chartPath;
 
+		/**
+		 * Creates the command.
+		 * @param showAction the action that reads chart contents
+		 */
 		public ReadmeCommand(ShowAction showAction) {
 			this.showAction = showAction;
 		}
@@ -101,6 +129,7 @@ public class ShowCommand implements Runnable {
 
 	}
 
+	/** Implements {@code show crds}: prints the chart's Custom Resource Definitions. */
 	@Component
 	@CommandLine.Command(name = "crds", mixinStandardHelpOptions = true,
 			description = "Show the chart's Custom Resource Definitions")
@@ -112,6 +141,10 @@ public class ShowCommand implements Runnable {
 		@CommandLine.Parameters(index = "0", description = "chart path")
 		String chartPath;
 
+		/**
+		 * Creates the command.
+		 * @param showAction the action that reads chart contents
+		 */
 		public CrdsCommand(ShowAction showAction) {
 			this.showAction = showAction;
 		}
@@ -133,6 +166,10 @@ public class ShowCommand implements Runnable {
 
 	}
 
+	/**
+	 * Implements {@code show all}: prints the chart's combined Chart.yaml, values, and
+	 * README.
+	 */
 	@Component
 	@CommandLine.Command(name = "all", mixinStandardHelpOptions = true,
 			description = "Show all information about the chart")
@@ -144,6 +181,10 @@ public class ShowCommand implements Runnable {
 		@CommandLine.Parameters(index = "0", description = "chart path")
 		String chartPath;
 
+		/**
+		 * Creates the command.
+		 * @param showAction the action that reads chart contents
+		 */
 		public AllCommand(ShowAction showAction) {
 			this.showAction = showAction;
 		}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/StatusCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/StatusCommand.java
@@ -12,6 +12,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
+/**
+ * Implements {@code jhelm status RELEASE}, displaying the status of a named release and
+ * optionally the readiness of its resources.
+ */
 @Component
 @CommandLine.Command(name = "status", mixinStandardHelpOptions = true,
 		description = "Display the status of the named release")
@@ -29,6 +33,10 @@ public class StatusCommand implements Runnable {
 	@CommandLine.Option(names = { "--show-resources" }, description = "show resource readiness status")
 	private boolean showResources;
 
+	/**
+	 * Creates the command.
+	 * @param statusAction the action that retrieves release status
+	 */
 	public StatusCommand(StatusAction statusAction) {
 		this.statusAction = statusAction;
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
@@ -13,6 +13,10 @@ import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
+/**
+ * Implements {@code jhelm template RELEASE CHART}, rendering a chart's templates locally
+ * without contacting a cluster. Supports values overrides and post-renderers.
+ */
 @Component
 @CommandLine.Command(name = "template", mixinStandardHelpOptions = true, description = "Locally render templates")
 @Slf4j
@@ -38,6 +42,10 @@ public class TemplateCommand implements Runnable {
 	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
 
+	/**
+	 * Creates the command.
+	 * @param templateAction the action that renders chart templates
+	 */
 	public TemplateCommand(TemplateAction templateAction) {
 		this.templateAction = templateAction;
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TestCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TestCommand.java
@@ -36,6 +36,10 @@ public class TestCommand implements Runnable {
 	@CommandLine.Option(names = { "--logs" }, description = "dump the logs from test hooks")
 	private boolean showLogs;
 
+	/**
+	 * Creates the command.
+	 * @param testAction the action that runs the release test hooks
+	 */
 	public TestCommand(TestAction testAction) {
 		this.testAction = testAction;
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
@@ -6,6 +6,10 @@ import org.alexmond.jhelm.core.action.UninstallAction;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+/**
+ * Implements {@code jhelm uninstall RELEASE}, removing a release and its resources from
+ * the cluster.
+ */
 @Component
 @CommandLine.Command(name = "uninstall", mixinStandardHelpOptions = true, description = "Uninstall a release")
 @Slf4j
@@ -19,6 +23,10 @@ public class UninstallCommand implements Runnable {
 	@CommandLine.Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
 	private String namespace;
 
+	/**
+	 * Creates the command.
+	 * @param uninstallAction the action that uninstalls the release
+	 */
 	public UninstallCommand(UninstallAction uninstallAction) {
 		this.uninstallAction = uninstallAction;
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -22,6 +22,11 @@ import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
+/**
+ * Implements {@code jhelm upgrade RELEASE CHART}, upgrading an existing release. Supports
+ * installing when the release is absent ({@code --install}), values overrides, dry-run,
+ * waiting for readiness, atomic rollback on failure, and post-renderers.
+ */
 @Component
 @CommandLine.Command(name = "upgrade", mixinStandardHelpOptions = true, description = "Upgrade a release")
 @Slf4j
@@ -72,6 +77,18 @@ public class UpgradeCommand implements Runnable {
 	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
 
+	/**
+	 * Creates the command.
+	 * @param kubeService the Kubernetes service used to look up releases and wait for
+	 * readiness
+	 * @param installAction the action used to install when {@code --install} is set
+	 * @param uninstallAction the action used to roll back a freshly installed release on
+	 * atomic failure
+	 * @param upgradeAction the action that performs the upgrade
+	 * @param rollbackAction the action used to roll back to the previous revision on
+	 * atomic failure
+	 * @param chartLoader the loader that reads the chart from disk
+	 */
 	public UpgradeCommand(KubeService kubeService, InstallAction installAction, UninstallAction uninstallAction,
 			UpgradeAction upgradeAction, RollbackAction rollbackAction, ChartLoader chartLoader) {
 		this.kubeService = kubeService;

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/VerifyCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/VerifyCommand.java
@@ -6,6 +6,10 @@ import org.alexmond.jhelm.core.action.VerifyAction;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+/**
+ * Implements {@code jhelm verify CHART}, checking that a packaged chart archive has a
+ * valid PGP provenance signature.
+ */
 @Component
 @CommandLine.Command(name = "verify", mixinStandardHelpOptions = true,
 		description = "Verify that a chart has a valid provenance file")
@@ -20,6 +24,10 @@ public class VerifyCommand implements Runnable {
 	@CommandLine.Option(names = { "--keyring" }, description = "path to the PGP public keyring file")
 	private String keyring;
 
+	/**
+	 * Creates the command.
+	 * @param verifyAction the action that verifies the chart provenance
+	 */
 	public VerifyCommand(VerifyAction verifyAction) {
 		this.verifyAction = verifyAction;
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -48,6 +48,11 @@ import org.apache.hc.client5.http.impl.classic.HttpClients;
 @EnableConfigurationProperties(JhelmCoreProperties.class)
 public class JhelmCoreAutoConfiguration {
 
+	/**
+	 * Provides the chart repository manager, configured from the jhelm properties.
+	 * @param props the jhelm core configuration properties
+	 * @return the repository manager bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public RepoManager repoManager(JhelmCoreProperties props) {
@@ -61,12 +66,23 @@ public class JhelmCoreAutoConfiguration {
 		return rm;
 	}
 
+	/**
+	 * Provides the OCI registry manager used for OCI-based charts.
+	 * @return the registry manager bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public RegistryManager registryManager() {
 		return new RegistryManager();
 	}
 
+	/**
+	 * Provides the template parse cache, enabled unless
+	 * {@code jhelm.template-cache-enabled} is set to {@code false}.
+	 * @param props the jhelm core configuration properties (supplies the max cache size)
+	 * @param metrics optional metrics for recording cache statistics
+	 * @return the template cache bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnProperty(name = "jhelm.template-cache-enabled", havingValue = "true", matchIfMissing = true)
@@ -74,12 +90,23 @@ public class JhelmCoreAutoConfiguration {
 		return new TemplateCache(props.getTemplateCacheMaxSize(), metrics.getIfAvailable());
 	}
 
+	/**
+	 * Provides the JSON-schema validator for chart values.
+	 * @return the schema validator bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public SchemaValidator schemaValidator() {
 		return new SchemaValidator();
 	}
 
+	/**
+	 * Provides the template rendering engine wired with the cache, validator and metrics.
+	 * @param templateCache optional template parse cache
+	 * @param schemaValidator the values schema validator
+	 * @param metrics optional metrics for instrumentation
+	 * @return the engine bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public Engine engine(ObjectProvider<TemplateCache> templateCache, SchemaValidator schemaValidator,
@@ -87,18 +114,32 @@ public class JhelmCoreAutoConfiguration {
 		return new Engine(templateCache.getIfAvailable(), schemaValidator, metrics.getIfAvailable());
 	}
 
+	/**
+	 * Provides the chart loader that reads charts from disk.
+	 * @return the chart loader bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public ChartLoader chartLoader() {
 		return new ChartLoader();
 	}
 
+	/**
+	 * Provides the {@code helm create} action for scaffolding new charts.
+	 * @return the create action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public CreateAction createAction() {
 		return new CreateAction();
 	}
 
+	/**
+	 * Provides the {@code helm template} action, wiring in any post-render processors.
+	 * @param engine the rendering engine
+	 * @param postRenderProcessors optional post-render processors applied to the manifest
+	 * @return the template action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public TemplateAction templateAction(Engine engine,
@@ -111,18 +152,40 @@ public class JhelmCoreAutoConfiguration {
 		return action;
 	}
 
+	/**
+	 * Provides the {@code helm show} action for inspecting chart metadata, values and
+	 * README.
+	 * @param chartLoader the chart loader
+	 * @return the show action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public ShowAction showAction(ChartLoader chartLoader) {
 		return new ShowAction(chartLoader);
 	}
 
+	/**
+	 * Provides the {@code helm lint} action for validating charts.
+	 * @param chartLoader the chart loader
+	 * @param engine the rendering engine
+	 * @param schemaValidator the values schema validator
+	 * @return the lint action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public LintAction lintAction(ChartLoader chartLoader, Engine engine, SchemaValidator schemaValidator) {
 		return new LintAction(chartLoader, engine, schemaValidator);
 	}
 
+	/**
+	 * Provides the {@code helm install} action; only created when a {@link KubeService}
+	 * is present.
+	 * @param engine the rendering engine
+	 * @param kubeService the cluster client
+	 * @param postRenderProcessors optional post-render processors applied to the manifest
+	 * @param lifecycleListeners optional listeners notified on install lifecycle events
+	 * @return the install action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(KubeService.class)
@@ -141,6 +204,15 @@ public class JhelmCoreAutoConfiguration {
 		return action;
 	}
 
+	/**
+	 * Provides the {@code helm upgrade} action; only created when a {@link KubeService}
+	 * is present.
+	 * @param engine the rendering engine
+	 * @param kubeService the cluster client
+	 * @param postRenderProcessors optional post-render processors applied to the manifest
+	 * @param lifecycleListeners optional listeners notified on upgrade lifecycle events
+	 * @return the upgrade action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(KubeService.class)
@@ -159,6 +231,12 @@ public class JhelmCoreAutoConfiguration {
 		return action;
 	}
 
+	/**
+	 * Provides the {@code helm uninstall} action; only created when a {@link KubeService}
+	 * is present.
+	 * @param kubeService the cluster client
+	 * @return the uninstall action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(KubeService.class)
@@ -166,6 +244,12 @@ public class JhelmCoreAutoConfiguration {
 		return new UninstallAction(kubeService);
 	}
 
+	/**
+	 * Provides the {@code helm list} action; only created when a {@link KubeService} is
+	 * present.
+	 * @param kubeService the cluster client
+	 * @return the list action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(KubeService.class)
@@ -173,6 +257,12 @@ public class JhelmCoreAutoConfiguration {
 		return new ListAction(kubeService);
 	}
 
+	/**
+	 * Provides the {@code helm status} action; only created when a {@link KubeService} is
+	 * present.
+	 * @param kubeService the cluster client
+	 * @return the status action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(KubeService.class)
@@ -180,6 +270,12 @@ public class JhelmCoreAutoConfiguration {
 		return new StatusAction(kubeService);
 	}
 
+	/**
+	 * Provides the {@code helm history} action; only created when a {@link KubeService}
+	 * is present.
+	 * @param kubeService the cluster client
+	 * @return the history action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(KubeService.class)
@@ -187,6 +283,12 @@ public class JhelmCoreAutoConfiguration {
 		return new HistoryAction(kubeService);
 	}
 
+	/**
+	 * Provides the {@code helm rollback} action; only created when a {@link KubeService}
+	 * is present.
+	 * @param kubeService the cluster client
+	 * @return the rollback action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(KubeService.class)
@@ -194,6 +296,12 @@ public class JhelmCoreAutoConfiguration {
 		return new RollbackAction(kubeService);
 	}
 
+	/**
+	 * Provides the {@code helm get} action; only created when a {@link KubeService} is
+	 * present.
+	 * @param kubeService the cluster client
+	 * @return the get action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(KubeService.class)
@@ -201,6 +309,12 @@ public class JhelmCoreAutoConfiguration {
 		return new GetAction(kubeService);
 	}
 
+	/**
+	 * Provides the {@code helm test} action; only created when a {@link KubeService} is
+	 * present.
+	 * @param kubeService the cluster client
+	 * @return the test action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(KubeService.class)
@@ -208,24 +322,44 @@ public class JhelmCoreAutoConfiguration {
 		return new TestAction(kubeService);
 	}
 
+	/**
+	 * Provides the PGP signature service used for signing and verifying chart packages.
+	 * @return the signature service bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public SignatureService signatureService() {
 		return new SignatureService();
 	}
 
+	/**
+	 * Provides the {@code helm package} action for packaging charts into {@code .tgz}
+	 * archives, optionally signed.
+	 * @param chartLoader the chart loader
+	 * @param signatureService the signature service used for optional signing
+	 * @return the package action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public PackageAction packageAction(ChartLoader chartLoader, SignatureService signatureService) {
 		return new PackageAction(chartLoader, signatureService);
 	}
 
+	/**
+	 * Provides the {@code helm verify} action for verifying a packaged chart's signature.
+	 * @param signatureService the signature service
+	 * @return the verify action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public VerifyAction verifyAction(SignatureService signatureService) {
 		return new VerifyAction(signatureService);
 	}
 
+	/**
+	 * Provides the {@code helm search hub} action backed by a default HTTP client.
+	 * @return the search-hub action bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public SearchHubAction searchHubAction() {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmMetricsAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmMetricsAutoConfiguration.java
@@ -18,6 +18,11 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnClass(MeterRegistry.class)
 public class JhelmMetricsAutoConfiguration {
 
+	/**
+	 * Provides the {@link JhelmMetrics} bean backed by the application's meter registry.
+	 * @param meterRegistry the Micrometer registry to publish metrics to
+	 * @return the metrics service bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(MeterRegistry.class)

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/CreateAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/CreateAction.java
@@ -6,9 +6,20 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.alexmond.jhelm.core.template.HelmChartTemplates;
 
+/**
+ * Implements {@code helm create}: scaffolds a new chart directory on disk from the
+ * default Helm chart templates, populating {@code Chart.yaml}, {@code values.yaml} and a
+ * starter set of templates with the chart name substituted in.
+ */
 @Slf4j
 public class CreateAction {
 
+	/**
+	 * Scaffolds a new chart at the given path, using its final path segment as the chart
+	 * name.
+	 * @param chartPath the directory to create the chart in; must not already exist
+	 * @throws IOException if the directory already exists or files cannot be written
+	 */
 	public void create(Path chartPath) throws IOException {
 		String chartName = chartPath.getFileName().toString();
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/GetAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/GetAction.java
@@ -16,20 +16,48 @@ import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.util.ValuesLoader;
 
+/**
+ * Implements {@code helm get} sub-commands: retrieves a deployed release and extracts its
+ * stored manifest, hooks, notes, computed values and metadata. Mirrors the output
+ * sections of {@code helm get all}.
+ */
 @RequiredArgsConstructor
 public class GetAction {
 
 	private final KubeService kubeService;
 
+	/**
+	 * Returns the latest revision of a named release.
+	 * @param name the release name
+	 * @param namespace the release namespace
+	 * @return the release if found, otherwise empty
+	 * @throws Exception if the release store cannot be read
+	 */
 	public Optional<Release> getRelease(String name, String namespace) throws Exception {
 		return kubeService.getRelease(name, namespace);
 	}
 
+	/**
+	 * Returns a specific revision of a named release.
+	 * @param name the release name
+	 * @param namespace the release namespace
+	 * @param revision the revision number to look up
+	 * @return the matching revision if found, otherwise empty
+	 * @throws Exception if the release history cannot be read
+	 */
 	public Optional<Release> getReleaseByRevision(String name, String namespace, int revision) throws Exception {
 		List<Release> history = kubeService.getReleaseHistory(name, namespace);
 		return history.stream().filter((r) -> r.getVersion() == revision).findFirst();
 	}
 
+	/**
+	 * Returns the release's values as YAML.
+	 * @param release the release to inspect
+	 * @param all if {@code true}, return the chart defaults merged with user overrides;
+	 * if {@code false}, return only the user-supplied overrides
+	 * @return the values rendered as YAML, or {@code "{}"} when there are none
+	 * @throws Exception if the values cannot be serialized
+	 */
 	public String getValues(Release release, boolean all) throws Exception {
 		if (all && release.getChart() != null && release.getChart().getValues() != null) {
 			Map<String, Object> merged = new LinkedHashMap<>(release.getChart().getValues());
@@ -45,10 +73,20 @@ public class GetAction {
 		return toYaml(release.getConfig().getValues());
 	}
 
+	/**
+	 * Returns the stored Kubernetes manifest for the release.
+	 * @param release the release to inspect
+	 * @return the manifest, or an empty string when none is stored
+	 */
 	public String getManifest(Release release) {
 		return (release.getManifest() != null) ? release.getManifest() : "";
 	}
 
+	/**
+	 * Returns the rendered {@code NOTES.txt} for the release.
+	 * @param release the release to inspect
+	 * @return the notes, or an empty string when none are stored
+	 */
 	public String getNotes(Release release) {
 		if (release.getInfo() != null && release.getInfo().getNotes() != null) {
 			return release.getInfo().getNotes();
@@ -56,6 +94,12 @@ public class GetAction {
 		return "";
 	}
 
+	/**
+	 * Extracts the hook resources from the release manifest (documents annotated with
+	 * {@code helm.sh/hook}), joined as a multi-document YAML string.
+	 * @param release the release to inspect
+	 * @return the hook documents, or an empty string when there are none
+	 */
 	public String getHooks(Release release) {
 		if (release.getManifest() == null || release.getManifest().isEmpty()) {
 			return "";
@@ -76,6 +120,12 @@ public class GetAction {
 		return hooks.toString();
 	}
 
+	/**
+	 * Builds a summary metadata map for the release (name, namespace, revision, chart
+	 * name/version, app version and deployment status).
+	 * @param release the release to inspect
+	 * @return an ordered map of metadata fields
+	 */
 	public Map<String, Object> getMetadata(Release release) {
 		Map<String, Object> metadata = new LinkedHashMap<>();
 		metadata.put("name", release.getName());
@@ -93,6 +143,15 @@ public class GetAction {
 		return metadata;
 	}
 
+	/**
+	 * Combines the manifest, hooks, notes and values into a single {@code helm get all}
+	 * style report, with each section under its own header.
+	 * @param release the release to inspect
+	 * @param allValues if {@code true}, include merged chart defaults in the VALUES
+	 * section
+	 * @return the combined multi-section report
+	 * @throws Exception if the values cannot be serialized
+	 */
 	public String getAll(Release release, boolean allValues) throws Exception {
 		StringBuilder sb = new StringBuilder();
 
@@ -123,6 +182,13 @@ public class GetAction {
 		return sb.toString();
 	}
 
+	/**
+	 * Serializes an object to YAML using the action's standard formatting (no document
+	 * start marker, minimized quotes, null values omitted).
+	 * @param obj the object to serialize
+	 * @return the YAML representation
+	 * @throws Exception if serialization fails
+	 */
 	public String toYaml(Object obj) throws Exception {
 		YAMLMapper yamlMapper = YAMLMapper.builder()
 			.disable(YAMLWriteFeature.WRITE_DOC_START_MARKER)
@@ -134,6 +200,12 @@ public class GetAction {
 		return yamlMapper.writeValueAsString(obj);
 	}
 
+	/**
+	 * Serializes an object to indented JSON.
+	 * @param obj the object to serialize
+	 * @return the JSON representation
+	 * @throws Exception if serialization fails
+	 */
 	public String toJson(Object obj) throws Exception {
 		JsonMapper jsonMapper = JsonMapper.builder().enable(SerializationFeature.INDENT_OUTPUT).build();
 		return jsonMapper.writeValueAsString(obj);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/HistoryAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/HistoryAction.java
@@ -6,11 +6,22 @@ import lombok.RequiredArgsConstructor;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.KubeService;
 
+/**
+ * Implements {@code helm history}: lists the stored revisions of a release in
+ * chronological order.
+ */
 @RequiredArgsConstructor
 public class HistoryAction {
 
 	private final KubeService kubeService;
 
+	/**
+	 * Returns the revision history of a named release.
+	 * @param name the release name
+	 * @param namespace the release namespace
+	 * @return the list of stored revisions, oldest first
+	 * @throws Exception if the release history cannot be read
+	 */
 	public List<Release> history(String name, String namespace) throws Exception {
 		return kubeService.getReleaseHistory(name, namespace);
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -20,6 +20,12 @@ import org.alexmond.jhelm.core.util.HookExecutor;
 import org.alexmond.jhelm.core.util.HookParser;
 import org.alexmond.jhelm.core.util.ValuesLoader;
 
+/**
+ * Implements {@code helm install}: renders a chart to a manifest, runs post-render
+ * processors and lifecycle hooks, applies the resulting resources (and any CRDs) to the
+ * cluster, and stores the resulting {@link Release}. On a failure after resources have
+ * been applied it rolls them back and raises a {@link DeploymentFailedException}.
+ */
 @RequiredArgsConstructor
 @Slf4j
 public class InstallAction {
@@ -34,6 +40,25 @@ public class InstallAction {
 	@Setter
 	private List<LifecycleListener> lifecycleListeners = List.of();
 
+	/**
+	 * Installs a chart as a new release. Chart default values are merged with the
+	 * supplied overrides, the templates are rendered, and—unless this is a dry run—the
+	 * resulting resources, CRDs and hooks are applied to the cluster and the release is
+	 * persisted.
+	 * @param chart the chart to install (must not be a library chart)
+	 * @param releaseName the name to give the release
+	 * @param namespace the target namespace
+	 * @param overrideValues user-supplied values merged over the chart defaults, may be
+	 * {@code null}
+	 * @param version the release revision number to assign
+	 * @param dryRun if {@code true}, render only and skip applying anything to the
+	 * cluster
+	 * @return the resulting release, including the rendered manifest
+	 * @throws IllegalArgumentException if the chart is a library chart
+	 * @throws DeploymentFailedException if applied resources cannot be persisted (they
+	 * are rolled back)
+	 * @throws Exception if rendering or a cluster operation fails
+	 */
 	public Release install(Chart chart, String releaseName, String namespace, Map<String, Object> overrideValues,
 			int version, boolean dryRun) throws Exception {
 		if ("library".equals(chart.getMetadata().getType())) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/ChartLoadException.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/ChartLoadException.java
@@ -13,12 +13,25 @@ public class ChartLoadException extends JhelmException {
 
 	private final String suggestion;
 
+	/**
+	 * Creates a chart-load failure.
+	 * @param message a description of why the chart could not be loaded
+	 * @param chartPath the path of the chart that failed to load, may be {@code null}
+	 * @param suggestion an actionable hint for resolving the error, may be {@code null}
+	 */
 	public ChartLoadException(String message, String chartPath, String suggestion) {
 		super(buildMessage(message, chartPath, suggestion));
 		this.chartPath = chartPath;
 		this.suggestion = suggestion;
 	}
 
+	/**
+	 * Creates a chart-load failure wrapping an underlying cause.
+	 * @param message a description of why the chart could not be loaded
+	 * @param cause the underlying error being wrapped
+	 * @param chartPath the path of the chart that failed to load, may be {@code null}
+	 * @param suggestion an actionable hint for resolving the error, may be {@code null}
+	 */
 	public ChartLoadException(String message, Throwable cause, String chartPath, String suggestion) {
 		super(buildMessage(message, chartPath, suggestion), cause);
 		this.chartPath = chartPath;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/DeploymentFailedException.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/DeploymentFailedException.java
@@ -8,6 +8,13 @@ public class DeploymentFailedException extends JhelmException {
 
 	private final String appliedManifest;
 
+	/**
+	 * Creates a new deployment failure.
+	 * @param message a description of what failed
+	 * @param cause the underlying error that triggered the failure
+	 * @param appliedManifest the manifest that was applied before the failure, used for
+	 * cleanup
+	 */
 	public DeploymentFailedException(String message, Throwable cause, String appliedManifest) {
 		super(message, cause);
 		this.appliedManifest = appliedManifest;
@@ -16,6 +23,7 @@ public class DeploymentFailedException extends JhelmException {
 	/**
 	 * Returns the manifest that was (partially) applied before the failure, or
 	 * {@code null} if nothing was applied.
+	 * @return the partially applied manifest, or {@code null}
 	 */
 	public String getAppliedManifest() {
 		return appliedManifest;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/JhelmException.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/JhelmException.java
@@ -7,10 +7,19 @@ package org.alexmond.jhelm.core.exception;
  */
 public class JhelmException extends RuntimeException {
 
+	/**
+	 * Creates an exception with the given detail message.
+	 * @param message a description of the failure
+	 */
 	public JhelmException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Creates an exception with the given detail message and underlying cause.
+	 * @param message a description of the failure
+	 * @param cause the underlying error being wrapped
+	 */
 	public JhelmException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/KubernetesOperationException.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/exception/KubernetesOperationException.java
@@ -8,21 +8,44 @@ public class KubernetesOperationException extends JhelmException {
 
 	private final int statusCode;
 
+	/**
+	 * Creates an exception with no associated HTTP status code (status reported as
+	 * {@code -1}).
+	 * @param message a description of the failed operation
+	 */
 	public KubernetesOperationException(String message) {
 		super(message);
 		this.statusCode = -1;
 	}
 
+	/**
+	 * Creates an exception wrapping an underlying cause, with no associated HTTP status
+	 * code.
+	 * @param message a description of the failed operation
+	 * @param cause the underlying API error
+	 */
 	public KubernetesOperationException(String message, Throwable cause) {
 		super(message, cause);
 		this.statusCode = -1;
 	}
 
+	/**
+	 * Creates an exception wrapping an underlying cause and the HTTP status code returned
+	 * by the Kubernetes API.
+	 * @param message a description of the failed operation
+	 * @param cause the underlying API error
+	 * @param statusCode the HTTP status code returned by the API
+	 */
 	public KubernetesOperationException(String message, Throwable cause, int statusCode) {
 		super(message, cause);
 		this.statusCode = statusCode;
 	}
 
+	/**
+	 * Returns the HTTP status code reported by the Kubernetes API, or {@code -1} if
+	 * unknown.
+	 * @return the HTTP status code, or {@code -1}
+	 */
 	public int getStatusCode() {
 		return statusCode;
 	}
@@ -30,6 +53,7 @@ public class KubernetesOperationException extends JhelmException {
 	/**
 	 * Returns {@code true} if the error is transient and may succeed on retry (5xx server
 	 * errors and 429 rate-limiting).
+	 * @return {@code true} if the operation may succeed on retry
 	 */
 	public boolean isTransient() {
 		return statusCode == 429 || (statusCode >= 500 && statusCode < 600);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/metrics/JhelmMetrics.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/metrics/JhelmMetrics.java
@@ -24,6 +24,11 @@ public class JhelmMetrics {
 
 	private final Counter cacheMissCounter;
 
+	/**
+	 * Creates the metrics service and registers the render timer and cache counters on
+	 * the given registry.
+	 * @param registry the Micrometer registry to publish metrics to
+	 */
 	public JhelmMetrics(MeterRegistry registry) {
 		this.registry = registry;
 		this.renderTimer = Timer.builder(PREFIX + ".engine.render")
@@ -108,7 +113,8 @@ public class JhelmMetrics {
 	}
 
 	/**
-	 * Return the underlying {@link MeterRegistry}.
+	 * Returns the underlying {@link MeterRegistry}.
+	 * @return the registry backing this metrics service
 	 */
 	public MeterRegistry getRegistry() {
 		return registry;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Chart.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Chart.java
@@ -10,6 +10,11 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * In-memory representation of a loaded Helm chart: its {@link ChartMetadata}, default
+ * values, templates, CRDs, subchart dependencies and any non-template files exposed via
+ * {@code .Files}. Produced by the chart loader and consumed by the rendering engine.
+ */
 @Data
 @Builder(toBuilder = true)
 @NoArgsConstructor
@@ -45,6 +50,10 @@ public class Chart {
 	@Builder.Default
 	private Map<String, String> files = new LinkedHashMap<>();
 
+	/**
+	 * A single template file in the chart, identified by its path relative to the chart
+	 * root (e.g. {@code templates/deployment.yaml}) and its raw text content.
+	 */
 	@Data
 	@Builder
 	@NoArgsConstructor
@@ -57,6 +66,11 @@ public class Chart {
 
 	}
 
+	/**
+	 * A CustomResourceDefinition file from the chart's {@code crds/} directory,
+	 * identified by its relative path and raw YAML content. CRDs are installed before
+	 * other resources and are not templated.
+	 */
 	@Data
 	@Builder
 	@NoArgsConstructor

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartFiles.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartFiles.java
@@ -39,6 +39,10 @@ public class ChartFiles extends AbstractMap<String, String> {
 
 	private final Map<String, String> files;
 
+	/**
+	 * Wraps a map of chart file paths to their text content.
+	 * @param files the path-to-content map, or {@code null} for an empty set of files
+	 */
 	public ChartFiles(Map<String, String> files) {
 		this.files = (files != null) ? files : Map.of();
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartMetadata.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartMetadata.java
@@ -10,6 +10,11 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * The contents of a chart's {@code Chart.yaml}: name, version, description, API version,
+ * type, app version, supported Kubernetes range, dependency declarations and annotations.
+ * Unknown keys are ignored on deserialization.
+ */
 @Data
 @Builder(toBuilder = true)
 @NoArgsConstructor
@@ -52,6 +57,11 @@ public class ChartMetadata {
 	@JsonIgnore
 	private Boolean root;
 
+	/**
+	 * Exposes Helm's {@code .Chart.IsRoot} flag to templates: {@code true} when this is
+	 * the top-level release chart, {@code false} when rendered as a subchart.
+	 * @return {@code true} if this chart is the root of the release
+	 */
 	@JsonIgnore
 	@SuppressWarnings("PMD.BooleanGetMethodName")
 	public boolean getIsRoot() {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
@@ -21,6 +21,11 @@ import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Dependency;
 import org.alexmond.jhelm.core.util.ValuesLoader;
 
+/**
+ * Loads a Helm chart from a directory on disk into an in-memory {@link Chart}, reading
+ * {@code Chart.yaml} metadata, {@code values.yaml}, templates, CRDs, subchart
+ * dependencies and arbitrary non-template files exposed via the {@code .Files} object.
+ */
 @Slf4j
 @Component
 public class ChartLoader {
@@ -32,6 +37,7 @@ public class ChartLoader {
 	 * archives create a single subdirectory (e.g. {@code parent/nginx/}).
 	 * @param parent the directory to search
 	 * @return the first subdirectory, or the parent itself if none found
+	 * @throws IOException if the directory cannot be listed
 	 */
 	public static Path findChartDir(Path parent) throws IOException {
 		try (var stream = Files.list(parent)) {
@@ -39,6 +45,14 @@ public class ChartLoader {
 		}
 	}
 
+	/**
+	 * Loads the chart rooted at the given directory, including its metadata, values,
+	 * templates, CRDs and subchart dependencies.
+	 * @param chartDir the chart's root directory (the one containing {@code Chart.yaml})
+	 * @return the fully populated chart
+	 * @throws IOException if a chart file cannot be read
+	 * @throws ChartLoadException if the directory is missing or has no {@code Chart.yaml}
+	 */
 	public Chart load(File chartDir) throws IOException {
 		if (!chartDir.exists() || !chartDir.isDirectory()) {
 			throw new ChartLoadException("Chart directory does not exist", chartDir.getPath(),

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/DependencyResolver.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/DependencyResolver.java
@@ -30,6 +30,11 @@ public class DependencyResolver {
 
 	private final RepoManager repoManager;
 
+	/**
+	 * Creates a resolver that fetches and caches dependency charts through the given
+	 * repository manager.
+	 * @param repoManager the repository manager used to download dependency charts
+	 */
 	public DependencyResolver(RepoManager repoManager) {
 		this.repoManager = repoManager;
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -27,6 +27,14 @@ import org.alexmond.jhelm.core.model.Dependency;
 import org.alexmond.jhelm.core.model.Values;
 import org.alexmond.jhelm.core.model.VersionSet;
 
+/**
+ * Renders a Helm {@link Chart} to Kubernetes manifests by driving the Go template engine.
+ * It assembles the rendering context ({@code .Values}, {@code .Release}, {@code .Chart},
+ * {@code .Capabilities}, {@code .Files}), resolves named templates and subchart
+ * dependencies, and validates values against the chart's JSON schema. Optionally backed
+ * by a {@link TemplateCache} for parse reuse and a {@link JhelmMetrics} for
+ * instrumentation.
+ */
 @Slf4j
 public class Engine {
 
@@ -67,14 +75,35 @@ public class Engine {
 
 	private GoTemplate factory;
 
+	/**
+	 * Creates an engine with no template cache and no metrics, using a default schema
+	 * validator.
+	 */
 	public Engine() {
 		this(null, new SchemaValidator(), null);
 	}
 
+	/**
+	 * Creates an engine with the given template cache and schema validator and no
+	 * metrics.
+	 * @param templateCache the parse cache to reuse compiled templates, or {@code null}
+	 * to disable caching
+	 * @param schemaValidator validates values against a chart's JSON schema, or
+	 * {@code null} for a default validator
+	 */
 	public Engine(TemplateCache templateCache, SchemaValidator schemaValidator) {
 		this(templateCache, schemaValidator, null);
 	}
 
+	/**
+	 * Creates an engine with the given template cache, schema validator and metrics.
+	 * @param templateCache the parse cache to reuse compiled templates, or {@code null}
+	 * to disable caching
+	 * @param schemaValidator validates values against a chart's JSON schema, or
+	 * {@code null} for a default validator
+	 * @param metrics records render and cache metrics, or {@code null} to disable
+	 * instrumentation
+	 */
 	public Engine(TemplateCache templateCache, SchemaValidator schemaValidator, JhelmMetrics metrics) {
 		this.templateCache = templateCache;
 		this.schemaValidator = (schemaValidator != null) ? schemaValidator : new SchemaValidator();
@@ -136,6 +165,19 @@ public class Engine {
 	 */
 	private static final long RENDER_STACK_SIZE = 32L * 1024 * 1024;
 
+	/**
+	 * Renders the chart's templates to a single concatenated manifest string. Rendering
+	 * runs on a dedicated thread with an enlarged stack to accommodate deeply nested
+	 * {@code tpl}/{@code include} chains.
+	 * @param chart the chart to render
+	 * @param values the user-supplied values merged over the chart defaults, exposed as
+	 * {@code .Values}
+	 * @param releaseInfo the release context exposed as {@code .Release} (name,
+	 * namespace, revision, etc.)
+	 * @return the rendered manifests joined into one document
+	 * @throws TemplateRenderException if a template fails to parse or execute
+	 * @throws SchemaValidationException if the values violate the chart's JSON schema
+	 */
 	@SneakyThrows
 	public String render(Chart chart, Map<String, Object> values, Map<String, Object> releaseInfo) {
 		long startNanos = System.nanoTime();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/template/HelmChartTemplates.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/template/HelmChartTemplates.java
@@ -11,12 +11,20 @@ public final class HelmChartTemplates {
 	}
 
 	/**
-	 * Replace CHARTNAME placeholder with actual chart name in all templates
+	 * Replaces every {@code CHARTNAME} placeholder in a template with the actual chart
+	 * name.
+	 * @param template the template text containing {@code CHARTNAME} placeholders
+	 * @param chartName the chart name to substitute in
+	 * @return the template with all placeholders replaced
 	 */
 	public static String substituteChartName(String template, String chartName) {
 		return template.replace("CHARTNAME", chartName);
 	}
 
+	/**
+	 * Returns the default {@code .helmignore} file contents.
+	 * @return the {@code .helmignore} template
+	 */
 	public static String getHelmIgnore() {
 		return """
 				# Patterns to ignore when building packages.
@@ -45,6 +53,10 @@ public final class HelmChartTemplates {
 				""";
 	}
 
+	/**
+	 * Returns the default {@code Chart.yaml} metadata template.
+	 * @return the {@code Chart.yaml} template
+	 */
 	public static String getChartYaml() {
 		return """
 				apiVersion: v2
@@ -74,6 +86,10 @@ public final class HelmChartTemplates {
 				""";
 	}
 
+	/**
+	 * Returns the default {@code values.yaml} template with commented example values.
+	 * @return the {@code values.yaml} template
+	 */
 	public static String getValuesYaml() {
 		return """
 				# Default values for CHARTNAME.
@@ -240,6 +256,10 @@ public final class HelmChartTemplates {
 				""";
 	}
 
+	/**
+	 * Returns the default {@code templates/NOTES.txt} template shown after install.
+	 * @return the {@code NOTES.txt} template
+	 */
 	public static String getNotesTemplate() {
 		return """
 				1. Get the application URL by running these commands:
@@ -280,6 +300,10 @@ public final class HelmChartTemplates {
 				""";
 	}
 
+	/**
+	 * Returns the default {@code templates/_helpers.tpl} with named template definitions.
+	 * @return the {@code _helpers.tpl} template
+	 */
 	public static String getHelpersTemplate() {
 		return """
 				{{/*
@@ -347,6 +371,10 @@ public final class HelmChartTemplates {
 				""";
 	}
 
+	/**
+	 * Returns the default {@code templates/deployment.yaml} template.
+	 * @return the Deployment template
+	 */
 	public static String getDeploymentTemplate() {
 		return """
 				apiVersion: apps/v1
@@ -430,6 +458,10 @@ public final class HelmChartTemplates {
 				""";
 	}
 
+	/**
+	 * Returns the default {@code templates/service.yaml} template.
+	 * @return the Service template
+	 */
 	public static String getServiceTemplate() {
 		return """
 				apiVersion: v1
@@ -450,6 +482,10 @@ public final class HelmChartTemplates {
 				""";
 	}
 
+	/**
+	 * Returns the default {@code templates/serviceaccount.yaml} template.
+	 * @return the ServiceAccount template
+	 */
 	public static String getServiceAccountTemplate() {
 		return """
 				{{- if .Values.serviceAccount.create -}}
@@ -468,6 +504,10 @@ public final class HelmChartTemplates {
 				""";
 	}
 
+	/**
+	 * Returns the default {@code templates/hpa.yaml} HorizontalPodAutoscaler template.
+	 * @return the HPA template
+	 */
 	public static String getHpaTemplate() {
 		return """
 				{{- if .Values.autoscaling.enabled }}
@@ -505,6 +545,10 @@ public final class HelmChartTemplates {
 				""";
 	}
 
+	/**
+	 * Returns the default {@code templates/ingress.yaml} template.
+	 * @return the Ingress template
+	 */
 	public static String getIngressTemplate() {
 		return """
 				{{- if .Values.ingress.enabled -}}
@@ -553,6 +597,11 @@ public final class HelmChartTemplates {
 				""";
 	}
 
+	/**
+	 * Returns the default {@code templates/httproute.yaml} Gateway API HTTPRoute
+	 * template.
+	 * @return the HTTPRoute template
+	 */
 	public static String getHttpRouteTemplate() {
 		return """
 				{{- if .Values.httpRoute.enabled -}}
@@ -596,6 +645,11 @@ public final class HelmChartTemplates {
 				""";
 	}
 
+	/**
+	 * Returns the default {@code templates/tests/test-connection.yaml} Helm test pod
+	 * template.
+	 * @return the test-connection template
+	 */
 	public static String getTestConnectionTemplate() {
 		return """
 				apiVersion: v1

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
@@ -7,6 +7,7 @@ import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.util.Config;
 import io.kubernetes.client.util.KubeConfig;
 import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
+import org.alexmond.jhelm.core.JhelmMetricsAutoConfiguration;
 import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
@@ -31,11 +32,27 @@ import java.time.Duration;
  * before {@link JhelmCoreAutoConfiguration} so that the {@link KubeService} bean is
  * available for its {@code @ConditionalOnBean} checks.
  */
-@AutoConfiguration(before = JhelmCoreAutoConfiguration.class,
-		after = org.alexmond.jhelm.core.JhelmMetricsAutoConfiguration.class)
+@AutoConfiguration(before = JhelmCoreAutoConfiguration.class, after = JhelmMetricsAutoConfiguration.class)
 @EnableConfigurationProperties(JhelmKubernetesProperties.class)
 public class JhelmKubeAutoConfiguration {
 
+	/**
+	 * Creates the auto-configuration. Instantiated by the Spring Boot auto-configuration
+	 * machinery; not intended to be constructed directly by application code.
+	 */
+	@SuppressWarnings("PMD.UnnecessaryConstructor")
+	public JhelmKubeAutoConfiguration() {
+	}
+
+	/**
+	 * Builds the Kubernetes {@link ApiClient} used by the module. When a kubeconfig path
+	 * is configured the client is built from that file, otherwise the default in-cluster
+	 * or local client is used.
+	 * @param props the Kubernetes configuration properties, providing the optional
+	 * kubeconfig path
+	 * @return the configured Kubernetes API client
+	 * @throws IOException if the configured kubeconfig file cannot be read
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public ApiClient apiClient(JhelmKubernetesProperties props) throws IOException {
@@ -45,6 +62,17 @@ public class JhelmKubeAutoConfiguration {
 		return Config.defaultClient();
 	}
 
+	/**
+	 * Builds the {@link KubeService} bean. The base {@link AsyncHelmKubeService} is
+	 * wrapped with {@link RetryableKubeService} when retry is enabled, and further
+	 * wrapped with {@link ObservableKubeService} when a {@link JhelmMetrics} bean is
+	 * available.
+	 * @param apiClient the configured Kubernetes API client
+	 * @param props the Kubernetes configuration properties, providing the retry settings
+	 * @param metricsProvider provider for the optional metrics bean used to enable
+	 * operation timing and counting
+	 * @return the (possibly decorated) Kubernetes service
+	 */
 	@Bean
 	@ConditionalOnMissingBean(KubeService.class)
 	public KubeService kubeService(ApiClient apiClient, JhelmKubernetesProperties props,

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/KubernetesConfig.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/KubernetesConfig.java
@@ -11,4 +11,11 @@ import org.springframework.context.annotation.Import;
 @Import(JhelmKubeAutoConfiguration.class)
 public class KubernetesConfig {
 
+	/**
+	 * Creates the configuration bridge. Instantiated by the Spring container.
+	 */
+	@SuppressWarnings("PMD.UnnecessaryConstructor")
+	public KubernetesConfig() {
+	}
+
 }

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
@@ -13,6 +13,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class JhelmKubernetesProperties {
 
 	/**
+	 * Creates the properties holder with default values.
+	 */
+	@SuppressWarnings("PMD.UnnecessaryConstructor")
+	public JhelmKubernetesProperties() {
+	}
+
+	/**
 	 * Path to the kubeconfig file. When not set, the Kubernetes client uses its standard
 	 * auto-detection: {@code ~/.kube/config} or in-cluster service account credentials.
 	 */
@@ -23,9 +30,20 @@ public class JhelmKubernetesProperties {
 	 */
 	private Retry retry = new Retry();
 
+	/**
+	 * Retry configuration for transient Kubernetes API failures, controlling the maximum
+	 * number of attempts and the exponential backoff between them.
+	 */
 	@Getter
 	@Setter
 	public static class Retry {
+
+		/**
+		 * Creates the retry settings with default values.
+		 */
+		@SuppressWarnings("PMD.UnnecessaryConstructor")
+		public Retry() {
+		}
 
 		/**
 		 * Whether retry is enabled for Kubernetes API calls.

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/AsyncHelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/AsyncHelmKubeService.java
@@ -27,6 +27,11 @@ public class AsyncHelmKubeService extends HelmKubeService implements AsyncKubeSe
 
 	private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
 
+	/**
+	 * Creates an async service backed by the given Kubernetes API client.
+	 * @param apiClient the configured Kubernetes API client used for all cluster
+	 * operations
+	 */
 	public AsyncHelmKubeService(ApiClient apiClient) {
 		super(apiClient);
 	}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
@@ -42,10 +42,22 @@ import java.util.Comparator;
 import java.util.stream.Collectors;
 import java.nio.charset.StandardCharsets;
 
+/**
+ * Default {@link KubeService} implementation backed by the official Kubernetes Java
+ * client. It stores and reads Helm releases as gzip-compressed, base64-encoded Secrets
+ * (matching Helm's {@code sh.helm.release.v1.*} storage format), applies rendered
+ * manifests, and waits on workload readiness.
+ *
+ * <p>
+ * Instances are created with a configured {@link ApiClient}; all operations issue calls
+ * through that client and surface failures as {@link ApiException} or the project's
+ * Kubernetes exception types.
+ */
 @RequiredArgsConstructor
 @Slf4j
 public class HelmKubeService implements KubeService {
 
+	/** Configured Kubernetes API client used for all cluster operations. */
 	private final ApiClient apiClient;
 
 	private final JsonMapper objectMapper = JsonMapper.builder().build();
@@ -188,7 +200,11 @@ public class HelmKubeService implements KubeService {
 	}
 
 	/**
-	 * Mimics basic "helm status" or pod listing in a namespace.
+	 * Lists the names of all pods in the given namespace, mimicking basic
+	 * {@code helm status} pod listing.
+	 * @param namespace the Kubernetes namespace to list pods from
+	 * @return the names of the pods found in the namespace, in API-returned order
+	 * @throws ApiException if the Kubernetes API call fails
 	 */
 	public List<String> listPods(String namespace) throws ApiException {
 		CoreV1Api api = new CoreV1Api(apiClient);
@@ -491,7 +507,13 @@ public class HelmKubeService implements KubeService {
 	}
 
 	/**
-	 * Mimics "helm install" by applying a ConfigMap from a YAML string.
+	 * Installs a ConfigMap parsed from a YAML string into the given namespace, mimicking
+	 * {@code helm install}. If a ConfigMap with the same name already exists (HTTP 409
+	 * conflict) it is replaced instead of created.
+	 * @param namespace the Kubernetes namespace to install the ConfigMap into
+	 * @param yamlContent the YAML representation of the ConfigMap to install
+	 * @throws ApiException if the Kubernetes API call fails for a reason other than an
+	 * already-existing ConfigMap
 	 */
 	public void installConfigMap(String namespace, String yamlContent) throws ApiException {
 		CoreV1Api api = new CoreV1Api(apiClient);

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/KubernetesClientProvider.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/KubernetesClientProvider.java
@@ -15,8 +15,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Implementation of KubernetesProvider using Kubernetes Java client. Provides real
- * Kubernetes API access for template functions.
+ * {@link KubernetesProvider} implementation backed by the official Kubernetes Java
+ * client. It provides real cluster access for template functions such as {@code lookup}
+ * and {@code Capabilities}, gracefully degrading to empty results or stub version
+ * information when the API server is unreachable.
  */
 @Slf4j
 public class KubernetesClientProvider implements KubernetesProvider {
@@ -31,6 +33,11 @@ public class KubernetesClientProvider implements KubernetesProvider {
 
 	private volatile Boolean available;
 
+	/**
+	 * Creates a provider backed by the given Kubernetes API client.
+	 * @param apiClient the configured Kubernetes API client used to look up resources and
+	 * query cluster version information
+	 */
 	public KubernetesClientProvider(ApiClient apiClient) {
 		this.apiClient = apiClient;
 		this.coreV1Api = new CoreV1Api(apiClient);

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/ObservableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/ObservableKubeService.java
@@ -37,6 +37,12 @@ public class ObservableKubeService implements KubeService {
 
 	private final Counter errorCounter;
 
+	/**
+	 * Creates a metrics-recording decorator around the given delegate.
+	 * @param delegate the underlying {@link KubeService} to which calls are forwarded
+	 * @param metrics the metrics registry used to build the per-operation timers and
+	 * success/error counters
+	 */
 	public ObservableKubeService(KubeService delegate, JhelmMetrics metrics) {
 		this.delegate = delegate;
 		this.applyTimer = metrics.kubeOperationTimer("apply");

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/RetryableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/RetryableKubeService.java
@@ -31,6 +31,12 @@ public class RetryableKubeService implements KubeService {
 
 	private final RetryTemplate retryTemplate;
 
+	/**
+	 * Creates a retrying decorator around the given delegate.
+	 * @param delegate the underlying {@link KubeService} to which calls are forwarded
+	 * @param retryTemplate the retry template defining the backoff and retry policy for
+	 * transient failures
+	 */
 	public RetryableKubeService(KubeService delegate, RetryTemplate retryTemplate) {
 		this.delegate = delegate;
 		this.retryTemplate = retryTemplate;
@@ -114,8 +120,15 @@ public class RetryableKubeService implements KubeService {
 	}
 
 	/**
-	 * Returns {@code true} if the given exception represents a transient Kubernetes API
-	 * error that may succeed on retry.
+	 * Determines whether the given exception represents a transient Kubernetes API error
+	 * that may succeed on retry. Transient errors include HTTP 429 rate-limiting
+	 * responses, 5xx server errors, connection-level failures
+	 * ({@link SocketException}/{@link ConnectException}), and any wrapped cause that is
+	 * itself transient.
+	 * @param ex the exception to classify; its wrapped {@link Throwable#getCause() cause}
+	 * is inspected when the exception itself is not transient
+	 * @return {@code true} if the error is transient and the operation may be retried,
+	 * {@code false} otherwise
 	 */
 	public static boolean isTransient(Throwable ex) {
 		if (ex instanceof ApiException apiEx) {

--- a/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/JhelmPluginAutoConfiguration.java
+++ b/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/JhelmPluginAutoConfiguration.java
@@ -22,36 +22,66 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnProperty(name = "jhelm.plugins.enabled", havingValue = "true")
 public class JhelmPluginAutoConfiguration {
 
+	/**
+	 * Provide the bridge that exposes host functions to WASM plugins.
+	 * @return the host function bridge bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public HostFunctionBridge hostFunctionBridge() {
 		return new HostFunctionBridge();
 	}
 
+	/**
+	 * Provide the Chicory-based WASM runtime.
+	 * @param hostFunctionBridge the host functions made available to plugins
+	 * @return the WASM runtime bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public WasmRuntime wasmRuntime(HostFunctionBridge hostFunctionBridge) {
 		return new WasmRuntime(hostFunctionBridge);
 	}
 
+	/**
+	 * Provide the executor that enforces per-plugin timeout limits.
+	 * @return the sandboxed executor bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public SandboxedExecutor sandboxedExecutor() {
 		return new SandboxedExecutor();
 	}
 
+	/**
+	 * Provide the loader that reads plugin archives.
+	 * @return the plugin loader bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public PluginLoader pluginLoader() {
 		return new PluginLoader();
 	}
 
+	/**
+	 * Provide the in-memory registry of loaded plugins.
+	 * @return the plugin registry bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public PluginRegistry pluginRegistry() {
 		return new PluginRegistry();
 	}
 
+	/**
+	 * Provide the top-level plugin manager that ties the registry, loader, runtime, and
+	 * executor together.
+	 * @param registry the plugin registry
+	 * @param loader the plugin loader
+	 * @param runtime the WASM runtime
+	 * @param executor the sandboxed executor
+	 * @return the plugin manager bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public PluginManager pluginManager(PluginRegistry registry, PluginLoader loader, WasmRuntime runtime,

--- a/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/exception/PluginException.java
+++ b/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/exception/PluginException.java
@@ -7,10 +7,19 @@ import org.alexmond.jhelm.core.exception.JhelmException;
  */
 public class PluginException extends JhelmException {
 
+	/**
+	 * Create a plugin exception with a detail message.
+	 * @param message the detail message
+	 */
 	public PluginException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Create a plugin exception with a detail message and cause.
+	 * @param message the detail message
+	 * @param cause the underlying cause
+	 */
 	public PluginException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/exception/PluginExecutionException.java
+++ b/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/exception/PluginExecutionException.java
@@ -5,10 +5,19 @@ package org.alexmond.jhelm.plugin.exception;
  */
 public class PluginExecutionException extends PluginException {
 
+	/**
+	 * Create an execution exception with a detail message.
+	 * @param message the detail message
+	 */
 	public PluginExecutionException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Create an execution exception with a detail message and cause.
+	 * @param message the detail message
+	 * @param cause the underlying cause
+	 */
 	public PluginExecutionException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/exception/PluginLoadException.java
+++ b/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/exception/PluginLoadException.java
@@ -5,10 +5,19 @@ package org.alexmond.jhelm.plugin.exception;
  */
 public class PluginLoadException extends PluginException {
 
+	/**
+	 * Create a load exception with a detail message.
+	 * @param message the detail message
+	 */
 	public PluginLoadException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Create a load exception with a detail message and cause.
+	 * @param message the detail message
+	 * @param cause the underlying cause
+	 */
 	public PluginLoadException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/exception/PluginNotFoundException.java
+++ b/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/exception/PluginNotFoundException.java
@@ -5,10 +5,19 @@ package org.alexmond.jhelm.plugin.exception;
  */
 public class PluginNotFoundException extends PluginException {
 
+	/**
+	 * Create a not-found exception with a detail message.
+	 * @param message the detail message
+	 */
 	public PluginNotFoundException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Create a not-found exception with a detail message and cause.
+	 * @param message the detail message
+	 * @param cause the underlying cause
+	 */
 	public PluginNotFoundException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/exception/PluginTimeoutException.java
+++ b/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/exception/PluginTimeoutException.java
@@ -5,10 +5,19 @@ package org.alexmond.jhelm.plugin.exception;
  */
 public class PluginTimeoutException extends PluginException {
 
+	/**
+	 * Create a timeout exception with a detail message.
+	 * @param message the detail message
+	 */
 	public PluginTimeoutException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Create a timeout exception with a detail message and cause.
+	 * @param message the detail message
+	 * @param cause the underlying cause
+	 */
 	public PluginTimeoutException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/exception/PluginValidationException.java
+++ b/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/exception/PluginValidationException.java
@@ -5,10 +5,19 @@ package org.alexmond.jhelm.plugin.exception;
  */
 public class PluginValidationException extends PluginException {
 
+	/**
+	 * Create a validation exception with a detail message.
+	 * @param message the detail message
+	 */
 	public PluginValidationException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Create a validation exception with a detail message and cause.
+	 * @param message the detail message
+	 * @param cause the underlying cause
+	 */
 	public PluginValidationException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/model/PluginManifest.java
+++ b/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/model/PluginManifest.java
@@ -29,6 +29,9 @@ public class PluginManifest {
 
 	private WasmConfig wasm;
 
+	/**
+	 * WASM-specific configuration declared under the manifest's {@code wasm} section.
+	 */
 	@Data
 	@Builder
 	@NoArgsConstructor

--- a/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/model/PluginType.java
+++ b/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/model/PluginType.java
@@ -2,12 +2,26 @@ package org.alexmond.jhelm.plugin.model;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * Enumerates the kinds of plugin the jhelm plugin system supports. The wire value of each
+ * constant matches the {@code type} field of a {@code plugin.yaml} manifest.
+ */
 public enum PluginType {
 
+	/**
+	 * Post-renderer plugin that transforms manifests after rendering, before they are
+	 * applied to the cluster.
+	 */
 	POST_RENDERER("postrenderer"),
 
+	/**
+	 * Downloader plugin that fetches charts from a custom protocol or location.
+	 */
 	DOWNLOADER("downloader"),
 
+	/**
+	 * Lifecycle-hook plugin that reacts to release lifecycle events.
+	 */
 	LIFECYCLE_HOOK("lifecyclehook");
 
 	private final String value;
@@ -16,11 +30,21 @@ public enum PluginType {
 		this.value = value;
 	}
 
+	/**
+	 * Return the manifest wire value for this plugin type.
+	 * @return the lowercase string used in {@code plugin.yaml}
+	 */
 	@JsonValue
 	public String getValue() {
 		return this.value;
 	}
 
+	/**
+	 * Resolve a {@link PluginType} from its manifest wire value.
+	 * @param value the manifest type string (case-insensitive)
+	 * @return the matching plugin type
+	 * @throws IllegalArgumentException if no type matches the given value
+	 */
 	public static PluginType fromValue(String value) {
 		for (PluginType type : values()) {
 			if (type.value.equalsIgnoreCase(value)) {

--- a/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/service/PluginLoader.java
+++ b/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/service/PluginLoader.java
@@ -90,6 +90,9 @@ public class PluginLoader {
 
 	/**
 	 * Result of loading a plugin archive.
+	 *
+	 * @param manifest the parsed {@code plugin.yaml} manifest
+	 * @param wasmBytes the raw bytes of the plugin's WASM binary
 	 */
 	public record LoadResult(PluginManifest manifest, byte[] wasmBytes) {
 	}

--- a/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/spi/Plugin.java
+++ b/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/spi/Plugin.java
@@ -9,11 +9,13 @@ public interface Plugin extends AutoCloseable {
 
 	/**
 	 * Return the plugin name.
+	 * @return the unique plugin name as declared in its manifest
 	 */
 	String name();
 
 	/**
 	 * Return the plugin type.
+	 * @return the {@link PluginType} this plugin implements
 	 */
 	PluginType type();
 

--- a/jhelm-rest-sample/src/main/java/org/alexmond/jhelm/rest/sample/JhelmRestSampleApplication.java
+++ b/jhelm-rest-sample/src/main/java/org/alexmond/jhelm/rest/sample/JhelmRestSampleApplication.java
@@ -3,10 +3,18 @@ package org.alexmond.jhelm.rest.sample;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Minimal Spring Boot application that exercises the jhelm REST module as a library,
+ * verifying that its controllers and services are auto-configured without manual wiring.
+ */
 @SpringBootApplication
 @SuppressWarnings("PMD.UseUtilityClass")
 public class JhelmRestSampleApplication {
 
+	/**
+	 * Application entry point.
+	 * @param args command-line arguments passed to Spring Boot
+	 */
 	public static void main(String[] args) {
 		SpringApplication.run(JhelmRestSampleApplication.class, args);
 	}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -41,12 +41,32 @@ import org.springframework.context.annotation.Bean;
 @EnableConfigurationProperties(JhelmRestProperties.class)
 public class JhelmRestAutoConfiguration {
 
+	/**
+	 * Registers the global REST exception handler unless one is already defined.
+	 * @return the exception handler bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	public JhelmRestExceptionHandler jhelmRestExceptionHandler() {
 		return new JhelmRestExceptionHandler();
 	}
 
+	/**
+	 * Registers the release controller when the required release actions are present.
+	 * @param listAction lists releases
+	 * @param statusAction reports release and resource status
+	 * @param getAction reads release values, manifest and notes
+	 * @param historyAction lists release revisions
+	 * @param installAction installs releases
+	 * @param upgradeAction upgrades releases
+	 * @param uninstallAction uninstalls releases
+	 * @param rollbackAction rolls releases back
+	 * @param testAction runs release test hooks
+	 * @param chartLoader loads charts for install and upgrade
+	 * @param repoManager pulls charts from repositories
+	 * @param properties REST module configuration
+	 * @return the release controller bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean({ ListAction.class, InstallAction.class, RepoManager.class })
@@ -58,6 +78,15 @@ public class JhelmRestAutoConfiguration {
 				uninstallAction, rollbackAction, testAction, chartLoader, repoManager, properties);
 	}
 
+	/**
+	 * Registers the chart controller when the required chart actions are present.
+	 * @param templateAction renders chart templates
+	 * @param createAction scaffolds new charts
+	 * @param showAction exposes chart information
+	 * @param repoManager pulls charts from repositories
+	 * @param properties REST module configuration
+	 * @return the chart controller bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean({ TemplateAction.class, RepoManager.class })
@@ -66,6 +95,12 @@ public class JhelmRestAutoConfiguration {
 		return new ChartController(templateAction, createAction, showAction, repoManager, properties);
 	}
 
+	/**
+	 * Registers the repository controller when a {@link RepoManager} is present.
+	 * @param repoManager manages chart repositories
+	 * @param properties REST module configuration
+	 * @return the repository controller bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(RepoManager.class)
@@ -73,6 +108,11 @@ public class JhelmRestAutoConfiguration {
 		return new RepoController(repoManager, properties);
 	}
 
+	/**
+	 * Registers the ArtifactHub controller when a {@link SearchHubAction} is present.
+	 * @param searchHubAction performs ArtifactHub searches
+	 * @return the hub controller bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(SearchHubAction.class)
@@ -80,6 +120,11 @@ public class JhelmRestAutoConfiguration {
 		return new HubController(searchHubAction);
 	}
 
+	/**
+	 * Registers the dependency resolver when a {@link RepoManager} is present.
+	 * @param repoManager pulls dependency charts from repositories
+	 * @return the dependency resolver bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(RepoManager.class)
@@ -87,6 +132,14 @@ public class JhelmRestAutoConfiguration {
 		return new DependencyResolver(repoManager);
 	}
 
+	/**
+	 * Registers the dependency controller when a {@link DependencyResolver} is present.
+	 * @param dependencyResolver resolves dependency versions
+	 * @param chartLoader loads the pulled chart
+	 * @param repoManager pulls the chart from its repository
+	 * @param properties REST module configuration
+	 * @return the dependency controller bean
+	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(DependencyResolver.class)

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandler.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandler.java
@@ -18,12 +18,23 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(basePackages = "org.alexmond.jhelm.rest")
 public class JhelmRestExceptionHandler {
 
+	/**
+	 * Maps invalid input to a {@code 400 Bad Request} JSON error response.
+	 * @param ex the rejected-argument exception
+	 * @return the structured error response
+	 */
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<Map<String, Object>> handleBadRequest(IllegalArgumentException ex) {
 		log.debug("Bad request: {}", ex.getMessage());
 		return errorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
 	}
 
+	/**
+	 * Maps any unhandled exception to a {@code 500 Internal Server Error} JSON error
+	 * response.
+	 * @param ex the unhandled exception
+	 * @return the structured error response
+	 */
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<Map<String, Object>> handleInternalError(Exception ex) {
 		log.error("Internal error", ex);

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
@@ -34,6 +34,10 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * REST endpoints for chart-level operations: rendering templates, scaffolding new charts,
+ * and inspecting chart metadata, values, and CRDs.
+ */
 @RestController
 @RequestMapping("${jhelm.rest.base-path:/api/v1}/charts")
 @Tag(name = "Charts", description = "Chart operations: template, create, show")
@@ -51,6 +55,14 @@ public class ChartController {
 
 	private final JhelmRestProperties properties;
 
+	/**
+	 * Creates the controller with the chart-related actions it delegates to.
+	 * @param templateAction renders chart templates
+	 * @param createAction scaffolds new charts
+	 * @param showAction exposes chart information
+	 * @param repoManager pulls charts from repositories
+	 * @param properties REST module configuration (temp directory, base path)
+	 */
 	public ChartController(TemplateAction templateAction, CreateAction createAction, ShowAction showAction,
 			RepoManager repoManager, JhelmRestProperties properties) {
 		this.templateAction = templateAction;
@@ -60,6 +72,13 @@ public class ChartController {
 		this.properties = properties;
 	}
 
+	/**
+	 * {@code POST} - renders a repository chart's templates with optional value overrides
+	 * and returns the combined manifest text.
+	 * @param request the chart reference, version, release name, namespace and values
+	 * @return {@code 200} with the rendered manifest
+	 * @throws Exception if the chart cannot be pulled or rendered
+	 */
 	@PostMapping("/template")
 	@Operation(summary = "Render templates",
 			description = "Render chart templates from a repository chart reference with optional value overrides")
@@ -76,6 +95,14 @@ public class ChartController {
 		}
 	}
 
+	/**
+	 * {@code POST} - renders templates from an uploaded {@code .tgz} chart archive and
+	 * returns the combined manifest text.
+	 * @param chart the uploaded chart archive
+	 * @param request the release name, namespace and value overrides
+	 * @return {@code 200} with the rendered manifest
+	 * @throws Exception if the upload cannot be extracted or rendered
+	 */
 	@PostMapping(path = "/template/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@Operation(summary = "Render templates from upload",
 			description = "Render chart templates from an uploaded .tgz chart archive")
@@ -93,6 +120,13 @@ public class ChartController {
 		}
 	}
 
+	/**
+	 * {@code POST} - scaffolds a new chart and returns it as a {@code .tgz} archive
+	 * download.
+	 * @param request the name of the chart to scaffold
+	 * @return {@code 200} with the {@code .tgz} archive as an attachment
+	 * @throws Exception if the chart cannot be created or archived
+	 */
 	@PostMapping("/create")
 	@Operation(summary = "Create a chart",
 			description = "Scaffold a new chart and return it as a .tgz archive download")
@@ -111,6 +145,14 @@ public class ChartController {
 		}
 	}
 
+	/**
+	 * {@code GET} - returns all available chart information (metadata, values, README and
+	 * CRDs) for a repository chart.
+	 * @param chartRef the chart reference (repo/chart or {@code oci://...})
+	 * @param version the optional chart version
+	 * @return {@code 200} with the combined chart information
+	 * @throws Exception if the chart cannot be pulled or read
+	 */
 	@GetMapping("/show")
 	@Operation(summary = "Show chart info", description = "Show all chart information: metadata, values, README, CRDs")
 	public ResponseEntity<String> showAll(
@@ -122,6 +164,13 @@ public class ChartController {
 		}
 	}
 
+	/**
+	 * {@code GET} - returns a repository chart's default {@code values.yaml}.
+	 * @param chartRef the chart reference (repo/chart or {@code oci://...})
+	 * @param version the optional chart version
+	 * @return {@code 200} with the default values
+	 * @throws Exception if the chart cannot be pulled or read
+	 */
 	@GetMapping("/show/values")
 	@Operation(summary = "Show chart values", description = "Show the default values.yaml")
 	public ResponseEntity<String> showValues(
@@ -133,6 +182,13 @@ public class ChartController {
 		}
 	}
 
+	/**
+	 * {@code GET} - returns a repository chart's README.
+	 * @param chartRef the chart reference (repo/chart or {@code oci://...})
+	 * @param version the optional chart version
+	 * @return {@code 200} with the README content
+	 * @throws Exception if the chart cannot be pulled or read
+	 */
 	@GetMapping("/show/readme")
 	@Operation(summary = "Show chart README")
 	public ResponseEntity<String> showReadme(
@@ -144,6 +200,13 @@ public class ChartController {
 		}
 	}
 
+	/**
+	 * {@code GET} - returns a repository chart's {@code Chart.yaml} metadata.
+	 * @param chartRef the chart reference (repo/chart or {@code oci://...})
+	 * @param version the optional chart version
+	 * @return {@code 200} with the chart metadata
+	 * @throws Exception if the chart cannot be pulled or read
+	 */
 	@GetMapping("/show/chart")
 	@Operation(summary = "Show chart metadata", description = "Show the Chart.yaml metadata")
 	public ResponseEntity<String> showChart(
@@ -155,6 +218,14 @@ public class ChartController {
 		}
 	}
 
+	/**
+	 * {@code GET} - returns the Custom Resource Definitions bundled with a repository
+	 * chart.
+	 * @param chartRef the chart reference (repo/chart or {@code oci://...})
+	 * @param version the optional chart version
+	 * @return {@code 200} with the bundled CRDs
+	 * @throws Exception if the chart cannot be pulled or read
+	 */
 	@GetMapping("/show/crds")
 	@Operation(summary = "Show chart CRDs", description = "Show Custom Resource Definitions bundled with the chart")
 	public ResponseEntity<String> showCrds(
@@ -166,6 +237,14 @@ public class ChartController {
 		}
 	}
 
+	/**
+	 * Pulls a chart into the temp directory and returns the path to its chart directory.
+	 * @param chartRef the chart reference
+	 * @param version the optional chart version
+	 * @param tempDir the temporary directory to pull into
+	 * @return the path to the extracted chart directory
+	 * @throws IOException if the pull or directory lookup fails
+	 */
 	private String pullChart(String chartRef, String version, TempDir tempDir) throws IOException {
 		this.repoManager.pull(chartRef, version, tempDir.path().toString());
 		return ChartLoader.findChartDir(tempDir.path()).toString();

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/DependencyController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/DependencyController.java
@@ -22,6 +22,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.alexmond.jhelm.core.util.ValuesOverrides;
 
+/**
+ * REST endpoints for managing a chart's dependencies: listing, updating, and building the
+ * {@code charts/} directory from {@code Chart.yaml}.
+ */
 @RestController
 @RequestMapping("${jhelm.rest.base-path:/api/v1}/dependencies")
 @Tag(name = "Dependencies", description = "Manage chart dependencies")
@@ -37,6 +41,13 @@ public class DependencyController {
 
 	private final JhelmRestProperties properties;
 
+	/**
+	 * Creates the controller with the collaborators used to resolve dependencies.
+	 * @param dependencyResolver resolves dependency versions
+	 * @param chartLoader loads the pulled chart
+	 * @param repoManager pulls the chart from its repository
+	 * @param properties REST module configuration (temp directory, base path)
+	 */
 	public DependencyController(DependencyResolver dependencyResolver, ChartLoader chartLoader, RepoManager repoManager,
 			JhelmRestProperties properties) {
 		this.dependencyResolver = dependencyResolver;
@@ -45,6 +56,13 @@ public class DependencyController {
 		this.properties = properties;
 	}
 
+	/**
+	 * {@code POST} - resolves a chart's dependency versions and returns the generated
+	 * {@code Chart.lock} content as YAML.
+	 * @param request the chart reference and optional version
+	 * @return {@code 200} with the {@code Chart.lock} YAML
+	 * @throws Exception if the chart cannot be pulled or its dependencies resolved
+	 */
 	@PostMapping("/resolve")
 	@Operation(summary = "Resolve dependencies",
 			description = "Resolve chart dependency versions from a repository chart reference and return the Chart.lock content")

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/HubController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/HubController.java
@@ -13,6 +13,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * REST endpoints for searching <a href="https://artifacthub.io">ArtifactHub</a> for
+ * charts.
+ */
 @RestController
 @RequestMapping("${jhelm.rest.base-path:/api/v1}/hub")
 @Tag(name = "Hub", description = "Search ArtifactHub for charts")
@@ -20,10 +24,21 @@ public class HubController {
 
 	private final SearchHubAction searchHubAction;
 
+	/**
+	 * Creates the controller with the ArtifactHub search action it delegates to.
+	 * @param searchHubAction performs ArtifactHub searches
+	 */
 	public HubController(SearchHubAction searchHubAction) {
 		this.searchHubAction = searchHubAction;
 	}
 
+	/**
+	 * {@code GET} - searches ArtifactHub for charts matching a keyword.
+	 * @param keyword the search keyword
+	 * @param maxResults the maximum number of results to return (capped at 60)
+	 * @return the matching chart results
+	 * @throws Exception if the ArtifactHub query fails
+	 */
 	@GetMapping("/search")
 	@Operation(summary = "Search ArtifactHub", description = "Search for Helm charts on ArtifactHub")
 	public List<HubSearchResultDto> search(@Parameter(description = "Search keyword") @RequestParam String keyword,

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
@@ -51,6 +51,10 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.alexmond.jhelm.core.util.ValuesOverrides;
 
+/**
+ * REST endpoints for the Helm release lifecycle: install, upgrade, rollback, and
+ * uninstall, plus list/status/history queries against a Kubernetes cluster.
+ */
 @RestController
 @RequestMapping("${jhelm.rest.base-path:/api/v1}/releases")
 @Tag(name = "Releases", description = "Manage Helm releases")
@@ -80,6 +84,21 @@ public class ReleaseController {
 
 	private final JhelmRestProperties properties;
 
+	/**
+	 * Creates the controller with the release lifecycle actions it delegates to.
+	 * @param listAction lists releases
+	 * @param statusAction reports release and resource status
+	 * @param getAction reads release values, manifest and notes
+	 * @param historyAction lists release revisions
+	 * @param installAction installs releases
+	 * @param upgradeAction upgrades releases
+	 * @param uninstallAction uninstalls releases
+	 * @param rollbackAction rolls releases back to a previous revision
+	 * @param testAction runs release test hooks
+	 * @param chartLoader loads charts for install and upgrade
+	 * @param repoManager pulls charts from repositories
+	 * @param properties REST module configuration (temp directory, base path)
+	 */
 	public ReleaseController(ListAction listAction, StatusAction statusAction, GetAction getAction,
 			HistoryAction historyAction, InstallAction installAction, UpgradeAction upgradeAction,
 			UninstallAction uninstallAction, RollbackAction rollbackAction, TestAction testAction,
@@ -98,6 +117,12 @@ public class ReleaseController {
 		this.properties = properties;
 	}
 
+	/**
+	 * {@code GET} - lists all Helm releases in a namespace.
+	 * @param namespace the Kubernetes namespace
+	 * @return the releases found in the namespace
+	 * @throws Exception if the releases cannot be listed
+	 */
 	@GetMapping
 	@Operation(summary = "List releases", description = "List all Helm releases in a namespace")
 	public List<ReleaseDto> list(
@@ -106,6 +131,13 @@ public class ReleaseController {
 		return this.listAction.list(namespace).stream().map(ReleaseDto::from).toList();
 	}
 
+	/**
+	 * {@code GET} - returns the status of a single release.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @return {@code 200} with the release, or {@code 404} if it does not exist
+	 * @throws Exception if the status cannot be read
+	 */
 	@GetMapping("/{name}")
 	@Operation(summary = "Get release status",
 			responses = { @ApiResponse(responseCode = "200", description = "Release found"),
@@ -119,6 +151,13 @@ public class ReleaseController {
 			.orElse(ResponseEntity.notFound().build());
 	}
 
+	/**
+	 * {@code POST} - installs a new release from a repository chart reference.
+	 * @param request the chart reference, release name, namespace, values and dry-run
+	 * flag
+	 * @return {@code 201} with the created release
+	 * @throws Exception if the chart cannot be pulled or installed
+	 */
 	@PostMapping
 	@Operation(summary = "Install a release",
 			description = "Install a new Helm release from a repository chart reference")
@@ -139,6 +178,13 @@ public class ReleaseController {
 		}
 	}
 
+	/**
+	 * {@code POST} - installs a new release from an uploaded {@code .tgz} chart archive.
+	 * @param chart the uploaded chart archive
+	 * @param request the release name, namespace, values and dry-run flag
+	 * @return {@code 201} with the created release
+	 * @throws Exception if the upload cannot be extracted or installed
+	 */
 	@PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@Operation(summary = "Install a release from upload",
 			description = "Install a new Helm release from an uploaded .tgz chart archive")
@@ -156,6 +202,14 @@ public class ReleaseController {
 		}
 	}
 
+	/**
+	 * {@code PUT} - upgrades an existing release from a repository chart reference.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @param request the chart reference, version, values and dry-run flag
+	 * @return the upgraded release
+	 * @throws Exception if the release is not found or the upgrade fails
+	 */
 	@PutMapping("/{name}")
 	@Operation(summary = "Upgrade a release",
 			description = "Upgrade an existing release from a repository chart reference")
@@ -176,6 +230,16 @@ public class ReleaseController {
 		}
 	}
 
+	/**
+	 * {@code POST} - upgrades an existing release from an uploaded {@code .tgz} chart
+	 * archive.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @param chart the uploaded chart archive
+	 * @param request the values and dry-run flag
+	 * @return the upgraded release
+	 * @throws Exception if the release is not found or the upgrade fails
+	 */
 	@PostMapping(path = "/{name}/upgrade/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@Operation(summary = "Upgrade a release from upload",
 			description = "Upgrade an existing release from an uploaded .tgz chart archive")
@@ -193,6 +257,13 @@ public class ReleaseController {
 		}
 	}
 
+	/**
+	 * {@code DELETE} - uninstalls a release.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @return {@code 204} when the release is uninstalled
+	 * @throws Exception if the release cannot be uninstalled
+	 */
 	@DeleteMapping("/{name}")
 	@Operation(summary = "Uninstall a release")
 	public ResponseEntity<Void> uninstall(@Parameter(description = "Release name") @PathVariable String name,
@@ -202,6 +273,13 @@ public class ReleaseController {
 		return ResponseEntity.noContent().build();
 	}
 
+	/**
+	 * {@code GET} - lists all revisions of a release.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @return the release revisions, newest first
+	 * @throws Exception if the history cannot be read
+	 */
 	@GetMapping("/{name}/history")
 	@Operation(summary = "Get release history", description = "List all revisions of a release")
 	public List<ReleaseDto> history(@Parameter(description = "Release name") @PathVariable String name,
@@ -210,6 +288,14 @@ public class ReleaseController {
 		return this.historyAction.history(name, namespace).stream().map(ReleaseDto::from).toList();
 	}
 
+	/**
+	 * {@code POST} - rolls a release back to a previous revision.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @param request the target revision number
+	 * @return {@code 204} when the rollback completes
+	 * @throws Exception if the rollback fails
+	 */
 	@PostMapping("/{name}/rollback")
 	@Operation(summary = "Rollback a release", description = "Rollback a release to a previous revision")
 	public ResponseEntity<Void> rollback(@Parameter(description = "Release name") @PathVariable String name,
@@ -219,6 +305,14 @@ public class ReleaseController {
 		return ResponseEntity.noContent().build();
 	}
 
+	/**
+	 * {@code POST} - runs the test hooks defined by a release.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @param timeoutSeconds the per-test timeout in seconds
+	 * @return one result per executed test hook
+	 * @throws Exception if the tests cannot be run
+	 */
 	@PostMapping("/{name}/test")
 	@Operation(summary = "Test a release", description = "Run test hooks for a release")
 	public List<TestResultDto> test(@Parameter(description = "Release name") @PathVariable String name,
@@ -228,6 +322,16 @@ public class ReleaseController {
 		return this.testAction.test(name, namespace, timeoutSeconds).stream().map(TestResultDto::from).toList();
 	}
 
+	/**
+	 * {@code GET} - returns the values used by a release.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @param all {@code true} to include computed (default) values, {@code false} for
+	 * only user-supplied overrides
+	 * @return {@code 200} with the values YAML, or {@code 404} if the release does not
+	 * exist
+	 * @throws Exception if the values cannot be read
+	 */
 	@GetMapping("/{name}/values")
 	@Operation(summary = "Get release values", description = "Get the values used by a release")
 	public ResponseEntity<String> getValues(@Parameter(description = "Release name") @PathVariable String name,
@@ -239,6 +343,13 @@ public class ReleaseController {
 			.orElse(ResponseEntity.notFound().build());
 	}
 
+	/**
+	 * {@code GET} - returns the rendered Kubernetes manifest of a release.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @return {@code 200} with the manifest, or {@code 404} if the release does not exist
+	 * @throws Exception if the manifest cannot be read
+	 */
 	@GetMapping("/{name}/manifest")
 	@Operation(summary = "Get release manifest", description = "Get the rendered Kubernetes manifest")
 	public ResponseEntity<String> getManifest(@Parameter(description = "Release name") @PathVariable String name,
@@ -249,6 +360,13 @@ public class ReleaseController {
 			.orElse(ResponseEntity.notFound().build());
 	}
 
+	/**
+	 * {@code GET} - returns the rendered notes (NOTES.txt) of a release.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @return {@code 200} with the notes, or {@code 404} if the release does not exist
+	 * @throws Exception if the notes cannot be read
+	 */
 	@GetMapping("/{name}/notes")
 	@Operation(summary = "Get release notes")
 	public ResponseEntity<String> getNotes(@Parameter(description = "Release name") @PathVariable String name,
@@ -259,6 +377,13 @@ public class ReleaseController {
 			.orElse(ResponseEntity.notFound().build());
 	}
 
+	/**
+	 * {@code GET} - lists the Helm hooks declared in a release manifest.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @return {@code 200} with the hooks, or {@code 404} if the release does not exist
+	 * @throws Exception if the hooks cannot be read
+	 */
 	@GetMapping("/{name}/hooks")
 	@Operation(summary = "Get release hooks", description = "List Helm hooks defined in the release")
 	public ResponseEntity<List<HelmHookDto>> getHooks(
@@ -274,6 +399,15 @@ public class ReleaseController {
 		}).orElse(ResponseEntity.notFound().build());
 	}
 
+	/**
+	 * {@code GET} - lists the Kubernetes resources owned by a release and their
+	 * readiness.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @return {@code 200} with the resource statuses, or {@code 404} if the release does
+	 * not exist
+	 * @throws Exception if the statuses cannot be read
+	 */
 	@GetMapping("/{name}/resources")
 	@Operation(summary = "Get resource statuses", description = "List Kubernetes resources and their status")
 	public ResponseEntity<List<ResourceStatusDto>> getResources(
@@ -286,6 +420,12 @@ public class ReleaseController {
 		}).orElse(ResponseEntity.notFound().build());
 	}
 
+	/**
+	 * Reads release values, returning an empty string instead of failing the request.
+	 * @param release the release whose values to read
+	 * @param all {@code true} to include computed values
+	 * @return the values YAML, or an empty string if they cannot be read
+	 */
 	private String safeGetValues(Release release, boolean all) {
 		try {
 			return this.getAction.getValues(release, all);
@@ -295,6 +435,11 @@ public class ReleaseController {
 		}
 	}
 
+	/**
+	 * Reads resource statuses, returning an empty list instead of failing the request.
+	 * @param release the release whose resources to inspect
+	 * @return the resource statuses, or an empty list if they cannot be read
+	 */
 	private List<ResourceStatusDto> safeGetResourceStatuses(Release release) {
 		try {
 			return this.statusAction.getResourceStatuses(release).stream().map(ResourceStatusDto::from).toList();

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/RepoController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/RepoController.java
@@ -34,6 +34,10 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.alexmond.jhelm.core.service.ChartLoader;
 
+/**
+ * REST endpoints for managing chart repositories: adding, removing, and listing repos,
+ * and searching their indexes.
+ */
 @RestController
 @RequestMapping("${jhelm.rest.base-path:/api/v1}/repos")
 @Tag(name = "Repositories", description = "Manage chart repositories")
@@ -45,11 +49,22 @@ public class RepoController {
 
 	private final JhelmRestProperties properties;
 
+	/**
+	 * Creates the controller with the repository manager it delegates to.
+	 * @param repoManager manages chart repositories
+	 * @param properties REST module configuration (temp directory, base path)
+	 */
 	public RepoController(RepoManager repoManager, JhelmRestProperties properties) {
 		this.repoManager = repoManager;
 		this.properties = properties;
 	}
 
+	/**
+	 * {@code POST} - registers a new chart repository by name and URL.
+	 * @param request the repository name and URL
+	 * @return {@code 201} when the repository is added
+	 * @throws Exception if the repository cannot be added
+	 */
 	@PostMapping
 	@Operation(summary = "Add a repository")
 	public ResponseEntity<Void> addRepo(@RequestBody RepoAddRequest request) throws Exception {
@@ -63,6 +78,11 @@ public class RepoController {
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 
+	/**
+	 * {@code GET} - lists all configured chart repositories.
+	 * @return the configured repositories, or an empty list when none are configured
+	 * @throws Exception if the repository configuration cannot be read
+	 */
 	@GetMapping
 	@Operation(summary = "List repositories")
 	public List<RepoDto> listRepos() throws Exception {
@@ -73,6 +93,12 @@ public class RepoController {
 		return config.getRepositories().stream().map(RepoDto::from).toList();
 	}
 
+	/**
+	 * {@code DELETE} - removes a configured chart repository.
+	 * @param name the repository name
+	 * @return {@code 204} when the repository is removed
+	 * @throws Exception if the repository cannot be removed
+	 */
 	@DeleteMapping("/{name}")
 	@Operation(summary = "Remove a repository")
 	public ResponseEntity<Void> removeRepo(@Parameter(description = "Repository name") @PathVariable String name)
@@ -81,6 +107,12 @@ public class RepoController {
 		return ResponseEntity.noContent().build();
 	}
 
+	/**
+	 * {@code POST} - refreshes a single repository's cached index.
+	 * @param name the repository name
+	 * @return {@code 200} when the index is refreshed
+	 * @throws Exception if the index cannot be updated
+	 */
 	@PostMapping("/{name}/update")
 	@Operation(summary = "Update repository index")
 	public ResponseEntity<Void> updateRepo(@Parameter(description = "Repository name") @PathVariable String name)
@@ -89,6 +121,12 @@ public class RepoController {
 		return ResponseEntity.ok().build();
 	}
 
+	/**
+	 * {@code GET} - lists all charts available in a repository.
+	 * @param name the repository name
+	 * @return the charts advertised by the repository index
+	 * @throws Exception if the repository index cannot be read
+	 */
 	@GetMapping("/{name}/charts")
 	@Operation(summary = "List charts", description = "List all charts available in a repository")
 	public List<ChartVersionDto> listCharts(@Parameter(description = "Repository name") @PathVariable String name)
@@ -96,6 +134,13 @@ public class RepoController {
 		return this.repoManager.listCharts(name).stream().map(ChartVersionDto::from).toList();
 	}
 
+	/**
+	 * {@code GET} - lists the available versions of a chart in a repository.
+	 * @param name the repository name
+	 * @param chart the chart name
+	 * @return the known versions of the chart
+	 * @throws Exception if the repository index cannot be read
+	 */
 	@GetMapping("/{name}/charts/{chart}/versions")
 	@Operation(summary = "List chart versions", description = "List available versions of a chart in a repository")
 	public List<ChartVersionDto> listVersions(@Parameter(description = "Repository name") @PathVariable String name,
@@ -103,6 +148,13 @@ public class RepoController {
 		return this.repoManager.getChartVersions(name, chart).stream().map(ChartVersionDto::from).toList();
 	}
 
+	/**
+	 * {@code POST} - pulls a chart from a repository or OCI registry and returns it as a
+	 * {@code .tgz} archive download.
+	 * @param request the chart reference and optional version
+	 * @return {@code 200} with the {@code .tgz} archive as an attachment
+	 * @throws Exception if the chart cannot be pulled or archived
+	 */
 	@PostMapping("/pull")
 	@Operation(summary = "Pull a chart",
 			description = "Pull a chart from a repository or OCI registry and return it as a .tgz archive")
@@ -131,6 +183,11 @@ public class RepoController {
 		}
 	}
 
+	/**
+	 * {@code POST} - refreshes the cached index of every configured repository.
+	 * @return {@code 200} when all indexes are refreshed
+	 * @throws Exception if any index cannot be updated
+	 */
 	@PostMapping("/update-all")
 	@Operation(summary = "Update all repositories", description = "Update the index of all configured repositories")
 	public ResponseEntity<Void> updateAll() throws Exception {
@@ -138,6 +195,14 @@ public class RepoController {
 		return ResponseEntity.ok().build();
 	}
 
+	/**
+	 * {@code POST} - pushes an uploaded {@code .tgz} chart archive to a remote OCI
+	 * registry.
+	 * @param chart the uploaded chart archive
+	 * @param remote the target OCI registry reference
+	 * @return {@code 200} when the chart is pushed
+	 * @throws Exception if the upload cannot be stored or pushed
+	 */
 	@PostMapping(path = "/push", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@Operation(summary = "Push a chart", description = "Push an uploaded .tgz chart archive to a remote registry")
 	public ResponseEntity<Void> push(@RequestParam("chart") MultipartFile chart, @RequestParam("remote") String remote)

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ChartVersionDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ChartVersionDto.java
@@ -6,6 +6,9 @@ import lombok.Data;
 
 import org.alexmond.jhelm.core.service.RepoManager;
 
+/**
+ * Describes a single chart version advertised by a repository index.
+ */
 @Data
 @Builder
 @Schema(description = "Available chart version in a repository")
@@ -23,6 +26,11 @@ public class ChartVersionDto {
 	@Schema(description = "Chart description")
 	private String description;
 
+	/**
+	 * Maps a core chart-version model to its REST representation.
+	 * @param cv the source chart version from the repository index
+	 * @return the populated DTO
+	 */
 	public static ChartVersionDto from(RepoManager.ChartVersion cv) {
 		return ChartVersionDto.builder()
 			.name(cv.getName())

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/CreateRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/CreateRequest.java
@@ -3,6 +3,9 @@ package org.alexmond.jhelm.rest.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+/**
+ * Request body for scaffolding a new chart skeleton.
+ */
 @Data
 @Schema(description = "Request to scaffold a new chart")
 public class CreateRequest {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/DependencyResolveRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/DependencyResolveRequest.java
@@ -3,6 +3,9 @@ package org.alexmond.jhelm.rest.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+/**
+ * Request body for resolving a chart's dependency versions into a {@code Chart.lock}.
+ */
 @Data
 @Schema(description = "Request to resolve chart dependencies")
 public class DependencyResolveRequest {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/HelmHookDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/HelmHookDto.java
@@ -8,6 +8,10 @@ import lombok.Data;
 
 import org.alexmond.jhelm.core.model.HelmHook;
 
+/**
+ * Describes a single Helm hook (kind, trigger phases, weight and delete policies)
+ * extracted from a release manifest.
+ */
 @Data
 @Builder
 @Schema(description = "Helm hook defined in a release")
@@ -28,6 +32,11 @@ public class HelmHookDto {
 	@Schema(description = "Hook delete policies", example = "[\"before-hook-creation\"]")
 	private List<String> deletePolicy;
 
+	/**
+	 * Maps a core hook model to its REST representation.
+	 * @param hook the source hook parsed from the manifest
+	 * @return the populated DTO
+	 */
 	public static HelmHookDto from(HelmHook hook) {
 		return HelmHookDto.builder()
 			.kind(hook.getKind())

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/HubSearchResultDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/HubSearchResultDto.java
@@ -6,6 +6,9 @@ import lombok.Data;
 
 import org.alexmond.jhelm.core.action.SearchHubAction;
 
+/**
+ * A single chart match returned from an ArtifactHub search.
+ */
 @Data
 @Builder
 @Schema(description = "ArtifactHub search result")
@@ -32,6 +35,11 @@ public class HubSearchResultDto {
 	@Schema(description = "ArtifactHub URL")
 	private String url;
 
+	/**
+	 * Maps a core hub-search result to its REST representation.
+	 * @param result the source search result
+	 * @return the populated DTO
+	 */
 	public static HubSearchResultDto from(SearchHubAction.HubResult result) {
 		return HubSearchResultDto.builder()
 			.name(result.getName())

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallRequest.java
@@ -5,6 +5,9 @@ import java.util.Map;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+/**
+ * Request body for installing a release from a repository chart reference.
+ */
 @Data
 @Schema(description = "Request to install a new Helm release from a repository chart reference")
 public class InstallRequest {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallUploadRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallUploadRequest.java
@@ -5,6 +5,9 @@ import java.util.Map;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+/**
+ * Metadata accompanying an uploaded {@code .tgz} chart archive when installing a release.
+ */
 @Data
 @Schema(description = "Metadata for installing a release from an uploaded .tgz chart archive")
 public class InstallUploadRequest {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/PullRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/PullRequest.java
@@ -3,6 +3,9 @@ package org.alexmond.jhelm.rest.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+/**
+ * Request body for pulling a chart from a repository or OCI registry.
+ */
 @Data
 @Schema(description = "Request to pull a chart from a repository or OCI registry")
 public class PullRequest {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ReleaseDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ReleaseDto.java
@@ -8,6 +8,9 @@ import lombok.Data;
 
 import org.alexmond.jhelm.core.model.Release;
 
+/**
+ * Summary view of a Helm release: identity, revision, status and chart metadata.
+ */
 @Data
 @Builder
 @Schema(description = "Summary of a Helm release")
@@ -40,6 +43,12 @@ public class ReleaseDto {
 	@Schema(description = "Timestamp of last deployment")
 	private OffsetDateTime lastDeployed;
 
+	/**
+	 * Maps a core release model to its REST representation, tolerating absent chart
+	 * metadata or release info.
+	 * @param release the source release
+	 * @return the populated DTO
+	 */
 	public static ReleaseDto from(Release release) {
 		ReleaseDto.ReleaseDtoBuilder builder = ReleaseDto.builder()
 			.name(release.getName())

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RepoAddRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RepoAddRequest.java
@@ -3,6 +3,9 @@ package org.alexmond.jhelm.rest.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+/**
+ * Request body for registering a new chart repository.
+ */
 @Data
 @Schema(description = "Request to add a chart repository")
 public class RepoAddRequest {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RepoDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RepoDto.java
@@ -6,6 +6,9 @@ import lombok.Data;
 
 import org.alexmond.jhelm.core.model.RepositoryConfig;
 
+/**
+ * A configured chart repository (name and URL).
+ */
 @Data
 @Builder
 @Schema(description = "Chart repository")
@@ -17,6 +20,11 @@ public class RepoDto {
 	@Schema(description = "Repository URL", example = "https://charts.bitnami.com/bitnami")
 	private String url;
 
+	/**
+	 * Maps a repository config entry to its REST representation.
+	 * @param repo the source repository entry
+	 * @return the populated DTO
+	 */
 	public static RepoDto from(RepositoryConfig.Repository repo) {
 		return RepoDto.builder().name(repo.getName()).url(repo.getUrl()).build();
 	}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ResourceStatusDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ResourceStatusDto.java
@@ -6,6 +6,9 @@ import lombok.Data;
 
 import org.alexmond.jhelm.core.model.ResourceStatus;
 
+/**
+ * Status of a single Kubernetes resource managed by a release, including readiness.
+ */
 @Data
 @Builder
 @Schema(description = "Status of a Kubernetes resource managed by a release")
@@ -26,6 +29,11 @@ public class ResourceStatusDto {
 	@Schema(description = "Status message")
 	private String message;
 
+	/**
+	 * Maps a core resource-status model to its REST representation.
+	 * @param rs the source resource status
+	 * @return the populated DTO
+	 */
 	public static ResourceStatusDto from(ResourceStatus rs) {
 		return ResourceStatusDto.builder()
 			.kind(rs.getKind())

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RollbackRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RollbackRequest.java
@@ -3,6 +3,9 @@ package org.alexmond.jhelm.rest.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+/**
+ * Request body for rolling a release back to a previous revision.
+ */
 @Data
 @Schema(description = "Request to rollback a release to a previous revision")
 public class RollbackRequest {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TemplateRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TemplateRequest.java
@@ -5,6 +5,9 @@ import java.util.Map;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+/**
+ * Request body for rendering chart templates from a repository chart reference.
+ */
 @Data
 @Schema(description = "Request to render chart templates")
 public class TemplateRequest {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TemplateUploadRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TemplateUploadRequest.java
@@ -5,6 +5,9 @@ import java.util.Map;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+/**
+ * Metadata accompanying an uploaded {@code .tgz} chart archive when rendering templates.
+ */
 @Data
 @Schema(description = "Metadata for rendering templates from an uploaded .tgz chart archive")
 public class TemplateUploadRequest {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TestResultDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TestResultDto.java
@@ -6,6 +6,9 @@ import lombok.Data;
 
 import org.alexmond.jhelm.core.action.TestAction;
 
+/**
+ * Outcome of one Helm test hook execution (resource, status and output message).
+ */
 @Data
 @Builder
 @Schema(description = "Result of a Helm test execution")
@@ -24,6 +27,11 @@ public class TestResultDto {
 	@Schema(description = "Test output message")
 	private String message;
 
+	/**
+	 * Maps a core test-result model to its REST representation.
+	 * @param result the source test result
+	 * @return the populated DTO
+	 */
 	public static TestResultDto from(TestAction.TestResult result) {
 		return TestResultDto.builder()
 			.kind(result.getKind())

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeRequest.java
@@ -5,6 +5,9 @@ import java.util.Map;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+/**
+ * Request body for upgrading an existing release from a repository chart reference.
+ */
 @Data
 @Schema(description = "Request to upgrade an existing Helm release from a repository chart reference")
 public class UpgradeRequest {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeUploadRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeUploadRequest.java
@@ -5,6 +5,9 @@ import java.util.Map;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+/**
+ * Metadata accompanying an uploaded {@code .tgz} chart archive when upgrading a release.
+ */
 @Data
 @Schema(description = "Metadata for upgrading a release from an uploaded .tgz chart archive")
 public class UpgradeUploadRequest {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/util/ChartArchiveUtil.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/util/ChartArchiveUtil.java
@@ -25,6 +25,7 @@ public final class ChartArchiveUtil {
 	 * @param dir the directory to archive
 	 * @param entryBase the top-level directory name inside the archive
 	 * @return the {@code .tgz} bytes
+	 * @throws IOException if walking the directory or writing the archive fails
 	 */
 	public static byte[] toTgzBytes(Path dir, String entryBase) throws IOException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/util/ChartSourceResolver.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/util/ChartSourceResolver.java
@@ -25,6 +25,7 @@ public final class ChartSourceResolver {
 	 * @param chartLoader loader to parse the chart directory
 	 * @param tempDir temporary directory to pull into
 	 * @return the loaded chart
+	 * @throws Exception if the pull fails or the chart cannot be located or parsed
 	 */
 	public static Chart fromChartRef(String chartRef, String version, RepoManager repoManager, ChartLoader chartLoader,
 			TempDir tempDir) throws Exception {
@@ -40,6 +41,7 @@ public final class ChartSourceResolver {
 	 * @param chartLoader loader to parse the chart directory
 	 * @param tempDir temporary directory to extract into
 	 * @return the loaded chart
+	 * @throws Exception if the upload cannot be stored, extracted, located, or parsed
 	 */
 	public static Chart fromUpload(MultipartFile file, RepoManager repoManager, ChartLoader chartLoader,
 			TempDir tempDir) throws Exception {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/util/TempDir.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/util/TempDir.java
@@ -16,10 +16,20 @@ public class TempDir implements Closeable {
 
 	private final Path path;
 
+	/**
+	 * Creates a fresh temporary directory under the given base path.
+	 * @param baseDir the base directory in which to create the temporary directory
+	 * @param prefix the prefix for the generated directory name
+	 * @throws IOException if the directory cannot be created
+	 */
 	public TempDir(Path baseDir, String prefix) throws IOException {
 		this.path = Files.createTempDirectory(baseDir, prefix);
 	}
 
+	/**
+	 * Returns the path of this temporary directory.
+	 * @return the temporary directory path
+	 */
 	public Path path() {
 		return this.path;
 	}

--- a/jhelm-sample/src/main/java/org/alexmond/jhelm/sample/JhelmSampleApplication.java
+++ b/jhelm-sample/src/main/java/org/alexmond/jhelm/sample/JhelmSampleApplication.java
@@ -12,6 +12,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SuppressWarnings("PMD.UseUtilityClass")
 public class JhelmSampleApplication {
 
+	/**
+	 * Application entry point.
+	 * @param args command-line arguments passed to Spring Boot
+	 */
 	public static void main(String[] args) {
 		SpringApplication.run(JhelmSampleApplication.class, args);
 	}


### PR DESCRIPTION
Javadoc was effectively unchecked — the plugin runs with `failOnError=false` and no doclint config, so **366 `-Xdoclint:all` warnings** had accumulated across the modules that publish a `-javadoc.jar` to Maven Central. This brings it to a clean baseline.

## What changed (92 files, Javadoc/comments only)
| Category | Before | After |
|---|---|---|
| Incomplete-javadoc **bugs** (`@param`/`@return`/`@throws` gaps) | ~22 | **0** |
| Public-API **"no comment"** (classes/methods/enums) | 274 | **0** |
| "default constructor" (Lombok `@Data` / Spring beans — inherent) | 70 | ~41 baseline |

- Fixed all `@param`/`@return`/`@throws` gaps (`HelmKubeService`, `RetryableKubeService`, `ChartLoader`, exception types, `PluginLoader`, `ChartArchiveUtil`/`ChartSourceResolver`, the `Plugin` SPI).
- Documented the public library API that had no comment: `jhelm-core` services/actions/models/exceptions, `jhelm-kube` services, the REST controllers + DTOs (one sentence per endpoint with status codes), the plugin SPI + enums, and every auto-config `@Bean`.
- Added class-level Javadoc to the five REST controllers that were still bare.

No production logic or test behavior changed — only Javadoc/comments and, where a doclint "default constructor" warning required it, explicit documented constructors. The remaining `-Xdoclint:all` warnings are the unavoidable "default constructor" note on Lombok-generated constructors.

## Verification
Full `./mvnw clean install` green across all modules (spring-javaformat, PMD, Checkstyle, JaCoCo, tests).

## Optional follow-up
Now that the real bugs are gone, we could enable doclint enforcement for the `reference,html,syntax` groups (failing the build on broken `@link`s / malformed HTML) without requiring every element to be documented — happy to do that in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)