### PR TITLE
feat(core): upgrade value strategies — fix silent drop of user values (#501)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -12,6 +12,7 @@ import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.RollbackAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -77,6 +78,18 @@ public class UpgradeCommand implements Runnable {
 	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
 
+	@Option(names = { "--reset-values" },
+			description = "when upgrading, reset the values to the ones built into the chart")
+	private boolean resetValues;
+
+	@Option(names = { "--reuse-values" },
+			description = "when upgrading, reuse the last release's values and merge in any overrides from the command line via --set and -f")
+	private boolean reuseValues;
+
+	@Option(names = { "--reset-then-reuse-values" },
+			description = "when upgrading, reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --set and -f")
+	private boolean resetThenReuseValues;
+
 	/**
 	 * Creates the command.
 	 * @param kubeService the Kubernetes service used to look up releases and wait for
@@ -131,7 +144,11 @@ public class UpgradeCommand implements Runnable {
 			}
 
 			previousVersion = currentReleaseOpt.get().getVersion();
-			Release upgradedRelease = upgradeAction.upgrade(currentReleaseOpt.get(), chart, overrides, dryRun);
+			UpgradeValueStrategy strategy = (resetValues) ? UpgradeValueStrategy.RESET
+					: (resetThenReuseValues) ? UpgradeValueStrategy.RESET_THEN_REUSE
+							: (reuseValues) ? UpgradeValueStrategy.REUSE : UpgradeValueStrategy.DEFAULT;
+			Release upgradedRelease = upgradeAction.upgrade(currentReleaseOpt.get(), chart, overrides, strategy,
+					dryRun);
 			applyCliPostRenderers(upgradedRelease);
 
 			if (dryRun) {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -9,6 +9,7 @@ import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.RollbackAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
 
 import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,7 +76,8 @@ class UpgradeCommandTest {
 		Release upgradedRelease = createMockRelease("my-release", 2);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
-		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), anyBoolean()))
+		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
+				anyBoolean()))
 			.thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
@@ -112,7 +114,8 @@ class UpgradeCommandTest {
 		Release upgradedRelease = createMockRelease("my-release", 2);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
-		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), anyBoolean()))
+		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
+				anyBoolean()))
 			.thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
@@ -150,7 +153,8 @@ class UpgradeCommandTest {
 		Release upgradedRelease = createMockRelease("my-release", 2);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
-		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), anyBoolean()))
+		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
+				anyBoolean()))
 			.thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
@@ -166,7 +170,8 @@ class UpgradeCommandTest {
 		Release upgradedRelease = createMockRelease("my-release", 2);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
-		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), anyBoolean()))
+		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
+				anyBoolean()))
 			.thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
@@ -196,7 +201,8 @@ class UpgradeCommandTest {
 		Release existingRelease = createMockRelease("my-release", 3);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
-		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), anyBoolean()))
+		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
+				anyBoolean()))
 			.thenThrow(new RuntimeException("upgrade failed"));
 
 		CommandLine cmd = new CommandLine(upgradeCommand);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -35,15 +35,28 @@ public class UpgradeAction {
 	@Setter
 	private List<LifecycleListener> lifecycleListeners = List.of();
 
-	public Release upgrade(Release currentRelease, Chart newChart, Map<String, Object> overrideValues, boolean dryRun) {
+	/**
+	 * Upgrades a release, resolving values according to the given
+	 * {@link UpgradeValueStrategy}.
+	 * @param currentRelease the currently deployed release (its chart defaults and
+	 * persisted user values feed the reuse strategies)
+	 * @param newChart the chart to upgrade to
+	 * @param overrideValues this command's value overrides (may be {@code null})
+	 * @param strategy how to resolve the previous user values against the overrides — see
+	 * {@link UpgradeValueStrategy}
+	 * @param dryRun when {@code true}, render only without applying to the cluster
+	 * @return the upgraded release
+	 */
+	public Release upgrade(Release currentRelease, Chart newChart, Map<String, Object> overrideValues,
+			UpgradeValueStrategy strategy, boolean dryRun) {
 		if ("library".equals(newChart.getMetadata().getType())) {
 			throw new IllegalArgumentException(
 					"chart '" + newChart.getMetadata().getName() + "' is a library chart and cannot be upgraded");
 		}
-		Map<String, Object> values = new HashMap<>(newChart.getValues());
-		if (overrideValues != null) {
-			ValuesLoader.deepMerge(values, overrideValues);
-		}
+
+		ResolvedValues resolved = resolveValues(currentRelease, newChart, overrideValues, strategy);
+		Map<String, Object> renderValues = resolved.render();
+		Map<String, Object> configValues = resolved.config();
 
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(currentRelease.getInfo().getFirstDeployed())
@@ -58,11 +71,10 @@ public class UpgradeAction {
 			.version(currentRelease.getVersion() + 1)
 			.chart(newChart)
 			.info(info)
-			// Persist the user-supplied values (Helm's release "config"), so that
+			// Persist the resolved user-supplied values (Helm's release "config"), so
+			// that
 			// `get values` reports them and a later upgrade can reuse them.
-			.config(Release.MapConfig.builder()
-				.values((overrideValues != null) ? new HashMap<>(overrideValues) : new HashMap<>())
-				.build())
+			.config(Release.MapConfig.builder().values(configValues).build())
 			.build();
 
 		Map<String, Object> releaseData = new HashMap<>();
@@ -73,7 +85,7 @@ public class UpgradeAction {
 		releaseData.put("IsUpgrade", true);
 		releaseData.put("Revision", newRelease.getVersion());
 
-		String manifest = engine.render(newChart, values, releaseData);
+		String manifest = engine.render(newChart, renderValues, releaseData);
 
 		for (PostRenderProcessor processor : postRenderProcessors) {
 			try {
@@ -106,6 +118,64 @@ public class UpgradeAction {
 		}
 
 		return newRelease;
+	}
+
+	/**
+	 * Resolves the render and config value maps for an upgrade per the strategy matrix.
+	 * <p>
+	 * Let {@code over} = this command's overrides, {@code prior} = the previous release's
+	 * persisted user values, {@code oldDefaults} = the previous chart's defaults and
+	 * {@code newDefaults} = the new chart's defaults (all null-guarded to empty, all
+	 * copied so inputs are never mutated):
+	 * <ul>
+	 * <li><b>RESET</b>: config = over; render = newDefaults + over (prior ignored)</li>
+	 * <li><b>DEFAULT</b> (no over): config = prior; render = newDefaults + prior</li>
+	 * <li><b>DEFAULT</b> (with over): config = over; render = newDefaults + over</li>
+	 * <li><b>RESET_THEN_REUSE</b>: merged = prior + over; config = merged; render =
+	 * newDefaults + merged</li>
+	 * <li><b>REUSE</b>: merged = prior + over; config = merged; render = oldDefaults +
+	 * prior + over</li>
+	 * </ul>
+	 * REUSE renders against the OLD defaults so new default changes are ignored, whereas
+	 * RESET_THEN_REUSE renders against the NEW defaults.
+	 */
+	private ResolvedValues resolveValues(Release currentRelease, Chart newChart, Map<String, Object> overrideValues,
+			UpgradeValueStrategy strategy) {
+		Map<String, Object> over = (overrideValues != null) ? overrideValues : Map.of();
+		Map<String, Object> prior = (currentRelease.getConfig() != null
+				&& currentRelease.getConfig().getValues() != null) ? currentRelease.getConfig().getValues() : Map.of();
+		Map<String, Object> oldDefaults = (currentRelease.getChart() != null
+				&& currentRelease.getChart().getValues() != null) ? currentRelease.getChart().getValues() : Map.of();
+		Map<String, Object> newDefaults = (newChart.getValues() != null) ? newChart.getValues() : Map.of();
+
+		switch (strategy) {
+			case RESET -> {
+				Map<String, Object> render = new HashMap<>(newDefaults);
+				ValuesLoader.deepMerge(render, over);
+				return new ResolvedValues(render, new HashMap<>(over));
+			}
+			case RESET_THEN_REUSE -> {
+				Map<String, Object> merged = new HashMap<>(prior);
+				ValuesLoader.deepMerge(merged, over);
+				Map<String, Object> render = new HashMap<>(newDefaults);
+				ValuesLoader.deepMerge(render, merged);
+				return new ResolvedValues(render, merged);
+			}
+			case REUSE -> {
+				Map<String, Object> merged = new HashMap<>(prior);
+				ValuesLoader.deepMerge(merged, over);
+				Map<String, Object> render = new HashMap<>(oldDefaults);
+				ValuesLoader.deepMerge(render, prior);
+				ValuesLoader.deepMerge(render, over);
+				return new ResolvedValues(render, merged);
+			}
+			default -> {
+				Map<String, Object> userLayer = over.isEmpty() ? prior : over;
+				Map<String, Object> render = new HashMap<>(newDefaults);
+				ValuesLoader.deepMerge(render, userLayer);
+				return new ResolvedValues(render, new HashMap<>(userLayer));
+			}
+		}
 	}
 
 	private void runHooks(HookExecutor hookExecutor, String namespace, List<HelmHook> hooks, String phase) {
@@ -145,6 +215,13 @@ public class UpgradeAction {
 				throw new JhelmException("Lifecycle listener failed for phase " + phase, ex);
 			}
 		}
+	}
+
+	/**
+	 * The two value maps resolved for an upgrade: {@code render} is passed to the engine,
+	 * {@code config} is persisted as the release's user-value layer.
+	 */
+	private record ResolvedValues(Map<String, Object> render, Map<String, Object> config) {
 	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeValueStrategy.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeValueStrategy.java
@@ -1,0 +1,36 @@
+package org.alexmond.jhelm.core.action;
+
+/**
+ * Controls how user-supplied values are resolved when upgrading a release, mirroring
+ * Helm's value-reuse flags.
+ */
+public enum UpgradeValueStrategy {
+
+	/**
+	 * Helm's default behaviour (no value flag). When this command supplies overrides,
+	 * only those overrides are used (over the new chart defaults); when no overrides are
+	 * given, the previous release's user values are reused.
+	 */
+	DEFAULT,
+
+	/**
+	 * Maps to {@code --reset-values}. Discards the previous release's user values and
+	 * resets to the new chart defaults, applying only this command's overrides.
+	 */
+	RESET,
+
+	/**
+	 * Maps to {@code --reuse-values}. Reuses the previous release's user values, layering
+	 * this command's overrides on top, rendered against the previous chart's defaults so
+	 * new default changes are ignored.
+	 */
+	REUSE,
+
+	/**
+	 * Maps to {@code --reset-then-reuse-values}. Reuses the previous release's user
+	 * values with this command's overrides on top, but renders against the new chart
+	 * defaults so new default changes are picked up.
+	 */
+	RESET_THEN_REUSE
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -83,7 +83,8 @@ class UpgradeActionTest {
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		Release upgradedRelease = upgradeAction.upgrade(currentRelease, newChart, null, false);
+		Release upgradedRelease = upgradeAction.upgrade(currentRelease, newChart, null, UpgradeValueStrategy.DEFAULT,
+				false);
 
 		assertNotNull(upgradedRelease);
 		assertEquals("myapp", upgradedRelease.getName());
@@ -137,7 +138,7 @@ class UpgradeActionTest {
 
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
 
-		upgradeAction.upgrade(currentRelease, chart, overrideValues, false);
+		upgradeAction.upgrade(currentRelease, chart, overrideValues, UpgradeValueStrategy.DEFAULT, false);
 
 		@SuppressWarnings("unchecked")
 		ArgumentCaptor<Map<String, Object>> valuesCaptor = ArgumentCaptor.forClass(Map.class);
@@ -169,7 +170,8 @@ class UpgradeActionTest {
 
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("dry-run-manifest");
 
-		Release upgradedRelease = upgradeAction.upgrade(currentRelease, chart, null, true);
+		Release upgradedRelease = upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT,
+				true);
 
 		assertNotNull(upgradedRelease);
 		assertEquals("pending-upgrade", upgradedRelease.getInfo().getStatus());
@@ -221,7 +223,7 @@ class UpgradeActionTest {
 		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		upgradeAction.upgrade(currentRelease, chart, null, false);
+		upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT, false);
 
 		List<HelmHook> hooks = HookParser.parseHooks(fullManifest);
 		String strippedManifest = HookParser.stripHooks(fullManifest);
@@ -252,7 +254,8 @@ class UpgradeActionTest {
 
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
 
-		Release upgradedRelease = upgradeAction.upgrade(currentRelease, chart, null, false);
+		Release upgradedRelease = upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT,
+				false);
 
 		assertEquals(43, upgradedRelease.getVersion());
 		assertEquals(info.getFirstDeployed(), upgradedRelease.getInfo().getFirstDeployed());
@@ -284,7 +287,8 @@ class UpgradeActionTest {
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doThrow(new RuntimeException("storage failed")).when(kubeService).storeRelease(any(Release.class));
 
-		assertThrows(DeploymentFailedException.class, () -> upgradeAction.upgrade(currentRelease, chart, null, false));
+		assertThrows(DeploymentFailedException.class,
+				() -> upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT, false));
 
 		// Verify: new manifest applied, then previous manifest re-applied on rollback
 		verify(kubeService, times(2)).apply(eq("default"), anyString());
@@ -303,7 +307,150 @@ class UpgradeActionTest {
 			.info(Release.ReleaseInfo.builder().status("deployed").build())
 			.build();
 
-		assertThrows(IllegalArgumentException.class, () -> upgradeAction.upgrade(currentRelease, chart, null, false));
+		assertThrows(IllegalArgumentException.class,
+				() -> upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT, false));
+	}
+
+	// --- Value-resolution strategy tests ---------------------------------------------
+	// currentRelease carries prior user values (config) and an OLD chart whose default
+	// "defaultKey" is "old"; the newChart changes that default to "new".
+
+	private Release currentReleaseWithPrior() {
+		ChartMetadata oldMetadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Map<String, Object> oldDefaults = new HashMap<>();
+		oldDefaults.put("defaultKey", "old");
+		oldDefaults.put("replicaCount", 1);
+		Chart oldChart = Chart.builder().metadata(oldMetadata).values(oldDefaults).build();
+
+		Map<String, Object> prior = new HashMap<>();
+		prior.put("userKey", "prior");
+
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status("deployed")
+			.build();
+
+		return Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(oldChart)
+			.config(Release.MapConfig.builder().values(prior).build())
+			.info(info)
+			.build();
+	}
+
+	private Chart newChartWithChangedDefault() {
+		ChartMetadata newMetadata = ChartMetadata.builder().name("mychart").version("2.0.0").build();
+		Map<String, Object> newDefaults = new HashMap<>();
+		newDefaults.put("defaultKey", "new");
+		newDefaults.put("replicaCount", 1);
+		return Chart.builder().metadata(newMetadata).values(newDefaults).build();
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> renderValuesFor(Release upgraded) {
+		ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+		verify(engine).render(any(Chart.class), captor.capture(), anyMap());
+		return captor.getValue();
+	}
+
+	@Test
+	void testDefaultNoOverridesReusesPriorConfig() {
+		Release current = currentReleaseWithPrior();
+		Chart newChart = newChartWithChangedDefault();
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+
+		Release upgraded = upgradeAction.upgrade(current, newChart, null, UpgradeValueStrategy.DEFAULT, true);
+
+		Map<String, Object> render = renderValuesFor(upgraded);
+		// Prior user value reused; new chart default present.
+		assertEquals("prior", render.get("userKey"));
+		assertEquals("new", render.get("defaultKey"));
+		// Config persists the prior user values.
+		assertEquals("prior", upgraded.getConfig().getValues().get("userKey"));
+	}
+
+	@Test
+	void testDefaultWithOverridesDropsPrior() {
+		Release current = currentReleaseWithPrior();
+		Chart newChart = newChartWithChangedDefault();
+		Map<String, Object> overrides = new HashMap<>();
+		overrides.put("extra", "x");
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+
+		Release upgraded = upgradeAction.upgrade(current, newChart, overrides, UpgradeValueStrategy.DEFAULT, true);
+
+		Map<String, Object> render = renderValuesFor(upgraded);
+		// Overrides used; prior user value dropped for unspecified keys.
+		assertEquals("x", render.get("extra"));
+		assertEquals(null, render.get("userKey"));
+		assertEquals("new", render.get("defaultKey"));
+		// Config holds only the overrides.
+		assertEquals("x", upgraded.getConfig().getValues().get("extra"));
+		assertEquals(null, upgraded.getConfig().getValues().get("userKey"));
+	}
+
+	@Test
+	void testResetOverridesNewDefaultsIgnoringPrior() {
+		Release current = currentReleaseWithPrior();
+		Chart newChart = newChartWithChangedDefault();
+		Map<String, Object> overrides = new HashMap<>();
+		overrides.put("extra", "x");
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+
+		Release upgraded = upgradeAction.upgrade(current, newChart, overrides, UpgradeValueStrategy.RESET, true);
+
+		Map<String, Object> render = renderValuesFor(upgraded);
+		// Overrides over NEW defaults; prior ignored.
+		assertEquals("x", render.get("extra"));
+		assertEquals(null, render.get("userKey"));
+		assertEquals("new", render.get("defaultKey"));
+		assertEquals(null, upgraded.getConfig().getValues().get("userKey"));
+	}
+
+	@Test
+	void testReuseRendersAgainstOldDefaults() {
+		Release current = currentReleaseWithPrior();
+		Chart newChart = newChartWithChangedDefault();
+		Map<String, Object> overrides = new HashMap<>();
+		overrides.put("extra", "x");
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+
+		Release upgraded = upgradeAction.upgrade(current, newChart, overrides, UpgradeValueStrategy.REUSE, true);
+
+		Map<String, Object> render = renderValuesFor(upgraded);
+		// Prior + overrides; render based on OLD defaults — the changed new default does
+		// NOT appear (defaultKey stays "old").
+		assertEquals("prior", render.get("userKey"));
+		assertEquals("x", render.get("extra"));
+		assertEquals("old", render.get("defaultKey"));
+		// Config is the prior + override user layer.
+		assertEquals("prior", upgraded.getConfig().getValues().get("userKey"));
+		assertEquals("x", upgraded.getConfig().getValues().get("extra"));
+	}
+
+	@Test
+	void testResetThenReuseRendersAgainstNewDefaults() {
+		Release current = currentReleaseWithPrior();
+		Chart newChart = newChartWithChangedDefault();
+		Map<String, Object> overrides = new HashMap<>();
+		overrides.put("extra", "x");
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+
+		Release upgraded = upgradeAction.upgrade(current, newChart, overrides, UpgradeValueStrategy.RESET_THEN_REUSE,
+				true);
+
+		Map<String, Object> render = renderValuesFor(upgraded);
+		// Prior + overrides over NEW defaults — the changed new default DOES appear
+		// (defaultKey becomes "new").
+		assertEquals("prior", render.get("userKey"));
+		assertEquals("x", render.get("extra"));
+		assertEquals("new", render.get("defaultKey"));
+		// Config is the same prior + override user layer as REUSE.
+		assertEquals("prior", upgraded.getConfig().getValues().get("userKey"));
+		assertEquals("x", upgraded.getConfig().getValues().get("extra"));
 	}
 
 }

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmFullFlowIntegrationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmFullFlowIntegrationTest.java
@@ -7,6 +7,7 @@ import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.CoreConfig;
 import org.alexmond.jhelm.kube.KubernetesConfig;
@@ -97,7 +98,8 @@ class HelmFullFlowIntegrationTest {
 
 		// 4. Upgrade
 		Release currentRelease = storedRelease.get();
-		Release upgradedRelease = upgradeAction.upgrade(currentRelease, chart, Map.of("replicaCount", 3), false);
+		Release upgradedRelease = upgradeAction.upgrade(currentRelease, chart, Map.of("replicaCount", 3),
+				UpgradeValueStrategy.DEFAULT, false);
 		assertEquals(2, upgradedRelease.getVersion());
 		// assertTrue(upgradedRelease.getManifest().contains("replicaCount") ||
 		// upgradedRelease.getManifest().contains("replicas"));
@@ -162,7 +164,8 @@ class HelmFullFlowIntegrationTest {
 		Release realRelease = installAction.install(chart, releaseName, namespace, Map.of("replicaCount", 1), 1, false);
 		assertNotNull(realRelease);
 
-		Release dryUpgraded = upgradeAction.upgrade(realRelease, chart, Map.of("replicaCount", 10), true);
+		Release dryUpgraded = upgradeAction.upgrade(realRelease, chart, Map.of("replicaCount", 10),
+				UpgradeValueStrategy.DEFAULT, true);
 		assertNotNull(dryUpgraded);
 		assertTrue(dryUpgraded.getManifest().contains("replicas: 10"));
 		assertEquals("pending-upgrade", dryUpgraded.getInfo().getStatus());

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
@@ -18,6 +18,7 @@ import org.alexmond.jhelm.core.action.StatusAction;
 import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -225,7 +226,11 @@ public class ReleaseController {
 			Chart chart = ChartSourceResolver.fromChartRef(request.getChartRef(), request.getVersion(),
 					this.repoManager, this.chartLoader, tempDir);
 			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
-			Release upgraded = this.upgradeAction.upgrade(current, chart, values, request.isDryRun());
+			// TODO: expose UpgradeValueStrategy (reset/reuse/reset-then-reuse) on the
+			// REST
+			// request as a follow-up.
+			Release upgraded = this.upgradeAction.upgrade(current, chart, values, UpgradeValueStrategy.DEFAULT,
+					request.isDryRun());
 			return ReleaseDto.from(upgraded);
 		}
 	}
@@ -252,7 +257,11 @@ public class ReleaseController {
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-upgrade-upload-")) {
 			Chart loaded = ChartSourceResolver.fromUpload(chart, this.repoManager, this.chartLoader, tempDir);
 			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
-			Release upgraded = this.upgradeAction.upgrade(current, loaded, values, request.isDryRun());
+			// TODO: expose UpgradeValueStrategy (reset/reuse/reset-then-reuse) on the
+			// REST
+			// request as a follow-up.
+			Release upgraded = this.upgradeAction.upgrade(current, loaded, values, UpgradeValueStrategy.DEFAULT,
+					request.isDryRun());
 			return ReleaseDto.from(upgraded);
 		}
 	}

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
@@ -191,7 +191,7 @@ class ReleaseControllerTest {
 		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
 		Release upgraded = sampleRelease();
 		upgraded.setVersion(2);
-		when(this.upgradeAction.upgrade(any(), any(), anyMap(), anyBoolean())).thenReturn(upgraded);
+		when(this.upgradeAction.upgrade(any(), any(), anyMap(), any(), anyBoolean())).thenReturn(upgraded);
 
 		this.mockMvc
 			.perform(put("/api/v1/releases/my-release").contentType(MediaType.APPLICATION_JSON)
@@ -212,7 +212,7 @@ class ReleaseControllerTest {
 		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
 		Release upgraded = sampleRelease();
 		upgraded.setVersion(2);
-		when(this.upgradeAction.upgrade(any(), any(), anyMap(), anyBoolean())).thenReturn(upgraded);
+		when(this.upgradeAction.upgrade(any(), any(), anyMap(), any(), anyBoolean())).thenReturn(upgraded);
 
 		MockMultipartFile chartFile = new MockMultipartFile("chart", "nginx-2.0.0.tgz", "application/gzip",
 				new byte[] { 1, 2, 3 });


### PR DESCRIPTION
Second slice of **#501** (after #516 persisted user values as release config). Fixes the upgrade data-loss bug.

## The bug
`UpgradeAction` always rendered `new-chart-defaults + this-command's overrides`, **silently discarding the prior release's user values on every upgrade**. With values now persisted as release `config` (#516), this implements Helm's value-resolution strategies.

## Strategies
New `UpgradeValueStrategy { DEFAULT, RESET, REUSE, RESET_THEN_REUSE }`, resolved in `UpgradeAction.resolveValues` into a **render** map (→ `engine.render`) and a persisted **config** map:

| Strategy | Flag | Render values | Persisted config |
|---|---|---|---|
| **DEFAULT** | _(none)_ | no `--set/-f` → newDefaults + **prior**; else newDefaults + new | prior, or new |
| **RESET** | `--reset-values` | newDefaults + new only | new only |
| **REUSE** | `--reuse-values` | **old**Defaults + prior + new | prior + new |
| **RESET_THEN_REUSE** | `--reset-then-reuse-values` | **new**Defaults + prior + new | prior + new |

DEFAULT matches Helm 3 (reuse prior values only when no new value flags) — **that's the data-loss fix**. REUSE vs RESET_THEN_REUSE differ on whether a changed chart default shows through (old vs new defaults base) — verified distinct in tests.

## Wiring
- `UpgradeCommand`: three Picocli flags, Helm precedence `reset > reset-then-reuse > reuse > default`.
- `ReleaseController`: passes `DEFAULT` for now (`// TODO` to expose on the REST request).

## ⚠️ Breaking change
`UpgradeAction.upgrade` gains a `UpgradeValueStrategy` parameter before `dryRun`.

## Verified
jhelm-core **505** (`UpgradeActionTest` 12 — one per strategy incl. the REUSE/RESET_THEN_REUSE old-vs-new-default base), jhelm-cli **171**, jhelm-rest **55** — 0 failures; full reactor green; PMD/Checkstyle clean.

## Follow-ups (#501)
History pruning (`--history-max`), orphan-resource deletion, `--no-hooks`, `--set-string/--set-file/--set-json`. Parity validation against real `helm upgrade` on a cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)