### PR TITLE
refactor(api)!: LifecycleListener phase String -> LifecyclePhase enum (#500)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -17,6 +17,7 @@ import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.service.LifecycleListener;
+import org.alexmond.jhelm.core.service.LifecyclePhase;
 import org.alexmond.jhelm.core.service.PostRenderProcessor;
 import org.alexmond.jhelm.core.util.HookExecutor;
 import org.alexmond.jhelm.core.util.HookParser;
@@ -105,7 +106,7 @@ public class InstallAction {
 				kubeService.ensureNamespace(namespace);
 			}
 			applyCrds(chart, namespace);
-			fireLifecycleEvent("pre-install", options.getReleaseName(), namespace);
+			fireLifecycleEvent(LifecyclePhase.PRE_INSTALL, options.getReleaseName(), namespace);
 			String regularManifest = HookParser.stripHooks(manifest);
 			List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(manifest);
 			HookExecutor hookExecutor = noHooks ? null : new HookExecutor(kubeService);
@@ -124,7 +125,7 @@ public class InstallAction {
 			if (!noHooks) {
 				runHooks(hookExecutor, namespace, hooks, "post-install");
 			}
-			fireLifecycleEvent("post-install", options.getReleaseName(), namespace);
+			fireLifecycleEvent(LifecyclePhase.POST_INSTALL, options.getReleaseName(), namespace);
 		}
 
 		return release;
@@ -178,13 +179,13 @@ public class InstallAction {
 		}
 	}
 
