### PR TITLE
fix(cli): keep stdout clean — jhelm banner + logs to stderr

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
@@ -22,7 +22,11 @@ import org.alexmond.jhelm.app.command.TestCommand;
 import org.alexmond.jhelm.app.command.UninstallCommand;
 import org.alexmond.jhelm.app.command.UpgradeCommand;
 import org.alexmond.jhelm.app.command.VerifyCommand;
+import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.springframework.boot.ResourceBanner;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
@@ -31,6 +35,7 @@ import picocli.CommandLine;
  * subcommand (install, upgrade, template, repo, and so on). Running it with no subcommand
  * prints the usage help.
  */
+@Slf4j
 @Component
 @CommandLine.Command(name = "jhelm", mixinStandardHelpOptions = true, version = "jhelm 0.0.1",
 		header = { "", "The Java Kubernetes package manager", "" },
@@ -47,9 +52,14 @@ import picocli.CommandLine;
 				RepoCommand.class, RegistryCommand.class, PluginCommand.class, SearchCommand.class })
 public class JHelmCommand implements Runnable {
 
-	/** Creates the command. */
-	@SuppressWarnings("PMD.UnnecessaryConstructor")
-	public JHelmCommand() {
+	private final Environment environment;
+
+	/**
+	 * Creates the command.
+	 * @param environment the Spring environment, used to resolve banner placeholders
+	 */
+	public JHelmCommand(Environment environment) {
+		this.environment = environment;
 	}
 
 	/**
@@ -66,11 +76,30 @@ public class JHelmCommand implements Runnable {
 	}
 
 	/**
-	 * Prints the usage help when {@code jhelm} is invoked without a subcommand.
+	 * Prints the jhelm banner (to stderr, so piped stdout stays clean) followed by the
+	 * usage help when {@code jhelm} is invoked without a subcommand.
 	 */
 	@Override
 	public void run() {
+		printBanner();
 		CommandLine.usage(this, System.out);
+	}
+
+	/**
+	 * Prints the {@code banner.txt} brand banner to stderr. Spring's automatic stdout
+	 * banner is disabled (see {@code application.properties}); this keeps the banner out
+	 * of command output while still branding the bare {@code jhelm} invocation. The
+	 * banner is purely cosmetic, so any failure is swallowed rather than aborting.
+	 */
+	private void printBanner() {
+		try {
+			new ResourceBanner(new ClassPathResource("banner.txt")).printBanner(this.environment, JHelmCommand.class,
+					System.err);
+		}
+		catch (RuntimeException ex) {
+			// Banner is cosmetic; never let it break the command.
+			log.debug("Skipping banner: {}", ex.getMessage());
+		}
 	}
 
 }

--- a/jhelm-cli/src/main/resources/application.properties
+++ b/jhelm-cli/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+# The jhelm banner is printed explicitly to stderr by JHelmCommand when invoked
+# with no subcommand, so that command output on stdout (e.g. `jhelm template`
+# piped to a file) stays clean. Disable Spring's automatic stdout banner here.
+spring.main.banner-mode=off

--- a/jhelm-cli/src/main/resources/banner.txt
+++ b/jhelm-cli/src/main/resources/banner.txt
@@ -1,0 +1,10 @@
+
+     _ _          _
+    (_) |__   ___| |_ __ ___
+    | | '_ \ / _ \ | '_ ` _ \
+    | | | | |  __/ | | | | | |
+   _/ |_| |_|\___|_|_| |_| |_|
+  |__/
+
+  The Java Kubernetes package manager  (v${application.version})
+

--- a/jhelm-cli/src/main/resources/logback-spring.xml
+++ b/jhelm-cli/src/main/resources/logback-spring.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  jhelm is a CLI: command output (rendered manifests, release data) goes to
+  stdout so it can be piped, and ALL diagnostics go to stderr — matching the
+  behaviour of the Go `helm` binary. Spring Boot's default console appender
+  targets stdout, which would corrupt `jhelm template ... > out.yaml`; this
+  config retargets it to stderr.
+-->
+<configuration>
+	<include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+	<appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+		<target>System.err</target>
+		<encoder>
+			<pattern>${CONSOLE_LOG_PATTERN}</pattern>
+			<charset>${CONSOLE_LOG_CHARSET}</charset>
+		</encoder>
+	</appender>
+
+	<root level="INFO">
+		<appender-ref ref="STDERR"/>
+	</root>
+</configuration>


### PR DESCRIPTION
## Problem
`jhelm template <release> <chart> > out.yaml` corrupted the rendered manifest: both the **Spring Boot banner** and the **startup INFO logs** were written to **stdout**. An 8,225-char grafana manifest came out as **9,206 bytes** of banner + logs + YAML — not valid, not pipeable, not drop-in with `helm template`.

## Fix
Align with the Go `helm` binary (data → stdout, diagnostics → stderr):
- **`banner.txt`** — jhelm-branded banner replacing the stock Spring leaf.
- **`application.properties`** — `spring.main.banner-mode=off` (no automatic stdout banner).
- **`JHelmCommand`** — prints the banner to **stderr** via `ResourceBanner`, but only on the no-subcommand path, so bare `jhelm` is still branded (with `${application.version}` resolved) while command output is untouched.
- **`logback-spring.xml`** — retargets the console appender to **stderr**, keeping all logging off stdout.

## Result
| | Before | After |
|---|---|---|
| `jhelm template … > out.yaml` | 9,206 B (banner + INFO logs in the YAML) | **8,226 B — pure manifest** (0 banner, 0 log lines) |
| bare `jhelm` | Spring leaf banner on stdout | jhelm banner on **stderr**, usage on stdout |

```
     _ _          _
    (_) |__   ___| |_ __ ___
    | | '_ \ / _ \ | '_ ` _ \
    | | | | |  __/ | | | | | |
   _/ |_| |_|\___|_|_| |_| |_|
  |__/
  The Java Kubernetes package manager  (v0.3.0-SNAPSHOT)
```

`jhelm-cli` build + tests pass; PMD/checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)