### PR TITLE
feat(mcp): complete tool surface — cluster-read + FULL-mode mutating tools (#519)

### DIFF
--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/JhelmMcpAutoConfiguration.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/JhelmMcpAutoConfiguration.java
@@ -1,18 +1,31 @@
 package org.alexmond.jhelm.mcp;
 
 import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
+import org.alexmond.jhelm.core.action.GetAction;
+import org.alexmond.jhelm.core.action.HistoryAction;
+import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.LintAction;
+import org.alexmond.jhelm.core.action.ListAction;
+import org.alexmond.jhelm.core.action.RollbackAction;
 import org.alexmond.jhelm.core.action.SearchHubAction;
 import org.alexmond.jhelm.core.action.ShowAction;
+import org.alexmond.jhelm.core.action.StatusAction;
 import org.alexmond.jhelm.core.action.TemplateAction;
+import org.alexmond.jhelm.core.action.TestAction;
+import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.mcp.config.JhelmMcpProperties;
 import org.alexmond.jhelm.mcp.tools.ChartTools;
 import org.alexmond.jhelm.mcp.tools.HubTools;
+import org.alexmond.jhelm.mcp.tools.ReleaseMutatingTools;
+import org.alexmond.jhelm.mcp.tools.ReleaseReadTools;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
@@ -30,8 +43,11 @@ import org.springframework.context.annotation.Bean;
  * <p>
  * <strong>Access mode:</strong> {@code jhelm.mcp.mode} mirrors {@code jhelm.rest.mode}.
  * In the default {@code READ_ONLY} mode only the non-mutating tools (template, show,
- * lint, search) are exposed. Cluster-mutating operations (install, upgrade, uninstall,
- * rollback, test) are a {@code FULL}-mode follow-up and are not registered here.
+ * lint, search, plus the cluster-read release tools: list, status, history, get
+ * values/manifest) are exposed. The cluster-mutating tools (install, upgrade, uninstall,
+ * rollback, test) are registered only when {@code jhelm.mcp.mode} is set to the
+ * upper-case value {@code FULL}; in {@code READ_ONLY} mode they are not registered and do
+ * not appear in the MCP tool list at all.
  */
 @AutoConfiguration(after = JhelmCoreAutoConfiguration.class)
 @ConditionalOnClass(McpTool.class)
