### PR TITLE
perf(gotemplate-helm): skip the quote-normalize regex on quoteless lines

### DIFF
--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -781,8 +781,16 @@ public final class ConversionFunctions {
 	 * Go's yaml.Marshal uses plain style in these cases.
 	 */
 	static String removeUnnecessaryQuotes(String yaml) {
-		StringBuilder sb = new StringBuilder();
+		StringBuilder sb = new StringBuilder(yaml.length());
 		for (String line : yaml.split("\n", -1)) {
+			// Fast path: QUOTED_VALUE requires a double-quoted scalar, so a line with no
+			// '"' can never match — skip the regex + Matcher allocation entirely. In a
+			// typical rendered manifest the large majority of lines are unquoted, so this
+			// avoids running the regex (and its garbage) on most of them.
+			if (line.indexOf('"') < 0) {
+				sb.append(line).append('\n');
+				continue;
+			}
 			Matcher m = QUOTED_VALUE.matcher(line);
 			if (m.matches()) {
 				String prefix = m.group(1);


### PR DESCRIPTION
Profiling a gitlab render loop (JFR → jvmlens) surfaced `ConversionFunctions.removeUnnecessaryQuotes` as **6% CPU and 1.2 GB allocation** — it ran the `QUOTED_VALUE` regex + a `Matcher` on **every line** of every `toYaml`/`toJson` output. But `QUOTED_VALUE` requires a double-quoted scalar, and the large majority of rendered-manifest lines are unquoted.

## Fix
An `indexOf('"') < 0` fast-path appends quoteless lines verbatim and skips the regex entirely (+ size the `StringBuilder` to the input). **Behaviour-identical** — a quoteless line takes the old no-match branch.

## Measured (jvmlens diff, 120× gitlab render)
- `removeUnnecessaryQuotes` — **GONE** from both hot paths (was 6% CPU) and allocation sites (was 1.2 GB)
- **Total allocation 23.4 GB → 22.2 GB (−1.1 GB, −5%)** — real absolute reduction
- (The Lexer/toYaml share *rises* in the diff are share-inversion from the smaller total; their absolute alloc fell or held.)

## Correctness
88 `jhelm-gotemplate-helm` tests green (`ConversionFunctionsTest` covers toYaml byte-output, `HelmConformanceTest`); 346-chart byte-parity running as a safety net.

Profiling also surfaced an engine-side allocator (`gotmpl4j CharUtils.isAnyOf` doing an `IntStream` per call in the lexer, ~2 GB) — filed as alexmond/gotmpl4j#64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)