### PR TITLE
refactor(api)!: release status String -> ReleaseStatus enum (#500)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/HistoryCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/HistoryCommand.java
@@ -45,7 +45,7 @@ public class HistoryCommand implements Runnable {
 			for (Release r : history) {
 				String chartInfo = r.getChart().getMetadata().getName() + "-" + r.getChart().getMetadata().getVersion();
 				CliOutput.printf("%-10d %-30s %-10s %-20s %-30s\n", r.getVersion(), r.getInfo().getLastDeployed(),
-						r.getInfo().getStatus(), chartInfo, r.getInfo().getDescription());
+						r.getInfo().getStatus().getValue(), chartInfo, r.getInfo().getDescription());
 			}
 		}
 		catch (Exception ex) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -122,7 +122,7 @@ public class InstallCommand implements Runnable {
 				CliOutput.println(CliOutput.bold("NAME:") + " " + release.getName());
 				CliOutput.println(CliOutput.bold("LAST DEPLOYED:") + " " + release.getInfo().getLastDeployed());
 				CliOutput.println(CliOutput.bold("NAMESPACE:") + " " + release.getNamespace());
-				CliOutput.println(CliOutput.bold("STATUS:") + " " + release.getInfo().getStatus());
+				CliOutput.println(CliOutput.bold("STATUS:") + " " + release.getInfo().getStatus().getValue());
 				CliOutput.println(CliOutput.bold("REVISION:") + " " + release.getVersion());
 				CliOutput.println("\n" + CliOutput.bold("MANIFEST:") + "\n" + release.getManifest());
 			}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
@@ -52,7 +52,7 @@ public class ListCommand implements Runnable {
 					CliOutput.bold("STATUS"), CliOutput.bold("CHART"));
 			for (Release r : releases) {
 				String chartInfo = r.getChart().getMetadata().getName() + "-" + r.getChart().getMetadata().getVersion();
-				String status = colorizeStatus(r.getInfo().getStatus());
+				String status = colorizeStatus(r.getInfo().getStatus().getValue());
 				CliOutput.printf("%-20s %-10d %-10s %-30s\n", r.getName(), r.getVersion(), status, chartInfo);
 			}
 		}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/StatusCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/StatusCommand.java
