### PR TITLE
refactor(api)!: make Release result model immutable (#500)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -116,7 +116,7 @@ public class InstallCommand implements Runnable {
 				.noHooks(noHooks)
 				.createNamespace(createNamespace)
 				.build());
-			applyCliPostRenderers(release);
+			release = applyCliPostRenderers(release);
 
 			if (dryRun) {
 				CliOutput.println(CliOutput.bold("NAME:") + " " + release.getName());
@@ -155,15 +155,15 @@ public class InstallCommand implements Runnable {
 		}
 	}
 
-	private void applyCliPostRenderers(Release release) throws Exception {
+	private Release applyCliPostRenderers(Release release) throws Exception {
 		if (postRenderers.isEmpty()) {
-			return;
+			return release;
 		}
 		String manifest = release.getManifest();
 		for (String renderer : postRenderers) {
 			manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
 		}
-		release.setManifest(manifest);
+		return release.toBuilder().manifest(manifest).build();
 	}
 
 }

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -146,7 +146,7 @@ public class UpgradeCommand implements Runnable {
 				if (install) {
 					wasInstall = true;
 					Release release = installAction.install(buildInstallOptions(chart, overrides));
-					applyCliPostRenderers(release);
+					release = applyCliPostRenderers(release);
 					if (dryRun) {
 						printRelease(release);
 					}
@@ -170,7 +170,7 @@ public class UpgradeCommand implements Runnable {
 							: (reuseValues) ? UpgradeValueStrategy.REUSE : UpgradeValueStrategy.DEFAULT;
 			Release upgradedRelease = upgradeAction
 				.upgrade(buildUpgradeOptions(currentReleaseOpt.get(), chart, overrides, strategy));
-			applyCliPostRenderers(upgradedRelease);
+			upgradedRelease = applyCliPostRenderers(upgradedRelease);
 
 			if (dryRun) {
 				printRelease(upgradedRelease);
@@ -238,15 +238,15 @@ public class UpgradeCommand implements Runnable {
 			.build();
 	}
 
-	private void applyCliPostRenderers(Release release) throws Exception {
+	private Release applyCliPostRenderers(Release release) throws Exception {
 		if (postRenderers.isEmpty()) {
-			return;
+			return release;
 		}
 		String manifest = release.getManifest();
 		for (String renderer : postRenderers) {
 			manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
 		}
-		release.setManifest(manifest);
+		return release.toBuilder().manifest(manifest).build();
 	}
 
 	private void printRelease(Release release) {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/GetCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/GetCommandTest.java
@@ -329,9 +329,9 @@ class GetCommandTest {
 	}
 
 	private Release createReleaseWithConfig() {
-		Release release = createRelease();
-		release.setConfig(Release.MapConfig.builder().values(Map.of("key", "value")).build());
-		return release;
+		return createRelease().toBuilder()
+			.config(Release.MapConfig.builder().values(Map.of("key", "value")).build())
+			.build();
 	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -95,7 +95,7 @@ public class InstallAction {
 
 		String manifest = runPostRenderProcessors(engine.render(chart, values, releaseData));
 
-		release.setManifest(manifest);
+		release = release.toBuilder().manifest(manifest).build();
 
 		if (kubeService != null && !options.isDryRun()) {
 			String namespace = options.getNamespace();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -95,7 +95,7 @@ public class UpgradeAction {
 			}
 		}
 
-		newRelease.setManifest(manifest);
+		newRelease = newRelease.toBuilder().manifest(manifest).build();
 
 		if (kubeService != null && !options.isDryRun()) {
 			boolean noHooks = options.isNoHooks();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Release.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Release.java
@@ -1,18 +1,23 @@
 package org.alexmond.jhelm.core.model;
 
 import java.time.OffsetDateTime;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import java.util.Map;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
+
+import lombok.Builder;
+import lombok.Value;
+
+@JsonDeserialize(builder = Release.ReleaseBuilder.class)
+@Builder(toBuilder = true)
+@Value
 public class Release {
+
+	// Note: @Jacksonized would emit com.fasterxml (Jackson 2) builder annotations,
+	// which are absent on this Jackson 3 (tools.jackson) classpath. The builder is
+	// wired to Jackson 3 manually so the immutable type round-trips through the
+	// Kubernetes release Secret.
 
 	private String name;
 
@@ -28,10 +33,14 @@ public class Release {
 
 	private String manifest;
 
-	@Data
+	@JsonPOJOBuilder(withPrefix = "")
+	public static class ReleaseBuilder {
+
+	}
+
+	@JsonDeserialize(builder = ReleaseInfo.ReleaseInfoBuilder.class)
 	@Builder
-	@NoArgsConstructor
-	@AllArgsConstructor
+	@Value
 	public static class ReleaseInfo {
 
 		private OffsetDateTime firstDeployed;
@@ -46,15 +55,24 @@ public class Release {
 
 		private String notes;
 
+		@JsonPOJOBuilder(withPrefix = "")
+		public static class ReleaseInfoBuilder {
+
+		}
+
 	}
 
-	@Data
+	@JsonDeserialize(builder = MapConfig.MapConfigBuilder.class)
 	@Builder
-	@NoArgsConstructor
-	@AllArgsConstructor
+	@Value
 	public static class MapConfig {
 
 		private Map<String, Object> values;
+
+		@JsonPOJOBuilder(withPrefix = "")
+		public static class MapConfigBuilder {
+
+		}
 
 	}
 

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
@@ -189,8 +189,7 @@ class ReleaseControllerTest {
 		stubPull();
 		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("2.0.0").build()).build();
 		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
-		Release upgraded = sampleRelease();
-		upgraded.setVersion(2);
+		Release upgraded = sampleRelease().toBuilder().version(2).build();
 		when(this.upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(upgraded);
 
 		this.mockMvc
@@ -210,8 +209,7 @@ class ReleaseControllerTest {
 		stubUntar();
 		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("2.0.0").build()).build();
 		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
-		Release upgraded = sampleRelease();
-		upgraded.setVersion(2);
+		Release upgraded = sampleRelease().toBuilder().version(2).build();
 		when(this.upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(upgraded);
 
 		MockMultipartFile chartFile = new MockMultipartFile("chart", "nginx-2.0.0.tgz", "application/gzip",


### PR DESCRIPTION
#500 conventions — `Release` / `ReleaseInfo` / `MapConfig` were `@Data @Builder` (mutable value types with public setters). Make them **immutable** (`@Value @Builder` + getters, no setters), matching the options-object direction.

## The round-trip gotcha (and fix)
Releases are stored as JSON in a Kubernetes Secret (`objectMapper.readValue(json, Release.class)`). Lombok's `@Jacksonized` **can't be used** — it emits Jackson 2 annotations and this project is Jackson 3 (`tools.jackson`). Instead the builder is wired to Jackson 3 explicitly: `@JsonDeserialize(builder = …Builder.class)` + a `@JsonPOJOBuilder(withPrefix = "")` stub per class, so the immutable types still deserialize through the builder. **Verified by the `HelmKubeServiceTest` Secret encode/decode tests (jhelm-kube 198/198).**

## Mutations
Only `setManifest` was called on `Release` — `InstallAction`/`UpgradeAction` and the two `applyCliPostRenderers` helpers now copy-on-write via `toBuilder()`. Three test setter-mutations converted. No other class mutates `Release`.

## ⚠️ Breaking change
`Release`/`ReleaseInfo`/`MapConfig` are immutable — use the builder / `toBuilder()` instead of setters.

## Verified
Full reactor **BUILD SUCCESS** (13 modules); jhelm-kube 198 (storage round-trip), jhelm-core 527, all green; PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)