### PR TITLE
fix(core): persist user-supplied values as the release config (#501)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -84,6 +84,11 @@ public class InstallAction {
 			.version(version)
 			.chart(chart)
 			.info(info)
+			// Persist the user-supplied values (Helm's release "config"), so that
+			// `get values` reports them and a later upgrade can reuse them.
+			.config(Release.MapConfig.builder()
+				.values((overrideValues != null) ? new HashMap<>(overrideValues) : new HashMap<>())
+				.build())
 			.build();
 
 		Map<String, Object> releaseData = new HashMap<>();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -58,6 +58,11 @@ public class UpgradeAction {
 			.version(currentRelease.getVersion() + 1)
 			.chart(newChart)
 			.info(info)
+			// Persist the user-supplied values (Helm's release "config"), so that
+			// `get values` reports them and a later upgrade can reuse them.
+			.config(Release.MapConfig.builder()
+				.values((overrideValues != null) ? new HashMap<>(overrideValues) : new HashMap<>())
+				.build())
 			.build();
 
 		Map<String, Object> releaseData = new HashMap<>();

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.core.action;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -66,6 +67,20 @@ class InstallActionTest {
 
 		verify(kubeService).apply("default", HookParser.stripHooks(manifest));
 		verify(kubeService).storeRelease(any(Release.class));
+	}
+
+	@Test
+	void testInstallPersistsUserValuesAsConfig() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("---\n");
+		Map<String, Object> overrides = Map.of("replicaCount", 3, "image", Map.of("tag", "v2"));
+
+		Release release = installAction.install(chart, "my-release", "default", overrides, 1, true);
+
+		assertNotNull(release.getConfig());
+		assertEquals(3, release.getConfig().getValues().get("replicaCount"));
+		assertEquals(Map.of("tag", "v2"), release.getConfig().getValues().get("image"));
 	}
 
 	@Test


### PR DESCRIPTION
First slice of the **#501 value-handling fix** (the upgrade data-loss mini-epic).

## The bug (two for one)
`InstallAction`/`UpgradeAction` merged the user-supplied `--set`/`-f` values into the render but **never set `Release.config`**. So:
1. **`helm get values` returned nothing user-supplied** — `GetAction` reads `release.getConfig().getValues()`, which was always `null`.
2. **A later upgrade couldn't reuse prior values** — they were never persisted. This is the root cause behind the upgrade value-drop (#501).

## Fix
Both actions now store the supplied overrides in `Release.config` (Helm's release `config`). The stored Secret already round-trips the whole `Release` via Jackson, so `config` persists and decodes with **no storage-format change**.

## Scope
This is the **prerequisite** slice. The upgrade `--reset-values` / `--reuse-values` / `--reset-then-reuse-values` strategy builds on the now-persisted `config` in a follow-up PR (parity-sensitive; validated against real `helm`).

## Verified
jhelm-core **500** tests (new `testInstallPersistsUserValuesAsConfig`), 0 failures; full affected build green; PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)