### PR TITLE
docs: prep 0.4.0 release

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,25 @@
 = Changelog
 
+== 0.4.0
+
+The pre-1.0 *API freeze* release.
+
+* *API freeze (breaking)* -- the action layer and `KubeService` throw the unchecked
+  `JhelmException` hierarchy; kubernetes-client and BouncyCastle PGP types are wrapped
+  (`KubeClient`, `SigningKey`/`VerificationKeyring`); the action API takes immutable options
+  objects (`InstallOptions`/`UpgradeOptions`/`UninstallOptions`/`RollbackOptions`); result
+  models (`Release`/`ReleaseInfo`/`MapConfig`) are immutable, with `ReleaseStatus` /
+  `LifecyclePhase` enums.
+* *MCP server* -- new `jhelm-mcp` + `jhelm-mcp-starter` exposing jhelm operations as Model
+  Context Protocol tools for AI agents (Spring AI 2.0), with a `READ_ONLY`/`FULL` access mode.
+* *REST split* -- `jhelm-rest` is now a pure library; the new `jhelm-rest-starter` carries the
+  auto-configuration, with a `READ_ONLY`/`FULL` access mode.
+* *Upgrade value-retention flags* -- `--reset-values`, `--reuse-values`, and
+  `--reset-then-reuse-values` are now implemented; user values are persisted as the release
+  config.
+* *Engine* -- now on `gotmpl4j 1.1.0`; recursive/too-deep renders fail with a
+  `TemplateRenderException` instead of an inline `ERROR:` string.
+
 == Unreleased (targeting 0.1.0)
 
 Toward the *0.1.0 prerelease target* (see the Roadmap in the docs): a *≥ 300-chart*

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 = jhelm
-:jhelm-version: 0.1.0
+:jhelm-version: 0.4.0
 :url-docs: https://www.alexmond.org/jhelm/current/index.html
 :toc:
 
@@ -40,8 +40,13 @@ the Go-based Helm binary.
   provenance files.
 * *Spring Boot integration* -- auto-configured beans, `@ConfigurationProperties`, and a
   programmatic action API.
-* *REST API* -- a Spring MVC module exposing chart and template operations over HTTP, with
-  OpenAPI/Swagger documentation.
+* *REST API* -- a Spring MVC library exposing chart and template operations over HTTP, with
+  OpenAPI/Swagger documentation. Split into a pure `jhelm-rest` library and a
+  `jhelm-rest-starter` that carries the auto-configuration, with a `READ_ONLY`/`FULL`
+  access mode gating the cluster-mutating endpoints.
+* *MCP server* -- `jhelm-mcp` / `jhelm-mcp-starter` expose jhelm operations as
+  https://modelcontextprotocol.io[Model Context Protocol] tools for AI agents (built on
+  Spring AI), mirroring the REST operation set with the same `READ_ONLY`/`FULL` access mode.
 * *JSON Schema validation* -- validates chart values against `values.schema.json` (Draft-07).
 * *Async Kubernetes operations* -- Java 21 virtual threads via `AsyncKubeService`.
 
@@ -54,7 +59,10 @@ the Go-based Helm binary.
 | `jhelm-core` | Chart model, loader, repository manager, rendering engine, and action API. The main entry point for library users.
 | `jhelm-gotemplate-helm` | Helm-specific template functions (`include`, `tpl`, `required`, `toYaml`, `lookup`, …) layered on top of gotmpl4j.
 | `jhelm-kube` | Kubernetes client integration -- apply/delete resources, ConfigMap-based release storage, async operations.
-| `jhelm-rest` | Spring MVC REST API over jhelm operations, with OpenAPI documentation.
+| `jhelm-rest` | Spring MVC REST API over jhelm operations, with OpenAPI documentation (pure library -- bring your own auto-configuration).
+| `jhelm-rest-starter` | Spring Boot starter that auto-configures the `jhelm-rest` API, with a `READ_ONLY`/`FULL` access mode gating cluster-mutating endpoints.
+| `jhelm-mcp` | Model Context Protocol server exposing jhelm operations as AI-agent tools (built on Spring AI), mirroring the REST operation set.
+| `jhelm-mcp-starter` | Spring Boot starter that auto-configures the `jhelm-mcp` server, with a `READ_ONLY`/`FULL` access mode.
 | `jhelm-plugin` | Maven plugin for packaging charts as part of a build.
 | `jhelm-cli` | Standalone CLI (Spring Boot + Picocli) -- 22 Helm-compatible commands.
 |===
