### PR TITLE
feat(mcp): jhelm-mcp module — MCP server (read-only tools) on Spring AI 2.0 (#519)

### DIFF
--- a/jhelm-mcp-sample/pom.xml
+++ b/jhelm-mcp-sample/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.alexmond</groupId>
+		<artifactId>jhelm-parent</artifactId>
+		<version>0.3.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>jhelm-mcp-sample</artifactId>
+	<name>jhelm-mcp-sample</name>
+	<description>Sample Spring Boot application exposing jhelm operations as MCP tools</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.alexmond</groupId>
+			<artifactId>jhelm-mcp-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.alexmond</groupId>
+			<artifactId>jhelm-kube</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/jhelm-mcp-sample/src/main/java/org/alexmond/jhelm/mcp/sample/JhelmMcpSampleApplication.java
+++ b/jhelm-mcp-sample/src/main/java/org/alexmond/jhelm/mcp/sample/JhelmMcpSampleApplication.java
@@ -1,0 +1,28 @@
+package org.alexmond.jhelm.mcp.sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Minimal Spring Boot application that exercises the jhelm MCP module as a library,
+ * verifying that the MCP server and the jhelm read-only tools are auto-configured without
+ * manual wiring.
+ *
+ * <p>
+ * <strong>Note:</strong> this is a DEMO/sample application only. It is unauthenticated
+ * and is not intended for production use. For real deployments, secure the
+ * {@code jhelm-mcp-starter} behind your own authentication.
+ */
+@SpringBootApplication
+@SuppressWarnings("PMD.UseUtilityClass")
+public class JhelmMcpSampleApplication {
+
+	/**
+	 * Application entry point.
+	 * @param args command-line arguments passed to Spring Boot
+	 */
+	public static void main(String[] args) {
+		SpringApplication.run(JhelmMcpSampleApplication.class, args);
+	}
+
+}

--- a/jhelm-mcp-sample/src/main/resources/application.properties
+++ b/jhelm-mcp-sample/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+spring.application.name=jhelm-mcp-sample
+
+# MCP server: synchronous API over the streamable HTTP protocol.
+spring.ai.mcp.server.type=SYNC
+spring.ai.mcp.server.protocol=STREAMABLE
+# Discover @McpTool methods on Spring beans (the jhelm tool holders).
+spring.ai.mcp.server.annotation-scanner.enabled=true
+
+# Expose only the non-mutating jhelm tools.
+jhelm.mcp.mode=READ_ONLY

--- a/jhelm-mcp-sample/src/test/java/org/alexmond/jhelm/mcp/sample/JhelmMcpSampleApplicationTest.java
+++ b/jhelm-mcp-sample/src/test/java/org/alexmond/jhelm/mcp/sample/JhelmMcpSampleApplicationTest.java
@@ -1,0 +1,24 @@
+package org.alexmond.jhelm.mcp.sample;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+class JhelmMcpSampleApplicationTest {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Test
+	void contextLoads() {
+		assertNotNull(this.context);
+		assertTrue(this.context.containsBean("jhelmChartTools"), "chart MCP tools should be registered");
+		assertTrue(this.context.containsBean("jhelmHubTools"), "hub MCP tools should be registered");
+	}
+
+}

--- a/jhelm-mcp-starter/pom.xml
+++ b/jhelm-mcp-starter/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.alexmond</groupId>
+        <artifactId>jhelm-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>jhelm-mcp-starter</artifactId>
+    <name>jhelm-mcp-starter</name>
+    <description>Spring Boot starter that auto-configures the jhelm MCP server. Add this to expose jhelm operations
+        as MCP tools automatically; depend on jhelm-mcp directly if you want the library without
+        auto-configuration.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.alexmond</groupId>
+            <artifactId>jhelm-mcp</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jhelm-mcp-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/jhelm-mcp-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.alexmond.jhelm.mcp.JhelmMcpAutoConfiguration

--- a/jhelm-mcp/pom.xml
+++ b/jhelm-mcp/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.alexmond</groupId>
+        <artifactId>jhelm-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>jhelm-mcp</artifactId>
+    <name>jhelm-mcp</name>
+    <description>MCP (Model Context Protocol) server library exposing jhelm operations as AI tools</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.alexmond</groupId>
+            <artifactId>jhelm-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/JhelmMcpAutoConfiguration.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/JhelmMcpAutoConfiguration.java
@@ -1,0 +1,69 @@
+package org.alexmond.jhelm.mcp;
+
+import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
+import org.alexmond.jhelm.core.action.LintAction;
+import org.alexmond.jhelm.core.action.SearchHubAction;
+import org.alexmond.jhelm.core.action.ShowAction;
+import org.alexmond.jhelm.core.action.TemplateAction;
+import org.alexmond.jhelm.mcp.config.JhelmMcpProperties;
+import org.alexmond.jhelm.mcp.tools.ChartTools;
+import org.alexmond.jhelm.mcp.tools.HubTools;
+import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration for the jhelm MCP (Model Context Protocol) server module. Activates
+ * only when the Spring AI MCP server annotation API is on the classpath. Runs after
+ * {@link JhelmCoreAutoConfiguration} so that all core action beans are available for the
+ * MCP tools.
+ *
+ * <p>
+ * Each tool holder is registered as a Spring bean so that Spring AI's MCP annotation
+ * scanner can discover the {@link McpTool @McpTool} methods (component scanning does not
+ * run for a library on the classpath).
+ *
+ * <p>
+ * <strong>Access mode:</strong> {@code jhelm.mcp.mode} mirrors {@code jhelm.rest.mode}.
+ * In the default {@code READ_ONLY} mode only the non-mutating tools (template, show,
+ * lint, search) are exposed. Cluster-mutating operations (install, upgrade, uninstall,
+ * rollback, test) are a {@code FULL}-mode follow-up and are not registered here.
+ */
+@AutoConfiguration(after = JhelmCoreAutoConfiguration.class)
+@ConditionalOnClass(McpTool.class)
+@EnableConfigurationProperties(JhelmMcpProperties.class)
+public class JhelmMcpAutoConfiguration {
+
+	/**
+	 * Registers the read-only chart MCP tools when the required chart actions are
+	 * present.
+	 * @param templateAction renders chart templates
+	 * @param showAction exposes chart metadata, values and README
+	 * @param lintAction validates charts
+	 * @return the chart tools bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnBean({ TemplateAction.class, ShowAction.class, LintAction.class })
+	public ChartTools jhelmChartTools(TemplateAction templateAction, ShowAction showAction, LintAction lintAction) {
+		return new ChartTools(templateAction, showAction, lintAction);
+	}
+
+	/**
+	 * Registers the read-only Artifact Hub MCP tool when a {@link SearchHubAction} is
+	 * present.
+	 * @param searchHubAction performs Artifact Hub searches
+	 * @return the hub tools bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnBean(SearchHubAction.class)
+	public HubTools jhelmHubTools(SearchHubAction searchHubAction) {
+		return new HubTools(searchHubAction);
+	}
+
+}

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/config/JhelmMcpProperties.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/config/JhelmMcpProperties.java
@@ -1,0 +1,29 @@
+package org.alexmond.jhelm.mcp.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the jhelm MCP (Model Context Protocol) server module.
+ *
+ * <p>
+ * The {@code jhelm.mcp.mode} property mirrors {@code jhelm.rest.mode}: it controls which
+ * jhelm operations are exposed as MCP tools. In {@link JhelmAccessMode#READ_ONLY
+ * READ_ONLY} mode only non-mutating tools (template, show, lint, search) are registered.
+ * Mutating operations (install, upgrade, uninstall, rollback, test) are not yet exposed
+ * by this module.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jhelm.mcp")
+public class JhelmMcpProperties {
+
+	/**
+	 * Access mode for the MCP server. Defaults to {@link JhelmAccessMode#READ_ONLY
+	 * READ_ONLY}, which exposes only the non-mutating jhelm tools.
+	 */
+	private JhelmAccessMode mode = JhelmAccessMode.READ_ONLY;
+
+}

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ChartTools.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ChartTools.java
@@ -1,0 +1,106 @@
+package org.alexmond.jhelm.mcp.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+import org.alexmond.jhelm.core.action.LintAction;
+import org.alexmond.jhelm.core.action.ShowAction;
+import org.alexmond.jhelm.core.action.TemplateAction;
+import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.McpToolParam;
+
+/**
+ * Read-only MCP tools for inspecting and rendering Helm charts. Each annotated method is
+ * discovered by Spring AI's MCP annotation scanner and exposed as an MCP tool.
+ */
+@RequiredArgsConstructor
+public class ChartTools {
+
+	private final TemplateAction templateAction;
+
+	private final ShowAction showAction;
+
+	private final LintAction lintAction;
+
+	/**
+	 * Renders the templates of a chart locally, like {@code helm template}.
+	 * @param chartPath path to the chart directory or packaged archive
+	 * @param releaseName name to use for the rendered release
+	 * @param namespace target Kubernetes namespace
+	 * @return the rendered Kubernetes manifests as YAML
+	 */
+	@McpTool(name = "helm_template",
+			description = "Render a Helm chart's templates locally (like 'helm template') and return the "
+					+ "generated Kubernetes manifests as YAML. Read-only; does not touch any cluster.")
+	public String template(
+			@McpToolParam(description = "Path to the chart directory or packaged .tgz archive") String chartPath,
+			@McpToolParam(description = "Release name to use while rendering") String releaseName,
+			@McpToolParam(description = "Target Kubernetes namespace") String namespace) {
+		return this.templateAction.render(chartPath, releaseName, namespace);
+	}
+
+	/**
+	 * Shows a chart's {@code Chart.yaml} metadata, like {@code helm show chart}.
+	 * @param chartPath path to the chart directory or packaged archive
+	 * @return the chart metadata as YAML
+	 */
+	@McpTool(name = "helm_show_chart",
+			description = "Show a chart's Chart.yaml metadata (like 'helm show chart'). Read-only.")
+	public String showChart(
+			@McpToolParam(description = "Path to the chart directory or packaged .tgz archive") String chartPath) {
+		return this.showAction.showChart(chartPath);
+	}
+
+	/**
+	 * Shows a chart's default values, like {@code helm show values}.
+	 * @param chartPath path to the chart directory or packaged archive
+	 * @return the default {@code values.yaml} content
+	 */
+	@McpTool(name = "helm_show_values",
+			description = "Show a chart's default values.yaml (like 'helm show values'). Read-only.")
+	public String showValues(
+			@McpToolParam(description = "Path to the chart directory or packaged .tgz archive") String chartPath) {
+		return this.showAction.showValues(chartPath);
+	}
+
+	/**
+	 * Shows a chart's README, like {@code helm show readme}.
+	 * @param chartPath path to the chart directory or packaged archive
+	 * @return the chart README content, or an empty string if none is present
+	 */
+	@McpTool(name = "helm_show_readme", description = "Show a chart's README (like 'helm show readme'). Read-only.")
+	public String showReadme(
+			@McpToolParam(description = "Path to the chart directory or packaged .tgz archive") String chartPath) {
+		return this.showAction.showReadme(chartPath);
+	}
+
+	/**
+	 * Lints a chart for problems, like {@code helm lint}.
+	 * @param chartPath path to the chart directory or packaged archive
+	 * @param strict whether to treat warnings as failures
+	 * @return a human-readable summary of lint errors and warnings
+	 */
+	@McpTool(name = "helm_lint",
+			description = "Lint a Helm chart for problems (like 'helm lint') and return errors and warnings. "
+					+ "Read-only.")
+	public String lint(
+			@McpToolParam(description = "Path to the chart directory or packaged .tgz archive") String chartPath,
+			@McpToolParam(required = false, description = "Treat warnings as failures when true") boolean strict) {
+		LintAction.LintResult result = this.lintAction.lint(chartPath, Map.of(), strict);
+		StringBuilder sb = new StringBuilder();
+		sb.append("Chart: ").append(result.getChartPath());
+		sb.append("\nStatus: ").append(result.isOk() ? "OK" : "FAILED").append('\n');
+		appendList(sb, "Errors", result.getErrors());
+		appendList(sb, "Warnings", result.getWarnings());
+		return sb.toString();
+	}
+
+	private static void appendList(StringBuilder sb, String label, List<String> messages) {
+		sb.append(label).append(" (").append(messages.size()).append("):\n");
+		for (String message : messages) {
+			sb.append("  - ").append(message).append('\n');
+		}
+	}
+
+}

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/HubTools.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/HubTools.java
@@ -1,0 +1,52 @@
+package org.alexmond.jhelm.mcp.tools;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import org.alexmond.jhelm.core.action.SearchHubAction;
+import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.McpToolParam;
+
+/**
+ * Read-only MCP tool for searching Artifact Hub for Helm charts. The annotated method is
+ * discovered by Spring AI's MCP annotation scanner and exposed as an MCP tool.
+ */
+@RequiredArgsConstructor
+public class HubTools {
+
+	private final SearchHubAction searchHubAction;
+
+	/**
+	 * Searches Artifact Hub for Helm charts matching a keyword, like
+	 * {@code helm search hub}.
+	 * @param keyword the search term
+	 * @param maxResults the maximum number of results to return
+	 * @return a human-readable, newline-separated list of matching charts
+	 */
+	@McpTool(name = "helm_search_hub",
+			description = "Search Artifact Hub for Helm charts matching a keyword (like 'helm search hub'). "
+					+ "Read-only.")
+	public String searchHub(@McpToolParam(description = "Keyword to search Artifact Hub for") String keyword,
+			@McpToolParam(required = false, description = "Maximum number of results to return") int maxResults) {
+		int limit = (maxResults > 0) ? maxResults : 25;
+		List<SearchHubAction.HubResult> results = this.searchHubAction.search(keyword, limit);
+		if (results.isEmpty()) {
+			return "No charts found for: " + keyword;
+		}
+		StringBuilder sb = new StringBuilder();
+		for (SearchHubAction.HubResult result : results) {
+			sb.append(result.getRepoName())
+				.append('/')
+				.append(result.getName())
+				.append("\tv")
+				.append(result.getVersion())
+				.append("\tapp ")
+				.append(result.getAppVersion())
+				.append('\t')
+				.append(result.getUrl())
+				.append('\n');
+		}
+		return sb.toString();
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <chicory.version>1.7.5</chicory.version>
         <swagger-annotations.version>2.2.52</swagger-annotations.version>
         <springdoc-openapi.version>3.0.3</springdoc-openapi.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
 
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
@@ -77,10 +78,13 @@
         <module>jhelm-kube</module>
         <module>jhelm-rest</module>
         <module>jhelm-rest-starter</module>
+        <module>jhelm-mcp</module>
+        <module>jhelm-mcp-starter</module>
         <module>jhelm-plugin</module>
         <module>jhelm-cli</module>
         <module>jhelm-sample</module>
         <module>jhelm-rest-sample</module>
+        <module>jhelm-mcp-sample</module>
     </modules>
 
     <dependencyManagement>
@@ -132,8 +136,26 @@
             </dependency>
             <dependency>
                 <groupId>org.alexmond</groupId>
+                <artifactId>jhelm-mcp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.alexmond</groupId>
+                <artifactId>jhelm-mcp-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.alexmond</groupId>
                 <artifactId>jhelm</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <!-- Spring AI BOM: manages spring-ai-* artifacts (MCP server) for jhelm-mcp. -->
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>${spring-ai.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!-- External Dependencies -->


### PR DESCRIPTION
New composable module exposing jhelm operations as **MCP (Model Context Protocol)** tools for AI agents, mirroring the REST read surface. Built on **Spring AI 2.0.0** (GA, Boot-4 compatible) via `spring-ai-starter-mcp-server-webmvc` (STREAMABLE transport).

## Structure (lib + starter, like #518)
- **`jhelm-mcp`** (library): `@McpTool` classes wrapping read-only core actions, `JhelmMcpProperties` (`jhelm.mcp.mode`, default **READ_ONLY**, reusing the shared `JhelmAccessMode`), auto-config class (no self-registration).
- **`jhelm-mcp-starter`**: the `.imports` trigger + `jhelm-mcp`.
- **`jhelm-mcp-sample`**: runnable demo; context starts headless (no live cluster).

## Tools (6, all read-only)
`helm_template`, `helm_show_chart`, `helm_show_values`, `helm_show_readme`, `helm_lint`, `helm_search_hub` — registered via Spring AI's annotation scanner (startup logs `Registered tools: 6`).

## Verified Spring AI 2.0.0 API
Annotations `org.springframework.ai.mcp.annotation.{McpTool,McpToolParam}`; scanner-based registration (`spring.ai.mcp.server.annotation-scanner`); properties `spring.ai.mcp.server.{type=SYNC,protocol=STREAMABLE}`. BOM `spring-ai-bom:2.0.0` added to dependencyManagement; the starter's transitive `spring-boot-starter-web:4.1.0` is managed down to Boot 4.0.7 by the parent — no conflict.

## Follow-up
`jhelm.mcp.mode` defaults READ_ONLY; the **FULL-mode mutating tools** (install/upgrade/uninstall/rollback/test, gated by mode — mirroring jhelm-rest) land in a follow-up PR.

## Build
Full reactor **BUILD SUCCESS**; `jhelm-mcp-sample` context test green; PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)