@@ -66,7 +66,7 @@ public class StatusCommand implements Runnable {
 			CliOutput.println(CliOutput.bold("NAME:") + " " + r.getName());
 			CliOutput.println(CliOutput.bold("LAST DEPLOYED:") + " " + r.getInfo().getLastDeployed());
 			CliOutput.println(CliOutput.bold("NAMESPACE:") + " " + r.getNamespace());
-			CliOutput.println(CliOutput.bold("STATUS:") + " " + colorizeStatus(r.getInfo().getStatus()));
+			CliOutput.println(CliOutput.bold("STATUS:") + " " + colorizeStatus(r.getInfo().getStatus().getValue()));
 			CliOutput.println(CliOutput.bold("REVISION:") + " " + r.getVersion());
 
 			if (showResources) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -253,7 +253,7 @@ public class UpgradeCommand implements Runnable {
 		CliOutput.println(CliOutput.bold("NAME:") + " " + release.getName());
 		CliOutput.println(CliOutput.bold("LAST DEPLOYED:") + " " + release.getInfo().getLastDeployed());
 		CliOutput.println(CliOutput.bold("NAMESPACE:") + " " + release.getNamespace());
-		CliOutput.println(CliOutput.bold("STATUS:") + " " + release.getInfo().getStatus());
+		CliOutput.println(CliOutput.bold("STATUS:") + " " + release.getInfo().getStatus().getValue());
 		CliOutput.println(CliOutput.bold("REVISION:") + " " + release.getVersion());
 		CliOutput.println("\n" + CliOutput.bold("MANIFEST:") + "\n" + release.getManifest());
 	}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/GetCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/GetCommandTest.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.app.command;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.action.GetAction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -314,7 +315,7 @@ class GetCommandTest {
 		Chart chart = Chart.builder().metadata(metadata).build();
 
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.lastDeployed(OffsetDateTime.now())
 			.build();
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/HistoryCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/HistoryCommandTest.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.app.command;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.action.HistoryAction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,7 +61,7 @@ class HistoryCommandTest {
 		Chart chart = Chart.builder().metadata(metadata).build();
 
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.lastDeployed(OffsetDateTime.now())
 			.description(description)
 			.build();

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -5,6 +5,7 @@ import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;
@@ -149,7 +150,7 @@ class InstallCommandTest {
 
 		Chart chart = Chart.builder().metadata(metadata).build();
 
-		Release.ReleaseInfo info = Release.ReleaseInfo.builder().status("deployed").build();
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder().status(ReleaseStatus.DEPLOYED).build();
 
 		return Release.builder()
 			.name(name)

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ListCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ListCommandTest.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.app.command;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.action.ListAction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ class ListCommandTest {
 
 		Chart chart = Chart.builder().metadata(metadata).build();
 
-		Release.ReleaseInfo info = Release.ReleaseInfo.builder().status("deployed").build();
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder().status(ReleaseStatus.DEPLOYED).build();
 
 		return Release.builder().name(name).namespace("default").version(version).chart(chart).info(info).build();
 	}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/StatusCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/StatusCommandTest.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.app.command;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.alexmond.jhelm.core.action.StatusAction;
 import org.junit.jupiter.api.BeforeEach;
@@ -98,7 +99,7 @@ class StatusCommandTest {
 		Chart chart = Chart.builder().metadata(metadata).build();
 
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.lastDeployed(OffsetDateTime.now())
 			.build();
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -4,6 +4,7 @@ import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
@@ -207,7 +208,7 @@ class UpgradeCommandTest {
 
 		Chart chart = Chart.builder().metadata(metadata).build();
 
-		Release.ReleaseInfo info = Release.ReleaseInfo.builder().status("deployed").build();
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder().status(ReleaseStatus.DEPLOYED).build();
 
 		return Release.builder()
 			.name(name)

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/GetAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/GetAction.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.util.ValuesLoader;
 
@@ -139,7 +140,8 @@ public class GetAction {
 			metadata.put("appVersion", cm.getAppVersion());
 		}
 		if (release.getInfo() != null) {
-			metadata.put("status", release.getInfo().getStatus());
+			ReleaseStatus status = release.getInfo().getStatus();
+			metadata.put("status", (status != null) ? status.getValue() : null);
 			metadata.put("deployedAt", release.getInfo().getLastDeployed());
 		}
 		return metadata;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -13,6 +13,7 @@ import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.service.LifecycleListener;
@@ -69,7 +70,7 @@ public class InstallAction {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now())
 			.lastDeployed(OffsetDateTime.now())
-			.status(options.isDryRun() ? "pending-install" : "deployed")
+			.status((options.isDryRun()) ? ReleaseStatus.PENDING_INSTALL : ReleaseStatus.DEPLOYED)
 			.description(options.isDryRun() ? "Dry run complete" : "Install complete")
 			.build();
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
@@ -10,6 +10,7 @@ import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.util.HookExecutor;
 import org.alexmond.jhelm.core.util.HookParser;
@@ -56,7 +57,7 @@ public class RollbackAction {
 			.info(Release.ReleaseInfo.builder()
 				.firstDeployed(targetRelease.getInfo().getFirstDeployed())
 				.lastDeployed(OffsetDateTime.now())
-				.status("deployed")
+				.status(ReleaseStatus.DEPLOYED)
 				.description("Rollback to " + revision)
 				.build())
 			.build();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -13,6 +13,7 @@ import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.service.LifecycleListener;
@@ -60,7 +61,7 @@ public class UpgradeAction {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(currentRelease.getInfo().getFirstDeployed())
 			.lastDeployed(OffsetDateTime.now())
-			.status(options.isDryRun() ? "pending-upgrade" : "deployed")
+			.status((options.isDryRun()) ? ReleaseStatus.PENDING_UPGRADE : ReleaseStatus.DEPLOYED)
 			.description(options.isDryRun() ? "Dry run complete" : "Upgrade complete")
 			.build();
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Release.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Release.java
@@ -51,7 +51,7 @@ public class Release {
 
 		private String description;
 
-		private String status; // e.g., "deployed", "uninstalled"
+		private ReleaseStatus status; // e.g., DEPLOYED, UNINSTALLED
 
 		private String notes;
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ReleaseStatus.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ReleaseStatus.java
@@ -1,0 +1,79 @@
+package org.alexmond.jhelm.core.model;
+
+import java.util.Locale;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Lifecycle status of a Helm release.
+ *
+ * <p>
+ * This enum mirrors Helm's {@code release.Status} type. Each constant carries the exact
+ * lowercase, hyphenated wire string that Helm writes into the release record stored in
+ * the Kubernetes Secret. Serialization is byte-compatible with Helm so a release created
+ * by the Helm CLI can be read back, and a release written by jhelm can be read by the
+ * Helm CLI.
+ * </p>
+ */
+public enum ReleaseStatus {
+
+	/** Status is unknown or could not be parsed. */
+	UNKNOWN("unknown"),
+	/** The release is currently deployed. */
+	DEPLOYED("deployed"),
+	/** The release has been uninstalled. */
+	UNINSTALLED("uninstalled"),
+	/** The release has been superseded by a newer revision. */
+	SUPERSEDED("superseded"),
+	/** The release install/upgrade failed. */
+	FAILED("failed"),
+	/** The release is in the process of being uninstalled. */
+	UNINSTALLING("uninstalling"),
+	/** An install is pending. */
+	PENDING_INSTALL("pending-install"),
+	/** An upgrade is pending. */
+	PENDING_UPGRADE("pending-upgrade"),
+	/** A rollback is pending. */
+	PENDING_ROLLBACK("pending-rollback");
+
+	private final String value;
+
+	ReleaseStatus(String value) {
+		this.value = value;
+	}
+
+	/**
+	 * Returns the exact Helm wire string for this status.
+	 * @return the lowercase, hyphenated Helm status string (e.g. {@code "deployed"})
+	 */
+	@JsonValue
+	public String getValue() {
+		return this.value;
+	}
+
+	/**
+	 * Maps a Helm wire string back to a {@link ReleaseStatus}, case-insensitively.
+	 *
+	 * <p>
+	 * Returns {@link #UNKNOWN} for {@code null} or any value not modelled here, so a Helm
+	 * release whose status we do not recognise still deserializes instead of throwing.
+	 * </p>
+	 * @param raw the wire string (any case), may be {@code null}
+	 * @return the matching status, or {@link #UNKNOWN} if unrecognised
+	 */
+	@JsonCreator
+	public static ReleaseStatus fromValue(String raw) {
+		if (raw == null) {
+			return UNKNOWN;
+		}
+		String normalized = raw.toLowerCase(Locale.ROOT);
+		for (ReleaseStatus status : values()) {
+			if (status.value.equals(normalized)) {
+				return status;
+			}
+		}
+		return UNKNOWN;
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/GetActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/GetActionTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.KubeService;
 
 class GetActionTest {
@@ -271,7 +272,7 @@ class GetActionTest {
 		Release release = Release.builder()
 			.name("test")
 			.manifest(manifest)
-			.info(Release.ReleaseInfo.builder().status("deployed").build())
+			.info(Release.ReleaseInfo.builder().status(ReleaseStatus.DEPLOYED).build())
 			.build();
 
 		String all = getAction.getAll(release, false);
@@ -302,7 +303,10 @@ class GetActionTest {
 			.chart(Chart.builder()
 				.metadata(ChartMetadata.builder().name("test-chart").version("1.0.0").appVersion("1.0").build())
 				.build())
-			.info(Release.ReleaseInfo.builder().status("deployed").lastDeployed(OffsetDateTime.now()).build())
+			.info(Release.ReleaseInfo.builder()
+				.status(ReleaseStatus.DEPLOYED)
+				.lastDeployed(OffsetDateTime.now())
+				.build())
 			.manifest("---\nkind: Service\nmetadata:\n  name: my-svc\n")
 			.build();
 	}
@@ -312,7 +316,7 @@ class GetActionTest {
 			.name("my-release")
 			.namespace("default")
 			.version(version)
-			.info(Release.ReleaseInfo.builder().status("deployed").build())
+			.info(Release.ReleaseInfo.builder().status(ReleaseStatus.DEPLOYED).build())
 			.build();
 	}
 
@@ -326,7 +330,7 @@ class GetActionTest {
 				.values(Map.of("chartDefault", "defaultVal", "key1", "chartVal1"))
 				.build())
 			.config(Release.MapConfig.builder().values(Map.of("key1", "userVal1")).build())
-			.info(Release.ReleaseInfo.builder().status("deployed").build())
+			.info(Release.ReleaseInfo.builder().status(ReleaseStatus.DEPLOYED).build())
 			.build();
 	}
 
@@ -339,7 +343,7 @@ class GetActionTest {
 				.metadata(ChartMetadata.builder().name("test-chart").version("1.0.0").build())
 				.build())
 			.info(Release.ReleaseInfo.builder()
-				.status("deployed")
+				.status(ReleaseStatus.DEPLOYED)
 				.notes("Thank you for installing test-chart.")
 				.build())
 			.manifest("---\nkind: Service\n")

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
@@ -26,6 +26,7 @@ import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.util.HookParser;
@@ -67,7 +68,7 @@ class InstallActionTest {
 		assertEquals("my-release", release.getName());
 		assertEquals("default", release.getNamespace());
 		assertEquals(1, release.getVersion());
-		assertEquals("deployed", release.getInfo().getStatus());
+		assertEquals(ReleaseStatus.DEPLOYED, release.getInfo().getStatus());
 		assertEquals(manifest, release.getManifest());
 
 		verify(kubeService).apply("default", HookParser.stripHooks(manifest));
@@ -110,7 +111,7 @@ class InstallActionTest {
 			.dryRun(true)
 			.build());
 
-		assertEquals("pending-install", release.getInfo().getStatus());
+		assertEquals(ReleaseStatus.PENDING_INSTALL, release.getInfo().getStatus());
 		verify(kubeService, never()).apply(anyString(), anyString());
 		verify(kubeService, never()).storeRelease(any(Release.class));
 	}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
@@ -28,6 +28,7 @@ import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.util.HookParser;
 
@@ -52,19 +53,19 @@ class RollbackActionTest {
 		Release.ReleaseInfo info1 = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(2))
 			.lastDeployed(OffsetDateTime.now().minusDays(2))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		Release.ReleaseInfo info2 = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(2))
 			.lastDeployed(OffsetDateTime.now().minusDays(1))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		Release.ReleaseInfo info3 = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(2))
 			.lastDeployed(OffsetDateTime.now())
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		Release v1 = Release.builder()
@@ -125,7 +126,7 @@ class RollbackActionTest {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(1))
 			.lastDeployed(OffsetDateTime.now().minusDays(1))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		Release v1 = Release.builder()
@@ -175,7 +176,7 @@ class RollbackActionTest {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(1))
 			.lastDeployed(OffsetDateTime.now().minusDays(1))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		Release v1 = Release.builder()
@@ -228,7 +229,7 @@ class RollbackActionTest {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(1))
 			.lastDeployed(OffsetDateTime.now().minusDays(1))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		Release v1 = Release.builder()

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/TestActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/TestActionTest.java
@@ -10,6 +10,7 @@ import org.alexmond.jhelm.core.exception.WaitTimeoutException;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.Release.ReleaseInfo;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.junit.jupiter.api.BeforeEach;
@@ -226,7 +227,7 @@ class TestActionTest {
 			.namespace("default")
 			.version(1)
 			.manifest(manifest)
-			.info(ReleaseInfo.builder().status("deployed").build())
+			.info(ReleaseInfo.builder().status(ReleaseStatus.DEPLOYED).build())
 			.build();
 	}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -35,6 +35,7 @@ import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.util.HookParser;
@@ -63,7 +64,7 @@ class UpgradeActionTest {
 		Release.ReleaseInfo oldInfo = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(1))
 			.lastDeployed(OffsetDateTime.now().minusDays(1))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.description("Install complete")
 			.build();
 
@@ -95,7 +96,7 @@ class UpgradeActionTest {
 		assertEquals("myapp", upgradedRelease.getName());
 		assertEquals("default", upgradedRelease.getNamespace());
 		assertEquals(2, upgradedRelease.getVersion());
-		assertEquals("deployed", upgradedRelease.getInfo().getStatus());
+		assertEquals(ReleaseStatus.DEPLOYED, upgradedRelease.getInfo().getStatus());
 		assertEquals("Upgrade complete", upgradedRelease.getInfo().getDescription());
 		assertEquals(renderedManifest, upgradedRelease.getManifest());
 
@@ -129,7 +130,7 @@ class UpgradeActionTest {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(1))
 			.lastDeployed(OffsetDateTime.now().minusDays(1))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		Release currentRelease = Release.builder()
@@ -169,7 +170,7 @@ class UpgradeActionTest {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(1))
 			.lastDeployed(OffsetDateTime.now().minusDays(1))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		Release currentRelease = Release.builder()
@@ -190,7 +191,7 @@ class UpgradeActionTest {
 			.build());
 
 		assertNotNull(upgradedRelease);
-		assertEquals("pending-upgrade", upgradedRelease.getInfo().getStatus());
+		assertEquals(ReleaseStatus.PENDING_UPGRADE, upgradedRelease.getInfo().getStatus());
 		assertEquals("Dry run complete", upgradedRelease.getInfo().getDescription());
 
 		verify(kubeService, never()).apply(anyString(), anyString());
@@ -206,7 +207,7 @@ class UpgradeActionTest {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(1))
 			.lastDeployed(OffsetDateTime.now().minusDays(1))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		Release currentRelease = Release.builder()
@@ -242,7 +243,7 @@ class UpgradeActionTest {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(1))
 			.lastDeployed(OffsetDateTime.now().minusDays(1))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		Release currentRelease = Release.builder()
@@ -298,7 +299,7 @@ class UpgradeActionTest {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(1))
 			.lastDeployed(OffsetDateTime.now().minusDays(1))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		Release currentRelease = Release.builder()
@@ -355,7 +356,7 @@ class UpgradeActionTest {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(5))
 			.lastDeployed(OffsetDateTime.now().minusDays(2))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		Release currentRelease = Release.builder()
@@ -387,7 +388,7 @@ class UpgradeActionTest {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(1))
 			.lastDeployed(OffsetDateTime.now().minusDays(1))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		Release currentRelease = Release.builder()
@@ -425,7 +426,7 @@ class UpgradeActionTest {
 			.namespace("default")
 			.version(1)
 			.chart(chart)
-			.info(Release.ReleaseInfo.builder().status("deployed").build())
+			.info(Release.ReleaseInfo.builder().status(ReleaseStatus.DEPLOYED).build())
 			.build();
 
 		assertThrows(IllegalArgumentException.class,
@@ -453,7 +454,7 @@ class UpgradeActionTest {
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now().minusDays(1))
 			.lastDeployed(OffsetDateTime.now().minusDays(1))
-			.status("deployed")
+			.status(ReleaseStatus.DEPLOYED)
 			.build();
 
 		return Release.builder()

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/model/ReleaseStatusTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/model/ReleaseStatusTest.java
@@ -1,0 +1,71 @@
+package org.alexmond.jhelm.core.model;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReleaseStatusTest {
+
+	private final JsonMapper mapper = JsonMapper.builder().build();
+
+	@Test
+	void getValueReturnsHelmWireStrings() {
+		assertEquals("unknown", ReleaseStatus.UNKNOWN.getValue());
+		assertEquals("deployed", ReleaseStatus.DEPLOYED.getValue());
+		assertEquals("uninstalled", ReleaseStatus.UNINSTALLED.getValue());
+		assertEquals("superseded", ReleaseStatus.SUPERSEDED.getValue());
+		assertEquals("failed", ReleaseStatus.FAILED.getValue());
+		assertEquals("uninstalling", ReleaseStatus.UNINSTALLING.getValue());
+		assertEquals("pending-install", ReleaseStatus.PENDING_INSTALL.getValue());
+		assertEquals("pending-upgrade", ReleaseStatus.PENDING_UPGRADE.getValue());
+		assertEquals("pending-rollback", ReleaseStatus.PENDING_ROLLBACK.getValue());
+	}
+
+	@Test
+	void fromValueMapsEachWireStringBack() {
+		for (ReleaseStatus status : ReleaseStatus.values()) {
+			assertEquals(status, ReleaseStatus.fromValue(status.getValue()));
+		}
+	}
+
+	@Test
+	void fromValueIsCaseInsensitive() {
+		assertEquals(ReleaseStatus.DEPLOYED, ReleaseStatus.fromValue("DEPLOYED"));
+		assertEquals(ReleaseStatus.DEPLOYED, ReleaseStatus.fromValue("Deployed"));
+		assertEquals(ReleaseStatus.PENDING_INSTALL, ReleaseStatus.fromValue("Pending-Install"));
+	}
+
+	@Test
+	void fromValueUnknownAndNullYieldUnknown() {
+		assertEquals(ReleaseStatus.UNKNOWN, ReleaseStatus.fromValue("nonsense"));
+		assertEquals(ReleaseStatus.UNKNOWN, ReleaseStatus.fromValue(null));
+	}
+
+	@Test
+	void serializesToHelmWireString() {
+		assertEquals("\"deployed\"", mapper.writeValueAsString(ReleaseStatus.DEPLOYED));
+		assertEquals("\"pending-install\"", mapper.writeValueAsString(ReleaseStatus.PENDING_INSTALL));
+	}
+
+	@Test
+	void deserializesFromHelmWireString() {
+		assertEquals(ReleaseStatus.DEPLOYED, mapper.readValue("\"deployed\"", ReleaseStatus.class));
+		assertEquals(ReleaseStatus.PENDING_UPGRADE, mapper.readValue("\"pending-upgrade\"", ReleaseStatus.class));
+		assertEquals(ReleaseStatus.UNKNOWN, mapper.readValue("\"bogus\"", ReleaseStatus.class));
+	}
+
+	@Test
+	void releaseInfoRoundTripsStatusField() {
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder().status(ReleaseStatus.DEPLOYED).build();
+		String json = mapper.writeValueAsString(info);
+		// the status field serializes to the Helm wire string
+		assertTrue(json.contains("\"status\":\"deployed\""), "expected wire string in: " + json);
+
+		Release.ReleaseInfo back = mapper.readValue(json, Release.ReleaseInfo.class);
+		assertEquals(ReleaseStatus.DEPLOYED, back.getStatus());
+	}
+
+}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
@@ -89,7 +89,8 @@ public class HelmKubeService implements KubeService {
 					.namespace(release.getNamespace())
 					.putLabelsItem("owner", "helm")
 					.putLabelsItem("name", release.getName())
-					.putLabelsItem("status", release.getInfo().getStatus())
+					.putLabelsItem("status",
+							(release.getInfo().getStatus() != null) ? release.getInfo().getStatus().getValue() : null)
 					.putLabelsItem("version", String.valueOf(release.getVersion())))
 				.type("helm.sh/release.v1")
 				.putDataItem("release", encoded);

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/AsyncHelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/AsyncHelmKubeServiceTest.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.kube.service;
 
 import io.kubernetes.client.openapi.ApiClient;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.alexmond.jhelm.core.service.AsyncKubeService;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,7 +55,7 @@ class AsyncHelmKubeServiceTest {
 			.namespace(namespace)
 			.version(version)
 			.info(Release.ReleaseInfo.builder()
-				.status("deployed")
+				.status(ReleaseStatus.DEPLOYED)
 				.firstDeployed(OffsetDateTime.now())
 				.lastDeployed(OffsetDateTime.now())
 				.description("Test release")

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmFullFlowIntegrationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmFullFlowIntegrationTest.java
@@ -5,6 +5,7 @@ import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.UpgradeAction;
@@ -162,7 +163,7 @@ class HelmFullFlowIntegrationTest {
 				.build());
 			assertNotNull(release);
 			assertTrue(release.getManifest().contains("name: dry-run-release"));
-			assertEquals("pending-install", release.getInfo().getStatus());
+			assertEquals(ReleaseStatus.PENDING_INSTALL, release.getInfo().getStatus());
 
 			// Verify NOT in Kube
 			Optional<Release> storedRelease = helmKubeService.getRelease(releaseName, namespace);
@@ -183,7 +184,7 @@ class HelmFullFlowIntegrationTest {
 			.build());
 		assertNotNull(release);
 		assertTrue(release.getManifest().contains("replicas: 5"));
-		assertEquals("pending-install", release.getInfo().getStatus());
+		assertEquals(ReleaseStatus.PENDING_INSTALL, release.getInfo().getStatus());
 
 		// 2. Verify NOT in Kube
 		Optional<Release> storedRelease = helmKubeService.getRelease(releaseName, namespace);
@@ -209,7 +210,7 @@ class HelmFullFlowIntegrationTest {
 			.build());
 		assertNotNull(dryUpgraded);
 		assertTrue(dryUpgraded.getManifest().contains("replicas: 10"));
-		assertEquals("pending-upgrade", dryUpgraded.getInfo().getStatus());
+		assertEquals(ReleaseStatus.PENDING_UPGRADE, dryUpgraded.getInfo().getStatus());
 		assertEquals(2, dryUpgraded.getVersion());
 
 		// 4. Verify Upgrade NOT in Kube

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
@@ -22,6 +22,7 @@ import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.exception.ReleaseStorageException;
 import org.alexmond.jhelm.core.exception.WaitTimeoutException;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -111,7 +112,7 @@ class HelmKubeServiceTest {
 			.namespace(namespace)
 			.version(version)
 			.info(Release.ReleaseInfo.builder()
-				.status(status)
+				.status(ReleaseStatus.fromValue(status))
 				.firstDeployed(OffsetDateTime.now())
 				.lastDeployed(OffsetDateTime.now())
 				.description("Test release")
@@ -129,7 +130,7 @@ class HelmKubeServiceTest {
 				.namespace(release.getNamespace())
 				.putLabelsItem("owner", "helm")
 				.putLabelsItem("name", release.getName())
-				.putLabelsItem("status", release.getInfo().getStatus())
+				.putLabelsItem("status", release.getInfo().getStatus().getValue())
 				.putLabelsItem("version", String.valueOf(release.getVersion())))
 			.type("helm.sh/release.v1")
 			.putDataItem("release", b64.getBytes(StandardCharsets.UTF_8));

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingTools.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingTools.java
@@ -186,7 +186,7 @@ public class ReleaseMutatingTools {
 		sb.append("' in namespace '").append(release.getNamespace());
 		sb.append("' at revision ").append(release.getVersion());
 		if (release.getInfo() != null && release.getInfo().getStatus() != null) {
-			sb.append(" (status: ").append(release.getInfo().getStatus()).append(')');
+			sb.append(" (status: ").append(release.getInfo().getStatus().getValue()).append(')');
 		}
 		return sb.toString();
 	}

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseReadTools.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseReadTools.java
@@ -163,7 +163,7 @@ public class ReleaseReadTools {
 
 	private static String statusOf(Release release) {
 		if (release.getInfo() != null && release.getInfo().getStatus() != null) {
-			return release.getInfo().getStatus();
+			return release.getInfo().getStatus().getValue();
 		}
 		return "unknown";
 	}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ReleaseDto.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/ReleaseDto.java
@@ -60,7 +60,7 @@ public class ReleaseDto {
 				.appVersion(release.getChart().getMetadata().getAppVersion());
 		}
 		if (release.getInfo() != null) {
-			builder.status(release.getInfo().getStatus())
+			builder.status((release.getInfo().getStatus() != null) ? release.getInfo().getStatus().getValue() : null)
 				.description(release.getInfo().getDescription())
 				.lastDeployed(release.getInfo().getLastDeployed());
 		}

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
@@ -23,6 +23,7 @@ import org.alexmond.jhelm.core.action.UpgradeOptions;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.rest.JhelmRestExceptionHandler;
@@ -102,7 +103,7 @@ class ReleaseControllerTest {
 				.metadata(ChartMetadata.builder().name("nginx").version("1.0.0").appVersion("1.25").build())
 				.build())
 			.info(Release.ReleaseInfo.builder()
-				.status("deployed")
+				.status(ReleaseStatus.DEPLOYED)
 				.description("Install complete")
 				.lastDeployed(OffsetDateTime.now())
 				.build())


### PR DESCRIPTION
#500 conventions — `ReleaseInfo.status` was a raw String. Replace with a typed `ReleaseStatus` enum covering Helm's full `release.Status` set, **preserving exact wire parity**.

## What
- New **`ReleaseStatus`** enum: `UNKNOWN`/`DEPLOYED`/`UNINSTALLED`/`SUPERSEDED`/`FAILED`/`UNINSTALLING`/`PENDING_INSTALL`/`PENDING_UPGRADE`/`PENDING_ROLLBACK`, each carrying its exact Helm string. `@JsonValue` serializes to that string; `@JsonCreator` reads it back **case-insensitively**, mapping null/unrecognized → `UNKNOWN` (so a Helm-created release with an unmodeled status still decodes).
- `ReleaseInfo.status` is now the enum. Actions set enum constants. Read sites use `.getValue()` where a String is required — including the **parity-critical `HelmKubeService` Secret `status` label** and the REST `ReleaseDto` (which **stays a String**, so the JSON API contract is unchanged).
- (Jackson 3 reuses the `com.fasterxml.jackson.annotation` artifact for `@JsonValue`/`@JsonCreator`, consistent with the existing `Dependency.java`.)

## ⚠️ Breaking change
`ReleaseInfo.getStatus()` returns `ReleaseStatus`, not `String` — use `getStatus().getValue()` for the wire string.

## Verified
Full reactor **BUILD SUCCESS**; new `ReleaseStatusTest` (wire strings, case-insensitive `fromValue`, unknown→UNKNOWN, JSON round-trip); the `HelmKubeService` Secret encode/decode round-trip passes (`"status":"deployed"` ↔ `DEPLOYED`); PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)