@@ -70,7 +78,7 @@ as a dependency.
 | Java | 21
 | Spring Boot | 4.0.7
 | Kubernetes Client | 26.0.0
-| Template engine | gotmpl4j 0.3.0
+| Template engine | gotmpl4j 1.1.0
 | CLI framework | Picocli 4.7.7
 |===
 

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -4,7 +4,7 @@ version: master
 start_page: ROOT:index.adoc
 asciidoc:
   attributes:
-    jhelm-version: 0.2.0
+    jhelm-version: 0.4.0
     toc: left
     sectnums: ''
     keywords: 'Helm, Java, Kubernetes, Spring Boot, Chart management, Template engine'

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -1,5 +1,67 @@
 = Changelog
 
+== 0.4.0
+
+The pre-1.0 *API freeze* release, plus an MCP server, a REST library/starter split, and the
+upgrade value-handling fixes (including the value-retention flags listed as a known
+limitation in `0.2.0`).
+
+=== API freeze (breaking, pre-1.0)
+
+* *Unchecked exceptions* -- the action layer and `KubeService` now throw the unchecked
+  `JhelmException` hierarchy instead of `throws Exception`.
+* *No leaked client types* -- the kubernetes-client `ApiException`/`ApiClient` are wrapped
+  behind `KubeClient`, and the BouncyCastle PGP types behind `SigningKey` /
+  `VerificationKeyring`.
+* *Options objects* -- the action API now takes immutable `InstallOptions`, `UpgradeOptions`,
+  `UninstallOptions`, and `RollbackOptions` objects instead of long parameter lists.
+* *Immutable result models* -- `Release`, `ReleaseInfo`, and `MapConfig` are now immutable;
+  release `status` is a typed `ReleaseStatus` enum and the lifecycle phase a `LifecyclePhase`
+  enum.
+
+=== MCP server
+
+* *`jhelm-mcp` + `jhelm-mcp-starter`* -- a new Model Context Protocol server exposing jhelm
+  operations as tools for AI agents, built on Spring AI 2.0 and mirroring the REST operation
+  set. A `READ_ONLY`/`FULL` access mode (`jhelm.mcp.mode`, default `READ_ONLY`) gates the
+  cluster-mutating tools.
+
+=== REST library/starter split
+
+* *Pure library* -- `jhelm-rest` is now a pure library; the new `jhelm-rest-starter` carries
+  the auto-configuration (Spring-Boot-Admin style).
+* *Access mode* -- a `READ_ONLY`/`FULL` mode (`jhelm.rest.mode`, default `FULL`) gates the
+  cluster-mutating endpoints. Authentication is the embedding application's responsibility
+  (Spring Security).
+
+=== Upgrade value handling
+
+* *User values persisted* -- user-supplied values are now persisted as the release config,
+  fixing a data-loss bug (and `get values`).
+* *Value-retention flags implemented* -- `--reset-values`, `--reuse-values`, and
+  `--reset-then-reuse-values` are now implemented. These were listed as a known limitation in
+  `0.2.0`.
+
+=== New flags
+
+* *Value flags* -- `--set` now type-coerces like Helm (int/bool/null; floats and leading-zero
+  values stay strings), joined by `--set-string`, `--set-file`, and `--set-json`.
+* *Lifecycle flags* -- `--no-hooks` (install/upgrade/uninstall/rollback), `--history-max`
+  (release-history pruning, default 10), and `--create-namespace`.
+
+=== Engine
+
+* *Loud render failures* -- recursive / too-deep template rendering now fails with a
+  `TemplateRenderException` instead of baking an `ERROR:` string into the manifest.
+* *gotmpl4j 1.1.0* -- the engine dependency moves to `gotmpl4j 1.1.0` (perf wave: double
+  formatting without `BigDecimal`, cached property accessors, an allocation-free lexer).
+
+=== CLI
+
+* *New commands* -- `jhelm version` and `jhelm env`.
+* *Clean stdout* -- command output is now clean on stdout (banner and logs go to stderr), so
+  `jhelm template … > out.yaml` produces valid YAML.
+
 == 0.2.0
 
 Helm template-function conformance improvements, grinding `jhelm-gotemplate-helm` against

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -21,7 +21,8 @@ tracks upstream Helm closely rather than approximating it.
 * *Dependency management* -- list, update, build chart dependencies
 * *Packaging & provenance* -- package charts to `.tgz`, PGP sign and verify
 * *Spring Boot auto-configuration* -- programmatic action API with `@ConfigurationProperties`
