### PR TITLE
docs: fix javadoc @throws references (#500)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/GetAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/GetAction.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.core.action;
 
+import org.alexmond.jhelm.core.exception.KubernetesOperationException;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.SerializationFeature;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/HistoryAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/HistoryAction.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.core.action;
 
+import org.alexmond.jhelm.core.exception.KubernetesOperationException;
+
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/PackageAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/PackageAction.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.core.action;
 
+import org.alexmond.jhelm.core.exception.SignatureException;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.IOException;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TestAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TestAction.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.core.action;
 
+import org.alexmond.jhelm.core.exception.KubernetesOperationException;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/VerifyAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/VerifyAction.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.core.action;
 
+import org.alexmond.jhelm.core.exception.SignatureException;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;


### PR DESCRIPTION
The API-freeze `@throws` docs referenced unchecked exceptions (`KubernetesOperationException`, `SignatureException`) that weren't imported, so the **release-profile javadoc** reported reference-not-found in 5 action classes. Adds the imports so the references resolve (checkstyle counts `@throws` usage). Full reactor release javadoc now clean. Needed for a clean 0.4.0 docs publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)