### PR TITLE
feat(rest): READ_ONLY/FULL access mode gating mutating endpoints (#519)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmAccessMode.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmAccessMode.java
@@ -1,0 +1,25 @@
+package org.alexmond.jhelm.core.config;
+
+/**
+ * Access mode controlling which jhelm operations an adapter exposes.
+ *
+ * <p>
+ * This enum is shared across jhelm adapters so they agree on a single vocabulary. It is
+ * consumed per-adapter (currently by jhelm-rest, and later by jhelm-mcp), each of which
+ * decides how to enforce it for its own surface.
+ */
+public enum JhelmAccessMode {
+
+	/**
+	 * Exposes only non-mutating operations: template, show, lint, search, get, list,
+	 * status and history. Cluster-mutating operations are rejected.
+	 */
+	READ_ONLY,
+
+	/**
+	 * Exposes everything {@link #READ_ONLY} does, plus the cluster-mutating operations:
+	 * install, upgrade, uninstall, rollback and test.
+	 */
+	FULL
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -24,12 +24,15 @@ import org.alexmond.jhelm.rest.controller.DependencyController;
 import org.alexmond.jhelm.rest.controller.HubController;
 import org.alexmond.jhelm.rest.controller.ReleaseController;
 import org.alexmond.jhelm.rest.controller.RepoController;
+import org.alexmond.jhelm.rest.security.AccessModeInterceptor;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
@@ -72,6 +75,35 @@ public class JhelmRestAutoConfiguration {
 	@ConditionalOnMissingBean
 	public JhelmRestExceptionHandler jhelmRestExceptionHandler() {
 		return new JhelmRestExceptionHandler();
+	}
+
+	/**
+	 * Registers the access-mode interceptor that rejects cluster-mutating endpoints when
+	 * the REST API is in {@code READ_ONLY} mode.
+	 * @param properties the REST module configuration carrying the access mode
+	 * @return the access-mode interceptor bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public AccessModeInterceptor accessModeInterceptor(JhelmRestProperties properties) {
+		return new AccessModeInterceptor(properties);
+	}
+
+	/**
+	 * Registers a {@link WebMvcConfigurer} that applies the {@link AccessModeInterceptor}
+	 * to all REST paths.
+	 * @param accessModeInterceptor the interceptor enforcing the access mode
+	 * @return the web MVC configurer bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean(name = "jhelmAccessModeWebMvcConfigurer")
+	public WebMvcConfigurer jhelmAccessModeWebMvcConfigurer(AccessModeInterceptor accessModeInterceptor) {
+		return new WebMvcConfigurer() {
+			@Override
+			public void addInterceptors(InterceptorRegistry registry) {
+				registry.addInterceptor(accessModeInterceptor);
+			}
+		};
 	}
 
 	/**

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/config/JhelmRestProperties.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/config/JhelmRestProperties.java
@@ -8,6 +8,7 @@ import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -28,6 +29,12 @@ public class JhelmRestProperties {
 	 * Base directory for temporary files. Defaults to the system temp directory.
 	 */
 	private Path tempDir;
+
+	/**
+	 * Access mode for the REST API. {@link JhelmAccessMode#READ_ONLY READ_ONLY} blocks
+	 * cluster-mutating endpoints; defaults to {@link JhelmAccessMode#FULL FULL}.
+	 */
+	private JhelmAccessMode mode = JhelmAccessMode.FULL;
 
 	/**
 	 * Returns the configured temp directory, or the system default if not set. The

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
@@ -25,6 +25,7 @@ import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.core.util.HookParser;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
+import org.alexmond.jhelm.rest.security.MutatingOperation;
 import org.alexmond.jhelm.rest.dto.HelmHookDto;
 import org.alexmond.jhelm.rest.dto.InstallRequest;
 import org.alexmond.jhelm.rest.dto.InstallUploadRequest;
@@ -160,6 +161,7 @@ public class ReleaseController {
 	 * @throws Exception if the chart cannot be pulled or installed
 	 */
 	@PostMapping
+	@MutatingOperation
 	@Operation(summary = "Install a release",
 			description = "Install a new Helm release from a repository chart reference")
 	public ResponseEntity<ReleaseDto> install(@RequestBody InstallRequest request) throws Exception {
@@ -187,6 +189,7 @@ public class ReleaseController {
 	 * @throws Exception if the upload cannot be extracted or installed
 	 */
 	@PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@MutatingOperation
 	@Operation(summary = "Install a release from upload",
 			description = "Install a new Helm release from an uploaded .tgz chart archive")
 	public ResponseEntity<ReleaseDto> installUpload(@RequestPart("chart") MultipartFile chart,
@@ -212,6 +215,7 @@ public class ReleaseController {
 	 * @throws Exception if the release is not found or the upgrade fails
 	 */
 	@PutMapping("/{name}")
+	@MutatingOperation
 	@Operation(summary = "Upgrade a release",
 			description = "Upgrade an existing release from a repository chart reference")
 	public ReleaseDto upgrade(@Parameter(description = "Release name") @PathVariable String name,
@@ -246,6 +250,7 @@ public class ReleaseController {
 	 * @throws Exception if the release is not found or the upgrade fails
 	 */
 	@PostMapping(path = "/{name}/upgrade/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@MutatingOperation
 	@Operation(summary = "Upgrade a release from upload",
 			description = "Upgrade an existing release from an uploaded .tgz chart archive")
 	public ReleaseDto upgradeUpload(@Parameter(description = "Release name") @PathVariable String name,
@@ -274,6 +279,7 @@ public class ReleaseController {
 	 * @throws Exception if the release cannot be uninstalled
 	 */
 	@DeleteMapping("/{name}")
+	@MutatingOperation
 	@Operation(summary = "Uninstall a release")
 	public ResponseEntity<Void> uninstall(@Parameter(description = "Release name") @PathVariable String name,
 			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace)
@@ -306,6 +312,7 @@ public class ReleaseController {
 	 * @throws Exception if the rollback fails
 	 */
 	@PostMapping("/{name}/rollback")
+	@MutatingOperation
 	@Operation(summary = "Rollback a release", description = "Rollback a release to a previous revision")
 	public ResponseEntity<Void> rollback(@Parameter(description = "Release name") @PathVariable String name,
 			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace,
@@ -323,6 +330,7 @@ public class ReleaseController {
 	 * @throws Exception if the tests cannot be run
 	 */
 	@PostMapping("/{name}/test")
+	@MutatingOperation
 	@Operation(summary = "Test a release", description = "Run test hooks for a release")
 	public List<TestResultDto> test(@Parameter(description = "Release name") @PathVariable String name,
 			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace,

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/security/AccessModeInterceptor.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/security/AccessModeInterceptor.java
@@ -1,0 +1,57 @@
+package org.alexmond.jhelm.rest.security;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.rest.config.JhelmRestProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * Rejects cluster-mutating endpoints when the REST API is in
+ * {@link JhelmAccessMode#READ_ONLY READ_ONLY} mode. An endpoint is considered mutating
+ * when its handler method is annotated with {@link MutatingOperation}.
+ */
+@Slf4j
+public class AccessModeInterceptor implements HandlerInterceptor {
+
+	private static final String MESSAGE = "Operation not permitted: the jhelm REST API is in READ_ONLY mode";
+
+	private final JhelmRestProperties properties;
+
+	/**
+	 * Creates the interceptor.
+	 * @param properties the REST module configuration carrying the access mode
+	 */
+	public AccessModeInterceptor(JhelmRestProperties properties) {
+		this.properties = properties;
+	}
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+			throws IOException {
+		if (handler instanceof HandlerMethod hm && hm.getMethodAnnotation(MutatingOperation.class) != null
+				&& this.properties.getMode() == JhelmAccessMode.READ_ONLY) {
+			log.info("Blocking mutating operation {} {}: jhelm REST API is in READ_ONLY mode", request.getMethod(),
+					request.getRequestURI());
+			response.setStatus(HttpStatus.FORBIDDEN.value());
+			response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+			response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+			String body = "{\"status\":" + HttpStatus.FORBIDDEN.value() + ",\"error\":\""
+					+ HttpStatus.FORBIDDEN.getReasonPhrase() + "\",\"message\":\"" + MESSAGE + "\",\"timestamp\":\""
+					+ Instant.now() + "\"}";
+			response.getWriter().write(body);
+			return false;
+		}
+		return true;
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/security/MutatingOperation.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/security/MutatingOperation.java
@@ -1,0 +1,17 @@
+package org.alexmond.jhelm.rest.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a controller endpoint as a cluster-mutating operation. Such endpoints are
+ * rejected with {@code 403 Forbidden} when {@code jhelm.rest.mode} is
+ * {@link org.alexmond.jhelm.core.config.JhelmAccessMode#READ_ONLY READ_ONLY}.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MutatingOperation {
+
+}

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/security/AccessModeInterceptorTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/security/AccessModeInterceptorTest.java
@@ -1,0 +1,91 @@
+package org.alexmond.jhelm.rest.security;
+
+import java.util.List;
+
+import org.alexmond.jhelm.core.action.GetAction;
+import org.alexmond.jhelm.core.action.HistoryAction;
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.ListAction;
+import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.StatusAction;
+import org.alexmond.jhelm.core.action.TestAction;
+import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.rest.config.JhelmRestProperties;
+import org.alexmond.jhelm.rest.controller.ReleaseController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies that {@link AccessModeInterceptor} blocks {@link MutatingOperation} endpoints
+ * in {@link JhelmAccessMode#READ_ONLY READ_ONLY} mode while leaving read endpoints (and
+ * all endpoints in {@link JhelmAccessMode#FULL FULL} mode) untouched.
+ */
+class AccessModeInterceptorTest {
+
+	private JhelmRestProperties properties;
+
+	private ListAction listAction;
+
+	private UninstallAction uninstallAction;
+
+	private ReleaseController controller;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		this.properties = new JhelmRestProperties();
+		this.listAction = mock(ListAction.class);
+		StatusAction statusAction = mock(StatusAction.class);
+		GetAction getAction = mock(GetAction.class);
+		HistoryAction historyAction = mock(HistoryAction.class);
+		InstallAction installAction = mock(InstallAction.class);
+		UpgradeAction upgradeAction = mock(UpgradeAction.class);
+		this.uninstallAction = mock(UninstallAction.class);
+		RollbackAction rollbackAction = mock(RollbackAction.class);
+		TestAction testAction = mock(TestAction.class);
+		ChartLoader chartLoader = mock(ChartLoader.class);
+		RepoManager repoManager = mock(RepoManager.class);
+		when(this.listAction.list(anyString())).thenReturn(List.of());
+		this.controller = new ReleaseController(this.listAction, statusAction, getAction, historyAction, installAction,
+				upgradeAction, this.uninstallAction, rollbackAction, testAction, chartLoader, repoManager,
+				this.properties);
+	}
+
+	private MockMvc mockMvc() {
+		return MockMvcBuilders.standaloneSetup(this.controller)
+			.addInterceptors(new AccessModeInterceptor(this.properties))
+			.addPlaceholderValue("jhelm.rest.base-path", "/api/v1")
+			.build();
+	}
+
+	@Test
+	void fullModeAllowsMutatingEndpoint() throws Exception {
+		this.properties.setMode(JhelmAccessMode.FULL);
+		mockMvc().perform(delete("/api/v1/releases/my-release")).andExpect(status().isNoContent());
+	}
+
+	@Test
+	void readOnlyModeBlocksMutatingEndpoint() throws Exception {
+		this.properties.setMode(JhelmAccessMode.READ_ONLY);
+		mockMvc().perform(delete("/api/v1/releases/my-release")).andExpect(status().isForbidden());
+	}
+
+	@Test
+	void readOnlyModeAllowsReadEndpoint() throws Exception {
+		this.properties.setMode(JhelmAccessMode.READ_ONLY);
+		mockMvc().perform(get("/api/v1/releases")).andExpect(status().isOk());
+	}
+
+}


### PR DESCRIPTION
Foundation for the **REST ⇄ MCP access-mode mirror** (#519). The future `jhelm-mcp` reuses the same enum.

## What
- Shared **`JhelmAccessMode { READ_ONLY, FULL }`** in `jhelm-core` (so `jhelm-mcp` reuses it).
- Per-module **`jhelm.rest.mode`** property — **default `FULL`** (no behavior change).
- **`@MutatingOperation`** marks the cluster-mutating REST endpoints: `install`, `installUpload`, `upgrade`, `upgradeUpload`, `uninstall`, `rollback`, `test`.
- **`AccessModeInterceptor`** returns **403** (matching `JhelmRestExceptionHandler`'s JSON shape) for a `@MutatingOperation` handler when mode is `READ_ONLY`; read endpoints untouched. Registered via a `WebMvcConfigurer` in the auto-config.

`READ_ONLY` exposes only non-mutating ops (template/show/lint/search/get/list/status/history); `FULL` adds the cluster-mutating ones. `jhelm-mcp` will mirror this with `jhelm.mcp.mode` (default `READ_ONLY`).

## Verified
jhelm-core **505**, jhelm-rest **58** (3 new `AccessModeInterceptorTest`: FULL allows, READ_ONLY blocks mutating → 403, READ_ONLY allows read → 200), 0 failures; full reactor green; PMD/Checkstyle clean. Default `FULL` ⇒ existing behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)