### PR TITLE
feat(cli): --no-hooks for install/upgrade/uninstall/rollback (#501)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -76,6 +76,9 @@ public class InstallCommand implements Runnable {
 	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
 
+	@Option(names = { "--no-hooks" }, description = "prevent hooks from running during this operation")
+	private boolean noHooks;
+
 	/**
 	 * Creates the command.
 	 * @param installAction the action that performs the install
@@ -98,7 +101,7 @@ public class InstallCommand implements Runnable {
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
 					setFileValues, setJsonValues);
 
-			Release release = installAction.install(chart, name, namespace, overrides, 1, dryRun);
+			Release release = installAction.install(chart, name, namespace, overrides, 1, dryRun, noHooks);
 			applyCliPostRenderers(release);
 
 			if (dryRun) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
@@ -27,6 +27,9 @@ public class RollbackCommand implements Runnable {
 	@CommandLine.Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
 	private String namespace;
 
+	@CommandLine.Option(names = { "--no-hooks" }, description = "prevent hooks from running during this operation")
+	private boolean noHooks;
+
 	/**
 	 * Creates the command.
 	 * @param rollbackAction the action that performs the rollback
@@ -38,7 +41,7 @@ public class RollbackCommand implements Runnable {
 	@Override
 	public void run() {
 		try {
-			rollbackAction.rollback(name, namespace, revision);
+			rollbackAction.rollback(name, namespace, revision, noHooks);
 			CliOutput.println(CliOutput.success("Rollback was a success! Happy Helming!"));
 		}
 		catch (Exception ex) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
@@ -23,6 +23,9 @@ public class UninstallCommand implements Runnable {
 	@CommandLine.Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
 	private String namespace;
 
+	@CommandLine.Option(names = { "--no-hooks" }, description = "prevent hooks from running during this operation")
+	private boolean noHooks;
+
 	/**
 	 * Creates the command.
 	 * @param uninstallAction the action that uninstalls the release
@@ -34,7 +37,7 @@ public class UninstallCommand implements Runnable {
 	@Override
 	public void run() {
 		try {
-			uninstallAction.uninstall(name, namespace);
+			uninstallAction.uninstall(name, namespace, noHooks);
 			CliOutput.println(CliOutput.success("release \"" + name + "\" uninstalled"));
 		}
 		catch (Exception ex) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -99,6 +99,9 @@ public class UpgradeCommand implements Runnable {
 			description = "when upgrading, reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --set and -f")
 	private boolean resetThenReuseValues;
 
+	@Option(names = { "--no-hooks" }, description = "prevent hooks from running during this operation")
+	private boolean noHooks;
+
 	/**
 	 * Creates the command.
 	 * @param kubeService the Kubernetes service used to look up releases and wait for
@@ -134,7 +137,7 @@ public class UpgradeCommand implements Runnable {
 			if (currentReleaseOpt.isEmpty()) {
 				if (install) {
 					wasInstall = true;
-					Release release = installAction.install(chart, name, namespace, overrides, 1, dryRun);
+					Release release = installAction.install(chart, name, namespace, overrides, 1, dryRun, noHooks);
 					applyCliPostRenderers(release);
 					if (dryRun) {
 						printRelease(release);
@@ -157,8 +160,8 @@ public class UpgradeCommand implements Runnable {
 			UpgradeValueStrategy strategy = (resetValues) ? UpgradeValueStrategy.RESET
 					: (resetThenReuseValues) ? UpgradeValueStrategy.RESET_THEN_REUSE
 							: (reuseValues) ? UpgradeValueStrategy.REUSE : UpgradeValueStrategy.DEFAULT;
-			Release upgradedRelease = upgradeAction.upgrade(currentReleaseOpt.get(), chart, overrides, strategy,
-					dryRun);
+			Release upgradedRelease = upgradeAction.upgrade(currentReleaseOpt.get(), chart, overrides, strategy, dryRun,
+					noHooks);
 			applyCliPostRenderers(upgradedRelease);
 
 			if (dryRun) {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -64,7 +64,8 @@ class InstallCommandTest {
 		File chartDir = createMockChart();
 		Release release = createMockRelease("my-release", 1);
 
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean()))
+		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
+				anyBoolean()))
 			.thenReturn(release);
 
 		CommandLine cmd = new CommandLine(installCommand);
@@ -76,7 +77,8 @@ class InstallCommandTest {
 		File chartDir = createMockChart();
 		Release release = createMockRelease("my-release", 1);
 
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean()))
+		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
+				anyBoolean()))
 			.thenReturn(release);
 
 		CommandLine cmd = new CommandLine(installCommand);
@@ -87,7 +89,8 @@ class InstallCommandTest {
 	void testInstallCommandWithError() throws Exception {
 		File chartDir = createMockChart();
 
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean()))
+		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
+				anyBoolean()))
 			.thenThrow(new RuntimeException("Test error"));
 
 		CommandLine cmd = new CommandLine(installCommand);
@@ -99,7 +102,8 @@ class InstallCommandTest {
 		File chartDir = createMockChart();
 		Release release = createMockRelease("my-release", 1);
 
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean()))
+		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
+				anyBoolean()))
 			.thenReturn(release);
 
 		CommandLine cmd = new CommandLine(installCommand);
@@ -113,7 +117,8 @@ class InstallCommandTest {
 		File chartDir = createMockChart();
 		Release release = createMockRelease("my-release", 1);
 
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean()))
+		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
+				anyBoolean()))
 			.thenReturn(release);
 
 		CommandLine cmd = new CommandLine(installCommand);
@@ -127,7 +132,8 @@ class InstallCommandTest {
 	void testInstallCommandAtomicUninstallsOnFailure() throws Exception {
 		File chartDir = createMockChart();
 
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean()))
+		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
+				anyBoolean()))
 			.thenThrow(new RuntimeException("deploy failed"));
 
 		CommandLine cmd = new CommandLine(installCommand);

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -77,7 +77,7 @@ class UpgradeCommandTest {
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
 		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean()))
+				anyBoolean(), anyBoolean()))
 			.thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
@@ -90,7 +90,8 @@ class UpgradeCommandTest {
 		Release newRelease = createMockRelease("my-release", 1);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean()))
+		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
+				anyBoolean()))
 			.thenReturn(newRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
@@ -115,7 +116,7 @@ class UpgradeCommandTest {
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
 		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean()))
+				anyBoolean(), anyBoolean()))
 			.thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
@@ -154,7 +155,7 @@ class UpgradeCommandTest {
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
 		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean()))
+				anyBoolean(), anyBoolean()))
 			.thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
@@ -171,7 +172,7 @@ class UpgradeCommandTest {
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
 		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean()))
+				anyBoolean(), anyBoolean()))
 			.thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
@@ -186,13 +187,15 @@ class UpgradeCommandTest {
 		Release newRelease = createMockRelease("my-release", 1);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean()))
+		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
+				anyBoolean()))
 			.thenReturn(newRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "--install", "--dry-run");
 
-		verify(installAction).install(any(Chart.class), eq("my-release"), eq("default"), anyMap(), eq(1), eq(true));
+		verify(installAction).install(any(Chart.class), eq("my-release"), eq("default"), anyMap(), eq(1), eq(true),
+				anyBoolean());
 	}
 
 	@Test
@@ -202,7 +205,7 @@ class UpgradeCommandTest {
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
 		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean()))
+				anyBoolean(), anyBoolean()))
 			.thenThrow(new RuntimeException("upgrade failed"));
 
 		CommandLine cmd = new CommandLine(upgradeCommand);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -62,6 +62,30 @@ public class InstallAction {
 	 */
 	public Release install(Chart chart, String releaseName, String namespace, Map<String, Object> overrideValues,
 			int version, boolean dryRun) {
+		return install(chart, releaseName, namespace, overrideValues, version, dryRun, false);
+	}
+
+	/**
+	 * Installs a chart as a new release, optionally skipping lifecycle hooks. Behaves
+	 * like {@link #install(Chart, String, String, Map, int, boolean)} but allows
+	 * suppressing pre-install and post-install hook execution.
+	 * @param chart the chart to install (must not be a library chart)
+	 * @param releaseName the name to give the release
+	 * @param namespace the target namespace
+	 * @param overrideValues user-supplied values merged over the chart defaults, may be
+	 * {@code null}
+	 * @param version the release revision number to assign
+	 * @param dryRun if {@code true}, render only and skip applying anything to the
+	 * cluster
+	 * @param noHooks if {@code true}, skip running pre-install and post-install hooks
+	 * @return the resulting release, including the rendered manifest
+	 * @throws IllegalArgumentException if the chart is a library chart
+	 * @throws DeploymentFailedException if applied resources cannot be persisted (they
+	 * are rolled back)
+	 * @throws JhelmException if rendering or a cluster operation fails
+	 */
+	public Release install(Chart chart, String releaseName, String namespace, Map<String, Object> overrideValues,
+			int version, boolean dryRun, boolean noHooks) {
 		if ("library".equals(chart.getMetadata().getType())) {
 			throw new IllegalArgumentException(
 					"chart '" + chart.getMetadata().getName() + "' is a library chart and cannot be installed");
@@ -115,10 +139,12 @@ public class InstallAction {
 		if (kubeService != null && !dryRun) {
 			applyCrds(chart, namespace);
 			fireLifecycleEvent("pre-install", releaseName, namespace);
-			List<HelmHook> hooks = HookParser.parseHooks(manifest);
 			String regularManifest = HookParser.stripHooks(manifest);
-			HookExecutor hookExecutor = new HookExecutor(kubeService);
-			runHooks(hookExecutor, namespace, hooks, "pre-install");
+			List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(manifest);
+			HookExecutor hookExecutor = noHooks ? null : new HookExecutor(kubeService);
+			if (!noHooks) {
+				runHooks(hookExecutor, namespace, hooks, "pre-install");
+			}
 			kubeService.apply(namespace, regularManifest);
 			try {
 				kubeService.storeRelease(release);
@@ -128,7 +154,9 @@ public class InstallAction {
 				throw new DeploymentFailedException("Failed to store release after apply; resources rolled back", ex,
 						regularManifest);
 			}
-			runHooks(hookExecutor, namespace, hooks, "post-install");
+			if (!noHooks) {
+				runHooks(hookExecutor, namespace, hooks, "post-install");
+			}
 			fireLifecycleEvent("post-install", releaseName, namespace);
 		}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
@@ -20,7 +20,25 @@ public class RollbackAction {
 
 	private final KubeService kubeService;
 
+	/**
+	 * Rolls a release back to a previous revision, running its pre-rollback and
+	 * post-rollback hooks.
+	 * @param name the release name
+	 * @param namespace the namespace the release lives in
+	 * @param revision the revision number to roll back to
+	 */
 	public void rollback(String name, String namespace, int revision) {
+		rollback(name, namespace, revision, false);
+	}
+
+	/**
+	 * Rolls a release back to a previous revision, optionally skipping lifecycle hooks.
+	 * @param name the release name
+	 * @param namespace the namespace the release lives in
+	 * @param revision the revision number to roll back to
+	 * @param noHooks if {@code true}, skip running pre-rollback and post-rollback hooks
+	 */
+	public void rollback(String name, String namespace, int revision, boolean noHooks) {
 		List<Release> history = kubeService.getReleaseHistory(name, namespace);
 		Optional<Release> targetReleaseOpt = history.stream().filter((r) -> r.getVersion() == revision).findFirst();
 
@@ -49,13 +67,17 @@ public class RollbackAction {
 			.build();
 
 		String manifest = newRelease.getManifest();
-		List<HelmHook> hooks = HookParser.parseHooks(manifest);
 		String regularManifest = HookParser.stripHooks(manifest);
-		HookExecutor hookExecutor = new HookExecutor(kubeService);
-		runHooks(hookExecutor, namespace, hooks, "pre-rollback");
+		List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(manifest);
+		HookExecutor hookExecutor = noHooks ? null : new HookExecutor(kubeService);
+		if (!noHooks) {
+			runHooks(hookExecutor, namespace, hooks, "pre-rollback");
+		}
 		kubeService.apply(namespace, regularManifest);
 		kubeService.storeRelease(newRelease);
-		runHooks(hookExecutor, namespace, hooks, "post-rollback");
+		if (!noHooks) {
+			runHooks(hookExecutor, namespace, hooks, "post-rollback");
+		}
 	}
 
 	private void runHooks(HookExecutor hookExecutor, String namespace, List<HelmHook> hooks, String phase) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
@@ -19,20 +19,39 @@ public class UninstallAction {
 
 	private final KubeService kubeService;
 
+	/**
+	 * Uninstalls a release, running its pre-delete and post-delete hooks.
+	 * @param releaseName the name of the release to remove
+	 * @param namespace the namespace the release lives in
+	 */
 	public void uninstall(String releaseName, String namespace) {
+		uninstall(releaseName, namespace, false);
+	}
+
+	/**
+	 * Uninstalls a release, optionally skipping lifecycle hooks.
+	 * @param releaseName the name of the release to remove
+	 * @param namespace the namespace the release lives in
+	 * @param noHooks if {@code true}, skip running pre-delete and post-delete hooks
+	 */
+	public void uninstall(String releaseName, String namespace, boolean noHooks) {
 		Optional<Release> releaseOpt = kubeService.getRelease(releaseName, namespace);
 		if (releaseOpt.isEmpty()) {
 			throw ReleaseNotFoundException.forRelease(releaseName, namespace);
 		}
 
 		Release release = releaseOpt.get();
-		List<HelmHook> hooks = HookParser.parseHooks(release.getManifest());
 		String regularManifest = HookParser.stripHooks(release.getManifest());
-		HookExecutor hookExecutor = new HookExecutor(kubeService);
-		runHooks(hookExecutor, namespace, hooks, "pre-delete");
+		List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(release.getManifest());
+		HookExecutor hookExecutor = noHooks ? null : new HookExecutor(kubeService);
+		if (!noHooks) {
+			runHooks(hookExecutor, namespace, hooks, "pre-delete");
+		}
 		String deletableManifest = HookParser.stripKeptResources(regularManifest);
 		kubeService.delete(namespace, deletableManifest);
-		runHooks(hookExecutor, namespace, hooks, "post-delete");
+		if (!noHooks) {
+			runHooks(hookExecutor, namespace, hooks, "post-delete");
+		}
 		kubeService.deleteReleaseHistory(releaseName, namespace);
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -49,6 +49,25 @@ public class UpgradeAction {
 	 */
 	public Release upgrade(Release currentRelease, Chart newChart, Map<String, Object> overrideValues,
 			UpgradeValueStrategy strategy, boolean dryRun) {
+		return upgrade(currentRelease, newChart, overrideValues, strategy, dryRun, false);
+	}
+
+	/**
+	 * Upgrades a release, optionally skipping lifecycle hooks. Behaves like
+	 * {@link #upgrade(Release, Chart, Map, UpgradeValueStrategy, boolean)} but allows
+	 * suppressing pre-upgrade and post-upgrade hook execution.
+	 * @param currentRelease the currently deployed release (its chart defaults and
+	 * persisted user values feed the reuse strategies)
+	 * @param newChart the chart to upgrade to
+	 * @param overrideValues this command's value overrides (may be {@code null})
+	 * @param strategy how to resolve the previous user values against the overrides — see
+	 * {@link UpgradeValueStrategy}
+	 * @param dryRun when {@code true}, render only without applying to the cluster
+	 * @param noHooks if {@code true}, skip running pre-upgrade and post-upgrade hooks
+	 * @return the upgraded release
+	 */
+	public Release upgrade(Release currentRelease, Chart newChart, Map<String, Object> overrideValues,
+			UpgradeValueStrategy strategy, boolean dryRun, boolean noHooks) {
 		if ("library".equals(newChart.getMetadata().getType())) {
 			throw new IllegalArgumentException(
 					"chart '" + newChart.getMetadata().getName() + "' is a library chart and cannot be upgraded");
@@ -100,10 +119,12 @@ public class UpgradeAction {
 
 		if (kubeService != null && !dryRun) {
 			fireLifecycleEvent("pre-upgrade", newRelease.getName(), newRelease.getNamespace());
-			List<HelmHook> hooks = HookParser.parseHooks(manifest);
 			String regularManifest = HookParser.stripHooks(manifest);
-			HookExecutor hookExecutor = new HookExecutor(kubeService);
-			runHooks(hookExecutor, newRelease.getNamespace(), hooks, "pre-upgrade");
+			List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(manifest);
+			HookExecutor hookExecutor = noHooks ? null : new HookExecutor(kubeService);
+			if (!noHooks) {
+				runHooks(hookExecutor, newRelease.getNamespace(), hooks, "pre-upgrade");
+			}
 			kubeService.apply(newRelease.getNamespace(), regularManifest);
 			try {
 				kubeService.storeRelease(newRelease);
@@ -113,7 +134,9 @@ public class UpgradeAction {
 				throw new DeploymentFailedException("Failed to store release after apply; previous release re-applied",
 						ex, regularManifest);
 			}
-			runHooks(hookExecutor, newRelease.getNamespace(), hooks, "post-upgrade");
+			if (!noHooks) {
+				runHooks(hookExecutor, newRelease.getNamespace(), hooks, "post-upgrade");
+			}
 			fireLifecycleEvent("post-upgrade", newRelease.getName(), newRelease.getNamespace());
 		}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
@@ -137,6 +137,44 @@ class InstallActionTest {
 	}
 
 	@Test
+	void testInstallNoHooksSkipsHooks() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		String hookYaml = """
+				apiVersion: batch/v1
+				kind: Job
+				metadata:
+				  name: my-release-pre-install
+				  namespace: default
+				  annotations:
+				    helm.sh/hook: pre-install
+				    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+				spec:
+				  template:
+				    spec:
+				      restartPolicy: Never
+				""";
+		String regularYaml = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
+		String fullManifest = "---\n" + hookYaml + regularYaml;
+
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(fullManifest);
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		installAction.install(chart, "my-release", "default", null, 1, false, true);
+
+		List<HelmHook> hooks = HookParser.parseHooks(fullManifest);
+		String strippedManifest = HookParser.stripHooks(fullManifest);
+
+		// Hook resource is NOT applied when noHooks is true
+		verify(kubeService, never()).apply("default", hooks.get(0).getYaml());
+		// Regular manifest is still applied and the release stored
+		verify(kubeService).apply("default", strippedManifest);
+		verify(kubeService).storeRelease(any(Release.class));
+	}
+
+	@Test
 	void testInstallWithNullKubeServiceNoop() throws Exception {
 		InstallAction noKubeInstall = new InstallAction(engine, null);
 		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
@@ -17,6 +17,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
@@ -160,6 +161,59 @@ class RollbackActionTest {
 
 		verify(kubeService).apply("default", hooks.get(0).getYaml());
 		verify(kubeService).apply("default", strippedManifest);
+	}
+
+	@Test
+	void testRollbackNoHooksSkipsHooks() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).build();
+
+		String hookYaml = """
+				apiVersion: batch/v1
+				kind: Job
+				metadata:
+				  name: myapp-pre-rollback
+				  namespace: default
+				  annotations:
+				    helm.sh/hook: pre-rollback
+				    helm.sh/hook-delete-policy: before-hook-creation
+				spec:
+				  template:
+				    spec:
+				      restartPolicy: Never
+				""";
+		String regularYaml = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: myapp-cfg\n";
+		String manifest = "---\n" + hookYaml + regularYaml;
+
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status("deployed")
+			.build();
+
+		Release v1 = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.manifest(manifest)
+			.info(info)
+			.build();
+
+		when(kubeService.getReleaseHistory(anyString(), anyString())).thenReturn(Arrays.asList(v1));
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		rollbackAction.rollback("myapp", "default", 1, true);
+
+		List<HelmHook> hooks = HookParser.parseHooks(manifest);
+		String strippedManifest = HookParser.stripHooks(manifest);
+
+		// Hook resource is NOT applied when noHooks is true
+		verify(kubeService, never()).apply("default", hooks.get(0).getYaml());
+		// Regular manifest is still applied and the release stored
+		verify(kubeService).apply("default", strippedManifest);
+		verify(kubeService).storeRelease(any(Release.class));
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UninstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UninstallActionTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.anyString;
 import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
@@ -84,6 +85,43 @@ class UninstallActionTest {
 		verify(kubeService).apply("default", hooks.get(0).getYaml());
 		// Regular resource deletion uses stripped manifest
 		verify(kubeService).delete("default", strippedManifest);
+		verify(kubeService).deleteReleaseHistory("myapp", "default");
+	}
+
+	@Test
+	void testUninstallNoHooksSkipsHooks() throws Exception {
+		String hookYaml = """
+				apiVersion: batch/v1
+				kind: Job
+				metadata:
+				  name: myapp-pre-delete
+				  namespace: default
+				  annotations:
+				    helm.sh/hook: pre-delete
+				    helm.sh/hook-delete-policy: before-hook-creation
+				spec:
+				  template:
+				    spec:
+				      restartPolicy: Never
+				""";
+		String regularYaml = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: myapp-cfg\n";
+		String fullManifest = "---\n" + hookYaml + regularYaml;
+
+		Release release = Release.builder().name("myapp").namespace("default").manifest(fullManifest).build();
+
+		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).deleteReleaseHistory(anyString(), anyString());
+
+		uninstallAction.uninstall("myapp", "default", true);
+
+		List<HelmHook> hooks = HookParser.parseHooks(fullManifest);
+		String deletableManifest = HookParser.stripKeptResources(HookParser.stripHooks(fullManifest));
+
+		// Hook resource is NOT applied when noHooks is true
+		verify(kubeService, never()).apply("default", hooks.get(0).getYaml());
+		// Regular resources are still deleted and history removed
+		verify(kubeService).delete("default", deletableManifest);
 		verify(kubeService).deleteReleaseHistory("myapp", "default");
 	}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -234,6 +234,58 @@ class UpgradeActionTest {
 	}
 
 	@Test
+	void testUpgradeNoHooksSkipsHooks() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("2.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status("deployed")
+			.build();
+
+		Release currentRelease = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.info(info)
+			.build();
+
+		String hookYaml = """
+				apiVersion: batch/v1
+				kind: Job
+				metadata:
+				  name: myapp-pre-upgrade
+				  namespace: default
+				  annotations:
+				    helm.sh/hook: pre-upgrade
+				    helm.sh/hook-delete-policy: before-hook-creation
+				spec:
+				  template:
+				    spec:
+				      restartPolicy: Never
+				""";
+		String regularYaml = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: myapp-svc\n";
+		String fullManifest = "---\n" + hookYaml + regularYaml;
+
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(fullManifest);
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT, false, true);
+
+		List<HelmHook> hooks = HookParser.parseHooks(fullManifest);
+		String strippedManifest = HookParser.stripHooks(fullManifest);
+
+		// Hook resource is NOT applied when noHooks is true
+		verify(kubeService, never()).apply("default", hooks.get(0).getYaml());
+		// Regular manifest is still applied and the release stored
+		verify(kubeService).apply("default", strippedManifest);
+		verify(kubeService).storeRelease(any(Release.class));
+	}
+
+	@Test
 	void testUpgradeIncrementsVersion() throws Exception {
 		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();


### PR DESCRIPTION
Adds Helm's `--no-hooks`, which skips running lifecycle hooks for the operation (#501).

## Non-breaking
Each action gains a trailing `boolean noHooks` parameter; the **existing signature delegates with `noHooks=false`**, so `ReleaseController` and the jhelm-mcp `ReleaseMutatingTools` keep compiling unchanged. When `noHooks=true` the action skips `HookParser.parseHooks` and both pre/post `runHooks` calls; the regular manifest apply, store/wait/delete, CRDs, lifecycle events and atomic rollback are unchanged.

`--no-hooks` wired into **install, upgrade, uninstall, rollback** CLI commands.

## Verified
jhelm-core **523**, jhelm-cli **171** tests, 0 failures (new `test*NoHooksSkipsHooks` per action assert the hook resource is never applied while the regular manifest still is); full reactor green; PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)