### PR TITLE
refactor(api)!: wrap ApiClient behind KubeClient, off the public surface (#500)

### DIFF
--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
@@ -12,6 +12,7 @@ import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
 import org.alexmond.jhelm.kube.service.AsyncHelmKubeService;
+import org.alexmond.jhelm.kube.service.KubeClient;
 import org.alexmond.jhelm.kube.service.ObservableKubeService;
 import org.alexmond.jhelm.kube.service.RetryableKubeService;
 import org.springframework.beans.factory.ObjectProvider;
@@ -24,8 +25,8 @@ import org.springframework.core.retry.RetryTemplate;
 import java.time.Duration;
 
 /**
- * Auto-configuration for the jhelm Kubernetes integration module. Registers an
- * {@link ApiClient} and a {@link KubeService} implementation. When retry is enabled (the
+ * Auto-configuration for the jhelm Kubernetes integration module. Registers a
+ * {@link KubeClient} and a {@link KubeService} implementation. When retry is enabled (the
  * default), the service is wrapped with {@link RetryableKubeService} for transient
  * failure recovery. When a {@link JhelmMetrics} bean is available, the service is further
  * wrapped with {@link ObservableKubeService} for operation timing and counting. Runs
@@ -45,6 +46,27 @@ public class JhelmKubeAutoConfiguration {
 	}
 
 	/**
+	 * Registers the {@link KubeClient} used by the module. If a consumer supplies their
+	 * own {@link ApiClient} bean (the intentional, documented customization seam) it is
+	 * wrapped as-is; otherwise a client is built from the configured kubeconfig path,
+	 * falling back to the default in-cluster or local client.
+	 * @param props the Kubernetes configuration properties, providing the optional
+	 * kubeconfig path
+	 * @param apiClientOverride provider for an optional consumer-supplied API client used
+	 * to override the built-in client
+	 * @return the registered {@link KubeClient}
+	 * @throws IOException if the configured kubeconfig file cannot be read
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public KubeClient kubeClient(JhelmKubernetesProperties props, ObjectProvider<ApiClient> apiClientOverride)
+			throws IOException {
+		ApiClient override = apiClientOverride.getIfAvailable();
+		ApiClient client = (override != null) ? override : buildApiClient(props);
+		return new KubeClient(client);
+	}
+
+	/**
 	 * Builds the Kubernetes {@link ApiClient} used by the module. When a kubeconfig path
 	 * is configured the client is built from that file, otherwise the default in-cluster
 	 * or local client is used.
@@ -53,9 +75,7 @@ public class JhelmKubeAutoConfiguration {
 	 * @return the configured Kubernetes API client
 	 * @throws IOException if the configured kubeconfig file cannot be read
 	 */
-	@Bean
-	@ConditionalOnMissingBean
-	public ApiClient apiClient(JhelmKubernetesProperties props) throws IOException {
+	private ApiClient buildApiClient(JhelmKubernetesProperties props) throws IOException {
 		if (props.getKubeconfigPath() != null) {
 			return Config.fromConfig(KubeConfig.loadKubeConfig(new FileReader(props.getKubeconfigPath())));
 		}
@@ -67,7 +87,7 @@ public class JhelmKubeAutoConfiguration {
 	 * wrapped with {@link RetryableKubeService} when retry is enabled, and further
 	 * wrapped with {@link ObservableKubeService} when a {@link JhelmMetrics} bean is
 	 * available.
-	 * @param apiClient the configured Kubernetes API client
+	 * @param kubeClient the registered Kubernetes client wrapper
 	 * @param props the Kubernetes configuration properties, providing the retry settings
 	 * @param metricsProvider provider for the optional metrics bean used to enable
 	 * operation timing and counting
@@ -75,9 +95,9 @@ public class JhelmKubeAutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean(KubeService.class)
-	public KubeService kubeService(ApiClient apiClient, JhelmKubernetesProperties props,
+	public KubeService kubeService(KubeClient kubeClient, JhelmKubernetesProperties props,
 			ObjectProvider<JhelmMetrics> metricsProvider) {
-		AsyncHelmKubeService base = new AsyncHelmKubeService(apiClient);
+		AsyncHelmKubeService base = new AsyncHelmKubeService(kubeClient);
 		KubeService service = base;
 		JhelmKubernetesProperties.Retry retryConfig = props.getRetry();
 		if (retryConfig.isEnabled()) {

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/AsyncHelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/AsyncHelmKubeService.java
@@ -6,7 +6,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import io.kubernetes.client.openapi.ApiClient;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
@@ -28,12 +27,12 @@ public class AsyncHelmKubeService extends HelmKubeService implements AsyncKubeSe
 	private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
 
 	/**
-	 * Creates an async service backed by the given Kubernetes API client.
-	 * @param apiClient the configured Kubernetes API client used for all cluster
-	 * operations
+	 * Creates an async service backed by the given {@link KubeClient}.
+	 * @param kubeClient the jhelm Kubernetes client wrapper holding the configured API
+	 * client used for all cluster operations
 	 */
-	public AsyncHelmKubeService(ApiClient apiClient) {
-		super(apiClient);
+	public AsyncHelmKubeService(KubeClient kubeClient) {
+		super(kubeClient);
 	}
 
 	@Override

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
@@ -20,7 +20,6 @@ import io.kubernetes.client.openapi.models.V1SecretList;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
 import io.kubernetes.client.util.PatchUtils;
 import io.kubernetes.client.util.Yaml;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.exception.ReleaseStorageException;
@@ -49,12 +48,11 @@ import java.nio.charset.StandardCharsets;
  * manifests, and waits on workload readiness.
  *
  * <p>
- * Instances are created with a configured {@link ApiClient}. {@link KubeService}
- * operations translate the client's checked {@link ApiException} into the unchecked
+ * Instances are created with a {@link KubeClient}. {@link KubeService} operations
+ * translate the client's checked {@link ApiException} into the unchecked
  * {@link KubernetesOperationException} (preserving the HTTP status code), so the public
  * surface never leaks the kubernetes-client exception type.
  */
-@RequiredArgsConstructor
 @Slf4j
 public class HelmKubeService implements KubeService {
 
@@ -64,6 +62,15 @@ public class HelmKubeService implements KubeService {
 	private final JsonMapper objectMapper = JsonMapper.builder().build();
 
 	private ResourcePluralizer pluralizer;
+
+	/**
+	 * Creates a service backed by the given {@link KubeClient}.
+	 * @param kubeClient the jhelm Kubernetes client wrapper holding the configured API
+	 * client
+	 */
+	public HelmKubeService(KubeClient kubeClient) {
+		this.apiClient = kubeClient.apiClient();
+	}
 
 	/**
 	 * Stores a release as a Secret in Kubernetes, matching Helm's storage format.

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/KubeClient.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/KubeClient.java
@@ -1,0 +1,40 @@
+package org.alexmond.jhelm.kube.service;
+
+import io.kubernetes.client.openapi.ApiClient;
+
+/**
+ * jhelm-owned wrapper around the kubernetes-client {@link ApiClient}. It holds the
+ * underlying {@code io.kubernetes.client.openapi.ApiClient} so that the concrete
+ * kubernetes-client type stays off jhelm's public service signatures: the client's major
+ * version is not pinned into jhelm's API, leaving jhelm free to upgrade the kubernetes
+ * client without breaking its own public surface.
+ *
+ * <p>
+ * Advanced users can still supply their own {@link ApiClient} bean (it is consumed as a
+ * customization seam by the auto-configuration) and have it wrapped in a
+ * {@code KubeClient}. The wrapped client is exposed only through a package-private
+ * accessor, so the services in this package can unwrap it while external code cannot.
+ */
+public final class KubeClient {
+
+	private final ApiClient apiClient;
+
+	/**
+	 * Creates a wrapper around the given Kubernetes API client.
+	 * @param apiClient the kubernetes-client API client to wrap
+	 */
+	public KubeClient(ApiClient apiClient) {
+		this.apiClient = apiClient;
+	}
+
+	/**
+	 * Returns the wrapped Kubernetes API client. Package-private on purpose: only the
+	 * services in this package may unwrap the client, keeping the concrete
+	 * kubernetes-client type off jhelm's public API.
+	 * @return the wrapped Kubernetes API client
+	 */
+	ApiClient apiClient() {
+		return this.apiClient;
+	}
+
+}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/KubernetesClientProvider.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/KubernetesClientProvider.java
@@ -34,11 +34,12 @@ public class KubernetesClientProvider implements KubernetesProvider {
 	private volatile Boolean available;
 
 	/**
-	 * Creates a provider backed by the given Kubernetes API client.
-	 * @param apiClient the configured Kubernetes API client used to look up resources and
-	 * query cluster version information
+	 * Creates a provider backed by the given {@link KubeClient}.
+	 * @param kubeClient the jhelm Kubernetes client wrapper holding the configured API
+	 * client used to look up resources and query cluster version information
 	 */
-	public KubernetesClientProvider(ApiClient apiClient) {
+	public KubernetesClientProvider(KubeClient kubeClient) {
+		ApiClient apiClient = kubeClient.apiClient();
 		this.apiClient = apiClient;
 		this.coreV1Api = new CoreV1Api(apiClient);
 		this.appsV1Api = new AppsV1Api(apiClient);

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfigurationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfigurationTest.java
@@ -6,6 +6,7 @@ import org.alexmond.jhelm.core.JhelmMetricsAutoConfiguration;
 import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.kube.service.HelmKubeService;
+import org.alexmond.jhelm.kube.service.KubeClient;
 import org.alexmond.jhelm.kube.service.ObservableKubeService;
 import org.alexmond.jhelm.kube.service.RetryableKubeService;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ class JhelmKubeAutoConfigurationTest {
 	@KubeClusterAvailable
 	void testKubeServiceIsRetryableByDefaultWithCluster() {
 		contextRunner.run((ctx) -> {
-			assertNotNull(ctx.getBean(ApiClient.class));
+			assertNotNull(ctx.getBean(KubeClient.class));
 			KubeService kubeService = ctx.getBean(KubeService.class);
 			assertInstanceOf(RetryableKubeService.class, kubeService);
 		});
@@ -35,7 +36,7 @@ class JhelmKubeAutoConfigurationTest {
 	void testKubeServiceIsRetryableByDefaultWithMockedClient() {
 		ApiClient mockClient = mock(ApiClient.class);
 		contextRunner.withBean(ApiClient.class, () -> mockClient).run((ctx) -> {
-			assertNotNull(ctx.getBean(ApiClient.class));
+			assertNotNull(ctx.getBean(KubeClient.class));
 			KubeService kubeService = ctx.getBean(KubeService.class);
 			assertInstanceOf(RetryableKubeService.class, kubeService);
 		});
@@ -82,7 +83,7 @@ class JhelmKubeAutoConfigurationTest {
 		KubeService custom = mock(KubeService.class);
 		contextRunner.withBean(ApiClient.class, () -> mockClient)
 			.withBean("customKubeService", KubeService.class, () -> custom)
-			.run((ctx) -> assertNotNull(ctx.getBean(ApiClient.class)));
+			.run((ctx) -> assertNotNull(ctx.getBean(KubeClient.class)));
 	}
 
 }

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/AsyncHelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/AsyncHelmKubeServiceTest.java
@@ -45,7 +45,7 @@ class AsyncHelmKubeServiceTest {
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		spyService = spy(new AsyncHelmKubeService(apiClient));
+		spyService = spy(new AsyncHelmKubeService(new KubeClient(apiClient)));
 	}
 
 	private Release createTestRelease(String name, String namespace, int version) {

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceIntegrationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceIntegrationTest.java
@@ -21,7 +21,7 @@ class HelmKubeServiceIntegrationTest {
 	private HelmKubeService helmKubeService;
 
 	@Autowired
-	private ApiClient apiClient;
+	private KubeClient kubeClient;
 
 	@Test
 	void testListPodsInKubeSystem() throws ApiException {
@@ -44,6 +44,7 @@ class HelmKubeServiceIntegrationTest {
 		helmKubeService.installConfigMap("default", yaml);
 
 		// Verify
+		ApiClient apiClient = kubeClient.apiClient();
 		CoreV1Api api = new CoreV1Api(apiClient);
 		V1ConfigMap cm = api.readNamespacedConfigMap("jhelm-test-cm", "default").execute();
 		assertNotNull(cm);

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
@@ -83,7 +83,7 @@ class HelmKubeServiceTest {
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		kubeService = new HelmKubeService(apiClient);
+		kubeService = new HelmKubeService(new KubeClient(apiClient));
 	}
 
 	@AfterEach

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/KubernetesClientProviderTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/KubernetesClientProviderTest.java
@@ -52,7 +52,7 @@ class KubernetesClientProviderTest {
 	@BeforeEach
 	void setUp() throws Exception {
 		MockitoAnnotations.openMocks(this);
-		provider = new KubernetesClientProvider(apiClient);
+		provider = new KubernetesClientProvider(new KubeClient(apiClient));
 		setField(provider, "coreV1Api", coreV1Api);
 		setField(provider, "appsV1Api", appsV1Api);
 		setField(provider, "versionApi", versionApi);


### PR DESCRIPTION
Fourth slice of the **0.4.0 API freeze** (#500) — finishing **blocker 2** (after #513 removed the last `ApiException` leak).

## Why
The kubernetes-client `ApiClient` was exposed as a public `@Bean` and as a constructor param on `HelmKubeService` / `AsyncHelmKubeService` / `KubernetesClientProvider`, pinning the client major version into jhelm's public API.

## What (decided design: wrapper + customizer)
- New jhelm-owned **`KubeClient`** holder (`kube.service`) wraps the `ApiClient`; the client is reachable only via a **package-private** accessor — services in the package unwrap it, external code cannot.
- `JhelmKubeAutoConfiguration`: drop the public `ApiClient` `@Bean`; build the client in a private helper and expose a **`KubeClient` `@Bean`** instead. A consumer-supplied `ApiClient` is still honoured via an **`ObjectProvider<ApiClient>` override seam** (custom auth/transport keeps working), then wrapped.
- Service constructors take `KubeClient` instead of `ApiClient`.

`ApiClient` no longer appears in any public method/constructor/`@Bean` signature **except the single intentional override seam**.

## ⚠️ Breaking change
`HelmKubeService`/`AsyncHelmKubeService`/`KubernetesClientProvider` constructors take `KubeClient`, not `ApiClient`; the module exposes a `KubeClient` bean instead of an `ApiClient` bean. Supply a custom `ApiClient` `@Bean` to override.

## Verified
Full reactor green — **jhelm-kube 191, jhelm-cli 171, jhelm-rest 55** tests, 0 failures; PMD/Checkstyle clean.

## #500 status after this
Blocker 1 (throws Exception) ✅ · Blocker 2 (kube-client leak) ✅ · Blocker 3 (BouncyCastle) ✅ — **all three API-freeze blockers done.** Remaining #500 items are the High/Medium polish (immutable result models, typed `ReleaseContext`, `RepoManager` threading, enums).

🤖 Generated with [Claude Code](https://claude.com/claude-code)