-* *REST API* -- Spring MVC endpoints with OpenAPI/Swagger documentation
+* *REST API* -- Spring MVC endpoints with OpenAPI/Swagger documentation (pure library plus a `jhelm-rest-starter`)
+* *MCP server* -- exposes jhelm operations as Model Context Protocol tools for AI agents (built on Spring AI)
 * *JSON Schema validation* -- validates chart values against `values.schema.json` (Draft-07)
 * *Async Kubernetes operations* -- Java 21 virtual threads via `AsyncKubeService`
 
@@ -30,7 +31,7 @@ tracks upstream Helm closely rather than approximating it.
 * Java 21
 * Spring Boot 4.0.7
 * Kubernetes Client 26.0.0
-* gotmpl4j 0.3.0 (Go template + Sprig engine)
+* gotmpl4j 1.1.0 (Go template + Sprig engine)
 * Picocli 4.7.7 (CLI framework)
 
 == Quick Links

--- a/docs/modules/ROOT/pages/rest-api.adoc
+++ b/docs/modules/ROOT/pages/rest-api.adoc
@@ -1,18 +1,22 @@
 = REST API Starter
 
-The `jhelm-rest` module provides a Spring Boot starter that exposes Helm operations as a REST API with OpenAPI/Swagger documentation.
+The `jhelm-rest` module exposes Helm operations as a REST API with OpenAPI/Swagger
+documentation. As of `0.4.0` it is split into a pure `jhelm-rest` library and a
+`jhelm-rest-starter` that carries the Spring Boot auto-configuration (Spring-Boot-Admin
+style). Add the starter for the auto-configured experience, or depend on the library directly
+to wire it up yourself.
 
 == Getting Started
 
 === Maven Dependency
 
-Add `jhelm-rest` to your Spring Boot web application:
+Add `jhelm-rest-starter` to your Spring Boot web application:
 
-[source,xml]
+[source,xml,subs="attributes"]
 ----
 <dependency>
     <groupId>org.alexmond</groupId>
-    <artifactId>jhelm-rest</artifactId>
+    <artifactId>jhelm-rest-starter</artifactId>
     <version>{jhelm-version}</version>
 </dependency>
 ----
@@ -46,6 +50,10 @@ Open http://localhost:8080/swagger-ui.html to see all endpoints.
 |===
 | Property | Default | Description
 
+| `jhelm.rest.mode`
+| `FULL`
+| Access mode. `READ_ONLY` disables the cluster-mutating endpoints (install/upgrade/uninstall/rollback/test, repo add/remove/push); `FULL` enables them.
+
 | `jhelm.rest.base-path`
 | `/api/v1`
 | Base path prefix for all REST endpoints
@@ -59,9 +67,14 @@ Open http://localhost:8080/swagger-ui.html to see all endpoints.
 ----
 jhelm:
   rest:
+    mode: FULL
     base-path: /api/v1
     temp-dir: /var/lib/jhelm/tmp
 ----
+
+NOTE: Authentication and authorization are the embedding application's responsibility
+(e.g. Spring Security). `jhelm.rest.mode` is a coarse mutating/read-only gate, not an auth
+mechanism.
 
 == Auto-Configuration
 
@@ -553,3 +566,34 @@ public class CustomReleaseController {
     // Your custom implementation
 }
 ----
