### PR TITLE
feat(cli): add jhelm version and jhelm env commands (#504)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
@@ -19,7 +19,9 @@ import org.alexmond.jhelm.app.command.ShowCommand;
 import org.alexmond.jhelm.app.command.StatusCommand;
 import org.alexmond.jhelm.app.command.TemplateCommand;
 import org.alexmond.jhelm.app.command.TestCommand;
+import org.alexmond.jhelm.app.command.EnvCommand;
 import org.alexmond.jhelm.app.command.UninstallCommand;
+import org.alexmond.jhelm.app.command.VersionCommand;
 import org.alexmond.jhelm.app.command.UpgradeCommand;
 import org.alexmond.jhelm.app.command.VerifyCommand;
 import lombok.extern.slf4j.Slf4j;
@@ -49,7 +51,8 @@ import picocli.CommandLine;
 				UninstallCommand.class, ListCommand.class, StatusCommand.class, HistoryCommand.class,
 				RollbackCommand.class, ShowCommand.class, GetCommand.class, TestCommand.class, DependencyCommand.class,
 				PullCommand.class, PushCommand.class, PackageCommand.class, VerifyCommand.class, LintCommand.class,
-				RepoCommand.class, RegistryCommand.class, PluginCommand.class, SearchCommand.class })
+				RepoCommand.class, RegistryCommand.class, PluginCommand.class, SearchCommand.class,
+				VersionCommand.class, EnvCommand.class })
 public class JHelmCommand implements Runnable {
 
 	private final Environment environment;

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/EnvCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/EnvCommand.java
@@ -1,0 +1,36 @@
+package org.alexmond.jhelm.app.command;
+
+import org.alexmond.jhelm.app.output.CliOutput;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+
+/**
+ * Implements {@code jhelm env}, printing the environment jhelm runs in — the active
+ * namespace, the jhelm/Java/OS versions, and which recognized environment variables are
+ * set. Mirrors {@code helm env} as a quick way to inspect the client environment.
+ */
+@Component
+@CommandLine.Command(name = "env", mixinStandardHelpOptions = true,
+		description = "Print the jhelm client environment information")
+public class EnvCommand implements Runnable {
+
+	/** Creates the command. */
+	@SuppressWarnings("PMD.UnnecessaryConstructor")
+	public EnvCommand() {
+	}
+
+	private static String orDefault(String envVar, String fallback) {
+		String value = System.getenv(envVar);
+		return ((value != null) && !value.isBlank()) ? value : fallback;
+	}
+
+	@Override
+	public void run() {
+		CliOutput.println("HELM_NAMESPACE=\"" + orDefault("HELM_NAMESPACE", "default") + "\"");
+		CliOutput.println("HELM_PASSPHRASE_SET=\"" + (System.getenv("HELM_PASSPHRASE") != null) + "\"");
+		CliOutput.println("JHELM_VERSION=\"" + VersionCommand.versionString() + "\"");
+		CliOutput.println("JAVA_VERSION=\"" + System.getProperty("java.version") + "\"");
+		CliOutput.println("OS=\"" + System.getProperty("os.name") + "/" + System.getProperty("os.arch") + "\"");
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/VersionCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/VersionCommand.java
@@ -1,0 +1,46 @@
+package org.alexmond.jhelm.app.command;
+
+import org.alexmond.jhelm.app.output.CliOutput;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+
+/**
+ * Implements {@code jhelm version}, printing the jhelm version (and the running Java
+ * version). Scripts and CI commonly probe {@code helm version} to confirm the binary is
+ * present; {@code --short} prints just the version string.
+ */
+@Component
+@CommandLine.Command(name = "version", mixinStandardHelpOptions = true,
+		description = "Print the jhelm version information")
+public class VersionCommand implements Runnable {
+
+	@CommandLine.Option(names = { "--short" }, description = "print the version number only")
+	private boolean shortOutput;
+
+	/** Creates the command. */
+	@SuppressWarnings("PMD.UnnecessaryConstructor")
+	public VersionCommand() {
+	}
+
+	/**
+	 * Resolves the jhelm version from the jar manifest's {@code Implementation-Version},
+	 * falling back to a dev placeholder when running from an exploded build.
+	 * @return the version string, prefixed with {@code v}
+	 */
+	static String versionString() {
+		String version = VersionCommand.class.getPackage().getImplementationVersion();
+		return ((version != null) && !version.isBlank()) ? "v" + version : "v0.0.0-dev";
+	}
+
+	@Override
+	public void run() {
+		if (this.shortOutput) {
+			CliOutput.println(versionString());
+		}
+		else {
+			CliOutput
+				.println("jhelm version " + versionString() + " (Java " + System.getProperty("java.version") + ")");
+		}
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/EnvCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/EnvCommandTest.java
@@ -1,0 +1,31 @@
+package org.alexmond.jhelm.app.command;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EnvCommandTest {
+
+	@Test
+	void testEnvPrintsKeyValues() {
+		ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		PrintStream original = System.out;
+		System.setOut(new PrintStream(bos, true, StandardCharsets.UTF_8));
+		try {
+			new CommandLine(new EnvCommand()).execute();
+		}
+		finally {
+			System.setOut(original);
+		}
+		String out = bos.toString(StandardCharsets.UTF_8);
+		assertTrue(out.contains("HELM_NAMESPACE="));
+		assertTrue(out.contains("JHELM_VERSION="));
+		assertTrue(out.contains("JAVA_VERSION="));
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/VersionCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/VersionCommandTest.java
@@ -1,0 +1,47 @@
+package org.alexmond.jhelm.app.command;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VersionCommandTest {
+
+	private String run(String... args) {
+		ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		PrintStream original = System.out;
+		System.setOut(new PrintStream(bos, true, StandardCharsets.UTF_8));
+		try {
+			new CommandLine(new VersionCommand()).execute(args);
+		}
+		finally {
+			System.setOut(original);
+		}
+		return bos.toString(StandardCharsets.UTF_8);
+	}
+
+	@Test
+	void testVersionStringIsPrefixed() {
+		assertTrue(VersionCommand.versionString().startsWith("v"), "version should be v-prefixed");
+	}
+
+	@Test
+	void testLongOutputIncludesJava() {
+		String out = run();
+		assertTrue(out.contains("jhelm version"));
+		assertTrue(out.contains("Java"));
+	}
+
+	@Test
+	void testShortOutputIsVersionOnly() {
+		String out = run("--short").trim();
+		assertTrue(out.startsWith("v"));
+		assertFalse(out.contains("jhelm version"));
+	}
+
+}


### PR DESCRIPTION
Scripts and CI commonly probe `helm version` to confirm the binary is present; jhelm's CLI lacked it (#504).

- **`jhelm version`** → `jhelm version v<ver> (Java <ver>)`; **`--short`** → just the v-prefixed version. Version resolves from the jar manifest's `Implementation-Version` (falls back to `v0.0.0-dev` from an exploded build).
- **`jhelm env`** → client environment (`HELM_NAMESPACE`, whether `HELM_PASSPHRASE` is set, `JHELM_VERSION`, `JAVA_VERSION`, `OS`), mirroring `helm env`.

Verified via the built jar: `jhelm version --short` → `v0.3.0-SNAPSHOT`.

## Verified
jhelm-cli build + tests green (`VersionCommandTest`, `EnvCommandTest` cover both branches); JaCoCo gate met; PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)