### PR TITLE
feat(cli): --set type coercion + --set-string/--set-file/--set-json (#501)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -55,6 +55,15 @@ public class InstallCommand implements Runnable {
 	@Option(names = { "--set" }, description = "set values on the command line (key=value, dot notation supported)")
 	private List<String> setValues = new ArrayList<>();
 
+	@Option(names = { "--set-string" }, description = "set STRING values on the command line (no type coercion)")
+	private List<String> setStringValues = new ArrayList<>();
+
+	@Option(names = { "--set-file" }, description = "set values from files (key=path), value is the file contents")
+	private List<String> setFileValues = new ArrayList<>();
+
+	@Option(names = { "--set-json" }, description = "set JSON values on the command line (key=json)")
+	private List<String> setJsonValues = new ArrayList<>();
+
 	@Option(names = { "--wait" }, description = "wait until all resources are ready")
 	private boolean wait;
 
@@ -86,7 +95,8 @@ public class InstallCommand implements Runnable {
 	public void run() {
 		try {
 			Chart chart = chartLoader.load(new File(chartPath));
-			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues);
+			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
+					setFileValues, setJsonValues);
 
 			Release release = installAction.install(chart, name, namespace, overrides, 1, dryRun);
 			applyCliPostRenderers(release);

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/LintCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/LintCommand.java
@@ -31,6 +31,15 @@ public class LintCommand implements Runnable {
 	@Option(names = { "--set" }, description = "set values on the command line (key=value)")
 	private List<String> setValues = new ArrayList<>();
 
+	@Option(names = { "--set-string" }, description = "set STRING values on the command line (no type coercion)")
+	private List<String> setStringValues = new ArrayList<>();
+
+	@Option(names = { "--set-file" }, description = "set values from files (key=path), value is the file contents")
+	private List<String> setFileValues = new ArrayList<>();
+
+	@Option(names = { "--set-json" }, description = "set JSON values on the command line (key=json)")
+	private List<String> setJsonValues = new ArrayList<>();
+
 	@Option(names = { "--strict" }, defaultValue = "false", description = "fail on lint warnings")
 	private boolean strict;
 
@@ -45,7 +54,8 @@ public class LintCommand implements Runnable {
 	@Override
 	public void run() {
 		try {
-			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues);
+			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
+					setFileValues, setJsonValues);
 			LintAction.LintResult result = lintAction.lint(chartPath, overrides, strict);
 
 			CliOutput.println("==> Linting " + result.getChartPath());

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
@@ -39,6 +39,15 @@ public class TemplateCommand implements Runnable {
 	@Option(names = { "--set" }, description = "set values on the command line (key=value, dot notation supported)")
 	private List<String> setValues = new ArrayList<>();
 
+	@Option(names = { "--set-string" }, description = "set STRING values on the command line (no type coercion)")
+	private List<String> setStringValues = new ArrayList<>();
+
+	@Option(names = { "--set-file" }, description = "set values from files (key=path), value is the file contents")
+	private List<String> setFileValues = new ArrayList<>();
+
+	@Option(names = { "--set-json" }, description = "set JSON values on the command line (key=json)")
+	private List<String> setJsonValues = new ArrayList<>();
+
 	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
 
@@ -53,7 +62,8 @@ public class TemplateCommand implements Runnable {
 	@Override
 	public void run() {
 		try {
-			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues);
+			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
+					setFileValues, setJsonValues);
 			String manifest = templateAction.render(chartPath, name, namespace, overrides);
 			for (String renderer : postRenderers) {
 				manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -66,6 +66,15 @@ public class UpgradeCommand implements Runnable {
 	@Option(names = { "--set" }, description = "set values on the command line (key=value, dot notation supported)")
 	private List<String> setValues = new ArrayList<>();
 
+	@Option(names = { "--set-string" }, description = "set STRING values on the command line (no type coercion)")
+	private List<String> setStringValues = new ArrayList<>();
+
+	@Option(names = { "--set-file" }, description = "set values from files (key=path), value is the file contents")
+	private List<String> setFileValues = new ArrayList<>();
+
+	@Option(names = { "--set-json" }, description = "set JSON values on the command line (key=json)")
+	private List<String> setJsonValues = new ArrayList<>();
+
 	@Option(names = { "--wait" }, description = "wait until all resources are ready")
 	private boolean wait;
 
@@ -119,7 +128,8 @@ public class UpgradeCommand implements Runnable {
 		try {
 			Optional<Release> currentReleaseOpt = kubeService.getRelease(name, namespace);
 			Chart chart = chartLoader.load(new File(chartPath));
-			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues);
+			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
+					setFileValues, setJsonValues);
 
 			if (currentReleaseOpt.isEmpty()) {
 				if (install) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesOverrides.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesOverrides.java
@@ -1,20 +1,39 @@
 package org.alexmond.jhelm.core.util;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+
+import org.alexmond.jhelm.core.exception.JhelmException;
+
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Utility for building value override maps from {@code -f}/ {@code --values} files and
- * {@code --set key=value} arguments.
+ * the command-line {@code --set} family of flags.
  * <p>
  * Files are loaded in order using {@link ValuesLoader} (which supports multi-document
- * YAML). {@code --set} arguments are parsed last so they take precedence over file
+ * YAML). The {@code --set} flags are parsed afterwards so they take precedence over file
  * values. Dot-separated keys create nested maps (e.g. {@code outer.inner=v} produces
  * {@code {outer: {inner: "v"}}}).
+ * <p>
+ * The four {@code --set} variants differ only in how the value is interpreted:
+ * <ul>
+ * <li>{@code --set} — the value is coerced to a typed scalar (boolean, integer,
+ * {@code null} or string), matching Helm's behaviour.</li>
+ * <li>{@code --set-string} — the value is always the raw string (no coercion).</li>
+ * <li>{@code --set-file} — the value is the contents of the file at the given path.</li>
+ * <li>{@code --set-json} — the value is parsed as JSON into a map, list or scalar.</li>
+ * </ul>
  */
 public final class ValuesOverrides {
+
+	private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
 
 	private ValuesOverrides() {
 	}
@@ -37,6 +56,30 @@ public final class ValuesOverrides {
 	 * @throws Exception if any values file cannot be read
 	 */
 	public static Map<String, Object> parse(List<String> files, List<String> setArgs) throws Exception {
+		return parse(files, setArgs, null, null, null);
+	}
+
+	/**
+	 * Build a merged override map from values files and the full {@code --set} family of
+	 * arguments.
+	 * <p>
+	 * Groups are applied in increasing order of precedence, with each later group
+	 * overriding earlier ones: files &rarr; {@code --set} &rarr; {@code --set-string}
+	 * &rarr; {@code --set-file} &rarr; {@code --set-json}.
+	 * @param files paths to YAML values files; {@code null} or empty means none
+	 * @param setArgs {@code key=value} strings, coerced to typed scalars; {@code null} or
+	 * empty means none
+	 * @param setStringArgs {@code key=value} strings kept as raw strings; {@code null} or
+	 * empty means none
+	 * @param setFileArgs {@code key=path} strings whose value is the file contents;
+	 * {@code null} or empty means none
+	 * @param setJsonArgs {@code key=json} strings whose value is parsed as JSON;
+	 * {@code null} or empty means none
+	 * @return merged override map
+	 * @throws Exception if any values file cannot be read
+	 */
+	public static Map<String, Object> parse(List<String> files, List<String> setArgs, List<String> setStringArgs,
+			List<String> setFileArgs, List<String> setJsonArgs) throws Exception {
 		Map<String, Object> merged = new HashMap<>();
 		if (files != null) {
 			for (String path : files) {
@@ -55,24 +98,83 @@ public final class ValuesOverrides {
 				applySet(merged, arg);
 			}
 		}
+		if (setStringArgs != null) {
+			for (String arg : setStringArgs) {
+				applySetString(merged, arg);
+			}
+		}
+		if (setFileArgs != null) {
+			for (String arg : setFileArgs) {
+				applySetFile(merged, arg);
+			}
+		}
+		if (setJsonArgs != null) {
+			for (String arg : setJsonArgs) {
+				applySetJson(merged, arg);
+			}
+		}
 		return merged;
 	}
 
 	/**
-	 * Parse a single {@code key=value} set argument and apply it to {@code target}.
+	 * Parse a single {@code key=value} set argument and apply it to {@code target},
+	 * coercing the value to a typed scalar like Helm: {@code null} &rarr; {@code null},
+	 * {@code true}/{@code false} &rarr; {@link Boolean}, a canonical integer &rarr;
+	 * {@link Long} (floats and leading-zero numbers stay strings), an empty value &rarr;
+	 * the empty string, and everything else stays a {@link String}.
 	 * <p>
 	 * Keys may use dot notation to set nested values (e.g. {@code a.b=v}).
 	 * @param target the map to merge into
 	 * @param arg the {@code key=value} string
 	 */
-	@SuppressWarnings("unchecked")
 	static void applySet(Map<String, Object> target, String arg) {
+		applyTyped(target, arg, ValuesOverrides::coerce);
+	}
+
+	/**
+	 * Parse a single {@code key=value} set argument and apply it to {@code target},
+	 * keeping the value as the raw string with no type coercion.
+	 * @param target the map to merge into
+	 * @param arg the {@code key=value} string
+	 */
+	static void applySetString(Map<String, Object> target, String arg) {
+		applyTyped(target, arg, Function.identity());
+	}
+
+	/**
+	 * Parse a single {@code key=path} set argument and apply it to {@code target}, with
+	 * the value being the contents of the file at {@code path} read as a string.
+	 * @param target the map to merge into
+	 * @param arg the {@code key=path} string
+	 * @throws JhelmException if the file cannot be read
+	 */
+	static void applySetFile(Map<String, Object> target, String arg) {
+		applyTyped(target, arg, ValuesOverrides::readFile);
+	}
+
+	/**
+	 * Parse a single {@code key=json} set argument and apply it to {@code target}, with
+	 * the value being the JSON parsed into a map, list or scalar.
+	 * @param target the map to merge into
+	 * @param arg the {@code key=json} string
+	 * @throws JhelmException if the JSON cannot be parsed
+	 */
+	static void applySetJson(Map<String, Object> target, String arg) {
+		applyTyped(target, arg, ValuesOverrides::parseJson);
+	}
+
+	private static void applyTyped(Map<String, Object> target, String arg, Function<String, ?> valueFn) {
 		int eq = arg.indexOf('=');
 		if (eq < 0) {
 			return;
 		}
 		String keyPath = arg.substring(0, eq);
-		String value = arg.substring(eq + 1);
+		String raw = arg.substring(eq + 1);
+		setAtPath(target, keyPath, valueFn.apply(raw));
+	}
+
+	@SuppressWarnings("unchecked")
+	private static void setAtPath(Map<String, Object> target, String keyPath, Object value) {
 		String[] parts = keyPath.split("\\.", -1);
 		Map<String, Object> current = target;
 		for (int i = 0; i < parts.length - 1; i++) {
@@ -87,6 +189,54 @@ public final class ValuesOverrides {
 			}
 		}
 		current.put(parts[parts.length - 1], value);
+	}
+
+	private static Object coerce(String value) {
+		if (value.isEmpty()) {
+			return "";
+		}
+		if ("null".equals(value)) {
+			return null;
+		}
+		if ("true".equals(value)) {
+			return Boolean.TRUE;
+		}
+		if ("false".equals(value)) {
+			return Boolean.FALSE;
+		}
+		try {
+			long parsed = Long.parseLong(value);
+			// Only coerce when the value round-trips exactly to its canonical form, so
+			// leading-zero strings ("007"), explicit signs ("+5") and floats stay strings
+			// — matching Helm's strvals (verified: helm --set keeps 007 and 1.5 as
+			// strings,
+			// coerces 3 to int64).
+			if (Long.toString(parsed).equals(value)) {
+				return parsed;
+			}
+		}
+		catch (NumberFormatException ignored) {
+			// not an integer literal; fall through to string
+		}
+		return value;
+	}
+
+	private static Object readFile(String path) {
+		try {
+			return Files.readString(Path.of(path));
+		}
+		catch (IOException ex) {
+			throw new JhelmException("Failed to read --set-file value from '" + path + "': " + ex.getMessage(), ex);
+		}
+	}
+
+	private static Object parseJson(String json) {
+		try {
+			return JSON_MAPPER.readValue(json, Object.class);
+		}
+		catch (RuntimeException ex) {
+			throw new JhelmException("Failed to parse --set-json value '" + json + "': " + ex.getMessage(), ex);
+		}
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesOverridesTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesOverridesTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -56,7 +57,7 @@ class ValuesOverridesTest {
 		ValuesOverrides.applySet(target, "db.port=5432");
 		Map<?, ?> db = (Map<?, ?>) target.get("db");
 		assertEquals("localhost", db.get("host"));
-		assertEquals("5432", db.get("port"));
+		assertEquals(5432L, db.get("port"));
 	}
 
 	@Test
@@ -79,6 +80,128 @@ class ValuesOverridesTest {
 		Map<String, Object> target = new HashMap<>();
 		ValuesOverrides.applySet(target, "key=a=b");
 		assertEquals("a=b", target.get("key"));
+	}
+
+	// --- applySet type coercion ---
+
+	@Test
+	void testApplySetCoercesBoolean() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "enabled=true");
+		ValuesOverrides.applySet(target, "disabled=false");
+		assertEquals(Boolean.TRUE, target.get("enabled"));
+		assertEquals(Boolean.FALSE, target.get("disabled"));
+	}
+
+	@Test
+	void testApplySetCoercesInteger() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "replicas=3");
+		assertEquals(3L, target.get("replicas"));
+		assertInstanceOf(Long.class, target.get("replicas"));
+	}
+
+	@Test
+	void testApplySetFloatStaysString() {
+		// Helm's --set does not coerce floats; "1.5" stays a string (verified vs helm).
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "ratio=1.5");
+		assertEquals("1.5", target.get("ratio"));
+		assertInstanceOf(String.class, target.get("ratio"));
+	}
+
+	@Test
+	void testApplySetLeadingZeroStaysString() {
+		// Leading-zero numbers stay strings (helm keeps "007").
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "code=007");
+		assertEquals("007", target.get("code"));
+		assertInstanceOf(String.class, target.get("code"));
+	}
+
+	@Test
+	void testApplySetCoercesNull() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "foo=null");
+		assertTrue(target.containsKey("foo"));
+		assertNull(target.get("foo"));
+	}
+
+	@Test
+	void testApplySetEmptyValueIsEmptyString() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "foo=");
+		assertEquals("", target.get("foo"));
+	}
+
+	@Test
+	void testApplySetPlainStringStaysString() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySet(target, "name=nginx");
+		assertEquals("nginx", target.get("name"));
+	}
+
+	// --- applySetString (no coercion) ---
+
+	@Test
+	void testApplySetStringKeepsRawString() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySetString(target, "foo=3");
+		assertEquals("3", target.get("foo"));
+		assertInstanceOf(String.class, target.get("foo"));
+	}
+
+	@Test
+	void testApplySetStringBooleanStaysString() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySetString(target, "foo=true");
+		assertEquals("true", target.get("foo"));
+	}
+
+	// --- applySetFile ---
+
+	@Test
+	void testApplySetFileReadsContents() throws Exception {
+		Path file = writeFile("cert.pem", "line1\nline2\n");
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySetFile(target, "cert=" + file);
+		assertEquals("line1\nline2\n", target.get("cert"));
+	}
+
+	// --- applySetJson ---
+
+	@Test
+	void testApplySetJsonParsesMap() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySetJson(target, "foo={\"a\":1}");
+		Map<?, ?> foo = (Map<?, ?>) target.get("foo");
+		assertEquals(1, foo.get("a"));
+	}
+
+	@Test
+	void testApplySetJsonParsesList() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySetJson(target, "items=[1,2,3]");
+		assertEquals(List.of(1, 2, 3), target.get("items"));
+	}
+
+	// --- precedence across variants ---
+
+	@Test
+	void testSetJsonOverridesSetOverridesFile() throws Exception {
+		Path f = writeFile("base.yaml", """
+				replicas: 1
+				image: nginx
+				tag: filetag
+				""");
+		Map<String, Object> result = ValuesOverrides.parse(List.of(f.toString()), List.of("replicas=2", "tag=settag"),
+				null, null, List.of("replicas=3"));
+		// set-json wins over set wins over file
+		assertEquals(3, result.get("replicas"));
+		// set wins over file
+		assertEquals("settag", result.get("tag"));
+		// untouched file value remains
+		assertEquals("nginx", result.get("image"));
 	}
 
 	// --- parse from files ---
