### PR TITLE
refactor(api)!: KubeService throws unchecked domain exceptions (#500)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
@@ -2,24 +2,79 @@ package org.alexmond.jhelm.core.service;
 
 import java.util.List;
 import java.util.Optional;
+import org.alexmond.jhelm.core.exception.KubernetesOperationException;
+import org.alexmond.jhelm.core.exception.ReleaseStorageException;
+import org.alexmond.jhelm.core.exception.WaitTimeoutException;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 
+/**
+ * Abstraction over the Kubernetes operations Helm needs: storing and reading releases,
+ * applying and deleting rendered manifests, and checking/waiting on resource readiness.
+ * <p>
+ * All failures are reported through the unchecked
+ * {@link org.alexmond.jhelm.core.exception.JhelmException} hierarchy (chiefly
+ * {@link KubernetesOperationException}), so callers are never forced to declare or catch
+ * a checked {@code Exception}.
+ */
 public interface KubeService {
 
-	void storeRelease(Release release) throws Exception;
+	/**
+	 * Stores a release, matching Helm's {@code sh.helm.release.v1.*} Secret format.
+	 * @param release the release to persist
+	 * @throws ReleaseStorageException if the release cannot be encoded or written
+	 */
+	void storeRelease(Release release);
 
-	Optional<Release> getRelease(String name, String namespace) throws Exception;
+	/**
+	 * Returns the latest revision of a release, if it exists.
+	 * @param name the release name
+	 * @param namespace the namespace to look in
+	 * @return the latest release revision, or {@link Optional#empty()} if not found
+	 * @throws KubernetesOperationException if the Kubernetes API cannot be reached
+	 */
+	Optional<Release> getRelease(String name, String namespace);
 
-	List<Release> listReleases(String namespace) throws Exception;
+	/**
+	 * Returns the latest revision of every release in a namespace.
+	 * @param namespace the namespace to list
+	 * @return the releases found, or an empty list if there are none
+	 * @throws KubernetesOperationException if the Kubernetes API cannot be reached
+	 */
+	List<Release> listReleases(String namespace);
 
-	List<Release> getReleaseHistory(String name, String namespace) throws Exception;
+	/**
+	 * Returns all stored revisions of a release, newest first.
+	 * @param name the release name
+	 * @param namespace the namespace to look in
+	 * @return the release history, or an empty list if the release is unknown
+	 * @throws KubernetesOperationException if the Kubernetes API cannot be reached
+	 */
+	List<Release> getReleaseHistory(String name, String namespace);
 
-	void deleteReleaseHistory(String name, String namespace) throws Exception;
+	/**
+	 * Deletes every stored revision of a release.
+	 * @param name the release name
+	 * @param namespace the namespace to look in
+	 * @throws KubernetesOperationException if the Kubernetes API cannot be reached
+	 */
+	void deleteReleaseHistory(String name, String namespace);
 
-	void apply(String namespace, String yamlContent) throws Exception;
+	/**
+	 * Applies a rendered manifest to the cluster via server-side apply.
+	 * @param namespace the target namespace
+	 * @param yamlContent rendered YAML manifest (may contain multiple documents)
+	 * @throws KubernetesOperationException if a resource cannot be applied
+	 */
+	void apply(String namespace, String yamlContent);
 
-	void delete(String namespace, String yamlContent) throws Exception;
+	/**
+	 * Deletes the resources described in a rendered manifest.
+	 * @param namespace the target namespace
+	 * @param yamlContent rendered YAML manifest (may contain multiple documents)
+	 * @throws KubernetesOperationException if a resource cannot be deleted
+	 */
+	void delete(String namespace, String yamlContent);
 
 	/**
 	 * Returns the readiness status of each Kubernetes resource described in the rendered
@@ -27,9 +82,10 @@ public interface KubeService {
 	 * @param namespace the namespace to query
 	 * @param manifest rendered YAML manifest (may contain multiple documents)
 	 * @return one {@link ResourceStatus} per resource found in the manifest
-	 * @throws Exception if the Kubernetes API cannot be reached
+	 * @throws KubernetesOperationException if the manifest cannot be parsed or the
+	 * Kubernetes API cannot be reached
 	 */
-	List<ResourceStatus> getResourceStatuses(String namespace, String manifest) throws Exception;
+	List<ResourceStatus> getResourceStatuses(String namespace, String manifest);
 
 	/**
 	 * Blocks until all resources described in the manifest are ready, or until the
@@ -37,9 +93,10 @@ public interface KubeService {
 	 * @param namespace the namespace to query
 	 * @param manifest rendered YAML manifest
 	 * @param timeoutSeconds maximum seconds to wait
-	 * @throws Exception if the timeout elapses before all resources are ready, or if the
-	 * Kubernetes API cannot be reached
+	 * @throws WaitTimeoutException if the timeout elapses before all resources are ready
+	 * @throws KubernetesOperationException if the wait is interrupted or the Kubernetes
+	 * API cannot be reached
 	 */
-	void waitForReady(String namespace, String manifest, int timeoutSeconds) throws Exception;
+	void waitForReady(String namespace, String manifest, int timeoutSeconds);
 
 }

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
@@ -49,9 +49,10 @@ import java.nio.charset.StandardCharsets;
  * manifests, and waits on workload readiness.
  *
  * <p>
- * Instances are created with a configured {@link ApiClient}; all operations issue calls
- * through that client and surface failures as {@link ApiException} or the project's
- * Kubernetes exception types.
+ * Instances are created with a configured {@link ApiClient}. {@link KubeService}
+ * operations translate the client's checked {@link ApiException} into the unchecked
+ * {@link KubernetesOperationException} (preserving the HTTP status code), so the public
+ * surface never leaks the kubernetes-client exception type.
  */
 @RequiredArgsConstructor
 @Slf4j
@@ -68,7 +69,7 @@ public class HelmKubeService implements KubeService {
 	 * Stores a release as a Secret in Kubernetes, matching Helm's storage format.
 	 */
 	@Override
-	public void storeRelease(Release release) throws ReleaseStorageException {
+	public void storeRelease(Release release) {
 		CoreV1Api api = new CoreV1Api(apiClient);
 		String name = "sh.helm.release.v1." + release.getName() + ".v" + release.getVersion();
 
@@ -106,11 +107,11 @@ public class HelmKubeService implements KubeService {
 	 * Retrieves the latest version of a release from Kubernetes.
 	 */
 	@Override
-	public Optional<Release> getRelease(String name, String namespace) throws Exception {
+	public Optional<Release> getRelease(String name, String namespace) {
 		CoreV1Api api = new CoreV1Api(apiClient);
 		String labelSelector = "owner=helm,name=" + name;
 
-		V1SecretList list = api.listNamespacedSecret(namespace).labelSelector(labelSelector).execute();
+		V1SecretList list = listSecrets(api, namespace, labelSelector, "read release " + name);
 
 		Optional<V1Secret> latest = list.getItems().stream().sorted((s1, s2) -> {
 			int v1 = Integer.parseInt(s1.getMetadata().getLabels().get("version"));
@@ -128,11 +129,11 @@ public class HelmKubeService implements KubeService {
 	 * Retrieves all releases in a namespace.
 	 */
 	@Override
-	public List<Release> listReleases(String namespace) throws Exception {
+	public List<Release> listReleases(String namespace) {
 		CoreV1Api api = new CoreV1Api(apiClient);
 		String labelSelector = "owner=helm";
 
-		V1SecretList list = api.listNamespacedSecret(namespace).labelSelector(labelSelector).execute();
+		V1SecretList list = listSecrets(api, namespace, labelSelector, "list releases in " + namespace);
 
 		// Group by name and pick the highest version for each
 		Map<String, List<V1Secret>> grouped = list.getItems()
@@ -166,11 +167,11 @@ public class HelmKubeService implements KubeService {
 	 * Retrieves all versions of a specific release.
 	 */
 	@Override
-	public List<Release> getReleaseHistory(String name, String namespace) throws Exception {
+	public List<Release> getReleaseHistory(String name, String namespace) {
 		CoreV1Api api = new CoreV1Api(apiClient);
 		String labelSelector = "owner=helm,name=" + name;
 
-		V1SecretList list = api.listNamespacedSecret(namespace).labelSelector(labelSelector).execute();
+		V1SecretList list = listSecrets(api, namespace, labelSelector, "read history for " + name);
 
 		List<V1Secret> sorted = list.getItems()
 			.stream()
@@ -190,12 +191,31 @@ public class HelmKubeService implements KubeService {
 	 * Deletes all versions of a release from Kubernetes.
 	 */
 	@Override
-	public void deleteReleaseHistory(String name, String namespace) throws ApiException {
+	public void deleteReleaseHistory(String name, String namespace) {
 		CoreV1Api api = new CoreV1Api(apiClient);
 		String labelSelector = "owner=helm,name=" + name;
-		V1SecretList list = api.listNamespacedSecret(namespace).labelSelector(labelSelector).execute();
-		for (V1Secret secret : list.getItems()) {
-			api.deleteNamespacedSecret(secret.getMetadata().getName(), namespace).execute();
+		V1SecretList list = listSecrets(api, namespace, labelSelector, "delete history for " + name);
+		try {
+			for (V1Secret secret : list.getItems()) {
+				api.deleteNamespacedSecret(secret.getMetadata().getName(), namespace).execute();
+			}
+		}
+		catch (ApiException ex) {
+			throw new KubernetesOperationException("Failed to delete release history for " + name, ex, ex.getCode());
+		}
+	}
+
+	/**
+	 * Lists release Secrets for a label selector, translating the kubernetes-client
+	 * {@link ApiException} into a {@link KubernetesOperationException} so callers never
+	 * see the client's checked exception.
+	 */
+	private V1SecretList listSecrets(CoreV1Api api, String namespace, String labelSelector, String operation) {
+		try {
+			return api.listNamespacedSecret(namespace).labelSelector(labelSelector).execute();
+		}
+		catch (ApiException ex) {
+			throw new KubernetesOperationException("Failed to " + operation, ex, ex.getCode());
 		}
 	}
 
@@ -217,7 +237,7 @@ public class HelmKubeService implements KubeService {
 	 * Applies a YAML manifest which can contain multiple resources.
 	 */
 	@Override
-	public void apply(String namespace, String yamlContent) throws Exception {
+	public void apply(String namespace, String yamlContent) {
 		try {
 			Iterable<Object> objects = Yaml.loadAll(yamlContent);
 			for (Object obj : objects) {
@@ -267,7 +287,7 @@ public class HelmKubeService implements KubeService {
 	 * Deletes resources in a YAML manifest.
 	 */
 	@Override
-	public void delete(String namespace, String yamlContent) throws Exception {
+	public void delete(String namespace, String yamlContent) {
 		try {
 			Iterable<Object> objects = Yaml.loadAll(yamlContent);
 			for (Object obj : objects) {
@@ -315,9 +335,15 @@ public class HelmKubeService implements KubeService {
 	 * Returns the readiness status for each resource in the rendered manifest.
 	 */
 	@Override
-	public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) throws Exception {
+	public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) {
 		List<ResourceStatus> statuses = new ArrayList<>();
-		Iterable<Object> objects = Yaml.loadAll(manifest);
+		Iterable<Object> objects;
+		try {
+			objects = Yaml.loadAll(manifest);
+		}
+		catch (Exception ex) {
+			throw new KubernetesOperationException("Failed to parse manifest", ex);
+		}
 		for (Object obj : objects) {
 			if (obj instanceof KubernetesObject k8sObj) {
 				statuses.add(checkResourceStatus(namespace, k8sObj));
@@ -430,7 +456,7 @@ public class HelmKubeService implements KubeService {
 	 * Polls until all resources in the manifest are ready or the timeout elapses.
 	 */
 	@Override
-	public void waitForReady(String namespace, String manifest, int timeoutSeconds) throws Exception {
+	public void waitForReady(String namespace, String manifest, int timeoutSeconds) {
 		long deadline = System.currentTimeMillis() + (long) timeoutSeconds * 1000;
 		int pollIntervalMs = 5000;
 
@@ -450,7 +476,13 @@ public class HelmKubeService implements KubeService {
 				.filter((s) -> !s.isReady())
 				.forEach((s) -> log.info("Waiting for {}/{}: {}", s.getKind(), s.getName(), s.getMessage()));
 
-			Thread.sleep(Math.min(pollIntervalMs, remaining));
+			try {
+				Thread.sleep(Math.min(pollIntervalMs, remaining));
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				throw new KubernetesOperationException("Interrupted while waiting for resources to be ready", ex);
+			}
 		}
 
 		List<ResourceStatus> finalStatuses = getResourceStatuses(namespace, manifest);

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/ObservableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/ObservableKubeService.java
@@ -11,6 +11,7 @@ import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.alexmond.jhelm.core.service.KubeService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * A {@link KubeService} decorator that records operation timers and success/error
@@ -56,58 +57,58 @@ public class ObservableKubeService implements KubeService {
 	}
 
 	@Override
-	public void storeRelease(Release release) throws Exception {
+	public void storeRelease(Release release) {
 		timeVoid(storeTimer, () -> delegate.storeRelease(release));
 	}
 
 	@Override
-	public Optional<Release> getRelease(String name, String namespace) throws Exception {
+	public Optional<Release> getRelease(String name, String namespace) {
 		return time(getTimer, () -> delegate.getRelease(name, namespace));
 	}
 
 	@Override
-	public List<Release> listReleases(String namespace) throws Exception {
+	public List<Release> listReleases(String namespace) {
 		return time(listTimer, () -> delegate.listReleases(namespace));
 	}
 
 	@Override
-	public List<Release> getReleaseHistory(String name, String namespace) throws Exception {
+	public List<Release> getReleaseHistory(String name, String namespace) {
 		return time(historyTimer, () -> delegate.getReleaseHistory(name, namespace));
 	}
 
 	@Override
-	public void deleteReleaseHistory(String name, String namespace) throws Exception {
+	public void deleteReleaseHistory(String name, String namespace) {
 		timeVoid(deleteTimer, () -> delegate.deleteReleaseHistory(name, namespace));
 	}
 
 	@Override
-	public void apply(String namespace, String yamlContent) throws Exception {
+	public void apply(String namespace, String yamlContent) {
 		timeVoid(applyTimer, () -> delegate.apply(namespace, yamlContent));
 	}
 
 	@Override
-	public void delete(String namespace, String yamlContent) throws Exception {
+	public void delete(String namespace, String yamlContent) {
 		timeVoid(deleteTimer, () -> delegate.delete(namespace, yamlContent));
 	}
 
 	@Override
-	public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) throws Exception {
+	public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) {
 		return time(getTimer, () -> delegate.getResourceStatuses(namespace, manifest));
 	}
 
 	@Override
-	public void waitForReady(String namespace, String manifest, int timeoutSeconds) throws Exception {
+	public void waitForReady(String namespace, String manifest, int timeoutSeconds) {
 		delegate.waitForReady(namespace, manifest, timeoutSeconds);
 	}
 
-	private <T> T time(Timer timer, CheckedSupplier<T> supplier) throws Exception {
+	private <T> T time(Timer timer, Supplier<T> supplier) {
 		long startNanos = System.nanoTime();
 		try {
 			T result = supplier.get();
 			successCounter.increment();
 			return result;
 		}
-		catch (Exception ex) {
+		catch (RuntimeException ex) {
 			errorCounter.increment();
 			throw ex;
 		}
@@ -116,33 +117,19 @@ public class ObservableKubeService implements KubeService {
 		}
 	}
 
-	private void timeVoid(Timer timer, CheckedRunnable runnable) throws Exception {
+	private void timeVoid(Timer timer, Runnable runnable) {
 		long startNanos = System.nanoTime();
 		try {
 			runnable.run();
 			successCounter.increment();
 		}
-		catch (Exception ex) {
+		catch (RuntimeException ex) {
 			errorCounter.increment();
 			throw ex;
 		}
 		finally {
 			timer.record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
 		}
-	}
-
-	@FunctionalInterface
-	private interface CheckedSupplier<T> {
-
-		T get() throws Exception;
-
-	}
-
-	@FunctionalInterface
-	private interface CheckedRunnable {
-
-		void run() throws Exception;
-
 	}
 
 }

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/RetryableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/RetryableKubeService.java
@@ -43,7 +43,7 @@ public class RetryableKubeService implements KubeService {
 	}
 
 	@Override
-	public void storeRelease(Release release) throws Exception {
+	public void storeRelease(Release release) {
 		executeWithRetry("storeRelease", () -> {
 			delegate.storeRelease(release);
 			return null;
@@ -51,22 +51,22 @@ public class RetryableKubeService implements KubeService {
 	}
 
 	@Override
-	public Optional<Release> getRelease(String name, String namespace) throws Exception {
+	public Optional<Release> getRelease(String name, String namespace) {
 		return executeWithRetry("getRelease", () -> delegate.getRelease(name, namespace));
 	}
 
 	@Override
-	public List<Release> listReleases(String namespace) throws Exception {
+	public List<Release> listReleases(String namespace) {
 		return executeWithRetry("listReleases", () -> delegate.listReleases(namespace));
 	}
 
 	@Override
-	public List<Release> getReleaseHistory(String name, String namespace) throws Exception {
+	public List<Release> getReleaseHistory(String name, String namespace) {
 		return executeWithRetry("getReleaseHistory", () -> delegate.getReleaseHistory(name, namespace));
 	}
 
 	@Override
-	public void deleteReleaseHistory(String name, String namespace) throws Exception {
+	public void deleteReleaseHistory(String name, String namespace) {
 		executeWithRetry("deleteReleaseHistory", () -> {
 			delegate.deleteReleaseHistory(name, namespace);
 			return null;
@@ -74,7 +74,7 @@ public class RetryableKubeService implements KubeService {
 	}
 
 	@Override
-	public void apply(String namespace, String yamlContent) throws Exception {
+	public void apply(String namespace, String yamlContent) {
 		executeWithRetry("apply", () -> {
 			delegate.apply(namespace, yamlContent);
 			return null;
@@ -82,7 +82,7 @@ public class RetryableKubeService implements KubeService {
 	}
 
 	@Override
-	public void delete(String namespace, String yamlContent) throws Exception {
+	public void delete(String namespace, String yamlContent) {
 		executeWithRetry("delete", () -> {
 			delegate.delete(namespace, yamlContent);
 			return null;
@@ -90,29 +90,31 @@ public class RetryableKubeService implements KubeService {
 	}
 
 	@Override
-	public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) throws Exception {
+	public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) {
 		return executeWithRetry("getResourceStatuses", () -> delegate.getResourceStatuses(namespace, manifest));
 	}
 
 	@Override
-	public void waitForReady(String namespace, String manifest, int timeoutSeconds) throws Exception {
+	public void waitForReady(String namespace, String manifest, int timeoutSeconds) {
 		// waitForReady already polls internally; do not retry the entire operation
 		delegate.waitForReady(namespace, manifest, timeoutSeconds);
 	}
 
-	private <T> T executeWithRetry(String operation, Retryable<T> callback) throws Exception {
+	private <T> T executeWithRetry(String operation, Retryable<T> callback) {
 		try {
 			return retryTemplate.execute(callback);
 		}
 		catch (RetryException ex) {
 			// Thrown when the policy stops retrying — either a non-transient failure (the
 			// predicate rejected it) or all retries exhausted. The cause is the last
-			// underlying failure; rethrow it as-is so callers see the original exception.
+			// underlying failure; rethrow it as-is (every jhelm exception is unchecked)
+			// so
+			// callers see the original exception.
 			Throwable last = ex.getCause();
 			if (log.isErrorEnabled()) {
 				log.error("All retry attempts exhausted for {}", operation, last);
 			}
-			if (last instanceof Exception cause) {
+			if (last instanceof RuntimeException cause) {
 				throw cause;
 			}
 			throw new KubernetesOperationException("Retry exhausted for " + operation, last);


### PR DESCRIPTION
First slice of **#500 (0.4.0 API freeze)** — eliminating `throws Exception` from the public surface, starting with the `KubeService` contract.

## Why (1.0 blocker)
`KubeService` declared `throws Exception` on all 9 methods. After a 1.0 semver commitment that's impossible to narrow without breaking every caller's `catch` blocks, and it leaked the kubernetes-client `ApiException` out of `HelmKubeService` — pinning the client major version into jhelm's API.

## What changed
- **`KubeService`** — dropped `throws Exception`; documents the unchecked `JhelmException` hierarchy (`KubernetesOperationException` / `ReleaseStorageException` / `WaitTimeoutException`) via `@throws`.
- **`HelmKubeService`** — translates the client's checked `ApiException` → `KubernetesOperationException` (preserving the HTTP status code) on every read/delete path; handles `InterruptedException` in `waitForReady`; wraps manifest-parse failures. **No longer leaks `ApiException`.**
- **`RetryableKubeService` / `ObservableKubeService`** — dropped `throws Exception`. The retry predicate already classifies `KubernetesOperationException` via `isTransient()`, so retry/observe behavior is unchanged.

## ⚠️ Breaking change
`KubeService` methods no longer declare `throws Exception`. Callers catching the checked `Exception` should catch `JhelmException` (or a subtype). Behavior is otherwise identical — this is part of the deliberate pre-1.0 API freeze.

## Verification
- **184** `jhelm-kube` unit tests green (incl. `HelmKubeServiceTest`, `RetryableKubeServiceTest`, `ObservableKubeServiceTest`)
- format / PMD / Checkstyle clean on core + kube; full reactor compiles
- Cluster integration tests run in CI (kind)

Part of #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)