@@ -64,6 +80,50 @@ public class JhelmMcpAutoConfiguration {
 	@ConditionalOnBean(SearchHubAction.class)
 	public HubTools jhelmHubTools(SearchHubAction searchHubAction) {
 		return new HubTools(searchHubAction);
+	}
+
+	/**
+	 * Registers the read-only release MCP tools when the required cluster-read actions
+	 * are present. These tools are always registered regardless of the configured access
+	 * mode.
+	 * @param listAction lists releases in a namespace
+	 * @param statusAction reports release status
+	 * @param getAction reads release values and manifest
+	 * @param historyAction lists release revisions
+	 * @return the read-only release tools bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnBean({ ListAction.class, StatusAction.class, GetAction.class, HistoryAction.class })
+	public ReleaseReadTools jhelmReleaseReadTools(ListAction listAction, StatusAction statusAction, GetAction getAction,
+			HistoryAction historyAction) {
+		return new ReleaseReadTools(listAction, statusAction, getAction, historyAction);
+	}
+
+	/**
+	 * Registers the cluster-mutating release MCP tools only when
+	 * {@code jhelm.mcp.mode=FULL} (upper-case) and the required mutating actions are
+	 * present. In the default {@code READ_ONLY} mode this bean is not created, so the
+	 * mutating tools never appear in the MCP tool list.
+	 * @param installAction installs releases
+	 * @param upgradeAction upgrades releases
+	 * @param uninstallAction uninstalls releases
+	 * @param rollbackAction rolls releases back to a previous revision
+	 * @param testAction runs release test hooks
+	 * @param getAction resolves the current release for upgrades
+	 * @param chartLoader loads charts for install and upgrade
+	 * @return the mutating release tools bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty(name = "jhelm.mcp.mode", havingValue = "FULL")
+	@ConditionalOnBean({ InstallAction.class, UpgradeAction.class, UninstallAction.class, RollbackAction.class,
+			TestAction.class })
+	public ReleaseMutatingTools jhelmReleaseMutatingTools(InstallAction installAction, UpgradeAction upgradeAction,
+			UninstallAction uninstallAction, RollbackAction rollbackAction, TestAction testAction, GetAction getAction,
+			ChartLoader chartLoader) {
+		return new ReleaseMutatingTools(installAction, upgradeAction, uninstallAction, rollbackAction, testAction,
+				getAction, chartLoader);
 	}
 
 }

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/config/JhelmMcpProperties.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/config/JhelmMcpProperties.java
@@ -11,9 +11,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * <p>
  * The {@code jhelm.mcp.mode} property mirrors {@code jhelm.rest.mode}: it controls which
  * jhelm operations are exposed as MCP tools. In {@link JhelmAccessMode#READ_ONLY
- * READ_ONLY} mode only non-mutating tools (template, show, lint, search) are registered.
- * Mutating operations (install, upgrade, uninstall, rollback, test) are not yet exposed
- * by this module.
+ * READ_ONLY} mode (the default) only non-mutating tools (template, show, lint, search,
+ * and the cluster-read release tools: list, status, history, get values/manifest) are
+ * registered. Setting the property to the upper-case value {@code FULL}
+ * ({@link JhelmAccessMode#FULL}) additionally registers the cluster-mutating release
+ * tools (install, upgrade, uninstall, rollback, test).
  */
 @Getter
 @Setter

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingTools.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingTools.java
@@ -1,0 +1,176 @@
+package org.alexmond.jhelm.mcp.tools;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+import org.alexmond.jhelm.core.action.GetAction;
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.TestAction;
+import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.McpToolParam;
+
+/**
+ * Cluster-mutating MCP tools for the Helm release lifecycle (install, upgrade, uninstall,
+ * rollback, test). Each annotated method is discovered by Spring AI's MCP annotation
+ * scanner and exposed as an MCP tool.
+ *
+ * <p>
+ * These tools are only registered when {@code jhelm.mcp.mode=FULL}. In the default
+ * {@code READ_ONLY} mode they are not registered and therefore do not appear in the MCP
+ * tool list at all — the MCP equivalent of the REST module's mutating-operation block.
+ *
+ * <p>
+ * Value overrides are not yet supported by these tools: installs and upgrades use the
+ * chart's default values. This is a deliberate v1 simplification noted in each tool's
+ * description.
+ */
+@RequiredArgsConstructor
+public class ReleaseMutatingTools {
+
+	private final InstallAction installAction;
+
+	private final UpgradeAction upgradeAction;
+
+	private final UninstallAction uninstallAction;
+
+	private final RollbackAction rollbackAction;
+
+	private final TestAction testAction;
+
+	private final GetAction getAction;
+
+	private final ChartLoader chartLoader;
+
+	/**
+	 * Installs a chart as a new release, like {@code helm install}. MUTATES the cluster
+	 * unless {@code dryRun} is set.
+	 * @param chartPath path to the chart directory to install
+	 * @param name the release name
+	 * @param namespace the target namespace
+	 * @param dryRun {@code true} to render only without applying to the cluster
+	 * @return a human-readable summary of the resulting release
+	 */
+	@McpTool(name = "helm_install",
+			description = "Install a Helm chart as a new release (like 'helm install'). MUTATES the cluster: "
+					+ "applies the rendered resources unless dryRun is true. Uses the chart's default values (value "
+					+ "overrides are not yet supported). Set dryRun=true to preview without changing the cluster.")
+	public String install(@McpToolParam(description = "Path to the chart directory to install") String chartPath,
+			@McpToolParam(description = "Release name to create") String name,
+			@McpToolParam(description = "Target Kubernetes namespace") String namespace,
+			@McpToolParam(description = "Render only without applying to the cluster when true") boolean dryRun) {
+		Chart chart = this.chartLoader.load(new File(chartPath));
+		Release release = this.installAction.install(chart, name, namespace, Map.of(), 1, dryRun);
+		return renderReleaseSummary("Installed", release, dryRun);
+	}
+
+	/**
+	 * Upgrades an existing release to a new chart, like {@code helm upgrade}. MUTATES the
+	 * cluster unless {@code dryRun} is set.
+	 * @param chartPath path to the new chart directory
+	 * @param name the release name to upgrade
+	 * @param namespace the Kubernetes namespace
+	 * @param dryRun {@code true} to render only without applying to the cluster
+	 * @return a human-readable summary of the upgraded release
+	 */
+	@McpTool(name = "helm_upgrade",
+			description = "Upgrade an existing Helm release to a new chart (like 'helm upgrade'). MUTATES the "
+					+ "cluster: applies the rendered resources unless dryRun is true. Uses the chart's default values "
+					+ "with the DEFAULT value strategy (value overrides are not yet supported). Set dryRun=true to "
+					+ "preview without changing the cluster.")
+	public String upgrade(@McpToolParam(description = "Path to the new chart directory") String chartPath,
+			@McpToolParam(description = "Release name to upgrade") String name,
+			@McpToolParam(description = "Kubernetes namespace") String namespace,
+			@McpToolParam(description = "Render only without applying to the cluster when true") boolean dryRun) {
+		Release current = this.getAction.getRelease(name, namespace)
+			.orElseThrow(() -> new IllegalArgumentException("Release '" + name + "' not found"));
+		Chart chart = this.chartLoader.load(new File(chartPath));
+		Release upgraded = this.upgradeAction.upgrade(current, chart, Map.of(), UpgradeValueStrategy.DEFAULT, dryRun);
+		return renderReleaseSummary("Upgraded", upgraded, dryRun);
+	}
+
+	/**
+	 * Uninstalls a release, like {@code helm uninstall}. MUTATES the cluster.
+	 * @param name the release name to uninstall
+	 * @param namespace the Kubernetes namespace
+	 * @return a confirmation message
+	 */
+	@McpTool(name = "helm_uninstall",
+			description = "Uninstall a Helm release (like 'helm uninstall'). MUTATES the cluster: deletes the "
+					+ "release's resources and removes its history.")
+	public String uninstall(@McpToolParam(description = "Release name to uninstall") String name,
+			@McpToolParam(description = "Kubernetes namespace") String namespace) {
+		this.uninstallAction.uninstall(name, namespace);
+		return "Uninstalled release '" + name + "' from namespace '" + namespace + '\'';
+	}
+
+	/**
+	 * Rolls a release back to a previous revision, like {@code helm rollback}. MUTATES
+	 * the cluster.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @param revision the target revision number to roll back to
+	 * @return a confirmation message
+	 */
+	@McpTool(name = "helm_rollback",
+			description = "Roll a Helm release back to a previous revision (like 'helm rollback'). MUTATES the "
+					+ "cluster: re-applies the target revision's resources as a new revision.")
+	public String rollback(@McpToolParam(description = "Release name") String name,
+			@McpToolParam(description = "Kubernetes namespace") String namespace,
+			@McpToolParam(description = "Target revision number to roll back to") int revision) {
+		this.rollbackAction.rollback(name, namespace, revision);
+		return "Rolled back release '" + name + "' in namespace '" + namespace + "' to revision " + revision;
+	}
+
+	/**
+	 * Runs the test hooks of a release, like {@code helm test}. MUTATES the cluster.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @param timeoutSeconds the per-test timeout in seconds
+	 * @return a human-readable summary of the test results
+	 */
+	@McpTool(name = "helm_test",
+			description = "Run the test hooks of a Helm release (like 'helm test'). MUTATES the cluster: applies "
+					+ "the test hook resources and waits for them to complete.")
+	public String test(@McpToolParam(description = "Release name") String name,
+			@McpToolParam(description = "Kubernetes namespace") String namespace,
+			@McpToolParam(description = "Per-test timeout in seconds") int timeoutSeconds) {
+		List<TestAction.TestResult> results = this.testAction.test(name, namespace, timeoutSeconds);
+		if (results.isEmpty()) {
+			return "No test hooks found for release '" + name + "' in namespace '" + namespace + '\'';
+		}
+		StringBuilder sb = new StringBuilder();
+		for (TestAction.TestResult result : results) {
+			sb.append(result.getStatus()).append('\t').append(result.getKind()).append('/').append(result.getName());
+			if (result.getMessage() != null) {
+				sb.append('\t').append(result.getMessage());
+			}
+			sb.append('\n');
+		}
+		return sb.toString();
+	}
+
+	private static String renderReleaseSummary(String verb, Release release, boolean dryRun) {
+		StringBuilder sb = new StringBuilder();
+		sb.append(verb);
+		if (dryRun) {
+			sb.append(" (dry run)");
+		}
+		sb.append(" release '").append(release.getName());
+		sb.append("' in namespace '").append(release.getNamespace());
+		sb.append("' at revision ").append(release.getVersion());
+		if (release.getInfo() != null && release.getInfo().getStatus() != null) {
+			sb.append(" (status: ").append(release.getInfo().getStatus()).append(')');
+		}
+		return sb.toString();
+	}
+
+}

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseReadTools.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseReadTools.java
@@ -1,0 +1,175 @@
+package org.alexmond.jhelm.mcp.tools;
+
+import java.util.List;
+import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
+import org.alexmond.jhelm.core.action.GetAction;
+import org.alexmond.jhelm.core.action.HistoryAction;
+import org.alexmond.jhelm.core.action.ListAction;
+import org.alexmond.jhelm.core.action.StatusAction;
+import org.alexmond.jhelm.core.model.Release;
+import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.McpToolParam;
+
+/**
+ * Read-only MCP tools for inspecting Helm releases deployed to a Kubernetes cluster. Each
+ * annotated method is discovered by Spring AI's MCP annotation scanner and exposed as an
+ * MCP tool. None of these tools mutate the cluster; they are always registered regardless
+ * of the configured access mode.
+ */
+@RequiredArgsConstructor
+public class ReleaseReadTools {
+
+	private final ListAction listAction;
+
+	private final StatusAction statusAction;
+
+	private final GetAction getAction;
+
+	private final HistoryAction historyAction;
+
+	/**
+	 * Lists the Helm releases in a namespace, like {@code helm list}.
+	 * @param namespace the Kubernetes namespace to list releases in
+	 * @return a human-readable, newline-separated summary of releases
+	 */
+	@McpTool(name = "helm_list",
+			description = "List the Helm releases deployed in a Kubernetes namespace (like 'helm list'), returning "
+					+ "each release's name, namespace, revision and status. Read-only; does not modify the cluster.")
+	public String list(@McpToolParam(description = "Kubernetes namespace to list releases in") String namespace) {
+		List<Release> releases = this.listAction.list(namespace);
+		if (releases.isEmpty()) {
+			return "No releases found in namespace: " + namespace;
+		}
+		StringBuilder sb = new StringBuilder();
+		sb.append("NAME\tNAMESPACE\tREVISION\tSTATUS\n");
+		for (Release release : releases) {
+			appendReleaseLine(sb, release);
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Reports the status of a single release, like {@code helm status}.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @return a human-readable status summary, or a not-found message
+	 */
+	@McpTool(name = "helm_status",
+			description = "Get the status of a single Helm release (like 'helm status'), including its revision, "
+					+ "deployment status and chart. Read-only; does not modify the cluster.")
+	public String status(@McpToolParam(description = "Release name") String name,
+			@McpToolParam(description = "Kubernetes namespace") String namespace) {
+		Optional<Release> release = this.statusAction.status(name, namespace);
+		if (release.isEmpty()) {
+			return notFound(name, namespace);
+		}
+		return renderReleaseDetail(release.get());
+	}
+
+	/**
+	 * Lists the revision history of a release, like {@code helm history}.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @return a human-readable, newline-separated summary of revisions
+	 */
+	@McpTool(name = "helm_history",
+			description = "List the revision history of a Helm release (like 'helm history'), one line per "
+					+ "revision. Read-only; does not modify the cluster.")
+	public String history(@McpToolParam(description = "Release name") String name,
+			@McpToolParam(description = "Kubernetes namespace") String namespace) {
+		List<Release> revisions = this.historyAction.history(name, namespace);
+		if (revisions.isEmpty()) {
+			return notFound(name, namespace);
+		}
+		StringBuilder sb = new StringBuilder();
+		sb.append("NAME\tNAMESPACE\tREVISION\tSTATUS\n");
+		for (Release revision : revisions) {
+			appendReleaseLine(sb, revision);
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Returns the values of a release as YAML, like {@code helm get values}.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @param all {@code true} to include computed chart defaults, {@code false} for only
+	 * user-supplied overrides
+	 * @return the values YAML, or a not-found message
+	 */
+	@McpTool(name = "helm_get_values",
+			description = "Get the values used by a Helm release as YAML (like 'helm get values'). Set 'all' to "
+					+ "include computed chart defaults. Read-only; does not modify the cluster.")
+	public String getValues(@McpToolParam(description = "Release name") String name,
+			@McpToolParam(description = "Kubernetes namespace") String namespace, @McpToolParam(required = false,
+					description = "Include computed chart defaults when true; only user overrides when false") boolean all) {
+		Optional<Release> release = this.getAction.getRelease(name, namespace);
+		if (release.isEmpty()) {
+			return notFound(name, namespace);
+		}
+		return this.getAction.getValues(release.get(), all);
+	}
+
+	/**
+	 * Returns the rendered Kubernetes manifest of a release, like
+	 * {@code helm get manifest}.
+	 * @param name the release name
+	 * @param namespace the Kubernetes namespace
+	 * @return the manifest YAML, or a not-found message
+	 */
+	@McpTool(name = "helm_get_manifest",
+			description = "Get the rendered Kubernetes manifest of a Helm release as YAML (like 'helm get "
+					+ "manifest'). Read-only; does not modify the cluster.")
+	public String getManifest(@McpToolParam(description = "Release name") String name,
+			@McpToolParam(description = "Kubernetes namespace") String namespace) {
+		Optional<Release> release = this.getAction.getRelease(name, namespace);
+		if (release.isEmpty()) {
+			return notFound(name, namespace);
+		}
+		return this.getAction.getManifest(release.get());
+	}
+
+	private static void appendReleaseLine(StringBuilder sb, Release release) {
+		sb.append(release.getName()).append('\t').append(release.getNamespace()).append('\t');
+		sb.append(release.getVersion()).append('\t').append(statusOf(release)).append('\n');
+	}
+
+	private static String renderReleaseDetail(Release release) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("Name: ").append(release.getName());
+		sb.append("\nNamespace: ").append(release.getNamespace());
+		sb.append("\nRevision: ").append(release.getVersion());
+		sb.append("\nStatus: ").append(statusOf(release));
+		Release.ReleaseInfo info = release.getInfo();
+		if (info != null) {
+			if (info.getDescription() != null) {
+				sb.append("\nDescription: ").append(info.getDescription());
+			}
+			if (info.getLastDeployed() != null) {
+				sb.append("\nLast deployed: ").append(info.getLastDeployed());
+			}
+		}
+		if (release.getChart() != null && release.getChart().getMetadata() != null) {
+			sb.append("\nChart: ")
+				.append(release.getChart().getMetadata().getName())
+				.append('-')
+				.append(release.getChart().getMetadata().getVersion());
+		}
+		sb.append('\n');
+		return sb.toString();
+	}
+
+	private static String statusOf(Release release) {
+		if (release.getInfo() != null && release.getInfo().getStatus() != null) {
+			return release.getInfo().getStatus();
+		}
+		return "unknown";
+	}
+
+	private static String notFound(String name, String namespace) {
+		return "Release '" + name + "' not found in namespace '" + namespace + '\'';
+	}
+
+}

--- a/jhelm-mcp/src/test/java/org/alexmond/jhelm/mcp/JhelmMcpAutoConfigurationTest.java
+++ b/jhelm-mcp/src/test/java/org/alexmond/jhelm/mcp/JhelmMcpAutoConfigurationTest.java
@@ -1,0 +1,127 @@
+package org.alexmond.jhelm.mcp;
+
+import org.alexmond.jhelm.core.action.GetAction;
+import org.alexmond.jhelm.core.action.HistoryAction;
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.ListAction;
+import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.StatusAction;
+import org.alexmond.jhelm.core.action.TestAction;
+import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.mcp.config.JhelmMcpProperties;
+import org.alexmond.jhelm.mcp.tools.ReleaseMutatingTools;
+import org.alexmond.jhelm.mcp.tools.ReleaseReadTools;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the MCP auto-configuration gates the cluster-mutating release tools
+ * behind {@code jhelm.mcp.mode=FULL}, while the read-only release tools are always
+ * registered. The required action beans are supplied as Mockito mocks so the
+ * {@code @ConditionalOnBean} conditions are satisfied without a live cluster.
+ */
+class JhelmMcpAutoConfigurationTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(JhelmMcpAutoConfiguration.class))
+		.withUserConfiguration(MockActionsConfiguration.class);
+
+	@Test
+	void readOnlyModeRegistersReadToolsButHidesMutatingTools() {
+		this.contextRunner.run((context) -> {
+			assertTrue(context.containsBean("jhelmReleaseReadTools"));
+			context.getBean(ReleaseReadTools.class);
+			assertFalse(context.containsBean("jhelmReleaseMutatingTools"),
+					"mutating tools must not be registered in READ_ONLY mode");
+			assertEquals(JhelmAccessMode.READ_ONLY, context.getBean(JhelmMcpProperties.class).getMode());
+		});
+	}
+
+	@Test
+	void explicitReadOnlyModeHidesMutatingTools() {
+		this.contextRunner.withPropertyValues("jhelm.mcp.mode=READ_ONLY").run((context) -> {
+			assertTrue(context.containsBean("jhelmReleaseReadTools"));
+			assertFalse(context.containsBean("jhelmReleaseMutatingTools"));
+		});
+	}
+
+	@Test
+	void fullModeRegistersMutatingTools() {
+		this.contextRunner.withPropertyValues("jhelm.mcp.mode=FULL").run((context) -> {
+			assertTrue(context.containsBean("jhelmReleaseReadTools"));
+			assertTrue(context.containsBean("jhelmReleaseMutatingTools"));
+			context.getBean(ReleaseMutatingTools.class);
+		});
+	}
+
+	/**
+	 * Supplies the action beans the MCP tool conditions depend on, as Mockito mocks (no
+	 * live cluster required).
+	 */
+	@Configuration
+	static class MockActionsConfiguration {
+
+		@Bean
+		ListAction listAction() {
+			return Mockito.mock(ListAction.class);
+		}
+
+		@Bean
+		StatusAction statusAction() {
+			return Mockito.mock(StatusAction.class);
+		}
+
+		@Bean
+		GetAction getAction() {
+			return Mockito.mock(GetAction.class);
+		}
+
+		@Bean
+		HistoryAction historyAction() {
+			return Mockito.mock(HistoryAction.class);
+		}
+
+		@Bean
+		InstallAction installAction() {
+			return Mockito.mock(InstallAction.class);
+		}
+
+		@Bean
+		UpgradeAction upgradeAction() {
+			return Mockito.mock(UpgradeAction.class);
+		}
+
+		@Bean
+		UninstallAction uninstallAction() {
+			return Mockito.mock(UninstallAction.class);
+		}
+
+		@Bean
+		RollbackAction rollbackAction() {
+			return Mockito.mock(RollbackAction.class);
+		}
+
+		@Bean
+		TestAction testAction() {
+			return Mockito.mock(TestAction.class);
+		}
+
+		@Bean
+		ChartLoader chartLoader() {
+			return Mockito.mock(ChartLoader.class);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Completes `jhelm-mcp` to mirror the full jhelm-rest operation set, with the same READ_ONLY/FULL access mode.

## Tools added
- **`ReleaseReadTools`** (always on, read-only): `helm_list`, `helm_status`, `helm_history`, `helm_get_values`, `helm_get_manifest` — wrapping List/Status/Get/History actions (same flow as `ReleaseController`).
- **`ReleaseMutatingTools`** (FULL only): `helm_install`, `helm_upgrade`, `helm_uninstall`, `helm_rollback`, `helm_test`.

## Mode gating (mirrors REST)
The mutating-tools bean is `@ConditionalOnProperty(name="jhelm.mcp.mode", havingValue="FULL")`. In the default **READ_ONLY** mode the mutating tools are **never registered** and never appear in the MCP tool list — the MCP equivalent of the REST interceptor's 403. Default registers **11 tools** (5 chart + 1 hub + 5 release-read), 0 mutating.

## v1 simplifications (documented in tool descriptions)
- install/upgrade use chart defaults (no values-map MCP param yet) and `UpgradeValueStrategy.DEFAULT` — matching the REST controller's current TODOs.
- chart loading is directory-path based (mirrors `TemplateAction`).

## Verified
jhelm-mcp 3 gating tests (READ_ONLY hides mutating, FULL registers them) + sample context green; full reactor **BUILD SUCCESS**; PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)