### PR TITLE
refactor(api)!: stop HelmKubeService leaking ApiException (#500)

### DIFF
--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
@@ -224,13 +224,17 @@ public class HelmKubeService implements KubeService {
 	 * {@code helm status} pod listing.
 	 * @param namespace the Kubernetes namespace to list pods from
 	 * @return the names of the pods found in the namespace, in API-returned order
-	 * @throws ApiException if the Kubernetes API call fails
+	 * @throws KubernetesOperationException if the Kubernetes API call fails
 	 */
-	public List<String> listPods(String namespace) throws ApiException {
+	public List<String> listPods(String namespace) {
 		CoreV1Api api = new CoreV1Api(apiClient);
-		V1PodList list = api.listNamespacedPod(namespace).execute();
-
-		return list.getItems().stream().map((pod) -> pod.getMetadata().getName()).collect(Collectors.toList());
+		try {
+			V1PodList list = api.listNamespacedPod(namespace).execute();
+			return list.getItems().stream().map((pod) -> pod.getMetadata().getName()).collect(Collectors.toList());
+		}
+		catch (ApiException ex) {
+			throw new KubernetesOperationException("Failed to list pods in " + namespace, ex, ex.getCode());
+		}
 	}
 
 	/**
@@ -544,10 +548,10 @@ public class HelmKubeService implements KubeService {
 	 * conflict) it is replaced instead of created.
 	 * @param namespace the Kubernetes namespace to install the ConfigMap into
 	 * @param yamlContent the YAML representation of the ConfigMap to install
-	 * @throws ApiException if the Kubernetes API call fails for a reason other than an
-	 * already-existing ConfigMap
+	 * @throws KubernetesOperationException if the Kubernetes API call fails for a reason
+	 * other than an already-existing ConfigMap
 	 */
-	public void installConfigMap(String namespace, String yamlContent) throws ApiException {
+	public void installConfigMap(String namespace, String yamlContent) {
 		CoreV1Api api = new CoreV1Api(apiClient);
 		V1ConfigMap cm = Yaml.loadAs(yamlContent, V1ConfigMap.class);
 
@@ -557,25 +561,28 @@ public class HelmKubeService implements KubeService {
 			}
 			api.createNamespacedConfigMap(namespace, cm).execute();
 		}
-		catch (Exception ex) {
-			if (ex instanceof ApiException ae && ae.getCode() == 409) { // Conflict/Already
-																		// exists
-				if (log.isInfoEnabled()) {
-					log.info("ConfigMap already exists, replacing");
-				}
-				api.replaceNamespacedConfigMap(cm.getMetadata().getName(), namespace, cm).execute();
+		catch (ApiException ex) {
+			if (ex.getCode() == 409) { // Conflict / already exists -> replace
+				replaceConfigMap(api, namespace, cm);
 			}
 			else {
 				if (log.isDebugEnabled()) {
-					log.debug("Error installing ConfigMap: {}", ex.getMessage());
+					log.debug("Error installing ConfigMap: {} / {}", ex.getMessage(), ex.getResponseBody());
 				}
-				if (ex instanceof ApiException ae) {
-					if (log.isDebugEnabled()) {
-						log.debug("API Response: {}", ae.getResponseBody());
-					}
-				}
-				throw ex;
+				throw new KubernetesOperationException("Failed to install ConfigMap in " + namespace, ex, ex.getCode());
 			}
+		}
+	}
+
+	private void replaceConfigMap(CoreV1Api api, String namespace, V1ConfigMap cm) {
+		if (log.isInfoEnabled()) {
+			log.info("ConfigMap already exists, replacing");
+		}
+		try {
+			api.replaceNamespacedConfigMap(cm.getMetadata().getName(), namespace, cm).execute();
+		}
+		catch (ApiException ex) {
+			throw new KubernetesOperationException("Failed to replace ConfigMap in " + namespace, ex, ex.getCode());
 		}
 	}
 

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
@@ -631,7 +631,7 @@ class HelmKubeServiceTest {
 			when(mock.createNamespacedConfigMap(eq("default"), any(V1ConfigMap.class))).thenReturn(createReq);
 		});
 
-		assertThrows(ApiException.class, () -> kubeService.installConfigMap("default", yaml));
+		assertThrows(KubernetesOperationException.class, () -> kubeService.installConfigMap("default", yaml));
 	}
 
 	@Test


### PR DESCRIPTION
Third slice of the **0.4.0 API freeze** (#500), after #505 (KubeService interface), #506 (BouncyCastle), and #512 (action layer).

## Why
`HelmKubeService.listPods` and `installConfigMap` were the **last two public methods declaring the kubernetes-client checked `ApiException`** — pinning the client major version into jhelm's public API. (#505 already cleaned the `KubeService` interface methods.)

## What
- **`listPods`** — translate `ApiException` → `KubernetesOperationException` (preserving the HTTP status code); drop `throws ApiException`.
- **`installConfigMap`** — replace the broad `catch (Exception)` + raw re-throw with a precise `catch (ApiException)`. The 409 replace path is extracted to a private `replaceConfigMap` that **also** translates its `ApiException` — that `replaceNamespacedConfigMap(...).execute()` call was a second uncaught leak. Drop `throws ApiException`.
- **Test** — `testInstallConfigMapThrowsOnOtherApiError` now asserts `KubernetesOperationException` instead of `ApiException`.

Both methods have **no production callers** (test-only today) but are intentional public API with unit + integration coverage, so they're **wrapped, not removed**.

## ⚠️ Breaking change
`HelmKubeService.listPods`/`installConfigMap` no longer declare `throws ApiException`; failures surface as the unchecked `KubernetesOperationException` (carrying the HTTP status). **The kubernetes-client `ApiException` no longer appears anywhere on jhelm's public method surface.**

## Verified
jhelm-kube **191** tests green; jhelm-cli/jhelm-rest build clean; PMD/Checkstyle clean.

## Remaining for #500 blocker 2 (next slice)
The `ApiClient` exposure — the public `@Bean apiClient()` + `ApiClient` constructor params on `HelmKubeService`/`AsyncHelmKubeService`/`KubernetesClientProvider`. That's an architectural choice (wrapper vs. demote-the-bean) and will be its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)