### PR TITLE
build: adopt gotmpl4j 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
              dedicated CI job (see .github/workflows/parity.yml). Override with
              -Dsurefire.excludedGroups= -Dgroups=comparison to run only the parity suite. -->
         <surefire.excludedGroups>comparison</surefire.excludedGroups>
-        <gotmpl4j.version>0.3.0</gotmpl4j.version>
+        <gotmpl4j.version>1.0.0</gotmpl4j.version>
         <kubernetes-client.version>26.0.0</kubernetes-client.version>
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>


### PR DESCRIPTION
Bumps the engine dependency from **gotmpl4j 0.3.0 → 1.0.0** (now GA on Maven Central).

The pre-release compatibility review was resolved before gotmpl4j tagged 1.0:
- **alexmond/gotmpl4j#49** — exception hierarchy unified under one unchecked root (`GoTemplateException`). jhelm's `FunctionExecutionException` (4 files) and `TemplateException` (1 test) usage is unaffected (now-unchecked → `catch`/`assertThrows` still compile).
- **alexmond/gotmpl4j#48** — the low-level `getRootNodes()`/`getFunctions()` getters were carved out of the 1.0 stability guarantee (option b). jhelm's 9 node-map call sites keep working; a first-class replacement is tracked there for post-1.0.

## Verification (against the published 1.0.0 artifact)
- `jhelm-core` + `jhelm-gotemplate-helm` build + unit tests green
- **346/346** chart byte-parity unchanged

One-line dependency bump. The starter changes in gotmpl4j 1.0 don't affect jhelm (it uses `gotmpl4j-core` + `gotmpl4j-sprig`, not the starter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)