-	private void fireLifecycleEvent(String phase, String releaseName, String namespace) {
+	private void fireLifecycleEvent(LifecyclePhase phase, String releaseName, String namespace) {
 		for (LifecycleListener listener : lifecycleListeners) {
 			try {
 				listener.onEvent(phase, releaseName, namespace, Map.of());
 			}
 			catch (Exception ex) {
-				throw new JhelmException("Lifecycle listener failed for phase " + phase, ex);
+				throw new JhelmException("Lifecycle listener failed for phase " + phase.getValue(), ex);
 			}
 		}
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -17,6 +17,7 @@ import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.service.LifecycleListener;
+import org.alexmond.jhelm.core.service.LifecyclePhase;
 import org.alexmond.jhelm.core.service.PostRenderProcessor;
 import org.alexmond.jhelm.core.util.HookExecutor;
 import org.alexmond.jhelm.core.util.HookParser;
@@ -100,7 +101,7 @@ public class UpgradeAction {
 
 		if (kubeService != null && !options.isDryRun()) {
 			boolean noHooks = options.isNoHooks();
-			fireLifecycleEvent("pre-upgrade", newRelease.getName(), newRelease.getNamespace());
+			fireLifecycleEvent(LifecyclePhase.PRE_UPGRADE, newRelease.getName(), newRelease.getNamespace());
 			String regularManifest = HookParser.stripHooks(manifest);
 			List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(manifest);
 			HookExecutor hookExecutor = noHooks ? null : new HookExecutor(kubeService);
@@ -120,7 +121,7 @@ public class UpgradeAction {
 			if (!noHooks) {
 				runHooks(hookExecutor, newRelease.getNamespace(), hooks, "post-upgrade");
 			}
-			fireLifecycleEvent("post-upgrade", newRelease.getName(), newRelease.getNamespace());
+			fireLifecycleEvent(LifecyclePhase.POST_UPGRADE, newRelease.getName(), newRelease.getNamespace());
 		}
 
 		return newRelease;
@@ -212,13 +213,13 @@ public class UpgradeAction {
 		}
 	}
 
-	private void fireLifecycleEvent(String phase, String releaseName, String namespace) {
+	private void fireLifecycleEvent(LifecyclePhase phase, String releaseName, String namespace) {
 		for (LifecycleListener listener : lifecycleListeners) {
 			try {
 				listener.onEvent(phase, releaseName, namespace, Map.of());
 			}
 			catch (Exception ex) {
-				throw new JhelmException("Lifecycle listener failed for phase " + phase, ex);
+				throw new JhelmException("Lifecycle listener failed for phase " + phase.getValue(), ex);
 			}
 		}
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/LifecycleListener.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/LifecycleListener.java
@@ -11,12 +11,13 @@ public interface LifecycleListener {
 
 	/**
 	 * Handle a lifecycle event.
-	 * @param phase the lifecycle phase (e.g., "pre-install", "post-install")
+	 * @param phase the lifecycle phase (e.g. {@link LifecyclePhase#PRE_INSTALL})
 	 * @param releaseName the release name
 	 * @param namespace the target namespace
 	 * @param metadata additional metadata about the event
 	 * @throws Exception if handling fails
 	 */
-	void onEvent(String phase, String releaseName, String namespace, Map<String, Object> metadata) throws Exception;
+	void onEvent(LifecyclePhase phase, String releaseName, String namespace, Map<String, Object> metadata)
+			throws Exception;
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/LifecyclePhase.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/LifecyclePhase.java
@@ -1,0 +1,40 @@
+package org.alexmond.jhelm.core.service;
+
+/**
+ * A release lifecycle phase delivered to a {@link LifecycleListener}. Mirrors Helm's
+ * pre/post hook phases; the {@link #getValue()} string is the Helm wire form (e.g.
+ * {@code pre-install}).
+ */
+public enum LifecyclePhase {
+
+	/** Before an install applies its manifest. */
+	PRE_INSTALL("pre-install"),
+	/** After an install has applied and stored its release. */
+	POST_INSTALL("post-install"),
+	/** Before an upgrade applies its manifest. */
+	PRE_UPGRADE("pre-upgrade"),
+	/** After an upgrade has applied and stored its release. */
+	POST_UPGRADE("post-upgrade"),
+	/** Before a rollback applies. */
+	PRE_ROLLBACK("pre-rollback"),
+	/** After a rollback has applied. */
+	POST_ROLLBACK("post-rollback"),
+	/** Before an uninstall deletes resources. */
+	PRE_DELETE("pre-delete"),
+	/** After an uninstall has deleted resources. */
+	POST_DELETE("post-delete");
+
+	private final String value;
+
+	LifecyclePhase(String value) {
+		this.value = value;
+	}
+
+	/**
+	 * @return the Helm wire string for this phase (e.g. {@code pre-install})
+	 */
+	public String getValue() {
+		return this.value;
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/LifecyclePhaseTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/LifecyclePhaseTest.java
@@ -1,0 +1,21 @@
+package org.alexmond.jhelm.core.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LifecyclePhaseTest {
+
+	@Test
+	void testWireValues() {
+		assertEquals("pre-install", LifecyclePhase.PRE_INSTALL.getValue());
+		assertEquals("post-install", LifecyclePhase.POST_INSTALL.getValue());
+		assertEquals("pre-upgrade", LifecyclePhase.PRE_UPGRADE.getValue());
+		assertEquals("post-upgrade", LifecyclePhase.POST_UPGRADE.getValue());
+		assertEquals("pre-rollback", LifecyclePhase.PRE_ROLLBACK.getValue());
+		assertEquals("post-rollback", LifecyclePhase.POST_ROLLBACK.getValue());
+		assertEquals("pre-delete", LifecyclePhase.PRE_DELETE.getValue());
+		assertEquals("post-delete", LifecyclePhase.POST_DELETE.getValue());
+	}
+
+}


### PR DESCRIPTION
Completes the #500 String→enum conventions item (paired with #532's `ReleaseStatus`).

`LifecycleListener.onEvent` took a raw `String` phase; replace with a typed **`LifecyclePhase`** enum (`PRE_INSTALL`/`POST_INSTALL`/`PRE_UPGRADE`/`POST_UPGRADE`/`PRE_ROLLBACK`/`POST_ROLLBACK`/`PRE_DELETE`/`POST_DELETE`), each carrying its Helm wire string via `getValue()`. Install/UpgradeAction fire the enum constants.

The phase is a runtime callback (**not serialized**), so this is parity-safe. Hook-phase strings (`HookExecutor`) are a separate concern, left as-is.

## ⚠️ Breaking change
`LifecycleListener.onEvent`'s first parameter is `LifecyclePhase`, not `String`.

## Verified
Full reactor green; new `LifecyclePhaseTest` covers the wire strings; PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)