### PR TITLE
refactor(api)!: action layer throws JhelmException, not Exception (#500)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/CreateCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/CreateCommand.java
@@ -3,10 +3,10 @@ package org.alexmond.jhelm.app.command;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.CreateAction;
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -47,7 +47,7 @@ public class CreateCommand implements Runnable {
 			createAction.create(chartPath);
 			CliOutput.println(CliOutput.success("Creating " + name));
 		}
-		catch (IOException ex) {
+		catch (JhelmException ex) {
 			CliOutput.errPrintln(CliOutput.error("Error creating chart: " + ex.getMessage()));
 			System.exit(1);
 		}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/SearchHubCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/SearchHubCommandTest.java
@@ -1,9 +1,9 @@
 package org.alexmond.jhelm.app.command;
 
-import java.io.IOException;
 import java.util.List;
 
 import org.alexmond.jhelm.core.action.SearchHubAction;
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -56,7 +56,7 @@ class SearchHubCommandTest {
 
 	@Test
 	void testSearchHubError() throws Exception {
-		when(searchHubAction.search(anyString(), anyInt())).thenThrow(new IOException("connection failed"));
+		when(searchHubAction.search(anyString(), anyInt())).thenThrow(new JhelmException("connection failed"));
 
 		CommandLine cmd = new CommandLine(searchHubCommand);
 		int exitCode = cmd.execute("nginx");

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/CreateAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/CreateAction.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.template.HelmChartTemplates;
 
 /**
@@ -18,52 +19,57 @@ public class CreateAction {
 	 * Scaffolds a new chart at the given path, using its final path segment as the chart
 	 * name.
 	 * @param chartPath the directory to create the chart in; must not already exist
-	 * @throws IOException if the directory already exists or files cannot be written
+	 * @throws JhelmException if the directory already exists or files cannot be written
 	 */
-	public void create(Path chartPath) throws IOException {
+	public void create(Path chartPath) {
 		String chartName = chartPath.getFileName().toString();
 
 		if (Files.exists(chartPath)) {
-			throw new IOException("directory " + chartName + " already exists");
+			throw new JhelmException("directory " + chartName + " already exists");
 		}
 
 		log.info("Creating {}", chartName);
 
-		// Create main directories
-		Files.createDirectories(chartPath);
-		Files.createDirectories(chartPath.resolve("templates"));
-		Files.createDirectories(chartPath.resolve("templates/tests"));
+		try {
+			// Create main directories
+			Files.createDirectories(chartPath);
+			Files.createDirectories(chartPath.resolve("templates"));
+			Files.createDirectories(chartPath.resolve("templates/tests"));
 
-		// Create .helmignore
-		Files.writeString(chartPath.resolve(".helmignore"), HelmChartTemplates.getHelmIgnore());
+			// Create .helmignore
+			Files.writeString(chartPath.resolve(".helmignore"), HelmChartTemplates.getHelmIgnore());
 
-		// Create Chart.yaml
-		Files.writeString(chartPath.resolve("Chart.yaml"),
-				HelmChartTemplates.substituteChartName(HelmChartTemplates.getChartYaml(), chartName));
+			// Create Chart.yaml
+			Files.writeString(chartPath.resolve("Chart.yaml"),
+					HelmChartTemplates.substituteChartName(HelmChartTemplates.getChartYaml(), chartName));
 
-		// Create values.yaml
-		Files.writeString(chartPath.resolve("values.yaml"),
-				HelmChartTemplates.substituteChartName(HelmChartTemplates.getValuesYaml(), chartName));
+			// Create values.yaml
+			Files.writeString(chartPath.resolve("values.yaml"),
+					HelmChartTemplates.substituteChartName(HelmChartTemplates.getValuesYaml(), chartName));
 
-		// Create template files
-		Files.writeString(chartPath.resolve("templates/NOTES.txt"),
-				HelmChartTemplates.substituteChartName(HelmChartTemplates.getNotesTemplate(), chartName));
-		Files.writeString(chartPath.resolve("templates/_helpers.tpl"),
-				HelmChartTemplates.substituteChartName(HelmChartTemplates.getHelpersTemplate(), chartName));
-		Files.writeString(chartPath.resolve("templates/deployment.yaml"),
-				HelmChartTemplates.substituteChartName(HelmChartTemplates.getDeploymentTemplate(), chartName));
-		Files.writeString(chartPath.resolve("templates/service.yaml"),
-				HelmChartTemplates.substituteChartName(HelmChartTemplates.getServiceTemplate(), chartName));
-		Files.writeString(chartPath.resolve("templates/serviceaccount.yaml"),
-				HelmChartTemplates.substituteChartName(HelmChartTemplates.getServiceAccountTemplate(), chartName));
-		Files.writeString(chartPath.resolve("templates/hpa.yaml"),
-				HelmChartTemplates.substituteChartName(HelmChartTemplates.getHpaTemplate(), chartName));
-		Files.writeString(chartPath.resolve("templates/ingress.yaml"),
-				HelmChartTemplates.substituteChartName(HelmChartTemplates.getIngressTemplate(), chartName));
-		Files.writeString(chartPath.resolve("templates/httproute.yaml"),
-				HelmChartTemplates.substituteChartName(HelmChartTemplates.getHttpRouteTemplate(), chartName));
-		Files.writeString(chartPath.resolve("templates/tests/test-connection.yaml"),
-				HelmChartTemplates.substituteChartName(HelmChartTemplates.getTestConnectionTemplate(), chartName));
+			// Create template files
+			Files.writeString(chartPath.resolve("templates/NOTES.txt"),
+					HelmChartTemplates.substituteChartName(HelmChartTemplates.getNotesTemplate(), chartName));
+			Files.writeString(chartPath.resolve("templates/_helpers.tpl"),
+					HelmChartTemplates.substituteChartName(HelmChartTemplates.getHelpersTemplate(), chartName));
+			Files.writeString(chartPath.resolve("templates/deployment.yaml"),
+					HelmChartTemplates.substituteChartName(HelmChartTemplates.getDeploymentTemplate(), chartName));
+			Files.writeString(chartPath.resolve("templates/service.yaml"),
+					HelmChartTemplates.substituteChartName(HelmChartTemplates.getServiceTemplate(), chartName));
+			Files.writeString(chartPath.resolve("templates/serviceaccount.yaml"),
+					HelmChartTemplates.substituteChartName(HelmChartTemplates.getServiceAccountTemplate(), chartName));
+			Files.writeString(chartPath.resolve("templates/hpa.yaml"),
+					HelmChartTemplates.substituteChartName(HelmChartTemplates.getHpaTemplate(), chartName));
+			Files.writeString(chartPath.resolve("templates/ingress.yaml"),
+					HelmChartTemplates.substituteChartName(HelmChartTemplates.getIngressTemplate(), chartName));
+			Files.writeString(chartPath.resolve("templates/httproute.yaml"),
+					HelmChartTemplates.substituteChartName(HelmChartTemplates.getHttpRouteTemplate(), chartName));
+			Files.writeString(chartPath.resolve("templates/tests/test-connection.yaml"),
+					HelmChartTemplates.substituteChartName(HelmChartTemplates.getTestConnectionTemplate(), chartName));
+		}
+		catch (IOException ex) {
+			throw new JhelmException("Failed to scaffold chart " + chartName, ex);
+		}
 	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/GetAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/GetAction.java
@@ -1,6 +1,7 @@
 package org.alexmond.jhelm.core.action;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.dataformat.yaml.YAMLMapper;
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.Optional;
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.KubeService;
@@ -31,9 +33,9 @@ public class GetAction {
 	 * @param name the release name
 	 * @param namespace the release namespace
 	 * @return the release if found, otherwise empty
-	 * @throws Exception if the release store cannot be read
+	 * @throws KubernetesOperationException if the release store cannot be read
 	 */
-	public Optional<Release> getRelease(String name, String namespace) throws Exception {
+	public Optional<Release> getRelease(String name, String namespace) {
 		return kubeService.getRelease(name, namespace);
 	}
 
@@ -43,9 +45,9 @@ public class GetAction {
 	 * @param namespace the release namespace
 	 * @param revision the revision number to look up
 	 * @return the matching revision if found, otherwise empty
-	 * @throws Exception if the release history cannot be read
+	 * @throws KubernetesOperationException if the release history cannot be read
 	 */
-	public Optional<Release> getReleaseByRevision(String name, String namespace, int revision) throws Exception {
+	public Optional<Release> getReleaseByRevision(String name, String namespace, int revision) {
 		List<Release> history = kubeService.getReleaseHistory(name, namespace);
 		return history.stream().filter((r) -> r.getVersion() == revision).findFirst();
 	}
@@ -56,9 +58,9 @@ public class GetAction {
 	 * @param all if {@code true}, return the chart defaults merged with user overrides;
 	 * if {@code false}, return only the user-supplied overrides
 	 * @return the values rendered as YAML, or {@code "{}"} when there are none
-	 * @throws Exception if the values cannot be serialized
+	 * @throws JhelmException if the values cannot be serialized
 	 */
-	public String getValues(Release release, boolean all) throws Exception {
+	public String getValues(Release release, boolean all) {
 		if (all && release.getChart() != null && release.getChart().getValues() != null) {
 			Map<String, Object> merged = new LinkedHashMap<>(release.getChart().getValues());
 			if (release.getConfig() != null && release.getConfig().getValues() != null) {
@@ -150,9 +152,9 @@ public class GetAction {
 	 * @param allValues if {@code true}, include merged chart defaults in the VALUES
 	 * section
 	 * @return the combined multi-section report
-	 * @throws Exception if the values cannot be serialized
+	 * @throws JhelmException if the values cannot be serialized
 	 */
-	public String getAll(Release release, boolean allValues) throws Exception {
+	public String getAll(Release release, boolean allValues) {
 		StringBuilder sb = new StringBuilder();
 
 		sb.append("MANIFEST:\n");
@@ -187,9 +189,9 @@ public class GetAction {
 	 * start marker, minimized quotes, null values omitted).
 	 * @param obj the object to serialize
 	 * @return the YAML representation
-	 * @throws Exception if serialization fails
+	 * @throws JhelmException if serialization fails
 	 */
-	public String toYaml(Object obj) throws Exception {
+	public String toYaml(Object obj) {
 		YAMLMapper yamlMapper = YAMLMapper.builder()
 			.disable(YAMLWriteFeature.WRITE_DOC_START_MARKER)
 			.enable(YAMLWriteFeature.MINIMIZE_QUOTES)
@@ -197,18 +199,28 @@ public class GetAction {
 			.changeDefaultPropertyInclusion((v) -> v.withValueInclusion(JsonInclude.Include.NON_NULL)
 				.withContentInclusion(JsonInclude.Include.NON_NULL))
 			.build();
-		return yamlMapper.writeValueAsString(obj);
+		try {
+			return yamlMapper.writeValueAsString(obj);
+		}
+		catch (JacksonException ex) {
+			throw new JhelmException("Failed to serialize values to YAML", ex);
+		}
 	}
 
 	/**
 	 * Serializes an object to indented JSON.
 	 * @param obj the object to serialize
 	 * @return the JSON representation
-	 * @throws Exception if serialization fails
+	 * @throws JhelmException if serialization fails
 	 */
-	public String toJson(Object obj) throws Exception {
+	public String toJson(Object obj) {
 		JsonMapper jsonMapper = JsonMapper.builder().enable(SerializationFeature.INDENT_OUTPUT).build();
-		return jsonMapper.writeValueAsString(obj);
+		try {
+			return jsonMapper.writeValueAsString(obj);
+		}
+		catch (JacksonException ex) {
+			throw new JhelmException("Failed to serialize values to JSON", ex);
+		}
 	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/HistoryAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/HistoryAction.java
@@ -20,9 +20,9 @@ public class HistoryAction {
 	 * @param name the release name
 	 * @param namespace the release namespace
 	 * @return the list of stored revisions, oldest first
-	 * @throws Exception if the release history cannot be read
+	 * @throws KubernetesOperationException if the release history cannot be read
 	 */
-	public List<Release> history(String name, String namespace) throws Exception {
+	public List<Release> history(String name, String namespace) {
 		return kubeService.getReleaseHistory(name, namespace);
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.DeploymentFailedException;
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
@@ -57,10 +58,10 @@ public class InstallAction {
 	 * @throws IllegalArgumentException if the chart is a library chart
 	 * @throws DeploymentFailedException if applied resources cannot be persisted (they
 	 * are rolled back)
-	 * @throws Exception if rendering or a cluster operation fails
+	 * @throws JhelmException if rendering or a cluster operation fails
 	 */
 	public Release install(Chart chart, String releaseName, String namespace, Map<String, Object> overrideValues,
-			int version, boolean dryRun) throws Exception {
+			int version, boolean dryRun) {
 		if ("library".equals(chart.getMetadata().getType())) {
 			throw new IllegalArgumentException(
 					"chart '" + chart.getMetadata().getName() + "' is a library chart and cannot be installed");
@@ -96,7 +97,12 @@ public class InstallAction {
 		String manifest = engine.render(chart, values, releaseData);
 
 		for (PostRenderProcessor processor : postRenderProcessors) {
-			manifest = processor.process(manifest);
+			try {
+				manifest = processor.process(manifest);
+			}
+			catch (Exception ex) {
+				throw new JhelmException("Post-render processor failed", ex);
+			}
 		}
 
 		release.setManifest(manifest);
@@ -107,7 +113,7 @@ public class InstallAction {
 			List<HelmHook> hooks = HookParser.parseHooks(manifest);
 			String regularManifest = HookParser.stripHooks(manifest);
 			HookExecutor hookExecutor = new HookExecutor(kubeService);
-			hookExecutor.run(namespace, hooks, "pre-install", 300);
+			runHooks(hookExecutor, namespace, hooks, "pre-install");
 			kubeService.apply(namespace, regularManifest);
 			try {
 				kubeService.storeRelease(release);
@@ -117,14 +123,23 @@ public class InstallAction {
 				throw new DeploymentFailedException("Failed to store release after apply; resources rolled back", ex,
 						regularManifest);
 			}
-			hookExecutor.run(namespace, hooks, "post-install", 300);
+			runHooks(hookExecutor, namespace, hooks, "post-install");
 			fireLifecycleEvent("post-install", releaseName, namespace);
 		}
 
 		return release;
 	}
 
-	private void applyCrds(Chart chart, String namespace) throws Exception {
+	private void runHooks(HookExecutor hookExecutor, String namespace, List<HelmHook> hooks, String phase) {
+		try {
+			hookExecutor.run(namespace, hooks, phase, 300);
+		}
+		catch (Exception ex) {
+			throw new JhelmException("Failed to run " + phase + " hooks", ex);
+		}
+	}
+
+	private void applyCrds(Chart chart, String namespace) {
 		if (chart.getCrds() == null || chart.getCrds().isEmpty()) {
 			return;
 		}
@@ -150,9 +165,14 @@ public class InstallAction {
 		}
 	}
 
-	private void fireLifecycleEvent(String phase, String releaseName, String namespace) throws Exception {
+	private void fireLifecycleEvent(String phase, String releaseName, String namespace) {
 		for (LifecycleListener listener : lifecycleListeners) {
-			listener.onEvent(phase, releaseName, namespace, Map.of());
+			try {
+				listener.onEvent(phase, releaseName, namespace, Map.of());
+			}
+			catch (Exception ex) {
+				throw new JhelmException("Lifecycle listener failed for phase " + phase, ex);
+			}
 		}
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/ListAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/ListAction.java
@@ -11,7 +11,7 @@ public class ListAction {
 
 	private final KubeService kubeService;
 
-	public List<Release> list(String namespace) throws Exception {
+	public List<Release> list(String namespace) {
 		return kubeService.listReleases(namespace);
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/PackageAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/PackageAction.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.SignatureService;
@@ -43,8 +44,9 @@ public class PackageAction {
 	 * Packages a chart directory into a {@code .tgz} archive.
 	 * @param chartPath path to the chart directory
 	 * @return the created archive file
+	 * @throws JhelmException if the chart cannot be read or the archive cannot be written
 	 */
-	public File packageChart(String chartPath) throws Exception {
+	public File packageChart(String chartPath) {
 		return packageChart(chartPath, null, null);
 	}
 
@@ -55,8 +57,10 @@ public class PackageAction {
 	 * @param keyId substring to match against key user IDs
 	 * @param passphrase the key passphrase
 	 * @return the created archive file
+	 * @throws JhelmException if the chart cannot be read or the archive cannot be written
+	 * @throws SignatureException if the signing key cannot be loaded or signing fails
 	 */
-	public File packageChart(String chartPath, String keyringPath, String keyId, char[] passphrase) throws Exception {
+	public File packageChart(String chartPath, String keyringPath, String keyId, char[] passphrase) {
 		SigningKey signingKey = signatureService.loadSigningKey(keyringPath, keyId);
 		return packageChart(chartPath, signingKey, passphrase);
 	}
@@ -67,26 +71,33 @@ public class PackageAction {
 	 * @param signingKey signing key, or {@code null} to skip signing
 	 * @param passphrase key passphrase, or {@code null} if not signing
 	 * @return the created archive file
+	 * @throws JhelmException if the chart cannot be read or the archive cannot be written
+	 * @throws SignatureException if signing fails
 	 */
-	public File packageChart(String chartPath, SigningKey signingKey, char[] passphrase) throws Exception {
+	public File packageChart(String chartPath, SigningKey signingKey, char[] passphrase) {
 		Chart chart = chartLoader.load(new File(chartPath));
 		String archiveName = chart.getMetadata().getName() + "-" + chart.getMetadata().getVersion() + ".tgz";
 
 		File destDir = (destination != null) ? destination : new File(".");
 		File archiveFile = new File(destDir, archiveName);
 
-		createTgz(new File(chartPath), chart.getMetadata().getName(), archiveFile);
-		if (log.isInfoEnabled()) {
-			log.info("Successfully packaged chart and saved it to: {}", archiveFile.getAbsolutePath());
-		}
-
-		if (signingKey != null) {
-			String provContent = signatureService.sign(archiveFile, chart.getMetadata(), signingKey, passphrase);
-			File provFile = new File(destDir, archiveName + ".prov");
-			Files.writeString(provFile.toPath(), provContent);
+		try {
+			createTgz(new File(chartPath), chart.getMetadata().getName(), archiveFile);
 			if (log.isInfoEnabled()) {
-				log.info("Successfully signed chart and saved provenance to: {}", provFile.getAbsolutePath());
+				log.info("Successfully packaged chart and saved it to: {}", archiveFile.getAbsolutePath());
 			}
+
+			if (signingKey != null) {
+				String provContent = signatureService.sign(archiveFile, chart.getMetadata(), signingKey, passphrase);
+				File provFile = new File(destDir, archiveName + ".prov");
+				Files.writeString(provFile.toPath(), provContent);
+				if (log.isInfoEnabled()) {
+					log.info("Successfully signed chart and saved provenance to: {}", provFile.getAbsolutePath());
+				}
+			}
+		}
+		catch (IOException ex) {
+			throw new JhelmException("Failed to package chart " + chartPath, ex);
 		}
 
 		return archiveFile;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
@@ -19,7 +20,7 @@ public class RollbackAction {
 
 	private final KubeService kubeService;
 
-	public void rollback(String name, String namespace, int revision) throws Exception {
+	public void rollback(String name, String namespace, int revision) {
 		List<Release> history = kubeService.getReleaseHistory(name, namespace);
 		Optional<Release> targetReleaseOpt = history.stream().filter((r) -> r.getVersion() == revision).findFirst();
 
@@ -51,10 +52,19 @@ public class RollbackAction {
 		List<HelmHook> hooks = HookParser.parseHooks(manifest);
 		String regularManifest = HookParser.stripHooks(manifest);
 		HookExecutor hookExecutor = new HookExecutor(kubeService);
-		hookExecutor.run(namespace, hooks, "pre-rollback", 300);
+		runHooks(hookExecutor, namespace, hooks, "pre-rollback");
 		kubeService.apply(namespace, regularManifest);
 		kubeService.storeRelease(newRelease);
-		hookExecutor.run(namespace, hooks, "post-rollback", 300);
+		runHooks(hookExecutor, namespace, hooks, "post-rollback");
+	}
+
+	private void runHooks(HookExecutor hookExecutor, String namespace, List<HelmHook> hooks, String phase) {
+		try {
+			hookExecutor.run(namespace, hooks, phase, 300);
+		}
+		catch (Exception ex) {
+			throw new JhelmException("Failed to run " + phase + " hooks", ex);
+		}
 	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/SearchHubAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/SearchHubAction.java
@@ -13,6 +13,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
+import org.alexmond.jhelm.core.exception.JhelmException;
 
 /**
  * Searches Artifact Hub for Helm charts matching a keyword.
@@ -31,24 +32,29 @@ public class SearchHubAction {
 		this.jsonMapper = JsonMapper.builder().build();
 	}
 
-	public List<HubResult> search(String keyword, int maxResults) throws IOException {
+	public List<HubResult> search(String keyword, int maxResults) {
 		String encoded = URLEncoder.encode(keyword, StandardCharsets.UTF_8);
 		String url = ARTIFACT_HUB_API + "?ts_query_web=" + encoded + "&kind=0&limit=" + maxResults;
 
 		HttpGet request = new HttpGet(url);
 		request.setHeader("Accept", "application/json");
 
-		return httpClient.execute(request, (response) -> {
-			int status = response.getCode();
-			String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-			if (status != 200) {
-				throw new IOException("Artifact Hub returned HTTP " + status);
-			}
-			return parseResponse(body);
-		});
+		try {
+			return httpClient.execute(request, (response) -> {
+				int status = response.getCode();
+				String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+				if (status != 200) {
+					throw new IOException("Artifact Hub returned HTTP " + status);
+				}
+				return parseResponse(body);
+			});
+		}
+		catch (IOException ex) {
+			throw new JhelmException("Failed to query Artifact Hub", ex);
+		}
 	}
 
-	private List<HubResult> parseResponse(String json) throws IOException {
+	private List<HubResult> parseResponse(String json) {
 		List<HubResult> results = new ArrayList<>();
 		JsonNode root = jsonMapper.readTree(json);
 		JsonNode packages = root.get("packages");

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/ShowAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/ShowAction.java
@@ -1,11 +1,13 @@
 package org.alexmond.jhelm.core.action;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import tools.jackson.core.JacksonException;
 import tools.jackson.dataformat.yaml.YAMLMapper;
 import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 import lombok.RequiredArgsConstructor;
 
 import java.io.File;
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.service.ChartLoader;
 
@@ -14,12 +16,12 @@ public class ShowAction {
 
 	private final ChartLoader chartLoader;
 
-	public String showChart(String chartPath) throws Exception {
+	public String showChart(String chartPath) {
 		Chart chart = chartLoader.load(new File(chartPath));
 		return toYaml(chart.getMetadata());
 	}
 
-	public String showValues(String chartPath) throws Exception {
+	public String showValues(String chartPath) {
 		Chart chart = chartLoader.load(new File(chartPath));
 		if (chart.getValues() == null || chart.getValues().isEmpty()) {
 			return "{}";
@@ -27,12 +29,12 @@ public class ShowAction {
 		return toYaml(chart.getValues());
 	}
 
-	public String showReadme(String chartPath) throws Exception {
+	public String showReadme(String chartPath) {
 		Chart chart = chartLoader.load(new File(chartPath));
 		return (chart.getReadme() != null) ? chart.getReadme() : "";
 	}
 
-	public String showCrds(String chartPath) throws Exception {
+	public String showCrds(String chartPath) {
 		Chart chart = chartLoader.load(new File(chartPath));
 		if (chart.getCrds() == null || chart.getCrds().isEmpty()) {
 			return "";
@@ -47,7 +49,7 @@ public class ShowAction {
 		return sb.toString();
 	}
 
-	public String showAll(String chartPath) throws Exception {
+	public String showAll(String chartPath) {
 		Chart chart = chartLoader.load(new File(chartPath));
 		StringBuilder sb = new StringBuilder();
 
@@ -80,7 +82,7 @@ public class ShowAction {
 		return sb.toString();
 	}
 
-	private String toYaml(Object obj) throws Exception {
+	private String toYaml(Object obj) {
 		YAMLMapper yamlMapper = YAMLMapper.builder()
 			.disable(YAMLWriteFeature.WRITE_DOC_START_MARKER)
 			.enable(YAMLWriteFeature.MINIMIZE_QUOTES)
@@ -88,7 +90,12 @@ public class ShowAction {
 			.changeDefaultPropertyInclusion((v) -> v.withValueInclusion(JsonInclude.Include.NON_NULL)
 				.withContentInclusion(JsonInclude.Include.NON_NULL))
 			.build();
-		return yamlMapper.writeValueAsString(obj);
+		try {
+			return yamlMapper.writeValueAsString(obj);
+		}
+		catch (JacksonException ex) {
+			throw new JhelmException("Failed to serialize chart to YAML", ex);
+		}
 	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/StatusAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/StatusAction.java
@@ -13,11 +13,11 @@ public class StatusAction {
 
 	private final KubeService kubeService;
 
-	public Optional<Release> status(String name, String namespace) throws Exception {
+	public Optional<Release> status(String name, String namespace) {
 		return kubeService.getRelease(name, namespace);
 	}
 
-	public List<ResourceStatus> getResourceStatuses(Release release) throws Exception {
+	public List<ResourceStatus> getResourceStatuses(Release release) {
 		if (release.getManifest() == null || release.getManifest().isBlank()) {
 			return List.of();
 		}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.Engine;
@@ -21,12 +22,11 @@ public class TemplateAction {
 	@Setter
 	private List<PostRenderProcessor> postRenderProcessors = List.of();
 
-	public String render(String chartPath, String releaseName, String namespace) throws Exception {
+	public String render(String chartPath, String releaseName, String namespace) {
 		return render(chartPath, releaseName, namespace, new HashMap<>());
 	}
 
-	public String render(String chartPath, String releaseName, String namespace, Map<String, Object> overrides)
-			throws Exception {
+	public String render(String chartPath, String releaseName, String namespace, Map<String, Object> overrides) {
 		ChartLoader loader = new ChartLoader();
 		Chart chart = loader.load(new File(chartPath));
 
@@ -44,7 +44,12 @@ public class TemplateAction {
 		String manifest = engine.render(chart, values, releaseData);
 
 		for (PostRenderProcessor processor : postRenderProcessors) {
-			manifest = processor.process(manifest);
+			try {
+				manifest = processor.process(manifest);
+			}
+			catch (Exception ex) {
+				throw new JhelmException("Post-render processor failed", ex);
+			}
 		}
 
 		return manifest;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TestAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TestAction.java
@@ -32,9 +32,9 @@ public class TestAction {
 	 * @param timeoutSeconds timeout for each test hook
 	 * @return list of test results
 	 * @throws ReleaseNotFoundException if the release does not exist
-	 * @throws Exception if a Kubernetes API error occurs
+	 * @throws KubernetesOperationException if a Kubernetes API error occurs
 	 */
-	public List<TestResult> test(String releaseName, String namespace, int timeoutSeconds) throws Exception {
+	public List<TestResult> test(String releaseName, String namespace, int timeoutSeconds) {
 		Optional<Release> releaseOpt = kubeService.getRelease(releaseName, namespace);
 		if (releaseOpt.isEmpty()) {
 			throw ReleaseNotFoundException.forRelease(releaseName, namespace);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
@@ -18,7 +19,7 @@ public class UninstallAction {
 
 	private final KubeService kubeService;
 
-	public void uninstall(String releaseName, String namespace) throws Exception {
+	public void uninstall(String releaseName, String namespace) {
 		Optional<Release> releaseOpt = kubeService.getRelease(releaseName, namespace);
 		if (releaseOpt.isEmpty()) {
 			throw ReleaseNotFoundException.forRelease(releaseName, namespace);
@@ -28,11 +29,20 @@ public class UninstallAction {
 		List<HelmHook> hooks = HookParser.parseHooks(release.getManifest());
 		String regularManifest = HookParser.stripHooks(release.getManifest());
 		HookExecutor hookExecutor = new HookExecutor(kubeService);
-		hookExecutor.run(namespace, hooks, "pre-delete", 300);
+		runHooks(hookExecutor, namespace, hooks, "pre-delete");
 		String deletableManifest = HookParser.stripKeptResources(regularManifest);
 		kubeService.delete(namespace, deletableManifest);
-		hookExecutor.run(namespace, hooks, "post-delete", 300);
+		runHooks(hookExecutor, namespace, hooks, "post-delete");
 		kubeService.deleteReleaseHistory(releaseName, namespace);
+	}
+
+	private void runHooks(HookExecutor hookExecutor, String namespace, List<HelmHook> hooks, String phase) {
+		try {
+			hookExecutor.run(namespace, hooks, phase, 300);
+		}
+		catch (Exception ex) {
+			throw new JhelmException("Failed to run " + phase + " hooks", ex);
+		}
 	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.DeploymentFailedException;
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
@@ -34,8 +35,7 @@ public class UpgradeAction {
 	@Setter
 	private List<LifecycleListener> lifecycleListeners = List.of();
 
-	public Release upgrade(Release currentRelease, Chart newChart, Map<String, Object> overrideValues, boolean dryRun)
-			throws Exception {
+	public Release upgrade(Release currentRelease, Chart newChart, Map<String, Object> overrideValues, boolean dryRun) {
 		if ("library".equals(newChart.getMetadata().getType())) {
 			throw new IllegalArgumentException(
 					"chart '" + newChart.getMetadata().getName() + "' is a library chart and cannot be upgraded");
@@ -71,7 +71,12 @@ public class UpgradeAction {
 		String manifest = engine.render(newChart, values, releaseData);
 
 		for (PostRenderProcessor processor : postRenderProcessors) {
-			manifest = processor.process(manifest);
+			try {
+				manifest = processor.process(manifest);
+			}
+			catch (Exception ex) {
+				throw new JhelmException("Post-render processor failed", ex);
+			}
 		}
 
 		newRelease.setManifest(manifest);
@@ -81,7 +86,7 @@ public class UpgradeAction {
 			List<HelmHook> hooks = HookParser.parseHooks(manifest);
 			String regularManifest = HookParser.stripHooks(manifest);
 			HookExecutor hookExecutor = new HookExecutor(kubeService);
-			hookExecutor.run(newRelease.getNamespace(), hooks, "pre-upgrade", 300);
+			runHooks(hookExecutor, newRelease.getNamespace(), hooks, "pre-upgrade");
 			kubeService.apply(newRelease.getNamespace(), regularManifest);
 			try {
 				kubeService.storeRelease(newRelease);
@@ -91,11 +96,20 @@ public class UpgradeAction {
 				throw new DeploymentFailedException("Failed to store release after apply; previous release re-applied",
 						ex, regularManifest);
 			}
-			hookExecutor.run(newRelease.getNamespace(), hooks, "post-upgrade", 300);
+			runHooks(hookExecutor, newRelease.getNamespace(), hooks, "post-upgrade");
 			fireLifecycleEvent("post-upgrade", newRelease.getName(), newRelease.getNamespace());
 		}
 
 		return newRelease;
+	}
+
+	private void runHooks(HookExecutor hookExecutor, String namespace, List<HelmHook> hooks, String phase) {
+		try {
+			hookExecutor.run(namespace, hooks, phase, 300);
+		}
+		catch (Exception ex) {
+			throw new JhelmException("Failed to run " + phase + " hooks", ex);
+		}
 	}
 
 	private void reapplyPreviousRelease(Release previousRelease) {
@@ -117,9 +131,14 @@ public class UpgradeAction {
 		}
 	}
 
-	private void fireLifecycleEvent(String phase, String releaseName, String namespace) throws Exception {
+	private void fireLifecycleEvent(String phase, String releaseName, String namespace) {
 		for (LifecycleListener listener : lifecycleListeners) {
-			listener.onEvent(phase, releaseName, namespace, Map.of());
+			try {
+				listener.onEvent(phase, releaseName, namespace, Map.of());
+			}
+			catch (Exception ex) {
+				throw new JhelmException("Lifecycle listener failed for phase " + phase, ex);
+			}
 		}
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/VerifyAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/VerifyAction.java
@@ -1,10 +1,12 @@
 package org.alexmond.jhelm.core.action;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.service.SignatureService;
 import org.alexmond.jhelm.core.service.VerificationKeyring;
 
@@ -21,8 +23,10 @@ public class VerifyAction {
 	 * Verifies the PGP signature and digest of a chart archive.
 	 * @param chartTgzPath path to the chart {@code .tgz} archive
 	 * @param keyringPath path to the PGP public keyring file
+	 * @throws JhelmException if the provenance file cannot be read
+	 * @throws SignatureException if verification fails
 	 */
-	public void verify(String chartTgzPath, String keyringPath) throws Exception {
+	public void verify(String chartTgzPath, String keyringPath) {
 		File chartFile = new File(chartTgzPath);
 		if (!chartFile.exists()) {
 			throw new IllegalArgumentException("Chart archive not found: " + chartTgzPath);
@@ -33,7 +37,13 @@ public class VerifyAction {
 			throw new IllegalArgumentException("Provenance file not found: " + provFile.getAbsolutePath());
 		}
 
-		String provContent = Files.readString(provFile.toPath());
+		String provContent;
+		try {
+			provContent = Files.readString(provFile.toPath());
+		}
+		catch (IOException ex) {
+			throw new JhelmException("Failed to read provenance file " + provFile.getAbsolutePath(), ex);
+		}
 		VerificationKeyring keyring = signatureService.loadVerificationKeyring(keyringPath);
 
 		signatureService.verify(chartFile, provContent, keyring);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ChartLoader.java
@@ -50,10 +50,10 @@ public class ChartLoader {
 	 * templates, CRDs and subchart dependencies.
 	 * @param chartDir the chart's root directory (the one containing {@code Chart.yaml})
 	 * @return the fully populated chart
-	 * @throws IOException if a chart file cannot be read
-	 * @throws ChartLoadException if the directory is missing or has no {@code Chart.yaml}
+	 * @throws ChartLoadException if the directory is missing, has no {@code Chart.yaml},
+	 * or a chart file cannot be read
 	 */
-	public Chart load(File chartDir) throws IOException {
+	public Chart load(File chartDir) {
 		if (!chartDir.exists() || !chartDir.isDirectory()) {
 			throw new ChartLoadException("Chart directory does not exist", chartDir.getPath(),
 					"Verify the path is correct and points to a valid Helm chart directory");
@@ -65,6 +65,17 @@ public class ChartLoader {
 			throw new ChartLoadException("Chart.yaml not found", chartDir.getPath(),
 					"A valid Helm chart requires a Chart.yaml file. Run 'helm create' to scaffold a new chart");
 		}
+
+		try {
+			return loadFromDir(chartDir, metadataFile);
+		}
+		catch (IOException ex) {
+			throw new ChartLoadException("Failed to load chart", ex, chartDir.getPath(),
+					"Verify the chart files are readable and well-formed");
+		}
+	}
+
+	private Chart loadFromDir(File chartDir, File metadataFile) throws IOException {
 		ChartMetadata metadata = yamlMapper.readValue(metadataFile, ChartMetadata.class);
 
 		// For apiVersion v1 charts, dependencies live in requirements.yaml rather than

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/CreateActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/CreateActionTest.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.core.action;
 
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -51,7 +52,7 @@ class CreateActionTest {
 		Path chartPath = tempDir.resolve("existing-chart");
 		Files.createDirectories(chartPath);
 
-		IOException exception = assertThrows(IOException.class, () -> createAction.create(chartPath));
+		JhelmException exception = assertThrows(JhelmException.class, () -> createAction.create(chartPath));
 
 		assertTrue(exception.getMessage().contains("already exists"));
 	}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/SearchHubActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/SearchHubActionTest.java
@@ -1,6 +1,5 @@
 package org.alexmond.jhelm.core.action;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -9,6 +8,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.alexmond.jhelm.core.exception.JhelmException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -97,7 +97,7 @@ class SearchHubActionTest {
 		});
 
 		SearchHubAction action = new SearchHubAction(mockClient);
-		assertThrows(IOException.class, () -> action.search("nginx", 25));
+		assertThrows(JhelmException.class, () -> action.search("nginx", 25));
 	}
 
 	@Test


### PR DESCRIPTION
Second slice of the **0.4.0 API freeze** (#500), after #505 (KubeService) and #506 (BouncyCastle wrapping).

## Why
Every public method in `core/action/*` declared `throws Exception`. That can't be narrowed after a 1.0 semver commitment without breaking every caller's catch blocks, and it leaks checked IO/serialization exceptions out of the public library surface. This converts the action layer to the unchecked `JhelmException` hierarchy.

## What
- **`ChartLoader.load(File)`** — drops `throws IOException`; internal IO is wrapped in the unchecked `ChartLoadException` at the public boundary (private `loadFromDir` keeps the IO and keeps both methods under the Checkstyle `MethodLength` limit).
- **Action layer** — `throws Exception` removed from all public methods. Pure `KubeService` delegators (`list`/`status`/`history`/`get*`/`rollback`/`uninstall`/`test`) needed no body change (#505 already made `KubeService` unchecked).
- **Real checked exceptions wrapped** into the hierarchy: `Files`/tar/HTTP `IOException` (Create/Package/Verify/SearchHub) and Jackson serialization → `JhelmException`. The still-checked collaborators (`HookExecutor.run`, `PostRenderProcessor.process`, `LifecycleListener.onEvent` — out of scope for this slice) are caught-and-wrapped at the call site, narrowly, so specific subtypes like `DeploymentFailedException` still propagate from the main install/upgrade path.
- **Callers** — `CreateCommand` `catch (IOException)` → `catch (JhelmException)`; three tests swap `assertThrows`/Mockito stubs from `IOException` to `JhelmException`.

No new exception classes — everything wraps into existing `JhelmException`/`ChartLoadException`.

## ⚠️ Breaking change
`core/action/*` and `ChartLoader.load` no longer declare `throws Exception`/`throws IOException`. Callers catching the checked `Exception` should catch `JhelmException` (or a subtype). Behaviour is otherwise identical.

## Verified
Full reactor build green — **jhelm-core 499, jhelm-cli 171, jhelm-rest 55** tests, 0 failures; PMD/Checkstyle clean.

## Follow-up slices for #500
- Narrow `HelmKubeService.listPods`/`installConfigMap` (still leak `ApiException`) + the `ApiClient` bean — the kubernetes-client type-leak blocker.
- Narrow the `HookExecutor`/`PostRenderProcessor`/`LifecycleListener` interfaces themselves (so the call-site wraps become unnecessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)