### PR TITLE
build: adopt gotmpl4j 1.1.0 (from 1.0.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
              dedicated CI job (see .github/workflows/parity.yml). Override with
              -Dsurefire.excludedGroups= -Dgroups=comparison to run only the parity suite. -->
         <surefire.excludedGroups>comparison</surefire.excludedGroups>
-        <gotmpl4j.version>1.0.0</gotmpl4j.version>
+        <gotmpl4j.version>1.1.0</gotmpl4j.version>
         <kubernetes-client.version>26.0.0</kubernetes-client.version>
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>


### PR DESCRIPTION
## What
Bumps the `gotmpl4j` dependency `1.0.0 → 1.1.0` (single property in root `pom.xml`).

## Why
Picks up the gotmpl4j post-1.0.0 **performance wave**:
- `floatString` without `BigDecimal`
- cached per-class property accessors, shared across renders
- allocation-free `CharUtils.isAnyOf` in the lexer hot loop — the ~2 GB allocation site the jhelm consumer profile originally surfaced (gotmpl4j #64)

## Verification
- `./mvnw clean install` against 1.1.0 — **2229 tests, 0 failures, 0 errors**.
- Warm steady-state render benchmark (jhelm engine, identical charts), 1.0.0 → 1.1.0:

| Chart | jhelm 1.0.0 | jhelm 1.1.0 | Δ |
|---|---|---|---|
| grafana | 31.4 ms | 28.3 ms | −9.9% |
| ingress-nginx | 32.9 ms | 27.7 ms | −15.8% |
| kube-prometheus-stack | 241.7 ms | 221.6 ms | −8.3% |

A real ~8–16% steady-state render speedup on actual charts, consistent across median and min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)