@@ -115,7 +238,7 @@ class ValuesOverridesTest {
 	void testParseFromSetArgs() throws Exception {
 		Map<String, Object> result = ValuesOverrides.parse(null, List.of("key=value", "other=123"));
 		assertEquals("value", result.get("key"));
-		assertEquals("123", result.get("other"));
+		assertEquals(123L, result.get("other"));
 	}
 
 	// --- combined ---
@@ -124,7 +247,7 @@ class ValuesOverridesTest {
 	void testSetOverridesFile() throws Exception {
 		Path f = writeValues("replicas: 1\nimage: nginx\n");
 		Map<String, Object> result = ValuesOverrides.parse(List.of(f.toString()), List.of("replicas=3"));
-		assertEquals("3", result.get("replicas"));
+		assertEquals(3L, result.get("replicas"));
 		assertEquals("nginx", result.get("image"));
 	}
 
@@ -194,7 +317,7 @@ class ValuesOverridesTest {
 				""");
 		Map<String, Object> result = ValuesOverrides.parse(List.of(f1.toString(), f2.toString()),
 				List.of("replicas=10"));
-		assertEquals("10", result.get("replicas"));
+		assertEquals(10L, result.get("replicas"));
 		assertEquals("nginx", result.get("image"));
 	}
 
@@ -313,7 +436,7 @@ class ValuesOverridesTest {
 			int port = server.getAddress().getPort();
 			String url = "http://localhost:" + port + "/values.yaml";
 			Map<String, Object> result = ValuesOverrides.parse(List.of(url), List.of("replicas=10"));
-			assertEquals("10", result.get("replicas"));
+			assertEquals(10L, result.get("replicas"));
 			assertEquals("nginx", result.get("image"));
 		}
 		finally {


### PR DESCRIPTION
Adds Helm's `--set` value typing and the `--set-string`/`--set-file`/`--set-json` variants (#501).

## Behavior
jhelm's `--set` previously stored every value as a raw String. Now it matches Helm:
- **`--set`** coerces to a typed scalar — `true`/`false`→Boolean, a **canonical** integer→Long, `null`→null, empty→`""`, and everything else (incl. floats like `1.5` and leading-zero numbers like `007`) **stays String**.
- **`--set-string`** — value always the raw string (jhelm's old `--set` behavior).
- **`--set-file`** (`key=path`) — value is the file contents.
- **`--set-json`** (`key=json`) — value parsed as JSON (map/list/scalar).

Coercion verified against **real `helm template`** (`{{ kindOf }}`): `int=int64`, `float=string`, `bool=bool`, `007=string`.

## API
`ValuesOverrides.parse` gains a 5-arg overload (precedence: files → `--set` → `--set-string` → `--set-file` → `--set-json`); the 2-arg overload is kept. The three new flags are wired into **install, upgrade, template, lint**.

## Verified
jhelm-core + jhelm-cli build green; `ValuesOverridesTest` covers coercion (bool/int/float-stays-string/leading-zero-stays-string), each variant, and precedence; PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)