### PR TITLE
fix(engine): fail loudly on render recursion instead of an ERROR manifest (#515)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -228,13 +228,14 @@ public class Engine {
 			return cleanManifest(rendered);
 		}
 		catch (StackOverflowError ex) {
+			// Fail loudly instead of returning an error string as the manifest: a
+			// recursive
+			// template would otherwise render "successfully" with garbage that could
+			// reach a
+			// cluster. The render thread captures this RuntimeException and rethrows it.
 			String chartName = chart.getMetadata().getName();
-			if (log.isErrorEnabled()) {
-				log.error("StackOverflowError during rendering of chart '{}': recursive template inclusion detected",
-						chartName);
-			}
-			return "ERROR: chart '" + chartName
-					+ "': recursive template inclusion or too deep nesting. Check for circular {{ template }} calls.";
+			throw new TemplateRenderException("recursive template inclusion or too deep nesting while rendering chart '"
+					+ chartName + "'; check for circular {{ template }} calls", ex, chartName, null);
 		}
 	}
 
@@ -764,11 +765,11 @@ public class Engine {
 				}
 			}
 			catch (StackOverflowError ex) {
-				if (log.isErrorEnabled()) {
-					log.error(
-							"StackOverflowError rendering chart '{}', template '{}': recursive template inclusion detected",
-							chart.getMetadata().getName(), t.getName());
-				}
+				// Fail loudly instead of silently dropping the template from the
+				// manifest.
+				String chartName = chart.getMetadata().getName();
+				throw new TemplateRenderException("recursive template inclusion or too deep nesting while rendering "
+						+ "template '" + t.getName() + "' of chart '" + chartName + "'", ex, chartName, t.getName());
 			}
 			catch (Exception ex) {
 				String chartName = chart.getMetadata().getName();

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/RecursiveTemplateTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/RecursiveTemplateTest.java
@@ -1,0 +1,36 @@
+package org.alexmond.jhelm.core;
+
+import java.io.File;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.exception.TemplateRenderException;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.Engine;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Regression test for #515: a chart whose template recurses without bound must fail
+ * loudly with a {@link TemplateRenderException}, not "succeed" with an {@code ERROR:}
+ * string baked into the rendered manifest (which could otherwise reach a cluster).
+ */
+class RecursiveTemplateTest {
+
+	private final ChartLoader chartLoader = new ChartLoader();
+
+	private final Engine engine = new Engine();
+
+	private final InstallAction installAction = new InstallAction(engine, null);
+
+	@Test
+	void testRecursiveTemplateFailsLoudly() throws Exception {
+		File chartDir = new File("src/test/resources/test-charts/recursive-template");
+		Chart chart = chartLoader.load(chartDir);
+		assertThrows(TemplateRenderException.class,
+				() -> installAction.install(chart, "rec", "default", Map.of(), 1, true));
+	}
+
+}

--- a/jhelm-core/src/test/resources/test-charts/recursive-template/Chart.yaml
+++ b/jhelm-core/src/test/resources/test-charts/recursive-template/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: recursive-template
+version: 0.1.0

--- a/jhelm-core/src/test/resources/test-charts/recursive-template/templates/recurse.yaml
+++ b/jhelm-core/src/test/resources/test-charts/recursive-template/templates/recurse.yaml
@@ -1,0 +1,4 @@
+{{- define "recurse" -}}
+{{ template "recurse" . }}
+{{- end -}}
+{{ template "recurse" . }}


### PR DESCRIPTION
Closes #515.

## Problem
`Engine`'s two `catch (StackOverflowError)` blocks were the only render paths that didn't fail loudly:
- `doRender` returned `"ERROR: chart '…'"` **as the manifest** — a recursive chart "succeeds" with garbage that could reach a cluster.
- the per-template loop **silently dropped** the template.

Either way the action layer got no failure signal.

## Fix
Both now throw `TemplateRenderException` (with the `StackOverflowError` as cause + chart/template name), aligning with the adjacent `catch (Exception)` that already throws. The large-stack render thread already captures `RuntimeException` and rethrows after `join()`, so it surfaces to the caller. Valid-chart behavior is unchanged.

## Test
New `recursive-template` test-chart + `RecursiveTemplateTest` — a self-referential `{{ template }}` now raises `TemplateRenderException` instead of an `ERROR:`-laden manifest.

## Verified
jhelm-core **506** tests (new test), 0 failures; no existing test depended on the old error-string/swallow behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)