### PR TITLE
feat: --create-namespace on install (#501)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -81,6 +81,9 @@ public class InstallCommand implements Runnable {
 	@Option(names = { "--no-hooks" }, description = "prevent hooks from running during this operation")
 	private boolean noHooks;
 
+	@CommandLine.Option(names = { "--create-namespace" }, description = "create the release namespace if not present")
+	private boolean createNamespace;
+
 	/**
 	 * Creates the command.
 	 * @param installAction the action that performs the install
@@ -111,6 +114,7 @@ public class InstallCommand implements Runnable {
 				.revision(1)
 				.dryRun(dryRun)
 				.noHooks(noHooks)
+				.createNamespace(createNamespace)
 				.build());
 			applyCliPostRenderers(release);
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -93,22 +93,16 @@ public class InstallAction {
 		releaseData.put("IsUpgrade", false);
 		releaseData.put("Revision", release.getVersion());
 
-		String manifest = engine.render(chart, values, releaseData);
-
-		for (PostRenderProcessor processor : postRenderProcessors) {
-			try {
-				manifest = processor.process(manifest);
-			}
-			catch (Exception ex) {
-				throw new JhelmException("Post-render processor failed", ex);
-			}
-		}
+		String manifest = runPostRenderProcessors(engine.render(chart, values, releaseData));
 
 		release.setManifest(manifest);
 
 		if (kubeService != null && !options.isDryRun()) {
 			String namespace = options.getNamespace();
 			boolean noHooks = options.isNoHooks();
+			if (options.isCreateNamespace()) {
+				kubeService.ensureNamespace(namespace);
+			}
 			applyCrds(chart, namespace);
 			fireLifecycleEvent("pre-install", options.getReleaseName(), namespace);
 			String regularManifest = HookParser.stripHooks(manifest);
@@ -133,6 +127,19 @@ public class InstallAction {
 		}
 
 		return release;
+	}
+
+	private String runPostRenderProcessors(String manifest) {
+		String result = manifest;
+		for (PostRenderProcessor processor : postRenderProcessors) {
+			try {
+				result = processor.process(result);
+			}
+			catch (Exception ex) {
+				throw new JhelmException("Post-render processor failed", ex);
+			}
+		}
+		return result;
 	}
 
 	private void runHooks(HookExecutor hookExecutor, String namespace, List<HelmHook> hooks, String phase) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallOptions.java
@@ -48,4 +48,11 @@ public final class InstallOptions {
 	 */
 	private final boolean noHooks;
 
+	/**
+	 * When {@code true}, create the target namespace before applying the release if it
+	 * does not already exist. Mirrors Helm's {@code --create-namespace}. Defaults to
+	 * {@code false}.
+	 */
+	private final boolean createNamespace;
+
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
@@ -74,6 +74,14 @@ public interface KubeService {
 	void pruneReleaseHistory(String name, String namespace, int maxHistory);
 
 	/**
+	 * Creates the given namespace if it does not already exist. A no-op if the namespace
+	 * is already present. Mirrors Helm's {@code --create-namespace}.
+	 * @param namespace the namespace to create
+	 * @throws KubernetesOperationException if the namespace cannot be created
+	 */
+	void ensureNamespace(String namespace);
+
+	/**
 	 * Applies a rendered manifest to the cluster via server-side apply.
 	 * @param namespace the target namespace
 	 * @param yamlContent rendered YAML manifest (may contain multiple documents)

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
@@ -274,6 +274,51 @@ class InstallActionTest {
 	}
 
 	@Test
+	void testInstallCreatesNamespaceBeforeApply() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		String manifest = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(manifest);
+		doNothing().when(kubeService).ensureNamespace(anyString());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.revision(1)
+			.createNamespace(true)
+			.build());
+
+		// Namespace is created before the manifest is applied.
+		org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(kubeService);
+		inOrder.verify(kubeService).ensureNamespace("default");
+		inOrder.verify(kubeService).apply("default", HookParser.stripHooks(manifest));
+	}
+
+	@Test
+	void testInstallSkipsNamespaceCreationByDefault() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		String manifest = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
+		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(manifest);
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.revision(1)
+			.build());
+
+		verify(kubeService, never()).ensureNamespace(anyString());
+	}
+
+	@Test
 	void testInstallRejectsLibraryChart() {
 		ChartMetadata metadata = ChartMetadata.builder().name("mylib").version("1.0.0").type("library").build();
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
@@ -12,6 +12,7 @@ import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
@@ -276,6 +277,28 @@ public class HelmKubeService implements KubeService {
 		}
 		catch (ApiException ex) {
 			throw new KubernetesOperationException("Failed to list pods in " + namespace, ex, ex.getCode());
+		}
+	}
+
+	/**
+	 * Creates the namespace if it does not already exist. An HTTP 409 conflict (the
+	 * namespace already exists) is treated as success.
+	 */
+	@Override
+	public void ensureNamespace(String namespace) {
+		CoreV1Api api = new CoreV1Api(apiClient);
+		V1Namespace ns = new V1Namespace().metadata(new V1ObjectMeta().name(namespace));
+		try {
+			if (log.isInfoEnabled()) {
+				log.info("Creating namespace {}", namespace);
+			}
+			api.createNamespace(ns).execute();
+		}
+		catch (ApiException ex) {
+			if (ex.getCode() == 409) { // Conflict / already exists -> no-op
+				return;
+			}
+			throw new KubernetesOperationException("Failed to create namespace " + namespace, ex, ex.getCode());
 		}
 	}
 

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/ObservableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/ObservableKubeService.java
@@ -87,6 +87,11 @@ public class ObservableKubeService implements KubeService {
 	}
 
 	@Override
+	public void ensureNamespace(String namespace) {
+		timeVoid(applyTimer, () -> delegate.ensureNamespace(namespace));
+	}
+
+	@Override
 	public void apply(String namespace, String yamlContent) {
 		timeVoid(applyTimer, () -> delegate.apply(namespace, yamlContent));
 	}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/RetryableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/RetryableKubeService.java
@@ -82,6 +82,14 @@ public class RetryableKubeService implements KubeService {
 	}
 
 	@Override
+	public void ensureNamespace(String namespace) {
+		executeWithRetry("ensureNamespace", () -> {
+			delegate.ensureNamespace(namespace);
+			return null;
+		});
+	}
+
+	@Override
 	public void apply(String namespace, String yamlContent) {
 		executeWithRetry("apply", () -> {
 			delegate.apply(namespace, yamlContent);

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
@@ -11,6 +11,7 @@ import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1DeploymentSpec;
 import io.kubernetes.client.openapi.models.V1DeploymentStatus;
+import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
@@ -643,6 +644,44 @@ class HelmKubeServiceTest {
 
 		kubeService.delete("", yaml);
 		verify(mockCustomObjectsApi).deleteClusterCustomObject("", "v1", "namespaces", "test-ns");
+	}
+
+	// --- ensureNamespace ---
+
+	@Test
+	void testEnsureNamespaceCreatesNamespace() throws Exception {
+		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
+			mockCoreV1Api = mock;
+			var createReq = mock(CoreV1Api.APIcreateNamespaceRequest.class);
+			when(createReq.execute()).thenReturn(new V1Namespace());
+			when(mock.createNamespace(any(V1Namespace.class))).thenReturn(createReq);
+		});
+
+		kubeService.ensureNamespace("my-ns");
+		verify(mockCoreV1Api).createNamespace(any(V1Namespace.class));
+	}
+
+	@Test
+	void testEnsureNamespaceSwallows409Conflict() {
+		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
+			var createReq = mock(CoreV1Api.APIcreateNamespaceRequest.class);
+			when(createReq.execute()).thenThrow(new ApiException(409, "Conflict"));
+			when(mock.createNamespace(any(V1Namespace.class))).thenReturn(createReq);
+		});
+
+		// An already-existing namespace (409) is a no-op, not an error.
+		assertDoesNotThrow(() -> kubeService.ensureNamespace("default"));
+	}
+
+	@Test
+	void testEnsureNamespaceThrowsOnOtherApiError() {
+		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
+			var createReq = mock(CoreV1Api.APIcreateNamespaceRequest.class);
+			when(createReq.execute()).thenThrow(new ApiException(500, "Server error"));
+			when(mock.createNamespace(any(V1Namespace.class))).thenReturn(createReq);
+		});
+
+		assertThrows(KubernetesOperationException.class, () -> kubeService.ensureNamespace("my-ns"));
 	}
 
 	// --- installConfigMap ---


### PR DESCRIPTION
First flag to land on the new options-object API (#528) as **just a new field** — no action signature change. That's the payoff.

## What
- **`KubeService.ensureNamespace(namespace)`** — create the namespace if absent, no-op if present. `HelmKubeService` creates a `V1Namespace` and treats **HTTP 409 as success**; other errors → `KubernetesOperationException`. Delegated through `RetryableKubeService` + `ObservableKubeService`.
- **`InstallOptions.createNamespace`** (default false). `InstallAction` calls `ensureNamespace` **before applying** the manifest when set and not a dry run.
- **`--create-namespace`** flag on the install command.

## Verified
Full reactor green — `HelmKubeServiceTest` covers create / 409-swallow / 500-translate; `InstallActionTest` asserts `ensureNamespace` runs before apply when set and `never()` by default; PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)