### PR TITLE
feat: --history-max release-history pruning (#501)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
@@ -30,6 +30,10 @@ public class RollbackCommand implements Runnable {
 	@CommandLine.Option(names = { "--no-hooks" }, description = "prevent hooks from running during this operation")
 	private boolean noHooks;
 
+	@CommandLine.Option(names = { "--history-max" }, defaultValue = "10",
+			description = "limit the maximum number of revisions saved per release (0 = no limit)")
+	private int historyMax;
+
 	/**
 	 * Creates the command.
 	 * @param rollbackAction the action that performs the rollback
@@ -41,7 +45,7 @@ public class RollbackCommand implements Runnable {
 	@Override
 	public void run() {
 		try {
-			rollbackAction.rollback(name, namespace, revision, noHooks);
+			rollbackAction.rollback(name, namespace, revision, noHooks, historyMax);
 			CliOutput.println(CliOutput.success("Rollback was a success! Happy Helming!"));
 		}
 		catch (Exception ex) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -102,6 +102,10 @@ public class UpgradeCommand implements Runnable {
 	@Option(names = { "--no-hooks" }, description = "prevent hooks from running during this operation")
 	private boolean noHooks;
 
+	@CommandLine.Option(names = { "--history-max" }, defaultValue = "10",
+			description = "limit the maximum number of revisions saved per release (0 = no limit)")
+	private int historyMax;
+
 	/**
 	 * Creates the command.
 	 * @param kubeService the Kubernetes service used to look up releases and wait for
@@ -161,7 +165,7 @@ public class UpgradeCommand implements Runnable {
 					: (resetThenReuseValues) ? UpgradeValueStrategy.RESET_THEN_REUSE
 							: (reuseValues) ? UpgradeValueStrategy.REUSE : UpgradeValueStrategy.DEFAULT;
 			Release upgradedRelease = upgradeAction.upgrade(currentReleaseOpt.get(), chart, overrides, strategy, dryRun,
-					noHooks);
+					noHooks, historyMax);
 			applyCliPostRenderers(upgradedRelease);
 
 			if (dryRun) {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RollbackCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RollbackCommandTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -27,7 +28,7 @@ class RollbackCommandTest {
 
 	@Test
 	void testRollbackCommandSuccess() throws Exception {
-		doNothing().when(rollbackAction).rollback(anyString(), anyString(), anyInt());
+		doNothing().when(rollbackAction).rollback(anyString(), anyString(), anyInt(), anyBoolean(), anyInt());
 
 		CommandLine cmd = new CommandLine(rollbackCommand);
 		cmd.execute("my-release", "1", "-n", "default");
@@ -35,7 +36,7 @@ class RollbackCommandTest {
 
 	@Test
 	void testRollbackCommandDefaultNamespace() throws Exception {
-		doNothing().when(rollbackAction).rollback(anyString(), anyString(), anyInt());
+		doNothing().when(rollbackAction).rollback(anyString(), anyString(), anyInt(), anyBoolean(), anyInt());
 
 		CommandLine cmd = new CommandLine(rollbackCommand);
 		cmd.execute("my-release", "2");
@@ -43,7 +44,8 @@ class RollbackCommandTest {
 
 	@Test
 	void testRollbackCommandWithError() throws Exception {
-		doThrow(new RuntimeException("Test error")).when(rollbackAction).rollback(anyString(), anyString(), anyInt());
+		doThrow(new RuntimeException("Test error")).when(rollbackAction)
+			.rollback(anyString(), anyString(), anyInt(), anyBoolean(), anyInt());
 
 		CommandLine cmd = new CommandLine(rollbackCommand);
 		cmd.execute("my-release", "1");

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -77,7 +77,7 @@ class UpgradeCommandTest {
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
 		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean(), anyBoolean()))
+				anyBoolean(), anyBoolean(), anyInt()))
 			.thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
@@ -116,7 +116,7 @@ class UpgradeCommandTest {
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
 		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean(), anyBoolean()))
+				anyBoolean(), anyBoolean(), anyInt()))
 			.thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
@@ -155,7 +155,7 @@ class UpgradeCommandTest {
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
 		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean(), anyBoolean()))
+				anyBoolean(), anyBoolean(), anyInt()))
 			.thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
@@ -172,7 +172,7 @@ class UpgradeCommandTest {
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
 		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean(), anyBoolean()))
+				anyBoolean(), anyBoolean(), anyInt()))
 			.thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
@@ -205,7 +205,7 @@ class UpgradeCommandTest {
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
 		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean(), anyBoolean()))
+				anyBoolean(), anyBoolean(), anyInt()))
 			.thenThrow(new RuntimeException("upgrade failed"));
 
 		CommandLine cmd = new CommandLine(upgradeCommand);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
@@ -39,6 +39,23 @@ public class RollbackAction {
 	 * @param noHooks if {@code true}, skip running pre-rollback and post-rollback hooks
 	 */
 	public void rollback(String name, String namespace, int revision, boolean noHooks) {
+		rollback(name, namespace, revision, noHooks, 10);
+	}
+
+	/**
+	 * Rolls a release back to a previous revision, optionally skipping lifecycle hooks
+	 * and pruning old revision history. Behaves like
+	 * {@link #rollback(String, String, int, boolean)} but, after the new revision is
+	 * stored, prunes the release's revision history to the newest {@code maxHistory}
+	 * revisions.
+	 * @param name the release name
+	 * @param namespace the namespace the release lives in
+	 * @param revision the revision number to roll back to
+	 * @param noHooks if {@code true}, skip running pre-rollback and post-rollback hooks
+	 * @param maxHistory maximum revisions to keep; {@code 0} = no limit (Helm
+	 * {@code --history-max}, default 10)
+	 */
+	public void rollback(String name, String namespace, int revision, boolean noHooks, int maxHistory) {
 		List<Release> history = kubeService.getReleaseHistory(name, namespace);
 		Optional<Release> targetReleaseOpt = history.stream().filter((r) -> r.getVersion() == revision).findFirst();
 
@@ -75,6 +92,7 @@ public class RollbackAction {
 		}
 		kubeService.apply(namespace, regularManifest);
 		kubeService.storeRelease(newRelease);
+		kubeService.pruneReleaseHistory(name, namespace, maxHistory);
 		if (!noHooks) {
 			runHooks(hookExecutor, namespace, hooks, "post-rollback");
 		}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -68,6 +68,29 @@ public class UpgradeAction {
 	 */
 	public Release upgrade(Release currentRelease, Chart newChart, Map<String, Object> overrideValues,
 			UpgradeValueStrategy strategy, boolean dryRun, boolean noHooks) {
+		return upgrade(currentRelease, newChart, overrideValues, strategy, dryRun, noHooks, 10);
+	}
+
+	/**
+	 * Upgrades a release, optionally skipping hooks and pruning old revision history.
+	 * Behaves like
+	 * {@link #upgrade(Release, Chart, Map, UpgradeValueStrategy, boolean, boolean)} but,
+	 * after a successful (non-dry-run) store, prunes the release's revision history to
+	 * the newest {@code maxHistory} revisions.
+	 * @param currentRelease the currently deployed release (its chart defaults and
+	 * persisted user values feed the reuse strategies)
+	 * @param newChart the chart to upgrade to
+	 * @param overrideValues this command's value overrides (may be {@code null})
+	 * @param strategy how to resolve the previous user values against the overrides — see
+	 * {@link UpgradeValueStrategy}
+	 * @param dryRun when {@code true}, render only without applying to the cluster
+	 * @param noHooks if {@code true}, skip running pre-upgrade and post-upgrade hooks
+	 * @param maxHistory maximum revisions to keep; {@code 0} = no limit (Helm
+	 * {@code --history-max}, default 10)
+	 * @return the upgraded release
+	 */
+	public Release upgrade(Release currentRelease, Chart newChart, Map<String, Object> overrideValues,
+			UpgradeValueStrategy strategy, boolean dryRun, boolean noHooks, int maxHistory) {
 		if ("library".equals(newChart.getMetadata().getType())) {
 			throw new IllegalArgumentException(
 					"chart '" + newChart.getMetadata().getName() + "' is a library chart and cannot be upgraded");
@@ -134,6 +157,7 @@ public class UpgradeAction {
 				throw new DeploymentFailedException("Failed to store release after apply; previous release re-applied",
 						ex, regularManifest);
 			}
+			kubeService.pruneReleaseHistory(newRelease.getName(), newRelease.getNamespace(), maxHistory);
 			if (!noHooks) {
 				runHooks(hookExecutor, newRelease.getNamespace(), hooks, "post-upgrade");
 			}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
@@ -61,6 +61,19 @@ public interface KubeService {
 	void deleteReleaseHistory(String name, String namespace);
 
 	/**
+	 * Prunes a release's stored revision history, keeping only the newest
+	 * {@code maxHistory} revisions and deleting the oldest ones. The current (highest
+	 * version) revision is always retained. A {@code maxHistory} of {@code 0} or less
+	 * means no limit, so the call is a no-op. Mirrors Helm's {@code --history-max}.
+	 * @param name the release name
+	 * @param namespace the namespace to look in
+	 * @param maxHistory the maximum number of revisions to keep; {@code 0} or less means
+	 * no limit
+	 * @throws KubernetesOperationException if the Kubernetes API cannot be reached
+	 */
+	void pruneReleaseHistory(String name, String namespace, int maxHistory);
+
+	/**
 	 * Applies a rendered manifest to the cluster via server-side apply.
 	 * @param namespace the target namespace
 	 * @param yamlContent rendered YAML manifest (may contain multiple documents)

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.core.action;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -21,6 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.inOrder;
 import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
@@ -109,6 +111,41 @@ class RollbackActionTest {
 		Release storedRelease = releaseCaptor.getValue();
 		assertEquals(4, storedRelease.getVersion());
 		assertEquals("Rollback to 1", storedRelease.getInfo().getDescription());
+
+		// The 3-arg overload defaults to Helm's --history-max default of 10.
+		verify(kubeService).pruneReleaseHistory("myapp", "default", 10);
+	}
+
+	@Test
+	void testRollbackPrunesHistoryAfterStoreWithGivenMaxHistory() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).build();
+
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status("deployed")
+			.build();
+
+		Release v1 = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.manifest("---\nv1 manifest")
+			.info(info)
+			.build();
+
+		when(kubeService.getReleaseHistory(anyString(), anyString())).thenReturn(Arrays.asList(v1));
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		rollbackAction.rollback("myapp", "default", 1, false, 5);
+
+		// Prune is invoked with the passed maxHistory, after the release is stored.
+		InOrder order = inOrder(kubeService);
+		order.verify(kubeService).storeRelease(any(Release.class));
+		order.verify(kubeService).pruneReleaseHistory("myapp", "default", 5);
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.core.action;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.inOrder;
 import org.alexmond.jhelm.core.exception.DeploymentFailedException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
@@ -98,6 +100,8 @@ class UpgradeActionTest {
 		// trailing \n)
 		verify(kubeService).apply("default", HookParser.stripHooks(renderedManifest));
 		verify(kubeService).storeRelease(any(Release.class));
+		// The 5-arg overload defaults to Helm's --history-max default of 10.
+		verify(kubeService).pruneReleaseHistory("myapp", "default", 10);
 
 		@SuppressWarnings("unchecked")
 		ArgumentCaptor<Map<String, Object>> releaseDataCaptor = ArgumentCaptor.forClass(Map.class);
@@ -179,6 +183,38 @@ class UpgradeActionTest {
 
 		verify(kubeService, never()).apply(anyString(), anyString());
 		verify(kubeService, never()).storeRelease(any(Release.class));
+		verify(kubeService, never()).pruneReleaseHistory(anyString(), anyString(), anyInt());
+	}
+
+	@Test
+	void testUpgradePrunesHistoryAfterStoreWithGivenMaxHistory() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("2.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status("deployed")
+			.build();
+
+		Release currentRelease = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.info(info)
+			.build();
+
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT, false, false, 5);
+
+		// Prune is invoked with the passed maxHistory, after the release is stored.
+		InOrder order = inOrder(kubeService);
+		order.verify(kubeService).storeRelease(any(Release.class));
+		order.verify(kubeService).pruneReleaseHistory("myapp", "default", 5);
 	}
 
 	@Test

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
@@ -213,6 +213,41 @@ public class HelmKubeService implements KubeService {
 	}
 
 	/**
+	 * Prunes a release's revision history to the newest {@code maxHistory} revisions,
+	 * deleting the oldest Secrets. The highest-version (current) revision is never
+	 * deleted.
+	 */
+	@Override
+	public void pruneReleaseHistory(String name, String namespace, int maxHistory) {
+		if (maxHistory <= 0) {
+			return;
+		}
+		CoreV1Api api = new CoreV1Api(apiClient);
+		String labelSelector = "owner=helm,name=" + name;
+		V1SecretList list = listSecrets(api, namespace, labelSelector, "prune history for " + name);
+
+		List<V1Secret> sorted = list.getItems()
+			.stream()
+			.sorted(Comparator
+				.comparingInt((V1Secret s) -> Integer.parseInt(s.getMetadata().getLabels().get("version"))))
+			.toList();
+
+		int toDelete = sorted.size() - maxHistory;
+		if (toDelete <= 0) {
+			return;
+		}
+
+		try {
+			for (V1Secret secret : sorted.subList(0, toDelete)) {
+				api.deleteNamespacedSecret(secret.getMetadata().getName(), namespace).execute();
+			}
+		}
+		catch (ApiException ex) {
+			throw new KubernetesOperationException("Failed to prune release history for " + name, ex, ex.getCode());
+		}
+	}
+
+	/**
 	 * Lists release Secrets for a label selector, translating the kubernetes-client
 	 * {@link ApiException} into a {@link KubernetesOperationException} so callers never
 	 * see the client's checked exception.

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/ObservableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/ObservableKubeService.java
@@ -82,6 +82,11 @@ public class ObservableKubeService implements KubeService {
 	}
 
 	@Override
+	public void pruneReleaseHistory(String name, String namespace, int maxHistory) {
+		timeVoid(deleteTimer, () -> delegate.pruneReleaseHistory(name, namespace, maxHistory));
+	}
+
+	@Override
 	public void apply(String namespace, String yamlContent) {
 		timeVoid(applyTimer, () -> delegate.apply(namespace, yamlContent));
 	}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/RetryableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/RetryableKubeService.java
@@ -74,6 +74,14 @@ public class RetryableKubeService implements KubeService {
 	}
 
 	@Override
+	public void pruneReleaseHistory(String name, String namespace, int maxHistory) {
+		executeWithRetry("pruneReleaseHistory", () -> {
+			delegate.pruneReleaseHistory(name, namespace, maxHistory);
+			return null;
+		});
+	}
+
+	@Override
 	public void apply(String namespace, String yamlContent) {
 		executeWithRetry("apply", () -> {
 			delegate.apply(namespace, yamlContent);

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
@@ -36,6 +36,7 @@ import org.mockito.MockitoAnnotations;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
@@ -52,6 +53,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 
@@ -368,6 +370,86 @@ class HelmKubeServiceTest {
 		kubeService.deleteReleaseHistory("myapp", "default");
 		verify(mockCoreV1Api).deleteNamespacedSecret("sh.helm.release.v1.myapp.v1", "default");
 		verify(mockCoreV1Api).deleteNamespacedSecret("sh.helm.release.v1.myapp.v2", "default");
+	}
+
+	// --- pruneReleaseHistory ---
+
+	private V1SecretList revisionSecrets(String name, String namespace, int from, int to) throws Exception {
+		List<V1Secret> items = new ArrayList<>();
+		for (int v = from; v <= to; v++) {
+			items.add(createSecretForRelease(createTestRelease(name, namespace, v, "superseded")));
+		}
+		return new V1SecretList().items(items);
+	}
+
+	@Test
+	void testPruneReleaseHistoryDeletesOldestRevisions() throws Exception {
+		// 12 revisions (v1..v12), keep newest 10 -> delete the two lowest versions only.
+		V1SecretList list = revisionSecrets("myapp", "default", 1, 12);
+
+		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
+			mockCoreV1Api = mock;
+			setupListRequest(mock, list);
+			var deleteReq = mock(CoreV1Api.APIdeleteNamespacedSecretRequest.class);
+			when(deleteReq.execute()).thenReturn(null);
+			when(mock.deleteNamespacedSecret(anyString(), eq("default"))).thenReturn(deleteReq);
+		});
+
+		kubeService.pruneReleaseHistory("myapp", "default", 10);
+
+		// The two oldest (lowest version) Secrets are deleted.
+		verify(mockCoreV1Api).deleteNamespacedSecret("sh.helm.release.v1.myapp.v1", "default");
+		verify(mockCoreV1Api).deleteNamespacedSecret("sh.helm.release.v1.myapp.v2", "default");
+		// The rest are kept, including the highest (current) version.
+		verify(mockCoreV1Api, never()).deleteNamespacedSecret("sh.helm.release.v1.myapp.v3", "default");
+		verify(mockCoreV1Api, never()).deleteNamespacedSecret("sh.helm.release.v1.myapp.v12", "default");
+	}
+
+	@Test
+	void testPruneReleaseHistoryZeroMaxHistoryDeletesNothing() {
+		// maxHistory <= 0 means no limit: the call returns before any API client is
+		// built.
+		coreV1ApiConstruction = mockConstruction(CoreV1Api.class);
+
+		kubeService.pruneReleaseHistory("myapp", "default", 0);
+
+		assertTrue(coreV1ApiConstruction.constructed().isEmpty());
+	}
+
+	@Test
+	void testPruneReleaseHistoryAtLimitDeletesNothing() throws Exception {
+		// Exactly maxHistory revisions present -> nothing to prune.
+		V1SecretList list = revisionSecrets("myapp", "default", 1, 10);
+
+		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
+			mockCoreV1Api = mock;
+			setupListRequest(mock, list);
+			var deleteReq = mock(CoreV1Api.APIdeleteNamespacedSecretRequest.class);
+			when(deleteReq.execute()).thenReturn(null);
+			when(mock.deleteNamespacedSecret(anyString(), eq("default"))).thenReturn(deleteReq);
+		});
+
+		kubeService.pruneReleaseHistory("myapp", "default", 10);
+
+		verify(mockCoreV1Api, never()).deleteNamespacedSecret(anyString(), anyString());
+	}
+
+	@Test
+	void testPruneReleaseHistoryFewerThanLimitDeletesNothing() throws Exception {
+		// Fewer than maxHistory revisions present -> nothing to prune.
+		V1SecretList list = revisionSecrets("myapp", "default", 1, 3);
+
+		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
+			mockCoreV1Api = mock;
+			setupListRequest(mock, list);
+			var deleteReq = mock(CoreV1Api.APIdeleteNamespacedSecretRequest.class);
+			when(deleteReq.execute()).thenReturn(null);
+			when(mock.deleteNamespacedSecret(anyString(), eq("default"))).thenReturn(deleteReq);
+		});
+
+		kubeService.pruneReleaseHistory("myapp", "default", 10);
+
+		verify(mockCoreV1Api, never()).deleteNamespacedSecret(anyString(), anyString());
 	}
 
 	// --- listPods ---


### PR DESCRIPTION
jhelm stored every release revision as a Secret and **never pruned** them, so `sh.helm.release.v1.<name>.v<n>` Secrets grew unbounded on every upgrade/rollback. Adds Helm's `--history-max` (default 10, `0` = no limit).

## What
- **`KubeService.pruneReleaseHistory(name, namespace, maxHistory)`** — keeps the newest `maxHistory` revisions, deleting the oldest **by Secret name**; `maxHistory <= 0` is a no-op. Implemented in `HelmKubeService` (ascending version sort, delete `subList(0, count-maxHistory)` — the current/highest revision is **structurally never** in the delete set). Delegated through `RetryableKubeService` + `ObservableKubeService`.
- **UpgradeAction/RollbackAction** prune after a successful **non-dryRun** `storeRelease`, via a new trailing `maxHistory` overload. Existing signatures default to **10**, so REST and jhelm-mcp prune to 10 too (Helm parity, not unbounded growth).
- **`--history-max`** (default 10) added to `upgrade` and `rollback`.

## Safety
Storage-sensitive: `maxHistory<=0` short-circuits before any API call; only the lowest-version Secrets are deleted; the just-stored current revision is always kept (newest `maxHistory ≥ 1`).

## Verified
Full reactor green — `HelmKubeServiceTest` proves oldest-deleted / current-kept / `0`=no-op / at-limit=no-op; `Upgrade`+`RollbackActionTest` assert store-then-prune (`InOrder`) and dry-run never prunes; jhelm-cli 175 tests; PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)