+
+== MCP Server
+
+In addition to the REST API, jhelm ships an https://modelcontextprotocol.io[Model Context
+Protocol] (MCP) server that exposes the same operation set as tools an AI agent can call. It
+is built on Spring AI and mirrors the REST surface (releases, charts, repositories,
+dependencies, hub search).
+
+Add `jhelm-mcp-starter` to a Spring Boot application for the auto-configured server:
+
+[source,xml,subs="attributes"]
+----
+<dependency>
+    <groupId>org.alexmond</groupId>
+    <artifactId>jhelm-mcp-starter</artifactId>
+    <version>{jhelm-version}</version>
+</dependency>
+----
+
+Like the REST starter, the MCP server has a `READ_ONLY`/`FULL` access mode. It defaults to
+`READ_ONLY`, so only the non-mutating tools are exposed unless you opt in:
+
+[source,yaml]
+----
+jhelm:
+  mcp:
+    mode: READ_ONLY   # READ_ONLY (default) or FULL
+----
+
+NOTE: As with the REST API, authentication is the embedding application's responsibility;
+`jhelm.mcp.mode` is a coarse mutating/read-only gate.

--- a/docs/modules/ROOT/pages/roadmap.adoc
+++ b/docs/modules/ROOT/pages/roadmap.adoc
@@ -24,7 +24,7 @@ extraction-ready engine*. The release is cut via `maven_release.yml`
 | Engine maturity
 | The Go template + Sprig engine ships as the standalone
   https://github.com/alexmond/gotmpl4j[gotmpl4j] library on Maven Central; jhelm consumes it
-  as a dependency (`gotmpl4j 0.3.0`). The 346-chart suite is its de-facto conformance test.
+  as a dependency (`gotmpl4j 1.1.0`). The 346-chart suite is its de-facto conformance test.
 | ✅ Extracted — gotmpl4j on Maven Central; 346-chart suite green
 
 | Supported surface
@@ -53,7 +53,8 @@ extraction-ready engine*. The release is cut via `maven_release.yml`
 
 The Go template engine has been extracted into the standalone
 https://github.com/alexmond/gotmpl4j[gotmpl4j] library, published to Maven Central
-(`org.alexmond:gotmpl4j-core`, `gotmpl4j-sprig`, plus a Spring Boot starter). jhelm consumes
+(`org.alexmond:gotmpl4j-core`, `gotmpl4j-sprig`, plus a Spring Boot starter; `gotmpl4j 1.1.0`).
+jhelm consumes
 it as an ordinary dependency, keeping only the Helm-specific function layer
 (`jhelm-gotemplate-helm`) in this repository. The extraction holds the properties that made it
 mechanical rather than a redesign:
@@ -65,6 +66,20 @@ mechanical rather than a redesign:
 * *Stable API* — `GoTemplate`, `Function`, `FunctionProvider` are settled.
 * *Coverage* — comprehensive unit tests for lexer/parser/executor and every function
   category, independent of the chart suite.
+
+=== API freeze (shipped in 0.4.0 — toward 1.0)
+
+The pre-1.0 *API freeze* milestone landed in `0.4.0`, settling the public surface ahead of a
+stable `1.0`:
+
+* *Unchecked exceptions* — the action layer and `KubeService` throw the `JhelmException`
+  hierarchy instead of `throws Exception`.
+* *No leaked Kubernetes-client types* — `ApiException`/`ApiClient` are wrapped behind
+  `KubeClient`; BouncyCastle PGP types behind `SigningKey`/`VerificationKeyring`.
+* *Options objects* — the action API takes immutable `InstallOptions`/`UpgradeOptions`/
+  `UninstallOptions`/`RollbackOptions` instead of long parameter lists.
+* *Immutable result models* — `Release`/`ReleaseInfo`/`MapConfig` are immutable; release
+  `status` is a typed `ReleaseStatus` enum and the lifecycle phase a `LifecyclePhase` enum.
 
 === Explicit non-goals for 0.1.0
 


### PR DESCRIPTION
Pre-release docs (release-prep): version attributes 0.2.0/0.1.0 → **0.4.0**, gotmpl4j 0.3.0 → 1.1.0, a comprehensive **0.4.0 changelog** (API freeze, MCP server, REST library/starter split, upgrade value-handling + now-implemented `--reuse-values`/`--reset-values`, new flags, engine, CLI), and README/rest-api updates for the new `jhelm-rest-starter`/`jhelm-mcp`/`jhelm-mcp-starter` modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)