### PR TITLE
fix(engine): gitlab subchart coalesce — global propagation + disabled-subchart pruning (A/B/C) (#21)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -787,7 +787,19 @@ public class Engine {
 	 */
 	@SuppressWarnings("unchecked")
 	private void mergeSubchartDefaults(Chart chart, Map<String, Object> mergedValues) {
+		// Helm copies the entire top-level .Values.global into every subchart's tree
+		// (.Values.<sub>.global), recursively, with the parent global winning. Thread it
+		// through the coalesce so the parent-visible .Values matches Helm's (#21).
+		Map<String, Object> topGlobal = (mergedValues.get("global") instanceof Map)
+				? (Map<String, Object>) mergedValues.get("global") : Map.of();
+		List<Dependency> depMetaList = (chart.getMetadata() != null) ? chart.getMetadata().getDependencies() : null;
 		for (Chart dep : chart.getDependencies()) {
+			// Helm's ProcessDependencies prunes a disabled subchart's defaults from
+			// .Values — only the parent's own stub for it remains. Skip coalescing the
+			// defaults of a subchart whose condition is false (#21).
+			if (!isSubchartEnabledForCoalesce(depMetaList, dep, mergedValues)) {
+				continue;
+			}
 			String depKey = (dep.getAlias() != null) ? dep.getAlias() : dep.getMetadata().getName();
 			// Coalesce the subchart's full default tree — its own values.yaml plus its
 			// nested subcharts' defaults, recursively — so parent templates that read
@@ -795,7 +807,7 @@ public class Engine {
 			// the
 			// same tree Helm builds. Anything already set on the parent for this key
 			// wins.
-			Map<String, Object> depDefaults = coalesceChartValues(dep);
+			Map<String, Object> depDefaults = coalesceChartValues(dep, topGlobal);
 			if (!depDefaults.isEmpty()) {
 				Map<String, Object> existing = (Map<String, Object>) mergedValues.getOrDefault(depKey, new HashMap<>());
 				mergedValues.put(depKey, mergeValues(depDefaults, existing));
@@ -804,17 +816,52 @@ public class Engine {
 	}
 
 	/**
+	 * Whether a subchart's defaults should be coalesced into the parent's
+	 * {@code .Values}. Mirrors Helm: a subchart whose {@code condition} (from the
+	 * parent's {@code Chart.yaml}) evaluates false is disabled, and Helm does not merge
+	 * its {@code values.yaml} defaults into {@code .Values} (only the parent's own stub
+	 * remains). A subchart with no condition is always coalesced.
+	 * @param parentDepMeta the parent chart's dependency declarations
+	 * @param dep the subchart being considered
+	 * @param values the values to evaluate the condition against
+	 * @return {@code true} if the subchart's defaults should be coalesced
+	 */
+	private boolean isSubchartEnabledForCoalesce(List<Dependency> parentDepMeta, Chart dep,
+			Map<String, Object> values) {
+		Dependency meta = findDependencyMetadata(parentDepMeta, dep);
+		if (meta != null && meta.getCondition() != null && !meta.getCondition().isEmpty()) {
+			return evaluateDependencyCondition(meta.getCondition(), values);
+		}
+		return true;
+	}
+
+	/**
 	 * Recursively coalesce a chart's default values: its own {@code values.yaml} with
 	 * each subchart's coalesced defaults placed under the subchart's name/alias key. The
 	 * chart's own values for a subchart key win over that subchart's defaults (Helm
-	 * precedence).
+	 * precedence). The top-level {@code global} is deep-merged into this chart's tree
+	 * (the chart's own global defaults are the base, {@code topGlobal} wins), matching
+	 * Helm's global propagation into every subchart.
+	 * @param chart the chart whose default tree to coalesce
+	 * @param topGlobal the umbrella chart's coalesced {@code global} values, propagated
+	 * into this subchart's {@code global} key
+	 * @return the coalesced default value tree
 	 */
 	@SuppressWarnings("unchecked")
-	private Map<String, Object> coalesceChartValues(Chart chart) {
+	private Map<String, Object> coalesceChartValues(Chart chart, Map<String, Object> topGlobal) {
 		Map<String, Object> base = (chart.getValues() != null) ? new HashMap<>(chart.getValues()) : new HashMap<>();
+		if (topGlobal != null && !topGlobal.isEmpty()) {
+			Map<String, Object> ownGlobal = (base.get("global") instanceof Map)
+					? (Map<String, Object>) base.get("global") : new HashMap<>();
+			base.put("global", mergeValues(ownGlobal, topGlobal));
+		}
+		List<Dependency> depMetaList = (chart.getMetadata() != null) ? chart.getMetadata().getDependencies() : null;
 		for (Chart dep : chart.getDependencies()) {
+			if (!isSubchartEnabledForCoalesce(depMetaList, dep, base)) {
+				continue;
+			}
 			String depKey = (dep.getAlias() != null) ? dep.getAlias() : dep.getMetadata().getName();
-			Map<String, Object> depDefaults = coalesceChartValues(dep);
+			Map<String, Object> depDefaults = coalesceChartValues(dep, topGlobal);
 			if (depDefaults.isEmpty()) {
 				continue;
 			}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -806,10 +806,12 @@ public class Engine {
 			// .Values.<sub>.<nestedsub>.* (e.g. gitlab's .Values.gitlab.webservice) see
 			// the
 			// same tree Helm builds. Anything already set on the parent for this key
-			// wins.
-			Map<String, Object> depDefaults = coalesceChartValues(dep, topGlobal);
+			// wins. The parent's overrides for this subchart are threaded down so nested
+			// dependency conditions see them (e.g. the umbrella disabling
+			// prometheus.kube-state-metrics.enabled).
+			Map<String, Object> existing = (Map<String, Object>) mergedValues.getOrDefault(depKey, new HashMap<>());
+			Map<String, Object> depDefaults = coalesceChartValues(dep, topGlobal, existing);
 			if (!depDefaults.isEmpty()) {
-				Map<String, Object> existing = (Map<String, Object>) mergedValues.getOrDefault(depKey, new HashMap<>());
 				mergedValues.put(depKey, mergeValues(depDefaults, existing));
 			}
 		}
@@ -845,30 +847,44 @@ public class Engine {
 	 * @param chart the chart whose default tree to coalesce
 	 * @param topGlobal the umbrella chart's coalesced {@code global} values, propagated
 	 * into this subchart's {@code global} key
+	 * @param overrides the parent's values for this chart, merged in only to evaluate
+	 * nested dependency conditions (so an umbrella disabling
+	 * {@code <sub>.<nested>.enabled} prunes the nested subchart's defaults, as Helm
+	 * does); they are not folded into the returned defaults (the caller applies them with
+	 * precedence)
 	 * @return the coalesced default value tree
 	 */
 	@SuppressWarnings("unchecked")
-	private Map<String, Object> coalesceChartValues(Chart chart, Map<String, Object> topGlobal) {
+	private Map<String, Object> coalesceChartValues(Chart chart, Map<String, Object> topGlobal,
+			Map<String, Object> overrides) {
 		Map<String, Object> base = (chart.getValues() != null) ? new HashMap<>(chart.getValues()) : new HashMap<>();
 		if (topGlobal != null && !topGlobal.isEmpty()) {
 			Map<String, Object> ownGlobal = (base.get("global") instanceof Map)
 					? (Map<String, Object>) base.get("global") : new HashMap<>();
 			base.put("global", mergeValues(ownGlobal, topGlobal));
 		}
+		// Effective values for condition checks: the chart's own values with the parent's
+		// overrides applied (overrides win), matching the values Helm evaluates
+		// conditions
+		// against.
+		Map<String, Object> effective = (overrides != null && !overrides.isEmpty()) ? mergeValues(base, overrides)
+				: base;
 		List<Dependency> depMetaList = (chart.getMetadata() != null) ? chart.getMetadata().getDependencies() : null;
 		for (Chart dep : chart.getDependencies()) {
-			if (!isSubchartEnabledForCoalesce(depMetaList, dep, base)) {
+			if (!isSubchartEnabledForCoalesce(depMetaList, dep, effective)) {
 				continue;
 			}
 			String depKey = (dep.getAlias() != null) ? dep.getAlias() : dep.getMetadata().getName();
-			Map<String, Object> depDefaults = coalesceChartValues(dep, topGlobal);
+			Map<String, Object> depOverrides = (overrides != null && overrides.get(depKey) instanceof Map)
+					? (Map<String, Object>) overrides.get(depKey) : Map.of();
+			Map<String, Object> depDefaults = coalesceChartValues(dep, topGlobal, depOverrides);
 			if (depDefaults.isEmpty()) {
 				continue;
 			}
 			Object existing = base.get(depKey);
-			Map<String, Object> overrides = (existing instanceof Map) ? (Map<String, Object>) existing
+			Map<String, Object> baseOverrides = (existing instanceof Map) ? (Map<String, Object>) existing
 					: new HashMap<>();
-			base.put(depKey, mergeValues(depDefaults, overrides));
+			base.put(depKey, mergeValues(depDefaults, baseOverrides));
 		}
 		return base;
 	}

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -6,12 +6,29 @@
 # Both render under `helm template` with the comparison-values in application-test.yaml,
 # so the remaining failure is a real jhelm bug (tracked here until fixed).
 #
-# gitlab: renders end-to-end; the only remaining divergence is the shared-secrets/
+# gitlab: renders end-to-end; the only manifest divergence is the shared-secrets/
 # migrations/issuer Jobs whose names carry a content-hash suffix from
-# `gitlab.jobNameSuffix` = sha256(.Chart.Version-.AppVersion-b64(toYaml(unset .Values
-# "local"))) | trunc 7. jhelm's coalesced .Values tree is ~5850 lines vs Helm's ~13029
-# (jhelm omits ~half the recursively-coalesced subchart defaults), so toYaml(.Values)
-# and thus the hash can never match — this needs a full Helm CoalesceValues/
-# ProcessDependencies reimplementation (the real scope of #21, a multi-session effort).
+# `gitlab.jobNameSuffix` = sha256(...b64(toYaml(unset .Values "local"))) | trunc 7,
+# so the names only match once jhelm's coalesced .Values tree equals Helm's.
+#
+# Progress (Engine subchart-coalesce, gated on the 346-chart parity staying green):
+#  A. (done) global propagation: bake the full top-level .Values.global into every
+#     subchart in the coalesced tree (coalesceChartValues), matching Helm — parent
+#     global wins. .Values.<sub>.global went 30->528 (Helm 533).
+#  B. (done) disabled-subchart pruning: skip coalescing a subchart's defaults when its
+#     `condition` is false (isSubchartEnabledForCoalesce). Disabled subcharts now match
+#     Helm's parent-stub EXACTLY (traefik 6=6, openbao 42=42, haproxy 12=12,
+#     gitlab-zoekt 7=7).
+# Net: jhelm .Values 5850 -> 15135 lines (Helm 13031); 346/346 parity still green.
+#
+#  C. (remaining, ~+2100 lines) global OVER-propagation into an ENABLED subchart's own
+#     subcharts. Helm bakes the global into gitlab's subcharts (gitlab.webservice.global
+#     ~532) but NOT into prometheus's subcharts (prometheus.alertmanager.global / 
+#     kube-state-metrics.global = absent in Helm, ~502 in jhelm). The exact rule Helm
+#     uses to decide which enabled-subchart subtrees receive the global is not yet
+#     characterised (it is not simply "the subchart declares a global"). Until C is
+#     solved jhelm overshoots and the jobNameSuffix hash won't match.
+# Diagnostic: render a copy of the chart with an added `{{ .Values | toYaml }}` template
+# via `helm template -s` and `jhelm template`, diff the dumps.
 # Also a webservice-test-runner Pod has a random name suffix (helm test hook).
 gitlab/gitlab,gitlab,https://charts.gitlab.io

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -6,29 +6,30 @@
 # Both render under `helm template` with the comparison-values in application-test.yaml,
 # so the remaining failure is a real jhelm bug (tracked here until fixed).
 #
-# gitlab: renders end-to-end; the only manifest divergence is the shared-secrets/
-# migrations/issuer Jobs whose names carry a content-hash suffix from
-# `gitlab.jobNameSuffix` = sha256(...b64(toYaml(unset .Values "local"))) | trunc 7,
-# so the names only match once jhelm's coalesced .Values tree equals Helm's.
+# gitlab: renders end-to-end; identical resource set (146=146), all 21 ConfigMaps
+# byte-identical. The ONLY manifest diffs are content hashes — 4 Job names
+# (gitlab.jobNameSuffix = sha256(toYaml(.Values))) and 5 Deployment checksum/config
+# annotations (sha256(include configmap.yml $)) — plus one ignorable random test-Pod
+# name. Verified NOT engine bugs: jhelm sha256sum and include framing match the CLI/Go
+# byte-for-byte. BOTH hash families trace to ONE root cause: jhelm's coalesced
+# .Values.global differs from Helm's (webservice sees 522 lines vs Helm's 531).
 #
-# Progress (Engine subchart-coalesce, gated on the 346-chart parity staying green):
-#  A. (done) global propagation: bake the full top-level .Values.global into every
-#     subchart in the coalesced tree (coalesceChartValues), matching Helm — parent
-#     global wins. .Values.<sub>.global went 30->528 (Helm 533).
-#  B. (done) disabled-subchart pruning: skip coalescing a subchart's defaults when its
-#     `condition` is false (isSubchartEnabledForCoalesce). Disabled subcharts now match
-#     Helm's parent-stub EXACTLY (traefik 6=6, openbao 42=42, haproxy 12=12,
-#     gitlab-zoekt 7=7).
-# Net: jhelm .Values 5850 -> 15135 lines (Helm 13031); 346/346 parity still green.
+# Coalesce progress (Engine, all gated on the 346-chart parity staying green):
+#  A. (done) bake the full top-level global into every subchart in the coalesced tree.
+#  B. (done) skip coalescing a DISABLED direct subchart's defaults (condition false).
+#  C. (done) thread parent overrides into the recursion so NESTED subchart conditions
+#     see them (e.g. umbrella's prometheus.kube-state-metrics.enabled=false prunes it).
+# Net: jhelm .Values 5850 -> 12395 lines (Helm 13031); 91% of the gap closed; 346/346
+# parity green throughout.
 #
-#  C. (remaining, ~+2100 lines) global OVER-propagation into an ENABLED subchart's own
-#     subcharts. Helm bakes the global into gitlab's subcharts (gitlab.webservice.global
-#     ~532) but NOT into prometheus's subcharts (prometheus.alertmanager.global / 
-#     kube-state-metrics.global = absent in Helm, ~502 in jhelm). The exact rule Helm
-#     uses to decide which enabled-subchart subtrees receive the global is not yet
-#     characterised (it is not simply "the subchart declares a global"). Until C is
-#     solved jhelm overshoots and the jobNameSuffix hash won't match.
-# Diagnostic: render a copy of the chart with an added `{{ .Values | toYaml }}` template
-# via `helm template -s` and `jhelm template`, diff the dumps.
-# Also a webservice-test-runner Pod has a random name suffix (helm test hook).
+#  D. (remaining) the last ~9 lines/subchart of the .Values.global gap is null/empty
+#     handling: jhelm PRUNES global nulls that Helm keeps (when/dsn/clientside_dsn/
+#     environment/autoSignInWithProvider: null) and collapses authToken {key,secret:""}
+#     to {}. Helm keeps top-level-global nulls when propagating into subcharts; jhelm's
+#     subchart slice (prepareRenderValues, pruneNulls for depth>0) drops them. Fix:
+#     exempt the propagated `global` subtree from subchart null-pruning (carefully —
+#     touches the #491 selective-null logic and all 346 parity charts). Closing D makes
+#     toYaml(.Values.global) exact, which fixes BOTH hash families -> gitlab passes.
+# Diagnostic: render a copy with `{{ .Values.global | toYaml }}` via helm -s and jhelm,
+# diff the dumps.
 gitlab/gitlab,gitlab,https://charts.gitlab.io


### PR DESCRIPTION
Concrete progress on the long-standing **gitlab subchart-coalesce** parity (#21), each step gated on the **346-chart parity staying green**.

## Three coalesce fixes
The parent-visible `.Values` tree (which feeds `toYaml(.Values)` and the `gitlab.jobNameSuffix` / `checksum/config` hashes) diverged from Helm — jhelm patched these only at render-dispatch, so manifests rendered but the hashes didn't.

- **A — global propagation:** bake the full top-level `.Values.global` into every subchart in the coalesced tree.
- **B — disabled-subchart pruning (direct):** skip coalescing a subchart's defaults when its dependency `condition` is false. Disabled subcharts now match Helm's stub **exactly** (traefik 6=6, openbao 42=42, …).
- **C — disabled-subchart pruning (nested):** thread parent overrides into the recursion so a nested dependency's condition sees them (e.g. the umbrella's `prometheus.kube-state-metrics.enabled=false` prunes that grandchild).

**Result:** jhelm's coalesced gitlab `.Values` **5850 → 12395 lines** (Helm 13031) — **91% of the gap closed**; prometheus 3655→915; disabled subcharts exact.

## Diagnosis: every remaining diff is one root cause
Full manifest diff (jhelm vs helm): **identical 146-resource set, all 21 ConfigMaps byte-identical.** The only diffs are content hashes — 4 Job names + 5 `checksum/config` annotations — plus one ignorable random test-Pod name. Verified jhelm's `sha256sum` and `include` framing are **byte-identical to the CLI/Go**, so both hash families trace to the **same** residual: jhelm's coalesced `.Values.global` (webservice sees 522 lines vs Helm's 531).

## Not yet closed (D, documented in failed.csv)
The last ~9 lines/subchart is null/empty handling — jhelm prunes propagated-global nulls that Helm keeps (`when`/`dsn`/`environment: null`) and collapses `authToken {key,secret:""}` → `{}`. Closing D makes `toYaml(.Values.global)` exact, fixing **both** hash families → gitlab passes. It touches the #491 selective-null logic, so it needs its own careful, parity-gated pass.

Part of #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)