### PR TITLE
refactor(api)!: action API takes an options object, not parameter lists (#500)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -8,7 +8,9 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -101,7 +103,15 @@ public class InstallCommand implements Runnable {
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
 					setFileValues, setJsonValues);
 
-			Release release = installAction.install(chart, name, namespace, overrides, 1, dryRun, noHooks);
+			Release release = installAction.install(InstallOptions.builder()
+				.chart(chart)
+				.releaseName(name)
+				.namespace(namespace)
+				.values(overrides)
+				.revision(1)
+				.dryRun(dryRun)
+				.noHooks(noHooks)
+				.build());
 			applyCliPostRenderers(release);
 
 			if (dryRun) {
@@ -124,7 +134,8 @@ public class InstallCommand implements Runnable {
 				CliOutput
 					.errPrintln(CliOutput.error("Install failed, performing atomic uninstall: " + ex.getMessage()));
 				try {
-					uninstallAction.uninstall(name, namespace);
+					uninstallAction
+						.uninstall(UninstallOptions.builder().releaseName(name).namespace(namespace).build());
 					CliOutput.println("Atomic uninstall of \"" + name + "\" complete.");
 				}
 				catch (Exception rollbackEx) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.app.command;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.RollbackOptions;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
@@ -45,7 +46,13 @@ public class RollbackCommand implements Runnable {
 	@Override
 	public void run() {
 		try {
-			rollbackAction.rollback(name, namespace, revision, noHooks, historyMax);
+			rollbackAction.rollback(RollbackOptions.builder()
+				.releaseName(name)
+				.namespace(namespace)
+				.revision(revision)
+				.noHooks(noHooks)
+				.maxHistory(historyMax)
+				.build());
 			CliOutput.println(CliOutput.success("Rollback was a success! Happy Helming!"));
 		}
 		catch (Exception ex) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.app.command;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
@@ -37,7 +38,8 @@ public class UninstallCommand implements Runnable {
 	@Override
 	public void run() {
 		try {
-			uninstallAction.uninstall(name, namespace, noHooks);
+			uninstallAction
+				.uninstall(UninstallOptions.builder().releaseName(name).namespace(namespace).noHooks(noHooks).build());
 			CliOutput.println(CliOutput.success("release \"" + name + "\" uninstalled"));
 		}
 		catch (Exception ex) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -9,9 +9,13 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.RollbackOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.action.UpgradeOptions;
 import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
@@ -141,7 +145,7 @@ public class UpgradeCommand implements Runnable {
 			if (currentReleaseOpt.isEmpty()) {
 				if (install) {
 					wasInstall = true;
-					Release release = installAction.install(chart, name, namespace, overrides, 1, dryRun, noHooks);
+					Release release = installAction.install(buildInstallOptions(chart, overrides));
 					applyCliPostRenderers(release);
 					if (dryRun) {
 						printRelease(release);
@@ -164,8 +168,8 @@ public class UpgradeCommand implements Runnable {
 			UpgradeValueStrategy strategy = (resetValues) ? UpgradeValueStrategy.RESET
 					: (resetThenReuseValues) ? UpgradeValueStrategy.RESET_THEN_REUSE
 							: (reuseValues) ? UpgradeValueStrategy.REUSE : UpgradeValueStrategy.DEFAULT;
-			Release upgradedRelease = upgradeAction.upgrade(currentReleaseOpt.get(), chart, overrides, strategy, dryRun,
-					noHooks, historyMax);
+			Release upgradedRelease = upgradeAction
+				.upgrade(buildUpgradeOptions(currentReleaseOpt.get(), chart, overrides, strategy));
 			applyCliPostRenderers(upgradedRelease);
 
 			if (dryRun) {
@@ -183,11 +187,16 @@ public class UpgradeCommand implements Runnable {
 				CliOutput.errPrintln(CliOutput.error("Upgrade failed, performing atomic rollback: " + ex.getMessage()));
 				try {
 					if (wasInstall || previousVersion < 0) {
-						uninstallAction.uninstall(name, namespace);
+						uninstallAction
+							.uninstall(UninstallOptions.builder().releaseName(name).namespace(namespace).build());
 						CliOutput.println("Atomic uninstall of \"" + name + "\" complete.");
 					}
 					else {
-						rollbackAction.rollback(name, namespace, previousVersion);
+						rollbackAction.rollback(RollbackOptions.builder()
+							.releaseName(name)
+							.namespace(namespace)
+							.revision(previousVersion)
+							.build());
 						CliOutput.println("Atomic rollback of \"" + name + "\" complete.");
 					}
 				}
@@ -202,6 +211,31 @@ public class UpgradeCommand implements Runnable {
 				log.debug("Upgrade error details", ex);
 			}
 		}
+	}
+
+	private InstallOptions buildInstallOptions(Chart chart, Map<String, Object> overrides) {
+		return InstallOptions.builder()
+			.chart(chart)
+			.releaseName(name)
+			.namespace(namespace)
+			.values(overrides)
+			.revision(1)
+			.dryRun(dryRun)
+			.noHooks(noHooks)
+			.build();
+	}
+
+	private UpgradeOptions buildUpgradeOptions(Release current, Chart chart, Map<String, Object> overrides,
+			UpgradeValueStrategy strategy) {
+		return UpgradeOptions.builder()
+			.currentRelease(current)
+			.newChart(chart)
+			.values(overrides)
+			.valueStrategy(strategy)
+			.dryRun(dryRun)
+			.noHooks(noHooks)
+			.maxHistory(historyMax)
+			.build();
 	}
 
 	private void applyCliPostRenderers(Release release) throws Exception {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -6,7 +6,9 @@ import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UninstallOptions;
 
 import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,8 +24,6 @@ import java.nio.file.Path;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -64,9 +64,7 @@ class InstallCommandTest {
 		File chartDir = createMockChart();
 		Release release = createMockRelease("my-release", 1);
 
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
-				anyBoolean()))
-			.thenReturn(release);
+		when(installAction.install(any(InstallOptions.class))).thenReturn(release);
 
 		CommandLine cmd = new CommandLine(installCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "-n", "default");
@@ -77,9 +75,7 @@ class InstallCommandTest {
 		File chartDir = createMockChart();
 		Release release = createMockRelease("my-release", 1);
 
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
-				anyBoolean()))
-			.thenReturn(release);
+		when(installAction.install(any(InstallOptions.class))).thenReturn(release);
 
 		CommandLine cmd = new CommandLine(installCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "--dry-run");
@@ -89,9 +85,7 @@ class InstallCommandTest {
 	void testInstallCommandWithError() throws Exception {
 		File chartDir = createMockChart();
 
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
-				anyBoolean()))
-			.thenThrow(new RuntimeException("Test error"));
+		when(installAction.install(any(InstallOptions.class))).thenThrow(new RuntimeException("Test error"));
 
 		CommandLine cmd = new CommandLine(installCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath());
@@ -102,9 +96,7 @@ class InstallCommandTest {
 		File chartDir = createMockChart();
 		Release release = createMockRelease("my-release", 1);
 
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
-				anyBoolean()))
-			.thenReturn(release);
+		when(installAction.install(any(InstallOptions.class))).thenReturn(release);
 
 		CommandLine cmd = new CommandLine(installCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "--wait", "--timeout", "120");
@@ -117,9 +109,7 @@ class InstallCommandTest {
 		File chartDir = createMockChart();
 		Release release = createMockRelease("my-release", 1);
 
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
-				anyBoolean()))
-			.thenReturn(release);
+		when(installAction.install(any(InstallOptions.class))).thenReturn(release);
 
 		CommandLine cmd = new CommandLine(installCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "--wait", "--dry-run");
@@ -132,14 +122,12 @@ class InstallCommandTest {
 	void testInstallCommandAtomicUninstallsOnFailure() throws Exception {
 		File chartDir = createMockChart();
 
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
-				anyBoolean()))
-			.thenThrow(new RuntimeException("deploy failed"));
+		when(installAction.install(any(InstallOptions.class))).thenThrow(new RuntimeException("deploy failed"));
 
 		CommandLine cmd = new CommandLine(installCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "--atomic");
 
-		verify(uninstallAction).uninstall("my-release", "default");
+		verify(uninstallAction).uninstall(any(UninstallOptions.class));
 	}
 
 	private File createMockChart() throws Exception {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RollbackCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RollbackCommandTest.java
@@ -1,15 +1,14 @@
 package org.alexmond.jhelm.app.command;
 
 import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.RollbackOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 
@@ -28,7 +27,7 @@ class RollbackCommandTest {
 
 	@Test
 	void testRollbackCommandSuccess() throws Exception {
-		doNothing().when(rollbackAction).rollback(anyString(), anyString(), anyInt(), anyBoolean(), anyInt());
+		doNothing().when(rollbackAction).rollback(any(RollbackOptions.class));
 
 		CommandLine cmd = new CommandLine(rollbackCommand);
 		cmd.execute("my-release", "1", "-n", "default");
@@ -36,7 +35,7 @@ class RollbackCommandTest {
 
 	@Test
 	void testRollbackCommandDefaultNamespace() throws Exception {
-		doNothing().when(rollbackAction).rollback(anyString(), anyString(), anyInt(), anyBoolean(), anyInt());
+		doNothing().when(rollbackAction).rollback(any(RollbackOptions.class));
 
 		CommandLine cmd = new CommandLine(rollbackCommand);
 		cmd.execute("my-release", "2");
@@ -44,8 +43,7 @@ class RollbackCommandTest {
 
 	@Test
 	void testRollbackCommandWithError() throws Exception {
-		doThrow(new RuntimeException("Test error")).when(rollbackAction)
-			.rollback(anyString(), anyString(), anyInt(), anyBoolean(), anyInt());
+		doThrow(new RuntimeException("Test error")).when(rollbackAction).rollback(any(RollbackOptions.class));
 
 		CommandLine cmd = new CommandLine(rollbackCommand);
 		cmd.execute("my-release", "1");

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UninstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UninstallCommandTest.java
@@ -1,13 +1,14 @@
 package org.alexmond.jhelm.app.command;
 
 import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 
@@ -26,7 +27,7 @@ class UninstallCommandTest {
 
 	@Test
 	void testUninstallCommandSuccess() throws Exception {
-		doNothing().when(uninstallAction).uninstall(anyString(), anyString());
+		doNothing().when(uninstallAction).uninstall(any(UninstallOptions.class));
 
 		CommandLine cmd = new CommandLine(uninstallCommand);
 		cmd.execute("my-release", "-n", "default");
@@ -34,7 +35,7 @@ class UninstallCommandTest {
 
 	@Test
 	void testUninstallCommandDefaultNamespace() throws Exception {
-		doNothing().when(uninstallAction).uninstall(anyString(), anyString());
+		doNothing().when(uninstallAction).uninstall(any(UninstallOptions.class));
 
 		CommandLine cmd = new CommandLine(uninstallCommand);
 		cmd.execute("my-release");
@@ -42,7 +43,7 @@ class UninstallCommandTest {
 
 	@Test
 	void testUninstallCommandWithError() throws Exception {
-		doThrow(new RuntimeException("Test error")).when(uninstallAction).uninstall(anyString(), anyString());
+		doThrow(new RuntimeException("Test error")).when(uninstallAction).uninstall(any(UninstallOptions.class));
 
 		CommandLine cmd = new CommandLine(uninstallCommand);
 		cmd.execute("my-release");

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -6,10 +6,12 @@ import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.RollbackOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
-import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
+import org.alexmond.jhelm.core.action.UpgradeOptions;
 
 import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,9 +27,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -76,9 +76,7 @@ class UpgradeCommandTest {
 		Release upgradedRelease = createMockRelease("my-release", 2);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
-		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean(), anyBoolean(), anyInt()))
-			.thenReturn(upgradedRelease);
+		when(upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "-n", "default");
@@ -90,9 +88,7 @@ class UpgradeCommandTest {
 		Release newRelease = createMockRelease("my-release", 1);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
-				anyBoolean()))
-			.thenReturn(newRelease);
+		when(installAction.install(any(InstallOptions.class))).thenReturn(newRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "--install");
@@ -115,9 +111,7 @@ class UpgradeCommandTest {
 		Release upgradedRelease = createMockRelease("my-release", 2);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
-		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean(), anyBoolean(), anyInt()))
-			.thenReturn(upgradedRelease);
+		when(upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "--dry-run");
@@ -154,9 +148,7 @@ class UpgradeCommandTest {
 		Release upgradedRelease = createMockRelease("my-release", 2);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
-		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean(), anyBoolean(), anyInt()))
-			.thenReturn(upgradedRelease);
+		when(upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "--wait", "--timeout", "120");
@@ -171,9 +163,7 @@ class UpgradeCommandTest {
 		Release upgradedRelease = createMockRelease("my-release", 2);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
-		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean(), anyBoolean(), anyInt()))
-			.thenReturn(upgradedRelease);
+		when(upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(upgradedRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "-n", "custom-namespace");
@@ -187,15 +177,13 @@ class UpgradeCommandTest {
 		Release newRelease = createMockRelease("my-release", 1);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
-		when(installAction.install(any(Chart.class), anyString(), anyString(), anyMap(), anyInt(), anyBoolean(),
-				anyBoolean()))
-			.thenReturn(newRelease);
+		when(installAction.install(any(InstallOptions.class))).thenReturn(newRelease);
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "--install", "--dry-run");
 
-		verify(installAction).install(any(Chart.class), eq("my-release"), eq("default"), anyMap(), eq(1), eq(true),
-				anyBoolean());
+		verify(installAction).install(argThat((InstallOptions options) -> "my-release".equals(options.getReleaseName())
+				&& "default".equals(options.getNamespace()) && options.getRevision() == 1 && options.isDryRun()));
 	}
 
 	@Test
@@ -204,14 +192,14 @@ class UpgradeCommandTest {
 		Release existingRelease = createMockRelease("my-release", 3);
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
-		when(upgradeAction.upgrade(any(Release.class), any(Chart.class), anyMap(), any(UpgradeValueStrategy.class),
-				anyBoolean(), anyBoolean(), anyInt()))
-			.thenThrow(new RuntimeException("upgrade failed"));
+		when(upgradeAction.upgrade(any(UpgradeOptions.class))).thenThrow(new RuntimeException("upgrade failed"));
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "--atomic");
 
-		verify(rollbackAction).rollback("my-release", "default", 3);
+		verify(rollbackAction)
+			.rollback(argThat((RollbackOptions options) -> "my-release".equals(options.getReleaseName())
+					&& "default".equals(options.getNamespace()) && options.getRevision() == 3));
 	}
 
 	private Release createMockRelease(String name, int version) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -46,50 +46,21 @@ public class InstallAction {
 	 * supplied overrides, the templates are rendered, and—unless this is a dry run—the
 	 * resulting resources, CRDs and hooks are applied to the cluster and the release is
 	 * persisted.
-	 * @param chart the chart to install (must not be a library chart)
-	 * @param releaseName the name to give the release
-	 * @param namespace the target namespace
-	 * @param overrideValues user-supplied values merged over the chart defaults, may be
-	 * {@code null}
-	 * @param version the release revision number to assign
-	 * @param dryRun if {@code true}, render only and skip applying anything to the
-	 * cluster
+	 * @param options the install options (chart, release name, namespace, value
+	 * overrides, revision, dry-run and no-hooks flags)
 	 * @return the resulting release, including the rendered manifest
 	 * @throws IllegalArgumentException if the chart is a library chart
 	 * @throws DeploymentFailedException if applied resources cannot be persisted (they
 	 * are rolled back)
 	 * @throws JhelmException if rendering or a cluster operation fails
 	 */
-	public Release install(Chart chart, String releaseName, String namespace, Map<String, Object> overrideValues,
-			int version, boolean dryRun) {
-		return install(chart, releaseName, namespace, overrideValues, version, dryRun, false);
-	}
-
-	/**
-	 * Installs a chart as a new release, optionally skipping lifecycle hooks. Behaves
-	 * like {@link #install(Chart, String, String, Map, int, boolean)} but allows
-	 * suppressing pre-install and post-install hook execution.
-	 * @param chart the chart to install (must not be a library chart)
-	 * @param releaseName the name to give the release
-	 * @param namespace the target namespace
-	 * @param overrideValues user-supplied values merged over the chart defaults, may be
-	 * {@code null}
-	 * @param version the release revision number to assign
-	 * @param dryRun if {@code true}, render only and skip applying anything to the
-	 * cluster
-	 * @param noHooks if {@code true}, skip running pre-install and post-install hooks
-	 * @return the resulting release, including the rendered manifest
-	 * @throws IllegalArgumentException if the chart is a library chart
-	 * @throws DeploymentFailedException if applied resources cannot be persisted (they
-	 * are rolled back)
-	 * @throws JhelmException if rendering or a cluster operation fails
-	 */
-	public Release install(Chart chart, String releaseName, String namespace, Map<String, Object> overrideValues,
-			int version, boolean dryRun, boolean noHooks) {
+	public Release install(InstallOptions options) {
+		Chart chart = options.getChart();
 		if ("library".equals(chart.getMetadata().getType())) {
 			throw new IllegalArgumentException(
 					"chart '" + chart.getMetadata().getName() + "' is a library chart and cannot be installed");
 		}
+		Map<String, Object> overrideValues = options.getValues();
 		Map<String, Object> values = new HashMap<>(chart.getValues());
 		if (overrideValues != null) {
 			ValuesLoader.deepMerge(values, overrideValues);
@@ -98,26 +69,25 @@ public class InstallAction {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now())
 			.lastDeployed(OffsetDateTime.now())
-			.status(dryRun ? "pending-install" : "deployed")
-			.description(dryRun ? "Dry run complete" : "Install complete")
+			.status(options.isDryRun() ? "pending-install" : "deployed")
+			.description(options.isDryRun() ? "Dry run complete" : "Install complete")
 			.build();
 
 		Release release = Release.builder()
-			.name(releaseName)
-			.namespace(namespace)
-			.version(version)
+			.name(options.getReleaseName())
+			.namespace(options.getNamespace())
+			.version(options.getRevision())
 			.chart(chart)
 			.info(info)
-			// Persist the user-supplied values (Helm's release "config"), so that
-			// `get values` reports them and a later upgrade can reuse them.
+			// Persist the user-supplied values (Helm's release "config").
 			.config(Release.MapConfig.builder()
 				.values((overrideValues != null) ? new HashMap<>(overrideValues) : new HashMap<>())
 				.build())
 			.build();
 
 		Map<String, Object> releaseData = new HashMap<>();
-		releaseData.put("Name", releaseName);
-		releaseData.put("Namespace", namespace);
+		releaseData.put("Name", options.getReleaseName());
+		releaseData.put("Namespace", options.getNamespace());
 		releaseData.put("Service", "Helm");
 		releaseData.put("IsInstall", true);
 		releaseData.put("IsUpgrade", false);
@@ -136,9 +106,11 @@ public class InstallAction {
 
 		release.setManifest(manifest);
 
-		if (kubeService != null && !dryRun) {
+		if (kubeService != null && !options.isDryRun()) {
+			String namespace = options.getNamespace();
+			boolean noHooks = options.isNoHooks();
 			applyCrds(chart, namespace);
-			fireLifecycleEvent("pre-install", releaseName, namespace);
+			fireLifecycleEvent("pre-install", options.getReleaseName(), namespace);
 			String regularManifest = HookParser.stripHooks(manifest);
 			List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(manifest);
 			HookExecutor hookExecutor = noHooks ? null : new HookExecutor(kubeService);
@@ -157,7 +129,7 @@ public class InstallAction {
 			if (!noHooks) {
 				runHooks(hookExecutor, namespace, hooks, "post-install");
 			}
-			fireLifecycleEvent("post-install", releaseName, namespace);
+			fireLifecycleEvent("post-install", options.getReleaseName(), namespace);
 		}
 
 		return release;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallOptions.java
@@ -1,0 +1,51 @@
+package org.alexmond.jhelm.core.action;
+
+import java.util.Map;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.alexmond.jhelm.core.model.Chart;
+
+/**
+ * Immutable options for {@link InstallAction#install(InstallOptions)}.
+ * <p>
+ * Built via the Lombok builder; unset fields fall back to defaults that reproduce Helm's
+ * standard install behavior (revision 1, no dry run, hooks enabled, empty value
+ * overrides).
+ */
+@Getter
+@Builder
+public final class InstallOptions {
+
+	/** The chart to install (must not be a library chart). */
+	private final Chart chart;
+
+	/** The name to give the release. */
+	private final String releaseName;
+
+	/** The target namespace. */
+	private final String namespace;
+
+	/**
+	 * User-supplied values merged over the chart defaults. Defaults to an empty map.
+	 */
+	@Builder.Default
+	private final Map<String, Object> values = Map.of();
+
+	/** The release revision number to assign. Defaults to {@code 1}. */
+	@Builder.Default
+	private final int revision = 1;
+
+	/**
+	 * When {@code true}, render only and skip applying anything to the cluster. Defaults
+	 * to {@code false}.
+	 */
+	private final boolean dryRun;
+
+	/**
+	 * When {@code true}, skip running pre-install and post-install hooks. Defaults to
+	 * {@code false}.
+	 */
+	private final boolean noHooks;
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
@@ -21,41 +21,19 @@ public class RollbackAction {
 	private final KubeService kubeService;
 
 	/**
-	 * Rolls a release back to a previous revision, running its pre-rollback and
-	 * post-rollback hooks.
-	 * @param name the release name
-	 * @param namespace the namespace the release lives in
-	 * @param revision the revision number to roll back to
-	 */
-	public void rollback(String name, String namespace, int revision) {
-		rollback(name, namespace, revision, false);
-	}
-
-	/**
-	 * Rolls a release back to a previous revision, optionally skipping lifecycle hooks.
-	 * @param name the release name
-	 * @param namespace the namespace the release lives in
-	 * @param revision the revision number to roll back to
-	 * @param noHooks if {@code true}, skip running pre-rollback and post-rollback hooks
-	 */
-	public void rollback(String name, String namespace, int revision, boolean noHooks) {
-		rollback(name, namespace, revision, noHooks, 10);
-	}
-
-	/**
-	 * Rolls a release back to a previous revision, optionally skipping lifecycle hooks
-	 * and pruning old revision history. Behaves like
-	 * {@link #rollback(String, String, int, boolean)} but, after the new revision is
+	 * Rolls a release back to a previous revision, optionally skipping its pre-rollback
+	 * and post-rollback hooks and pruning old revision history. After the new revision is
 	 * stored, prunes the release's revision history to the newest {@code maxHistory}
 	 * revisions.
-	 * @param name the release name
-	 * @param namespace the namespace the release lives in
-	 * @param revision the revision number to roll back to
-	 * @param noHooks if {@code true}, skip running pre-rollback and post-rollback hooks
-	 * @param maxHistory maximum revisions to keep; {@code 0} = no limit (Helm
-	 * {@code --history-max}, default 10)
+	 * @param options the rollback options (release name, namespace, target revision,
+	 * no-hooks flag and the history cap)
 	 */
-	public void rollback(String name, String namespace, int revision, boolean noHooks, int maxHistory) {
+	public void rollback(RollbackOptions options) {
+		String name = options.getReleaseName();
+		String namespace = options.getNamespace();
+		int revision = options.getRevision();
+		boolean noHooks = options.isNoHooks();
+		int maxHistory = options.getMaxHistory();
 		List<Release> history = kubeService.getReleaseHistory(name, namespace);
 		Optional<Release> targetReleaseOpt = history.stream().filter((r) -> r.getVersion() == revision).findFirst();
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackOptions.java
@@ -1,0 +1,39 @@
+package org.alexmond.jhelm.core.action;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Immutable options for {@link RollbackAction#rollback(RollbackOptions)}.
+ * <p>
+ * Built via the Lombok builder; unset fields fall back to defaults that reproduce Helm's
+ * standard rollback behavior (hooks enabled, history capped at 10 revisions). The target
+ * {@code revision} is required and has no default.
+ */
+@Getter
+@Builder
+public final class RollbackOptions {
+
+	/** The release name. */
+	private final String releaseName;
+
+	/** The namespace the release lives in. */
+	private final String namespace;
+
+	/** The revision number to roll back to (required). */
+	private final int revision;
+
+	/**
+	 * When {@code true}, skip running pre-rollback and post-rollback hooks. Defaults to
+	 * {@code false}.
+	 */
+	private final boolean noHooks;
+
+	/**
+	 * Maximum revisions to keep; {@code 0} = no limit (Helm {@code --history-max}).
+	 * Defaults to {@code 10}.
+	 */
+	@Builder.Default
+	private final int maxHistory = 10;
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
@@ -20,21 +20,13 @@ public class UninstallAction {
 	private final KubeService kubeService;
 
 	/**
-	 * Uninstalls a release, running its pre-delete and post-delete hooks.
-	 * @param releaseName the name of the release to remove
-	 * @param namespace the namespace the release lives in
+	 * Uninstalls a release, optionally skipping its pre-delete and post-delete hooks.
+	 * @param options the uninstall options (release name, namespace and no-hooks flag)
 	 */
-	public void uninstall(String releaseName, String namespace) {
-		uninstall(releaseName, namespace, false);
-	}
-
-	/**
-	 * Uninstalls a release, optionally skipping lifecycle hooks.
-	 * @param releaseName the name of the release to remove
-	 * @param namespace the namespace the release lives in
-	 * @param noHooks if {@code true}, skip running pre-delete and post-delete hooks
-	 */
-	public void uninstall(String releaseName, String namespace, boolean noHooks) {
+	public void uninstall(UninstallOptions options) {
+		String releaseName = options.getReleaseName();
+		String namespace = options.getNamespace();
+		boolean noHooks = options.isNoHooks();
 		Optional<Release> releaseOpt = kubeService.getRelease(releaseName, namespace);
 		if (releaseOpt.isEmpty()) {
 			throw ReleaseNotFoundException.forRelease(releaseName, namespace);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallOptions.java
@@ -1,0 +1,29 @@
+package org.alexmond.jhelm.core.action;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Immutable options for {@link UninstallAction#uninstall(UninstallOptions)}.
+ * <p>
+ * Built via the Lombok builder; an unset {@code noHooks} flag defaults to {@code false},
+ * reproducing Helm's standard uninstall behavior of running pre-delete and post-delete
+ * hooks.
+ */
+@Getter
+@Builder
+public final class UninstallOptions {
+
+	/** The name of the release to remove. */
+	private final String releaseName;
+
+	/** The namespace the release lives in. */
+	private final String namespace;
+
+	/**
+	 * When {@code true}, skip running pre-delete and post-delete hooks. Defaults to
+	 * {@code false}.
+	 */
+	private final boolean noHooks;
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -36,75 +36,32 @@ public class UpgradeAction {
 	private List<LifecycleListener> lifecycleListeners = List.of();
 
 	/**
-	 * Upgrades a release, resolving values according to the given
-	 * {@link UpgradeValueStrategy}.
-	 * @param currentRelease the currently deployed release (its chart defaults and
-	 * persisted user values feed the reuse strategies)
-	 * @param newChart the chart to upgrade to
-	 * @param overrideValues this command's value overrides (may be {@code null})
-	 * @param strategy how to resolve the previous user values against the overrides — see
-	 * {@link UpgradeValueStrategy}
-	 * @param dryRun when {@code true}, render only without applying to the cluster
+	 * Upgrades a release, resolving values according to the configured
+	 * {@link UpgradeValueStrategy}, optionally skipping hooks and pruning old revision
+	 * history. After a successful (non-dry-run) store, prunes the release's revision
+	 * history to the newest {@code maxHistory} revisions.
+	 * @param options the upgrade options (current release, new chart, value overrides,
+	 * value strategy, dry-run and no-hooks flags, and the history cap)
 	 * @return the upgraded release
 	 */
-	public Release upgrade(Release currentRelease, Chart newChart, Map<String, Object> overrideValues,
-			UpgradeValueStrategy strategy, boolean dryRun) {
-		return upgrade(currentRelease, newChart, overrideValues, strategy, dryRun, false);
-	}
-
-	/**
-	 * Upgrades a release, optionally skipping lifecycle hooks. Behaves like
-	 * {@link #upgrade(Release, Chart, Map, UpgradeValueStrategy, boolean)} but allows
-	 * suppressing pre-upgrade and post-upgrade hook execution.
-	 * @param currentRelease the currently deployed release (its chart defaults and
-	 * persisted user values feed the reuse strategies)
-	 * @param newChart the chart to upgrade to
-	 * @param overrideValues this command's value overrides (may be {@code null})
-	 * @param strategy how to resolve the previous user values against the overrides — see
-	 * {@link UpgradeValueStrategy}
-	 * @param dryRun when {@code true}, render only without applying to the cluster
-	 * @param noHooks if {@code true}, skip running pre-upgrade and post-upgrade hooks
-	 * @return the upgraded release
-	 */
-	public Release upgrade(Release currentRelease, Chart newChart, Map<String, Object> overrideValues,
-			UpgradeValueStrategy strategy, boolean dryRun, boolean noHooks) {
-		return upgrade(currentRelease, newChart, overrideValues, strategy, dryRun, noHooks, 10);
-	}
-
-	/**
-	 * Upgrades a release, optionally skipping hooks and pruning old revision history.
-	 * Behaves like
-	 * {@link #upgrade(Release, Chart, Map, UpgradeValueStrategy, boolean, boolean)} but,
-	 * after a successful (non-dry-run) store, prunes the release's revision history to
-	 * the newest {@code maxHistory} revisions.
-	 * @param currentRelease the currently deployed release (its chart defaults and
-	 * persisted user values feed the reuse strategies)
-	 * @param newChart the chart to upgrade to
-	 * @param overrideValues this command's value overrides (may be {@code null})
-	 * @param strategy how to resolve the previous user values against the overrides — see
-	 * {@link UpgradeValueStrategy}
-	 * @param dryRun when {@code true}, render only without applying to the cluster
-	 * @param noHooks if {@code true}, skip running pre-upgrade and post-upgrade hooks
-	 * @param maxHistory maximum revisions to keep; {@code 0} = no limit (Helm
-	 * {@code --history-max}, default 10)
-	 * @return the upgraded release
-	 */
-	public Release upgrade(Release currentRelease, Chart newChart, Map<String, Object> overrideValues,
-			UpgradeValueStrategy strategy, boolean dryRun, boolean noHooks, int maxHistory) {
+	public Release upgrade(UpgradeOptions options) {
+		Chart newChart = options.getNewChart();
 		if ("library".equals(newChart.getMetadata().getType())) {
 			throw new IllegalArgumentException(
 					"chart '" + newChart.getMetadata().getName() + "' is a library chart and cannot be upgraded");
 		}
 
-		ResolvedValues resolved = resolveValues(currentRelease, newChart, overrideValues, strategy);
+		Release currentRelease = options.getCurrentRelease();
+		ResolvedValues resolved = resolveValues(currentRelease, newChart, options.getValues(),
+				options.getValueStrategy());
 		Map<String, Object> renderValues = resolved.render();
 		Map<String, Object> configValues = resolved.config();
 
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(currentRelease.getInfo().getFirstDeployed())
 			.lastDeployed(OffsetDateTime.now())
-			.status(dryRun ? "pending-upgrade" : "deployed")
-			.description(dryRun ? "Dry run complete" : "Upgrade complete")
+			.status(options.isDryRun() ? "pending-upgrade" : "deployed")
+			.description(options.isDryRun() ? "Dry run complete" : "Upgrade complete")
 			.build();
 
 		Release newRelease = Release.builder()
@@ -140,7 +97,8 @@ public class UpgradeAction {
 
 		newRelease.setManifest(manifest);
 
-		if (kubeService != null && !dryRun) {
+		if (kubeService != null && !options.isDryRun()) {
+			boolean noHooks = options.isNoHooks();
 			fireLifecycleEvent("pre-upgrade", newRelease.getName(), newRelease.getNamespace());
 			String regularManifest = HookParser.stripHooks(manifest);
 			List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(manifest);
@@ -157,7 +115,7 @@ public class UpgradeAction {
 				throw new DeploymentFailedException("Failed to store release after apply; previous release re-applied",
 						ex, regularManifest);
 			}
-			kubeService.pruneReleaseHistory(newRelease.getName(), newRelease.getNamespace(), maxHistory);
+			kubeService.pruneReleaseHistory(newRelease.getName(), newRelease.getNamespace(), options.getMaxHistory());
 			if (!noHooks) {
 				runHooks(hookExecutor, newRelease.getNamespace(), hooks, "post-upgrade");
 			}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeOptions.java
@@ -1,0 +1,63 @@
+package org.alexmond.jhelm.core.action;
+
+import java.util.Map;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.Release;
+
+/**
+ * Immutable options for {@link UpgradeAction#upgrade(UpgradeOptions)}.
+ * <p>
+ * Built via the Lombok builder; unset fields fall back to defaults that reproduce Helm's
+ * standard upgrade behavior (DEFAULT value strategy, no dry run, hooks enabled, history
+ * capped at 10 revisions, empty value overrides).
+ */
+@Getter
+@Builder
+public final class UpgradeOptions {
+
+	/**
+	 * The currently deployed release (its chart defaults and persisted user values feed
+	 * the reuse strategies).
+	 */
+	private final Release currentRelease;
+
+	/** The chart to upgrade to. */
+	private final Chart newChart;
+
+	/**
+	 * This command's value overrides, merged according to the value strategy. Defaults to
+	 * an empty map.
+	 */
+	@Builder.Default
+	private final Map<String, Object> values = Map.of();
+
+	/**
+	 * How to resolve the previous user values against the overrides. Defaults to
+	 * {@link UpgradeValueStrategy#DEFAULT}.
+	 */
+	@Builder.Default
+	private final UpgradeValueStrategy valueStrategy = UpgradeValueStrategy.DEFAULT;
+
+	/**
+	 * When {@code true}, render only without applying to the cluster. Defaults to
+	 * {@code false}.
+	 */
+	private final boolean dryRun;
+
+	/**
+	 * When {@code true}, skip running pre-upgrade and post-upgrade hooks. Defaults to
+	 * {@code false}.
+	 */
+	private final boolean noHooks;
+
+	/**
+	 * Maximum revisions to keep; {@code 0} = no limit (Helm {@code --history-max}).
+	 * Defaults to {@code 10}.
+	 */
+	@Builder.Default
+	private final int maxHistory = 10;
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/ChartIsRootTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/ChartIsRootTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Map;
 
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -28,7 +29,14 @@ class ChartIsRootTest {
 
 		Chart chart = chartLoader.load(new File("src/test/resources/test-charts/chart-isroot"));
 		assertNotNull(chart, "Chart should be loaded");
-		Release release = installAction.install(chart, "r", "default", Map.of(), 1, true);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("r")
+			.namespace("default")
+			.values(Map.of())
+			.revision(1)
+			.dryRun(true)
+			.build());
 		String manifest = release.getManifest();
 
 		// Parent ConfigMap: the release chart is root.

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/DefineOrderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/DefineOrderTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Map;
 
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -35,7 +36,14 @@ class DefineOrderTest {
 		Chart chart = chartLoader.load(chartDir);
 		assertNotNull(chart, "Chart should be loaded");
 
-		Release release = installAction.install(chart, "test-release", "default", Map.of(), 1, true);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("test-release")
+			.namespace("default")
+			.values(Map.of())
+			.revision(1)
+			.dryRun(true)
+			.build());
 		assertNotNull(release, "Release should be created");
 		String manifest = release.getManifest();
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
@@ -5,6 +5,7 @@ import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.dataformat.yaml.YAMLMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.config.JhelmTestProperties;
 import org.alexmond.jhelm.core.config.KpsTestConfig;
 import org.alexmond.jhelm.core.model.Chart;
@@ -177,7 +178,14 @@ class KpsComparisonTest {
 				.build())))
 			.build();
 
-		Release release = installAction.install(chart, "simple", "default", Map.of(), 1, false);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("simple")
+			.namespace("default")
+			.values(Map.of())
+			.revision(1)
+			.dryRun(false)
+			.build());
 		log.info("Simple manifest: [{}]", release.getManifest().trim());
 		assertTrue(release.getManifest().contains("hello world enabled"));
 	}
@@ -335,7 +343,14 @@ class KpsComparisonTest {
 		try {
 			log.info("{} - Running JHelm rendering...", chartName);
 			// JHelm dry-run
-			Release release = installAction.install(chart, sanitizedReleaseName, "default", overrideValues, 1, true);
+			Release release = installAction.install(InstallOptions.builder()
+				.chart(chart)
+				.releaseName(sanitizedReleaseName)
+				.namespace("default")
+				.values(overrideValues)
+				.revision(1)
+				.dryRun(true)
+				.build());
 			assertNotNull(release);
 
 			String jhelmManifest = release.getManifest();

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/NameCollisionTemplateTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/NameCollisionTemplateTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Map;
 
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -35,7 +36,14 @@ class NameCollisionTemplateTest {
 		Chart chart = chartLoader.load(chartDir);
 		assertNotNull(chart, "Chart should be loaded");
 
-		Release release = installAction.install(chart, "test-release", "default", Map.of(), 1, true);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("test-release")
+			.namespace("default")
+			.values(Map.of())
+			.revision(1)
+			.dryRun(true)
+			.build());
 		assertNotNull(release, "Release should be created");
 		String manifest = release.getManifest();
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/NestedSubchartValuesTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/NestedSubchartValuesTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Map;
 
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -34,7 +35,14 @@ class NestedSubchartValuesTest {
 		Chart chart = chartLoader.load(chartDir);
 		assertNotNull(chart, "Chart should be loaded");
 
-		Release release = installAction.install(chart, "test-release", "default", Map.of(), 1, true);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("test-release")
+			.namespace("default")
+			.values(Map.of())
+			.revision(1)
+			.dryRun(true)
+			.build());
 		assertNotNull(release, "Release should be created");
 		String manifest = release.getManifest();
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/RecursiveTemplateTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/RecursiveTemplateTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Map;
 
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.exception.TemplateRenderException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -30,7 +31,14 @@ class RecursiveTemplateTest {
 		File chartDir = new File("src/test/resources/test-charts/recursive-template");
 		Chart chart = chartLoader.load(chartDir);
 		assertThrows(TemplateRenderException.class,
-				() -> installAction.install(chart, "rec", "default", Map.of(), 1, true));
+				() -> installAction.install(InstallOptions.builder()
+					.chart(chart)
+					.releaseName("rec")
+					.namespace("default")
+					.values(Map.of())
+					.revision(1)
+					.dryRun(true)
+					.build()));
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/SubchartNullCoalesceTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/SubchartNullCoalesceTest.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -43,7 +44,14 @@ class SubchartNullCoalesceTest {
 		childOverride.put("foo", null);
 		Map<String, Object> overrides = Map.of("child", childOverride);
 
-		Release release = installAction.install(chart, "rel", "default", overrides, 1, true);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("rel")
+			.namespace("default")
+			.values(overrides)
+			.revision(1)
+			.dryRun(true)
+			.build());
 		String manifest = release.getManifest();
 		assertTrue(manifest.contains("haskey: \"true\""),
 				"a null override of an undeclared subchart key must keep the key (hasKey true): " + manifest);

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/SubchartValuePropagationTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/SubchartValuePropagationTest.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -44,7 +45,14 @@ class SubchartValuePropagationTest {
 	}
 
 	private String renderManifest(Chart chart, Map<String, Object> overrides) throws Exception {
-		Release release = installAction.install(chart, "test-release", "default", overrides, 1, true);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("test-release")
+			.namespace("default")
+			.values(overrides)
+			.revision(1)
+			.dryRun(true)
+			.build());
 		assertNotNull(release, "Release should be created");
 		String manifest = release.getManifest();
 		assertNotNull(manifest, "Manifest should not be null");

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/VariableScopingTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/VariableScopingTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -36,7 +37,14 @@ class VariableScopingTest {
 		assertNotNull(chart, "Chart should be loaded");
 
 		// Render the chart
-		Release release = installAction.install(chart, "test-release", "default", Map.of(), 1, true);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("test-release")
+			.namespace("default")
+			.values(Map.of())
+			.revision(1)
+			.dryRun(true)
+			.build());
 		assertNotNull(release, "Release should be created");
 
 		String manifest = release.getManifest();
@@ -108,7 +116,14 @@ class VariableScopingTest {
 		File chartDir = new File("src/test/resources/test-charts/variable-scoping-test");
 		Chart chart = chartLoader.load(chartDir);
 
-		Release release = installAction.install(chart, "test-release", "default", Map.of(), 1, true);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("test-release")
+			.namespace("default")
+			.values(Map.of())
+			.revision(1)
+			.dryRun(true)
+			.build());
 		String manifest = release.getManifest();
 
 		// Test that empty map evaluates to false
@@ -128,7 +143,14 @@ class VariableScopingTest {
 		Map<String, Object> overrides = Map.of("subchart",
 				Map.of("replicas", 5, "config", Map.of("setting1", "overridden1")));
 
-		Release release = installAction.install(chart, "test-release", "default", overrides, 1, true);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("test-release")
+			.namespace("default")
+			.values(overrides)
+			.revision(1)
+			.dryRun(true)
+			.build());
 		String manifest = release.getManifest();
 
 		// Verify overrides are applied

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
@@ -56,7 +56,12 @@ class InstallActionTest {
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		Release release = installAction.install(chart, "my-release", "default", null, 1, false);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.revision(1)
+			.build());
 
 		assertNotNull(release);
 		assertEquals("my-release", release.getName());
@@ -76,7 +81,14 @@ class InstallActionTest {
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("---\n");
 		Map<String, Object> overrides = Map.of("replicaCount", 3, "image", Map.of("tag", "v2"));
 
-		Release release = installAction.install(chart, "my-release", "default", overrides, 1, true);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.values(overrides)
+			.revision(1)
+			.dryRun(true)
+			.build());
 
 		assertNotNull(release.getConfig());
 		assertEquals(3, release.getConfig().getValues().get("replicaCount"));
@@ -90,7 +102,13 @@ class InstallActionTest {
 
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("---\nkind: ConfigMap\n");
 
-		Release release = installAction.install(chart, "my-release", "default", null, 1, true);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.revision(1)
+			.dryRun(true)
+			.build());
 
 		assertEquals("pending-install", release.getInfo().getStatus());
 		verify(kubeService, never()).apply(anyString(), anyString());
@@ -125,7 +143,12 @@ class InstallActionTest {
 		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		installAction.install(chart, "my-release", "default", null, 1, false);
+		installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.revision(1)
+			.build());
 
 		List<HelmHook> hooks = HookParser.parseHooks(fullManifest);
 		String strippedManifest = HookParser.stripHooks(fullManifest);
@@ -162,7 +185,13 @@ class InstallActionTest {
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		installAction.install(chart, "my-release", "default", null, 1, false, true);
+		installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.revision(1)
+			.noHooks(true)
+			.build());
 
 		List<HelmHook> hooks = HookParser.parseHooks(fullManifest);
 		String strippedManifest = HookParser.stripHooks(fullManifest);
@@ -182,7 +211,12 @@ class InstallActionTest {
 
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("---\nkind: ConfigMap\n");
 
-		Release release = noKubeInstall.install(chart, "my-release", "default", null, 1, false);
+		Release release = noKubeInstall.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.revision(1)
+			.build());
 
 		assertNotNull(release);
 		assertEquals("my-release", release.getName());
@@ -200,7 +234,12 @@ class InstallActionTest {
 		doNothing().when(kubeService).delete(anyString(), anyString());
 
 		DeploymentFailedException ex = assertThrows(DeploymentFailedException.class,
-				() -> installAction.install(chart, "my-release", "default", null, 1, false));
+				() -> installAction.install(InstallOptions.builder()
+					.chart(chart)
+					.releaseName("my-release")
+					.namespace("default")
+					.revision(1)
+					.build()));
 
 		assertEquals(HookParser.stripHooks(manifest), ex.getAppliedManifest());
 		// Verify rollback was attempted
@@ -221,7 +260,12 @@ class InstallActionTest {
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		installAction.install(chart, "my-release", "default", null, 1, false);
+		installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.revision(1)
+			.build());
 
 		// CRD should be applied before the regular manifest
 		org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(kubeService);
@@ -235,7 +279,12 @@ class InstallActionTest {
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
 
 		assertThrows(IllegalArgumentException.class,
-				() -> installAction.install(chart, "my-release", "default", null, 1, false));
+				() -> installAction.install(InstallOptions.builder()
+					.chart(chart)
+					.releaseName("my-release")
+					.namespace("default")
+					.revision(1)
+					.build()));
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
@@ -99,7 +99,8 @@ class RollbackActionTest {
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		rollbackAction.rollback("myapp", "default", 1);
+		rollbackAction
+			.rollback(RollbackOptions.builder().releaseName("myapp").namespace("default").revision(1).build());
 
 		// apply receives the hook-stripped manifest (HookParser normalises docs with
 		// trailing \n)
@@ -140,7 +141,8 @@ class RollbackActionTest {
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		rollbackAction.rollback("myapp", "default", 1, false, 5);
+		rollbackAction.rollback(
+				RollbackOptions.builder().releaseName("myapp").namespace("default").revision(1).maxHistory(5).build());
 
 		// Prune is invoked with the passed maxHistory, after the release is stored.
 		InOrder order = inOrder(kubeService);
@@ -191,7 +193,8 @@ class RollbackActionTest {
 		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		rollbackAction.rollback("myapp", "default", 1);
+		rollbackAction
+			.rollback(RollbackOptions.builder().releaseName("myapp").namespace("default").revision(1).build());
 
 		List<HelmHook> hooks = HookParser.parseHooks(manifest);
 		String strippedManifest = HookParser.stripHooks(manifest);
@@ -241,7 +244,8 @@ class RollbackActionTest {
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		rollbackAction.rollback("myapp", "default", 1, true);
+		rollbackAction.rollback(
+				RollbackOptions.builder().releaseName("myapp").namespace("default").revision(1).noHooks(true).build());
 
 		List<HelmHook> hooks = HookParser.parseHooks(manifest);
 		String strippedManifest = HookParser.stripHooks(manifest);
@@ -258,8 +262,8 @@ class RollbackActionTest {
 		Release v1 = Release.builder().name("myapp").version(1).build();
 		when(kubeService.getReleaseHistory(anyString(), anyString())).thenReturn(Arrays.asList(v1));
 
-		ReleaseNotFoundException exception = assertThrows(ReleaseNotFoundException.class,
-				() -> rollbackAction.rollback("myapp", "default", 99));
+		ReleaseNotFoundException exception = assertThrows(ReleaseNotFoundException.class, () -> rollbackAction
+			.rollback(RollbackOptions.builder().releaseName("myapp").namespace("default").revision(99).build()));
 
 		assertTrue(exception.getMessage().contains("Revision 99 not found"));
 	}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UninstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UninstallActionTest.java
@@ -43,7 +43,7 @@ class UninstallActionTest {
 		doNothing().when(kubeService).delete(anyString(), anyString());
 		doNothing().when(kubeService).deleteReleaseHistory(anyString(), anyString());
 
-		uninstallAction.uninstall("myapp", "default");
+		uninstallAction.uninstall(UninstallOptions.builder().releaseName("myapp").namespace("default").build());
 
 		verify(kubeService).delete("default", "---\nkind: Service\n");
 		verify(kubeService).deleteReleaseHistory("myapp", "default");
@@ -76,7 +76,7 @@ class UninstallActionTest {
 		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
 		doNothing().when(kubeService).deleteReleaseHistory(anyString(), anyString());
 
-		uninstallAction.uninstall("myapp", "default");
+		uninstallAction.uninstall(UninstallOptions.builder().releaseName("myapp").namespace("default").build());
 
 		List<HelmHook> hooks = HookParser.parseHooks(fullManifest);
 		String strippedManifest = HookParser.stripHooks(fullManifest);
@@ -113,7 +113,8 @@ class UninstallActionTest {
 		doNothing().when(kubeService).delete(anyString(), anyString());
 		doNothing().when(kubeService).deleteReleaseHistory(anyString(), anyString());
 
-		uninstallAction.uninstall("myapp", "default", true);
+		uninstallAction
+			.uninstall(UninstallOptions.builder().releaseName("myapp").namespace("default").noHooks(true).build());
 
 		List<HelmHook> hooks = HookParser.parseHooks(fullManifest);
 		String deletableManifest = HookParser.stripKeptResources(HookParser.stripHooks(fullManifest));
@@ -146,7 +147,7 @@ class UninstallActionTest {
 		doNothing().when(kubeService).delete(anyString(), anyString());
 		doNothing().when(kubeService).deleteReleaseHistory(anyString(), anyString());
 
-		uninstallAction.uninstall("myapp", "default");
+		uninstallAction.uninstall(UninstallOptions.builder().releaseName("myapp").namespace("default").build());
 
 		// Only ConfigMap should be deleted — PVC with resource-policy: keep is preserved
 		String deletedManifest = HookParser.stripKeptResources(HookParser.stripHooks(fullManifest));
@@ -157,8 +158,8 @@ class UninstallActionTest {
 	void testUninstallThrowsWhenReleaseNotFound() throws Exception {
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.empty());
 
-		ReleaseNotFoundException exception = assertThrows(ReleaseNotFoundException.class,
-				() -> uninstallAction.uninstall("non-existent", "default"));
+		ReleaseNotFoundException exception = assertThrows(ReleaseNotFoundException.class, () -> uninstallAction
+			.uninstall(UninstallOptions.builder().releaseName("non-existent").namespace("default").build()));
 
 		assertTrue(exception.getMessage().contains("Release not found"));
 	}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -85,8 +85,11 @@ class UpgradeActionTest {
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		Release upgradedRelease = upgradeAction.upgrade(currentRelease, newChart, null, UpgradeValueStrategy.DEFAULT,
-				false);
+		Release upgradedRelease = upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(newChart)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.build());
 
 		assertNotNull(upgradedRelease);
 		assertEquals("myapp", upgradedRelease.getName());
@@ -142,7 +145,12 @@ class UpgradeActionTest {
 
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
 
-		upgradeAction.upgrade(currentRelease, chart, overrideValues, UpgradeValueStrategy.DEFAULT, false);
+		upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(chart)
+			.values(overrideValues)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.build());
 
 		@SuppressWarnings("unchecked")
 		ArgumentCaptor<Map<String, Object>> valuesCaptor = ArgumentCaptor.forClass(Map.class);
@@ -174,8 +182,12 @@ class UpgradeActionTest {
 
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("dry-run-manifest");
 
-		Release upgradedRelease = upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT,
-				true);
+		Release upgradedRelease = upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(chart)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.dryRun(true)
+			.build());
 
 		assertNotNull(upgradedRelease);
 		assertEquals("pending-upgrade", upgradedRelease.getInfo().getStatus());
@@ -209,7 +221,12 @@ class UpgradeActionTest {
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT, false, false, 5);
+		upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(chart)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.maxHistory(5)
+			.build());
 
 		// Prune is invoked with the passed maxHistory, after the release is stored.
 		InOrder order = inOrder(kubeService);
@@ -259,7 +276,11 @@ class UpgradeActionTest {
 		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT, false);
+		upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(chart)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.build());
 
 		List<HelmHook> hooks = HookParser.parseHooks(fullManifest);
 		String strippedManifest = HookParser.stripHooks(fullManifest);
@@ -309,7 +330,12 @@ class UpgradeActionTest {
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
-		upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT, false, true);
+		upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(chart)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.noHooks(true)
+			.build());
 
 		List<HelmHook> hooks = HookParser.parseHooks(fullManifest);
 		String strippedManifest = HookParser.stripHooks(fullManifest);
@@ -342,8 +368,11 @@ class UpgradeActionTest {
 
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
 
-		Release upgradedRelease = upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT,
-				false);
+		Release upgradedRelease = upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(chart)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.build());
 
 		assertEquals(43, upgradedRelease.getVersion());
 		assertEquals(info.getFirstDeployed(), upgradedRelease.getInfo().getFirstDeployed());
@@ -376,7 +405,11 @@ class UpgradeActionTest {
 		doThrow(new RuntimeException("storage failed")).when(kubeService).storeRelease(any(Release.class));
 
 		assertThrows(DeploymentFailedException.class,
-				() -> upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT, false));
+				() -> upgradeAction.upgrade(UpgradeOptions.builder()
+					.currentRelease(currentRelease)
+					.newChart(chart)
+					.valueStrategy(UpgradeValueStrategy.DEFAULT)
+					.build()));
 
 		// Verify: new manifest applied, then previous manifest re-applied on rollback
 		verify(kubeService, times(2)).apply(eq("default"), anyString());
@@ -396,7 +429,11 @@ class UpgradeActionTest {
 			.build();
 
 		assertThrows(IllegalArgumentException.class,
-				() -> upgradeAction.upgrade(currentRelease, chart, null, UpgradeValueStrategy.DEFAULT, false));
+				() -> upgradeAction.upgrade(UpgradeOptions.builder()
+					.currentRelease(currentRelease)
+					.newChart(chart)
+					.valueStrategy(UpgradeValueStrategy.DEFAULT)
+					.build()));
 	}
 
 	// --- Value-resolution strategy tests ---------------------------------------------
@@ -450,7 +487,12 @@ class UpgradeActionTest {
 		Chart newChart = newChartWithChangedDefault();
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
 
-		Release upgraded = upgradeAction.upgrade(current, newChart, null, UpgradeValueStrategy.DEFAULT, true);
+		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(current)
+			.newChart(newChart)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.dryRun(true)
+			.build());
 
 		Map<String, Object> render = renderValuesFor(upgraded);
 		// Prior user value reused; new chart default present.
@@ -468,7 +510,13 @@ class UpgradeActionTest {
 		overrides.put("extra", "x");
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
 
-		Release upgraded = upgradeAction.upgrade(current, newChart, overrides, UpgradeValueStrategy.DEFAULT, true);
+		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(current)
+			.newChart(newChart)
+			.values(overrides)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.dryRun(true)
+			.build());
 
 		Map<String, Object> render = renderValuesFor(upgraded);
 		// Overrides used; prior user value dropped for unspecified keys.
@@ -488,7 +536,13 @@ class UpgradeActionTest {
 		overrides.put("extra", "x");
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
 
-		Release upgraded = upgradeAction.upgrade(current, newChart, overrides, UpgradeValueStrategy.RESET, true);
+		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(current)
+			.newChart(newChart)
+			.values(overrides)
+			.valueStrategy(UpgradeValueStrategy.RESET)
+			.dryRun(true)
+			.build());
 
 		Map<String, Object> render = renderValuesFor(upgraded);
 		// Overrides over NEW defaults; prior ignored.
@@ -506,7 +560,13 @@ class UpgradeActionTest {
 		overrides.put("extra", "x");
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
 
-		Release upgraded = upgradeAction.upgrade(current, newChart, overrides, UpgradeValueStrategy.REUSE, true);
+		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(current)
+			.newChart(newChart)
+			.values(overrides)
+			.valueStrategy(UpgradeValueStrategy.REUSE)
+			.dryRun(true)
+			.build());
 
 		Map<String, Object> render = renderValuesFor(upgraded);
 		// Prior + overrides; render based on OLD defaults — the changed new default does
@@ -527,8 +587,13 @@ class UpgradeActionTest {
 		overrides.put("extra", "x");
 		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
 
-		Release upgraded = upgradeAction.upgrade(current, newChart, overrides, UpgradeValueStrategy.RESET_THEN_REUSE,
-				true);
+		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(current)
+			.newChart(newChart)
+			.values(overrides)
+			.valueStrategy(UpgradeValueStrategy.RESET_THEN_REUSE)
+			.dryRun(true)
+			.build());
 
 		Map<String, Object> render = renderValuesFor(upgraded);
 		// Prior + overrides over NEW defaults — the changed new default DOES appear

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/DependencyConditionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/DependencyConditionTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Map;
 
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,14 @@ class DependencyConditionTest {
 	}
 
 	private String renderManifest(Chart chart, Map<String, Object> overrides) throws Exception {
-		Release release = installAction.install(chart, "test-release", "default", overrides, 1, true);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("test-release")
+			.namespace("default")
+			.values(overrides)
+			.revision(1)
+			.dryRun(true)
+			.build());
 		assertNotNull(release, "Release should be created");
 		String manifest = release.getManifest();
 		assertNotNull(manifest, "Manifest should not be null");

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmFullFlowIntegrationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmFullFlowIntegrationTest.java
@@ -6,9 +6,12 @@ import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.action.UpgradeOptions;
 import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
 import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.alexmond.jhelm.core.CoreConfig;
 import org.alexmond.jhelm.kube.KubernetesConfig;
 import org.junit.jupiter.api.Test;
@@ -84,7 +87,14 @@ class HelmFullFlowIntegrationTest {
 			.build();
 
 		// 2. Install
-		Release release = installAction.install(chart, releaseName, namespace, Map.of("replicaCount", 2), 1, false);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName(releaseName)
+			.namespace(namespace)
+			.values(Map.of("replicaCount", 2))
+			.revision(1)
+			.dryRun(false)
+			.build());
 		assertNotNull(release);
 		// log.info("Manifest: {}", release.getManifest());
 		// assertTrue(release.getManifest().contains("replicaCount") ||
@@ -98,8 +108,13 @@ class HelmFullFlowIntegrationTest {
 
 		// 4. Upgrade
 		Release currentRelease = storedRelease.get();
-		Release upgradedRelease = upgradeAction.upgrade(currentRelease, chart, Map.of("replicaCount", 3),
-				UpgradeValueStrategy.DEFAULT, false);
+		Release upgradedRelease = upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(chart)
+			.values(Map.of("replicaCount", 3))
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.dryRun(false)
+			.build());
 		assertEquals(2, upgradedRelease.getVersion());
 		// assertTrue(upgradedRelease.getManifest().contains("replicaCount") ||
 		// upgradedRelease.getManifest().contains("replicas"));
@@ -110,7 +125,7 @@ class HelmFullFlowIntegrationTest {
 		assertEquals(2, storedRelease.get().getVersion());
 
 		// 6. Uninstall/Cleanup
-		uninstallAction.uninstall(releaseName, namespace);
+		uninstallAction.uninstall(UninstallOptions.builder().releaseName(releaseName).namespace(namespace).build());
 
 		storedRelease = helmKubeService.getRelease(releaseName, namespace);
 		assertFalse(storedRelease.isPresent());
@@ -137,7 +152,14 @@ class HelmFullFlowIntegrationTest {
 				.build();
 
 			// Install Dry Run
-			Release release = installAction.install(simpleChart, releaseName, namespace, Map.of(), 1, true);
+			Release release = installAction.install(InstallOptions.builder()
+				.chart(simpleChart)
+				.releaseName(releaseName)
+				.namespace(namespace)
+				.values(Map.of())
+				.revision(1)
+				.dryRun(true)
+				.build());
 			assertNotNull(release);
 			assertTrue(release.getManifest().contains("name: dry-run-release"));
 			assertEquals("pending-install", release.getInfo().getStatus());
@@ -151,7 +173,14 @@ class HelmFullFlowIntegrationTest {
 		Chart chart = chartLoader.load(chartDir);
 
 		// 1. Install Dry Run
-		Release release = installAction.install(chart, releaseName, namespace, Map.of("replicaCount", 5), 1, true);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName(releaseName)
+			.namespace(namespace)
+			.values(Map.of("replicaCount", 5))
+			.revision(1)
+			.dryRun(true)
+			.build());
 		assertNotNull(release);
 		assertTrue(release.getManifest().contains("replicas: 5"));
 		assertEquals("pending-install", release.getInfo().getStatus());
@@ -161,11 +190,23 @@ class HelmFullFlowIntegrationTest {
 		assertFalse(storedRelease.isPresent());
 
 		// 3. Upgrade Dry Run (need a real release first)
-		Release realRelease = installAction.install(chart, releaseName, namespace, Map.of("replicaCount", 1), 1, false);
+		Release realRelease = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName(releaseName)
+			.namespace(namespace)
+			.values(Map.of("replicaCount", 1))
+			.revision(1)
+			.dryRun(false)
+			.build());
 		assertNotNull(realRelease);
 
-		Release dryUpgraded = upgradeAction.upgrade(realRelease, chart, Map.of("replicaCount", 10),
-				UpgradeValueStrategy.DEFAULT, true);
+		Release dryUpgraded = upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(realRelease)
+			.newChart(chart)
+			.values(Map.of("replicaCount", 10))
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.dryRun(true)
+			.build());
 		assertNotNull(dryUpgraded);
 		assertTrue(dryUpgraded.getManifest().contains("replicas: 10"));
 		assertEquals("pending-upgrade", dryUpgraded.getInfo().getStatus());
@@ -177,7 +218,7 @@ class HelmFullFlowIntegrationTest {
 		assertEquals(1, storedRelease.get().getVersion()); // Still version 1
 
 		// Cleanup
-		uninstallAction.uninstall(releaseName, namespace);
+		uninstallAction.uninstall(UninstallOptions.builder().releaseName(releaseName).namespace(namespace).build());
 	}
 
 }

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmIntegrationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmIntegrationTest.java
@@ -4,6 +4,7 @@ import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.CoreConfig;
 import org.alexmond.jhelm.kube.KubernetesConfig;
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,14 @@ class HelmIntegrationTest {
 		assertNotNull(chart.getMetadata());
 
 		// 2. Prepare Install Action
-		Release release = installAction.install(chart, "test-release", "default", new HashMap<>(), 1, false);
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("test-release")
+			.namespace("default")
+			.values(new HashMap<>())
+			.revision(1)
+			.dryRun(false)
+			.build());
 		assertNotNull(release);
 		assertNotNull(release.getManifest());
 		assertTrue(release.getManifest().contains("test-configmap"));

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingTools.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingTools.java
@@ -7,10 +7,14 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.RollbackOptions;
 import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.action.UpgradeOptions;
 import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
@@ -68,7 +72,14 @@ public class ReleaseMutatingTools {
 			@McpToolParam(description = "Target Kubernetes namespace") String namespace,
 			@McpToolParam(description = "Render only without applying to the cluster when true") boolean dryRun) {
 		Chart chart = this.chartLoader.load(new File(chartPath));
-		Release release = this.installAction.install(chart, name, namespace, Map.of(), 1, dryRun);
+		Release release = this.installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName(name)
+			.namespace(namespace)
+			.values(Map.of())
+			.revision(1)
+			.dryRun(dryRun)
+			.build());
 		return renderReleaseSummary("Installed", release, dryRun);
 	}
 
@@ -93,7 +104,13 @@ public class ReleaseMutatingTools {
 		Release current = this.getAction.getRelease(name, namespace)
 			.orElseThrow(() -> new IllegalArgumentException("Release '" + name + "' not found"));
 		Chart chart = this.chartLoader.load(new File(chartPath));
-		Release upgraded = this.upgradeAction.upgrade(current, chart, Map.of(), UpgradeValueStrategy.DEFAULT, dryRun);
+		Release upgraded = this.upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(current)
+			.newChart(chart)
+			.values(Map.of())
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.dryRun(dryRun)
+			.build());
 		return renderReleaseSummary("Upgraded", upgraded, dryRun);
 	}
 
@@ -108,7 +125,7 @@ public class ReleaseMutatingTools {
 					+ "release's resources and removes its history.")
 	public String uninstall(@McpToolParam(description = "Release name to uninstall") String name,
 			@McpToolParam(description = "Kubernetes namespace") String namespace) {
-		this.uninstallAction.uninstall(name, namespace);
+		this.uninstallAction.uninstall(UninstallOptions.builder().releaseName(name).namespace(namespace).build());
 		return "Uninstalled release '" + name + "' from namespace '" + namespace + '\'';
 	}
 
@@ -126,7 +143,8 @@ public class ReleaseMutatingTools {
 	public String rollback(@McpToolParam(description = "Release name") String name,
 			@McpToolParam(description = "Kubernetes namespace") String namespace,
 			@McpToolParam(description = "Target revision number to roll back to") int revision) {
-		this.rollbackAction.rollback(name, namespace, revision);
+		this.rollbackAction
+			.rollback(RollbackOptions.builder().releaseName(name).namespace(namespace).revision(revision).build());
 		return "Rolled back release '" + name + "' in namespace '" + namespace + "' to revision " + revision;
 	}
 

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
@@ -12,12 +12,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.HistoryAction;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.ListAction;
 import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.RollbackOptions;
 import org.alexmond.jhelm.core.action.StatusAction;
 import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.action.UpgradeOptions;
 import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
@@ -175,8 +179,14 @@ public class ReleaseController {
 			Chart chart = ChartSourceResolver.fromChartRef(request.getChartRef(), request.getVersion(),
 					this.repoManager, this.chartLoader, tempDir);
 			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
-			Release release = this.installAction.install(chart, request.getReleaseName(), request.getNamespace(),
-					values, 1, request.isDryRun());
+			Release release = this.installAction.install(InstallOptions.builder()
+				.chart(chart)
+				.releaseName(request.getReleaseName())
+				.namespace(request.getNamespace())
+				.values(values)
+				.revision(1)
+				.dryRun(request.isDryRun())
+				.build());
 			return ResponseEntity.status(HttpStatus.CREATED).body(ReleaseDto.from(release));
 		}
 	}
@@ -200,8 +210,14 @@ public class ReleaseController {
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-install-upload-")) {
 			Chart loaded = ChartSourceResolver.fromUpload(chart, this.repoManager, this.chartLoader, tempDir);
 			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
-			Release release = this.installAction.install(loaded, request.getReleaseName(), request.getNamespace(),
-					values, 1, request.isDryRun());
+			Release release = this.installAction.install(InstallOptions.builder()
+				.chart(loaded)
+				.releaseName(request.getReleaseName())
+				.namespace(request.getNamespace())
+				.values(values)
+				.revision(1)
+				.dryRun(request.isDryRun())
+				.build());
 			return ResponseEntity.status(HttpStatus.CREATED).body(ReleaseDto.from(release));
 		}
 	}
@@ -233,8 +249,13 @@ public class ReleaseController {
 			// TODO: expose UpgradeValueStrategy (reset/reuse/reset-then-reuse) on the
 			// REST
 			// request as a follow-up.
-			Release upgraded = this.upgradeAction.upgrade(current, chart, values, UpgradeValueStrategy.DEFAULT,
-					request.isDryRun());
+			Release upgraded = this.upgradeAction.upgrade(UpgradeOptions.builder()
+				.currentRelease(current)
+				.newChart(chart)
+				.values(values)
+				.valueStrategy(UpgradeValueStrategy.DEFAULT)
+				.dryRun(request.isDryRun())
+				.build());
 			return ReleaseDto.from(upgraded);
 		}
 	}
@@ -265,8 +286,13 @@ public class ReleaseController {
 			// TODO: expose UpgradeValueStrategy (reset/reuse/reset-then-reuse) on the
 			// REST
 			// request as a follow-up.
-			Release upgraded = this.upgradeAction.upgrade(current, loaded, values, UpgradeValueStrategy.DEFAULT,
-					request.isDryRun());
+			Release upgraded = this.upgradeAction.upgrade(UpgradeOptions.builder()
+				.currentRelease(current)
+				.newChart(loaded)
+				.values(values)
+				.valueStrategy(UpgradeValueStrategy.DEFAULT)
+				.dryRun(request.isDryRun())
+				.build());
 			return ReleaseDto.from(upgraded);
 		}
 	}
@@ -284,7 +310,7 @@ public class ReleaseController {
 	public ResponseEntity<Void> uninstall(@Parameter(description = "Release name") @PathVariable String name,
 			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace)
 			throws Exception {
-		this.uninstallAction.uninstall(name, namespace);
+		this.uninstallAction.uninstall(UninstallOptions.builder().releaseName(name).namespace(namespace).build());
 		return ResponseEntity.noContent().build();
 	}
 
@@ -317,7 +343,11 @@ public class ReleaseController {
 	public ResponseEntity<Void> rollback(@Parameter(description = "Release name") @PathVariable String name,
 			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace,
 			@RequestBody RollbackRequest request) throws Exception {
-		this.rollbackAction.rollback(name, namespace, request.getRevision());
+		this.rollbackAction.rollback(RollbackOptions.builder()
+			.releaseName(name)
+			.namespace(namespace)
+			.revision(request.getRevision())
+			.build());
 		return ResponseEntity.noContent().build();
 	}
 

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
@@ -10,12 +10,16 @@ import java.util.Optional;
 import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.HistoryAction;
 import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.ListAction;
 import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.RollbackOptions;
 import org.alexmond.jhelm.core.action.StatusAction;
 import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.action.UpgradeOptions;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
@@ -35,10 +39,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -138,8 +140,7 @@ class ReleaseControllerTest {
 		stubPull();
 		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("1.0.0").build()).build();
 		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
-		when(this.installAction.install(any(), eq("my-release"), eq("default"), anyMap(), anyInt(), anyBoolean()))
-			.thenReturn(sampleRelease());
+		when(this.installAction.install(any(InstallOptions.class))).thenReturn(sampleRelease());
 
 		this.mockMvc
 			.perform(post("/api/v1/releases").contentType(MediaType.APPLICATION_JSON)
@@ -168,8 +169,7 @@ class ReleaseControllerTest {
 		stubUntar();
 		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("1.0.0").build()).build();
 		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
-		when(this.installAction.install(any(), eq("my-release"), eq("default"), anyMap(), anyInt(), anyBoolean()))
-			.thenReturn(sampleRelease());
+		when(this.installAction.install(any(InstallOptions.class))).thenReturn(sampleRelease());
 
 		MockMultipartFile chartFile = new MockMultipartFile("chart", "nginx-1.0.0.tgz", "application/gzip",
 				new byte[] { 1, 2, 3 });
@@ -191,7 +191,7 @@ class ReleaseControllerTest {
 		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
 		Release upgraded = sampleRelease();
 		upgraded.setVersion(2);
-		when(this.upgradeAction.upgrade(any(), any(), anyMap(), any(), anyBoolean())).thenReturn(upgraded);
+		when(this.upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(upgraded);
 
 		this.mockMvc
 			.perform(put("/api/v1/releases/my-release").contentType(MediaType.APPLICATION_JSON)
@@ -212,7 +212,7 @@ class ReleaseControllerTest {
 		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
 		Release upgraded = sampleRelease();
 		upgraded.setVersion(2);
-		when(this.upgradeAction.upgrade(any(), any(), anyMap(), any(), anyBoolean())).thenReturn(upgraded);
+		when(this.upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(upgraded);
 
 		MockMultipartFile chartFile = new MockMultipartFile("chart", "nginx-2.0.0.tgz", "application/gzip",
 				new byte[] { 1, 2, 3 });
@@ -226,7 +226,9 @@ class ReleaseControllerTest {
 	@Test
 	void uninstallRelease() throws Exception {
 		this.mockMvc.perform(delete("/api/v1/releases/my-release")).andExpect(status().isNoContent());
-		verify(this.uninstallAction).uninstall("my-release", "default");
+		verify(this.uninstallAction)
+			.uninstall(argThat((UninstallOptions options) -> "my-release".equals(options.getReleaseName())
+					&& "default".equals(options.getNamespace())));
 	}
 
 	@Test
@@ -246,7 +248,9 @@ class ReleaseControllerTest {
 						{"revision": 1}
 						"""))
 			.andExpect(status().isNoContent());
-		verify(this.rollbackAction).rollback("my-release", "default", 1);
+		verify(this.rollbackAction)
+			.rollback(argThat((RollbackOptions options) -> "my-release".equals(options.getReleaseName())
+					&& "default".equals(options.getNamespace()) && options.getRevision() == 1));
 	}
 
 	@Test


### PR DESCRIPTION
Part of the #500 pre-1.0 API freeze, and the design decision to stop overload-proliferation.

## Why
The mutating actions had grown long parameter lists + stacked overloads (`UpgradeAction.upgrade` reached **7 params across 3 overloads**) as `--no-hooks` and `--history-max` landed. Each future flag (`--create-namespace`, `--wait`, `--atomic`, `--force`) would add another overload.

## What
- New **immutable** `@Getter @Builder` options in `core.action`: `InstallOptions`, `UpgradeOptions`, `UninstallOptions`, `RollbackOptions`. `@Builder.Default` reproduces today's defaults exactly: `values=Map.of()`, `revision=1`, `valueStrategy=DEFAULT`, `maxHistory=10`, `dryRun/noHooks=false`.
- **Single signatures**, all old overloads removed: `install(InstallOptions)`, `upgrade(UpgradeOptions)`, `uninstall(UninstallOptions)`, `rollback(RollbackOptions)`. Bodies/logic unchanged — inputs sourced from the options object.
- **All callers** build the options object: CLI (install/upgrade incl. `--install` fallback + atomic recovery, uninstall, rollback), REST `ReleaseController` (install ×2, upgrade ×2, uninstall, rollback), jhelm-mcp `ReleaseMutatingTools`.

Future flags now slot in as new option fields — **no more signature churn**.

## ⚠️ Breaking change
`install/upgrade/uninstall/rollback` take an `*Options` object instead of positional parameters. Behavior and defaults are identical.

## Verified
Full reactor **BUILD SUCCESS** (13 modules); action/command/controller tests adapted (builders + `ArgumentCaptor`/`argThat` for the strategy, maxHistory, noHooks, dry-run assertions); PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)