### PR TITLE
feat(security): unified deny-by-default API-key gate for rest + mcp (#538)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -3,8 +3,12 @@ package org.alexmond.jhelm.core;
 import java.util.List;
 
 import org.alexmond.jhelm.core.cache.TemplateCache;
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
 import org.alexmond.jhelm.core.metrics.JhelmMetrics;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -12,6 +16,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.beans.factory.ObjectProvider;
+import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.action.CreateAction;
 import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.HistoryAction;
@@ -44,9 +49,46 @@ import org.apache.hc.client5.http.impl.classic.HttpClients;
  * require a {@link KubeService} are only created when one is present in the application
  * context.
  */
+@Slf4j
 @AutoConfiguration(after = JhelmMetricsAutoConfiguration.class)
-@EnableConfigurationProperties(JhelmCoreProperties.class)
+@EnableConfigurationProperties({ JhelmCoreProperties.class, JhelmSecurityProperties.class })
 public class JhelmCoreAutoConfiguration {
+
+	/**
+	 * Provides the unified security policy derived from {@link JhelmSecurityProperties}.
+	 * This single policy gates cluster-mutating operations across all jhelm adapters
+	 * (REST, MCP) under deny-by-default semantics.
+	 * @param props the unified security properties
+	 * @return the resolved security policy bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public JhelmSecurityPolicy jhelmSecurityPolicy(JhelmSecurityProperties props) {
+		return new JhelmSecurityPolicy(props);
+	}
+
+	/**
+	 * Logs a single line describing the resolved security posture at startup, so
+	 * operators can confirm whether mutating operations are enabled and protected.
+	 * @param policy the resolved security policy
+	 * @return an application runner that logs the posture once
+	 */
+	@Bean
+	@ConditionalOnMissingBean(name = "jhelmSecurityPostureLogger")
+	public ApplicationRunner jhelmSecurityPostureLogger(JhelmSecurityPolicy policy) {
+		return (args) -> {
+			if (policy.mutatingEnabled()) {
+				log.info("jhelm security: FULL — mutating operations ENABLED, protected by an API key.");
+			}
+			else if (policy.mode() == JhelmAccessMode.FULL) {
+				log.warn("jhelm security: FULL requested but no jhelm.security.api-key is set — mutating "
+						+ "operations are DISABLED (deny-by-default). Set jhelm.security.api-key to enable them.");
+			}
+			else {
+				log.info("jhelm security: READ_ONLY — mutating operations are disabled.");
+			}
+		};
+	}
 
 	/**
 	 * Provides the chart repository manager, configured from the jhelm properties.

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmSecurityPolicy.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmSecurityPolicy.java
@@ -1,0 +1,84 @@
+package org.alexmond.jhelm.core.config;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+/**
+ * The effective, resolved security posture for jhelm adapters, derived from
+ * {@link JhelmSecurityProperties}.
+ *
+ * <p>
+ * <strong>Deny-by-default:</strong> mutating (cluster-changing) operations are enabled
+ * <em>only</em> when the operator both selects {@link JhelmAccessMode#FULL FULL}
+ * <em>and</em> configures an API key. Requesting {@code FULL} without a key does
+ * <em>not</em> enable mutating operations — the safe default wins so an adapter cannot be
+ * accidentally started as an open, unauthenticated cluster-mutation API.
+ */
+public final class JhelmSecurityPolicy {
+
+	private final JhelmAccessMode mode;
+
+	private final String apiKey;
+
+	private final String apiKeyHeader;
+
+	/**
+	 * Creates a policy snapshot from the supplied properties.
+	 * @param properties the unified security properties
+	 */
+	public JhelmSecurityPolicy(JhelmSecurityProperties properties) {
+		this.mode = properties.getMode();
+		this.apiKey = properties.getApiKey();
+		this.apiKeyHeader = properties.getApiKeyHeader();
+	}
+
+	/**
+	 * Returns the configured access mode.
+	 * @return the access mode
+	 */
+	public JhelmAccessMode mode() {
+		return this.mode;
+	}
+
+	/**
+	 * Indicates whether a non-blank API key is configured.
+	 * @return {@code true} if an API key is set and not blank
+	 */
+	public boolean apiKeyConfigured() {
+		return this.apiKey != null && !this.apiKey.isBlank();
+	}
+
+	/**
+	 * Indicates whether cluster-mutating operations are enabled.
+	 *
+	 * <p>
+	 * <strong>Deny-by-default:</strong> this returns {@code true} only when the mode is
+	 * {@link JhelmAccessMode#FULL FULL} <em>and</em> an API key is configured. Selecting
+	 * {@code FULL} without a key does <em>not</em> enable mutating operations.
+	 * @return {@code true} if mutating operations are enabled
+	 */
+	public boolean mutatingEnabled() {
+		return this.mode == JhelmAccessMode.FULL && apiKeyConfigured();
+	}
+
+	/**
+	 * Validates a presented API key against the configured key using a constant-time
+	 * comparison (resistant to timing attacks). Returns {@code false} when no key is
+	 * configured or the presented value is {@code null}.
+	 * @param presented the API key presented by the caller
+	 * @return {@code true} if the presented key matches the configured key
+	 */
+	public boolean validApiKey(String presented) {
+		return apiKeyConfigured() && presented != null && MessageDigest
+			.isEqual(this.apiKey.getBytes(StandardCharsets.UTF_8), presented.getBytes(StandardCharsets.UTF_8));
+	}
+
+	/**
+	 * Returns the request header name that carries the API key.
+	 * @return the API key header name
+	 */
+	public String apiKeyHeader() {
+		return this.apiKeyHeader;
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmSecurityProperties.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmSecurityProperties.java
@@ -1,0 +1,48 @@
+package org.alexmond.jhelm.core.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Unified security configuration shared by every jhelm adapter (REST, MCP, ...).
+ *
+ * <p>
+ * This replaces the per-adapter {@code jhelm.rest.mode} and {@code jhelm.mcp.mode}
+ * properties with a single {@code jhelm.security.*} namespace, so an operator configures
+ * the security posture once and every surface agrees on it.
+ *
+ * <p>
+ * <strong>Deny-by-default:</strong> the mode defaults to {@link JhelmAccessMode#READ_ONLY
+ * READ_ONLY} and there is no default API key, so a freshly started jhelm adapter never
+ * exposes cluster-mutating operations until an operator both opts into
+ * {@link JhelmAccessMode#FULL FULL} and configures an API key. The effective policy is
+ * derived by {@link JhelmSecurityPolicy}.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jhelm.security")
+public class JhelmSecurityProperties {
+
+	/**
+	 * Unified access mode for all jhelm adapters. Defaults to
+	 * {@link JhelmAccessMode#READ_ONLY READ_ONLY} (read-only by default):
+	 * cluster-mutating operations stay disabled until this is set to
+	 * {@link JhelmAccessMode#FULL FULL} <em>and</em> an {@link #apiKey} is configured.
+	 */
+	private JhelmAccessMode mode = JhelmAccessMode.READ_ONLY;
+
+	/**
+	 * The API key that protects cluster-mutating operations. When {@code null} or blank,
+	 * no key is configured and mutating operations remain disabled regardless of
+	 * {@link #mode} (deny-by-default). Callers present this value in the
+	 * {@link #apiKeyHeader} request header.
+	 */
+	private String apiKey;
+
+	/**
+	 * Name of the request header carrying the API key. Defaults to {@code X-API-Key}.
+	 */
+	private String apiKeyHeader = "X-API-Key";
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/config/JhelmSecurityPolicyTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/config/JhelmSecurityPolicyTest.java
@@ -1,0 +1,75 @@
+package org.alexmond.jhelm.core.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the deny-by-default semantics of {@link JhelmSecurityPolicy}: mutating
+ * operations are enabled only when the mode is {@link JhelmAccessMode#FULL FULL}
+ * <em>and</em> an API key is configured, and API-key validation is correct.
+ */
+class JhelmSecurityPolicyTest {
+
+	private static JhelmSecurityPolicy policy(JhelmAccessMode mode, String apiKey) {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(mode);
+		props.setApiKey(apiKey);
+		return new JhelmSecurityPolicy(props);
+	}
+
+	@Test
+	void readOnlyNeverEnablesMutating() {
+		assertFalse(policy(JhelmAccessMode.READ_ONLY, null).mutatingEnabled());
+		assertFalse(policy(JhelmAccessMode.READ_ONLY, "secret").mutatingEnabled(),
+				"READ_ONLY must stay read-only even with a key");
+	}
+
+	@Test
+	void fullWithoutKeyDoesNotEnableMutating() {
+		assertFalse(policy(JhelmAccessMode.FULL, null).mutatingEnabled(), "FULL without a key must stay disabled");
+		assertFalse(policy(JhelmAccessMode.FULL, "   ").mutatingEnabled(), "FULL with a blank key must stay disabled");
+	}
+
+	@Test
+	void fullWithKeyEnablesMutating() {
+		assertTrue(policy(JhelmAccessMode.FULL, "secret").mutatingEnabled());
+	}
+
+	@Test
+	void apiKeyConfiguredReflectsKeyPresence() {
+		assertFalse(policy(JhelmAccessMode.FULL, null).apiKeyConfigured());
+		assertFalse(policy(JhelmAccessMode.FULL, "").apiKeyConfigured());
+		assertFalse(policy(JhelmAccessMode.FULL, "  ").apiKeyConfigured());
+		assertTrue(policy(JhelmAccessMode.FULL, "secret").apiKeyConfigured());
+	}
+
+	@Test
+	void validApiKeyMatchesOnlyCorrectKey() {
+		JhelmSecurityPolicy policy = policy(JhelmAccessMode.FULL, "secret");
+		assertTrue(policy.validApiKey("secret"));
+		assertFalse(policy.validApiKey("wrong"));
+		assertFalse(policy.validApiKey(""));
+		assertFalse(policy.validApiKey(null));
+	}
+
+	@Test
+	void validApiKeyFalseWhenNoKeyConfigured() {
+		JhelmSecurityPolicy policy = policy(JhelmAccessMode.FULL, null);
+		assertFalse(policy.validApiKey("anything"));
+		assertFalse(policy.validApiKey(null));
+	}
+
+	@Test
+	void exposesModeAndHeaderName() {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(JhelmAccessMode.FULL);
+		props.setApiKeyHeader("X-Custom-Key");
+		JhelmSecurityPolicy policy = new JhelmSecurityPolicy(props);
+		assertEquals(JhelmAccessMode.FULL, policy.mode());
+		assertEquals("X-Custom-Key", policy.apiKeyHeader());
+	}
+
+}

--- a/jhelm-mcp-sample/src/main/resources/application.properties
+++ b/jhelm-mcp-sample/src/main/resources/application.properties
@@ -6,5 +6,9 @@ spring.ai.mcp.server.protocol=STREAMABLE
 # Discover @McpTool methods on Spring beans (the jhelm tool holders).
 spring.ai.mcp.server.annotation-scanner.enabled=true
 
-# Expose only the non-mutating jhelm tools.
-jhelm.mcp.mode=READ_ONLY
+# Unified deny-by-default security (jhelm.security.*).
+# Expose only the non-mutating jhelm tools. MCP defaults to a local deployment
+# (stdio / localhost), where the stdio transport never reaches the servlet and an API key
+# is not required. To enable cluster-mutating tools over HTTP, set jhelm.security.mode=FULL
+# AND jhelm.security.api-key=<key> (FULL without a key keeps mutating tools disabled).
+jhelm.security.mode=READ_ONLY

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/JhelmMcpAutoConfiguration.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/JhelmMcpAutoConfiguration.java
@@ -14,6 +14,7 @@ import org.alexmond.jhelm.core.action.TemplateAction;
 import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.mcp.config.JhelmMcpProperties;
 import org.alexmond.jhelm.mcp.tools.ChartTools;
@@ -25,9 +26,10 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 
 /**
  * Auto-configuration for the jhelm MCP (Model Context Protocol) server module. Activates
@@ -41,13 +43,14 @@ import org.springframework.context.annotation.Bean;
  * run for a library on the classpath).
  *
  * <p>
- * <strong>Access mode:</strong> {@code jhelm.mcp.mode} mirrors {@code jhelm.rest.mode}.
- * In the default {@code READ_ONLY} mode only the non-mutating tools (template, show,
- * lint, search, plus the cluster-read release tools: list, status, history, get
- * values/manifest) are exposed. The cluster-mutating tools (install, upgrade, uninstall,
- * rollback, test) are registered only when {@code jhelm.mcp.mode} is set to the
- * upper-case value {@code FULL}; in {@code READ_ONLY} mode they are not registered and do
- * not appear in the MCP tool list at all.
+ * <strong>Security:</strong> the MCP server uses the unified {@code jhelm.security.*}
+ * policy. The non-mutating tools (template, show, lint, search, plus the cluster-read
+ * release tools: list, status, history, get values/manifest) are always exposed. The
+ * cluster-mutating tools (install, upgrade, uninstall, rollback, test) are registered
+ * only when, under deny-by-default semantics, {@code jhelm.security.mode=FULL}
+ * <em>and</em> a non-blank {@code jhelm.security.api-key} is set (see
+ * {@link OnMutatingEnabledCondition}). Without an API key they are never registered and
+ * do not appear in the MCP tool list.
  */
 @AutoConfiguration(after = JhelmCoreAutoConfiguration.class)
 @ConditionalOnClass(McpTool.class)
@@ -101,10 +104,11 @@ public class JhelmMcpAutoConfiguration {
 	}
 
 	/**
-	 * Registers the cluster-mutating release MCP tools only when
-	 * {@code jhelm.mcp.mode=FULL} (upper-case) and the required mutating actions are
-	 * present. In the default {@code READ_ONLY} mode this bean is not created, so the
-	 * mutating tools never appear in the MCP tool list.
+	 * Registers the cluster-mutating release MCP tools only when, under deny-by-default
+	 * semantics, {@code jhelm.security.mode=FULL} <em>and</em> a non-blank
+	 * {@code jhelm.security.api-key} is set (see {@link OnMutatingEnabledCondition}), and
+	 * the required mutating actions are present. Without an API key this bean is not
+	 * created, so the mutating tools never appear in the MCP tool list.
 	 * @param installAction installs releases
 	 * @param upgradeAction upgrades releases
 	 * @param uninstallAction uninstalls releases
@@ -116,7 +120,7 @@ public class JhelmMcpAutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnProperty(name = "jhelm.mcp.mode", havingValue = "FULL")
+	@Conditional(OnMutatingEnabledCondition.class)
 	@ConditionalOnBean({ InstallAction.class, UpgradeAction.class, UninstallAction.class, RollbackAction.class,
 			TestAction.class })
 	public ReleaseMutatingTools jhelmReleaseMutatingTools(InstallAction installAction, UpgradeAction upgradeAction,
@@ -124,6 +128,23 @@ public class JhelmMcpAutoConfiguration {
 			ChartLoader chartLoader) {
 		return new ReleaseMutatingTools(installAction, upgradeAction, uninstallAction, rollbackAction, testAction,
 				getAction, chartLoader);
+	}
+
+	/**
+	 * Registers the MCP HTTP API-key filter, but only when a non-blank
+	 * {@code jhelm.security.api-key} is configured (see
+	 * {@link OnApiKeyConfiguredCondition}) and the application is a servlet web
+	 * application. A read-only MCP server with no API key stays open and the stdio
+	 * transport is unaffected; configuring a key enforces it on the MCP HTTP endpoint.
+	 * @param policy the unified security policy used to validate the presented API key
+	 * @return the MCP API-key filter bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnWebApplication
+	@Conditional(OnApiKeyConfiguredCondition.class)
+	public McpApiKeyFilter mcpApiKeyFilter(JhelmSecurityPolicy policy) {
+		return new McpApiKeyFilter(policy);
 	}
 
 }

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/McpApiKeyFilter.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/McpApiKeyFilter.java
@@ -1,0 +1,77 @@
+package org.alexmond.jhelm.mcp;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Requires a valid {@code X-API-Key} on HTTP requests to the Spring AI MCP server
+ * endpoint, returning {@code 401 Unauthorized} otherwise.
+ *
+ * <p>
+ * <strong>When it runs:</strong> this filter is registered as a bean only when an API key
+ * is configured ({@link JhelmSecurityPolicy#apiKeyConfigured()}). A read-only MCP server
+ * with no API key stays open — "read-only is safe to expose" — and the local stdio
+ * transport never reaches the servlet container, so the local developer path is
+ * unaffected.
+ *
+ * <p>
+ * <strong>Endpoint scope:</strong> the Spring AI
+ * {@code spring-ai-starter-mcp-server-webmvc} defaults are {@code /mcp} for the
+ * streamable HTTP transport and {@code /sse} + {@code /mcp/message} for the SSE
+ * transport. This filter therefore guards requests whose path starts with {@code /mcp} or
+ * {@code /sse}, covering both transports' default mappings. (If those endpoints are
+ * remapped via {@code spring.ai.mcp.server.streamable-http.mcp-endpoint} /
+ * {@code .sse-endpoint}, adjust the configured prefixes accordingly.)
+ */
+@Slf4j
+public class McpApiKeyFilter extends OncePerRequestFilter {
+
+	private static final String MESSAGE = "missing or invalid API key";
+
+	private final JhelmSecurityPolicy policy;
+
+	/**
+	 * Creates the filter.
+	 * @param policy the unified security policy used to validate the presented API key
+	 */
+	public McpApiKeyFilter(JhelmSecurityPolicy policy) {
+		this.policy = policy;
+	}
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		return !(path.startsWith("/mcp") || path.startsWith("/sse"));
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+		if (!this.policy.validApiKey(request.getHeader(this.policy.apiKeyHeader()))) {
+			log.info("Rejecting MCP request {} {}: missing or invalid API key", request.getMethod(),
+					request.getRequestURI());
+			response.setStatus(HttpStatus.UNAUTHORIZED.value());
+			response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+			response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+			String body = "{\"status\":" + HttpStatus.UNAUTHORIZED.value() + ",\"error\":\""
+					+ HttpStatus.UNAUTHORIZED.getReasonPhrase() + "\",\"message\":\"" + MESSAGE + "\",\"timestamp\":\""
+					+ Instant.now() + "\"}";
+			response.getWriter().write(body);
+			return;
+		}
+		filterChain.doFilter(request, response);
+	}
+
+}

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/OnApiKeyConfiguredCondition.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/OnApiKeyConfiguredCondition.java
@@ -1,0 +1,24 @@
+package org.alexmond.jhelm.mcp;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
+
+/**
+ * Spring {@link Condition} that matches only when a non-blank
+ * {@code jhelm.security.api-key} is configured.
+ *
+ * <p>
+ * Used to register the {@link McpApiKeyFilter} only when an API key exists. A read-only,
+ * no-key MCP server therefore stays open ("read-only is safe to expose"), while
+ * configuring a key enforces it on the MCP HTTP endpoint.
+ */
+public class OnApiKeyConfiguredCondition implements Condition {
+
+	@Override
+	public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		return StringUtils.hasText(context.getEnvironment().getProperty("jhelm.security.api-key"));
+	}
+
+}

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/OnMutatingEnabledCondition.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/OnMutatingEnabledCondition.java
@@ -1,0 +1,32 @@
+package org.alexmond.jhelm.mcp;
+
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
+
+/**
+ * Spring {@link Condition} that matches only when cluster-mutating operations are enabled
+ * under the unified deny-by-default security policy.
+ *
+ * <p>
+ * It reads {@code jhelm.security.mode} and {@code jhelm.security.api-key} directly from
+ * the {@link Environment} (a {@code Condition} runs before bean instantiation, so the
+ * resolved {@code JhelmSecurityPolicy} bean is not yet available) and matches only when
+ * the mode resolves to {@link JhelmAccessMode#FULL FULL} <em>and</em> a non-blank API key
+ * is set. Without an API key the mutating MCP tools are never registered.
+ */
+public class OnMutatingEnabledCondition implements Condition {
+
+	@Override
+	public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		Environment env = context.getEnvironment();
+		String mode = env.getProperty("jhelm.security.mode");
+		String apiKey = env.getProperty("jhelm.security.api-key");
+		boolean full = mode != null && JhelmAccessMode.FULL.name().equalsIgnoreCase(mode.trim());
+		return full && StringUtils.hasText(apiKey);
+	}
+
+}

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/config/JhelmMcpProperties.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/config/JhelmMcpProperties.java
@@ -2,30 +2,21 @@ package org.alexmond.jhelm.mcp.config;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.alexmond.jhelm.core.config.JhelmAccessMode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Configuration properties for the jhelm MCP (Model Context Protocol) server module.
  *
  * <p>
- * The {@code jhelm.mcp.mode} property mirrors {@code jhelm.rest.mode}: it controls which
- * jhelm operations are exposed as MCP tools. In {@link JhelmAccessMode#READ_ONLY
- * READ_ONLY} mode (the default) only non-mutating tools (template, show, lint, search,
- * and the cluster-read release tools: list, status, history, get values/manifest) are
- * registered. Setting the property to the upper-case value {@code FULL}
- * ({@link JhelmAccessMode#FULL}) additionally registers the cluster-mutating release
- * tools (install, upgrade, uninstall, rollback, test).
+ * Security for the MCP server is governed by the unified {@code jhelm.security.*}
+ * namespace (see {@link org.alexmond.jhelm.core.config.JhelmSecurityProperties}), not by
+ * an MCP-specific mode. The cluster-mutating MCP tools are registered only when, under
+ * deny-by-default semantics, {@code jhelm.security.mode=FULL} <em>and</em> a non-blank
+ * {@code jhelm.security.api-key} is set.
  */
 @Getter
 @Setter
 @ConfigurationProperties(prefix = "jhelm.mcp")
 public class JhelmMcpProperties {
-
-	/**
-	 * Access mode for the MCP server. Defaults to {@link JhelmAccessMode#READ_ONLY
-	 * READ_ONLY}, which exposes only the non-mutating jhelm tools.
-	 */
-	private JhelmAccessMode mode = JhelmAccessMode.READ_ONLY;
 
 }

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingTools.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingTools.java
@@ -28,9 +28,11 @@ import org.springframework.ai.mcp.annotation.McpToolParam;
  * scanner and exposed as an MCP tool.
  *
  * <p>
- * These tools are only registered when {@code jhelm.mcp.mode=FULL}. In the default
- * {@code READ_ONLY} mode they are not registered and therefore do not appear in the MCP
- * tool list at all — the MCP equivalent of the REST module's mutating-operation block.
+ * These tools are only registered when, under deny-by-default semantics,
+ * {@code jhelm.security.mode=FULL} <em>and</em> a non-blank
+ * {@code jhelm.security.api-key} is set. Otherwise they are not registered and therefore
+ * do not appear in the MCP tool list at all — the MCP equivalent of the REST module's
+ * mutating-operation block.
  *
  * <p>
  * Value overrides are not yet supported by these tools: installs and upgrades use the

--- a/jhelm-mcp/src/test/java/org/alexmond/jhelm/mcp/JhelmMcpAutoConfigurationTest.java
+++ b/jhelm-mcp/src/test/java/org/alexmond/jhelm/mcp/JhelmMcpAutoConfigurationTest.java
@@ -9,9 +9,7 @@ import org.alexmond.jhelm.core.action.StatusAction;
 import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
-import org.alexmond.jhelm.core.config.JhelmAccessMode;
 import org.alexmond.jhelm.core.service.ChartLoader;
-import org.alexmond.jhelm.mcp.config.JhelmMcpProperties;
 import org.alexmond.jhelm.mcp.tools.ReleaseMutatingTools;
 import org.alexmond.jhelm.mcp.tools.ReleaseReadTools;
 import org.junit.jupiter.api.Test;
@@ -21,15 +19,16 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies that the MCP auto-configuration gates the cluster-mutating release tools
- * behind {@code jhelm.mcp.mode=FULL}, while the read-only release tools are always
- * registered. The required action beans are supplied as Mockito mocks so the
- * {@code @ConditionalOnBean} conditions are satisfied without a live cluster.
+ * behind the unified deny-by-default security policy: they are registered only when
+ * {@code jhelm.security.mode=FULL} <em>and</em> {@code jhelm.security.api-key} is set,
+ * while the read-only release tools are always registered. The required action beans are
+ * supplied as Mockito mocks so the {@code @ConditionalOnBean} conditions are satisfied
+ * without a live cluster.
  */
 class JhelmMcpAutoConfigurationTest {
 
@@ -38,31 +37,39 @@ class JhelmMcpAutoConfigurationTest {
 		.withUserConfiguration(MockActionsConfiguration.class);
 
 	@Test
-	void readOnlyModeRegistersReadToolsButHidesMutatingTools() {
+	void defaultRegistersReadToolsButHidesMutatingTools() {
 		this.contextRunner.run((context) -> {
 			assertTrue(context.containsBean("jhelmReleaseReadTools"));
 			context.getBean(ReleaseReadTools.class);
 			assertFalse(context.containsBean("jhelmReleaseMutatingTools"),
-					"mutating tools must not be registered in READ_ONLY mode");
-			assertEquals(JhelmAccessMode.READ_ONLY, context.getBean(JhelmMcpProperties.class).getMode());
+					"mutating tools must not be registered by default (READ_ONLY, no key)");
 		});
 	}
 
 	@Test
-	void explicitReadOnlyModeHidesMutatingTools() {
-		this.contextRunner.withPropertyValues("jhelm.mcp.mode=READ_ONLY").run((context) -> {
+	void fullModeWithoutApiKeyHidesMutatingTools() {
+		this.contextRunner.withPropertyValues("jhelm.security.mode=FULL").run((context) -> {
 			assertTrue(context.containsBean("jhelmReleaseReadTools"));
-			assertFalse(context.containsBean("jhelmReleaseMutatingTools"));
+			assertFalse(context.containsBean("jhelmReleaseMutatingTools"),
+					"deny-by-default: FULL without an api-key must not register mutating tools");
 		});
 	}
 
 	@Test
-	void fullModeRegistersMutatingTools() {
-		this.contextRunner.withPropertyValues("jhelm.mcp.mode=FULL").run((context) -> {
-			assertTrue(context.containsBean("jhelmReleaseReadTools"));
-			assertTrue(context.containsBean("jhelmReleaseMutatingTools"));
-			context.getBean(ReleaseMutatingTools.class);
-		});
+	void apiKeyWithoutFullModeHidesMutatingTools() {
+		this.contextRunner.withPropertyValues("jhelm.security.api-key=secret")
+			.run((context) -> assertFalse(context.containsBean("jhelmReleaseMutatingTools"),
+					"a key alone (READ_ONLY) must not register mutating tools"));
+	}
+
+	@Test
+	void fullModeWithApiKeyRegistersMutatingTools() {
+		this.contextRunner.withPropertyValues("jhelm.security.mode=FULL", "jhelm.security.api-key=secret")
+			.run((context) -> {
+				assertTrue(context.containsBean("jhelmReleaseReadTools"));
+				assertTrue(context.containsBean("jhelmReleaseMutatingTools"));
+				context.getBean(ReleaseMutatingTools.class);
+			});
 	}
 
 	/**

--- a/jhelm-rest-sample/src/main/resources/application.yaml
+++ b/jhelm-rest-sample/src/main/resources/application.yaml
@@ -13,3 +13,10 @@ springdoc:
 jhelm:
   rest:
     base-path: /api/v1
+  # Unified deny-by-default security (jhelm.security.*).
+  # This demo enables cluster-mutating endpoints (FULL) behind an API key: callers must
+  # send the key in the X-API-Key header. Remove the api-key (or drop mode below FULL) and
+  # mutating endpoints are denied automatically — FULL without a key does NOT open them.
+  security:
+    mode: FULL
+    api-key: change-me-sample-key

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -1,6 +1,7 @@
 package org.alexmond.jhelm.rest;
 
 import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.action.CreateAction;
 import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.SearchHubAction;
@@ -34,38 +35,23 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import jakarta.annotation.PostConstruct;
-import lombok.extern.slf4j.Slf4j;
-
 /**
  * Auto-configuration for the jhelm REST API module. Activates only when the application
  * is a web application (servlet-based). Runs after {@link JhelmCoreAutoConfiguration} so
  * that all core beans (actions, services) are available for REST controllers.
  *
  * <p>
- * <strong>Security:</strong> the jhelm REST API exposes cluster-mutating operations
- * (install, upgrade, uninstall, rollback) and ships with <strong>no
- * authentication</strong>. Securing it is the responsibility of the embedding application
- * (for example via Spring Security); it must never be exposed unauthenticated to an
- * untrusted network.
+ * <strong>Security:</strong> cluster-mutating endpoints are gated by the shared
+ * {@code jhelm.security.*} policy — read-only by default, and mutating operations are
+ * disabled unless {@code jhelm.security.mode=FULL} and a {@code jhelm.security.api-key}
+ * are set (deny-by-default), then required as a header on each request. The built-in API
+ * key is the floor; wire Spring Security in the application for real multi-user auth. The
+ * startup security posture is logged by the core module.
  */
-@Slf4j
 @AutoConfiguration(after = JhelmCoreAutoConfiguration.class)
 @ConditionalOnWebApplication
 @EnableConfigurationProperties(JhelmRestProperties.class)
 public class JhelmRestAutoConfiguration {
-
-	/**
-	 * Logs a single startup warning that the REST API is unauthenticated, reminding
-	 * operators to secure it (for example with Spring Security) in the consuming
-	 * application.
-	 */
-	@PostConstruct
-	public void warnUnauthenticated() {
-		log.warn("jhelm REST API is enabled with NO authentication and exposes cluster-mutating "
-				+ "operations; secure it (e.g. set up Spring Security) in your application before "
-				+ "exposing it to any untrusted network.");
-	}
 
 	/**
 	 * Registers the global REST exception handler unless one is already defined.
@@ -78,15 +64,15 @@ public class JhelmRestAutoConfiguration {
 	}
 
 	/**
-	 * Registers the access-mode interceptor that rejects cluster-mutating endpoints when
-	 * the REST API is in {@code READ_ONLY} mode.
-	 * @param properties the REST module configuration carrying the access mode
+	 * Registers the access-mode interceptor that gates cluster-mutating endpoints behind
+	 * the unified security policy (deny-by-default 403, then API-key 401).
+	 * @param securityPolicy the unified security policy that gates mutating operations
 	 * @return the access-mode interceptor bean
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	public AccessModeInterceptor accessModeInterceptor(JhelmRestProperties properties) {
-		return new AccessModeInterceptor(properties);
+	public AccessModeInterceptor accessModeInterceptor(JhelmSecurityPolicy securityPolicy) {
+		return new AccessModeInterceptor(securityPolicy);
 	}
 
 	/**

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/config/JhelmRestProperties.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/config/JhelmRestProperties.java
@@ -8,7 +8,6 @@ import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.alexmond.jhelm.core.config.JhelmAccessMode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -29,12 +28,6 @@ public class JhelmRestProperties {
 	 * Base directory for temporary files. Defaults to the system temp directory.
 	 */
 	private Path tempDir;
-
-	/**
-	 * Access mode for the REST API. {@link JhelmAccessMode#READ_ONLY READ_ONLY} blocks
-	 * cluster-mutating endpoints; defaults to {@link JhelmAccessMode#FULL FULL}.
-	 */
-	private JhelmAccessMode mode = JhelmAccessMode.FULL;
 
 	/**
 	 * Returns the configured temp directory, or the system default if not set. The

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/security/AccessModeInterceptor.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/security/AccessModeInterceptor.java
@@ -8,50 +8,73 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
-import org.alexmond.jhelm.core.config.JhelmAccessMode;
-import org.alexmond.jhelm.rest.config.JhelmRestProperties;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
- * Rejects cluster-mutating endpoints when the REST API is in
- * {@link JhelmAccessMode#READ_ONLY READ_ONLY} mode. An endpoint is considered mutating
- * when its handler method is annotated with {@link MutatingOperation}.
+ * Gates cluster-mutating REST endpoints behind the unified {@link JhelmSecurityPolicy}.
+ * An endpoint is considered mutating when its handler method is annotated with
+ * {@link MutatingOperation}.
+ *
+ * <p>
+ * For a mutating handler the decision is, in order:
+ * <ul>
+ * <li>if mutating operations are not enabled (deny-by-default — not {@code FULL}, or no
+ * API key configured) → {@code 403 Forbidden};</li>
+ * <li>otherwise if the request does not carry a valid API key → {@code 401
+ * Unauthorized};</li>
+ * <li>otherwise the request proceeds.</li>
+ * </ul>
+ * Non-mutating (read) endpoints are always allowed.
  */
 @Slf4j
 public class AccessModeInterceptor implements HandlerInterceptor {
 
-	private static final String MESSAGE = "Operation not permitted: the jhelm REST API is in READ_ONLY mode";
+	private static final String DISABLED_MESSAGE = "mutating operations are disabled — set jhelm.security.mode=FULL "
+			+ "and jhelm.security.api-key to enable";
 
-	private final JhelmRestProperties properties;
+	private static final String UNAUTHORIZED_MESSAGE = "missing or invalid API key";
+
+	private final JhelmSecurityPolicy policy;
 
 	/**
 	 * Creates the interceptor.
-	 * @param properties the REST module configuration carrying the access mode
+	 * @param policy the unified security policy that gates mutating operations
 	 */
-	public AccessModeInterceptor(JhelmRestProperties properties) {
-		this.properties = properties;
+	public AccessModeInterceptor(JhelmSecurityPolicy policy) {
+		this.policy = policy;
 	}
 
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
 			throws IOException {
-		if (handler instanceof HandlerMethod hm && hm.getMethodAnnotation(MutatingOperation.class) != null
-				&& this.properties.getMode() == JhelmAccessMode.READ_ONLY) {
-			log.info("Blocking mutating operation {} {}: jhelm REST API is in READ_ONLY mode", request.getMethod(),
-					request.getRequestURI());
-			response.setStatus(HttpStatus.FORBIDDEN.value());
-			response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-			response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-			String body = "{\"status\":" + HttpStatus.FORBIDDEN.value() + ",\"error\":\""
-					+ HttpStatus.FORBIDDEN.getReasonPhrase() + "\",\"message\":\"" + MESSAGE + "\",\"timestamp\":\""
-					+ Instant.now() + "\"}";
-			response.getWriter().write(body);
-			return false;
+		if (handler instanceof HandlerMethod hm && hm.getMethodAnnotation(MutatingOperation.class) != null) {
+			if (!this.policy.mutatingEnabled()) {
+				log.info("Blocking mutating operation {} {}: mutating operations are disabled (deny-by-default)",
+						request.getMethod(), request.getRequestURI());
+				writeError(response, HttpStatus.FORBIDDEN, DISABLED_MESSAGE);
+				return false;
+			}
+			if (!this.policy.validApiKey(request.getHeader(this.policy.apiKeyHeader()))) {
+				log.info("Rejecting mutating operation {} {}: missing or invalid API key", request.getMethod(),
+						request.getRequestURI());
+				writeError(response, HttpStatus.UNAUTHORIZED, UNAUTHORIZED_MESSAGE);
+				return false;
+			}
 		}
 		return true;
+	}
+
+	private void writeError(HttpServletResponse response, HttpStatus status, String message) throws IOException {
+		response.setStatus(status.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+		String body = "{\"status\":" + status.value() + ",\"error\":\"" + status.getReasonPhrase() + "\",\"message\":\""
+				+ message + "\",\"timestamp\":\"" + Instant.now() + "\"}";
+		response.getWriter().write(body);
 	}
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/security/MutatingOperation.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/security/MutatingOperation.java
@@ -6,9 +6,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a controller endpoint as a cluster-mutating operation. Such endpoints are
- * rejected with {@code 403 Forbidden} when {@code jhelm.rest.mode} is
- * {@link org.alexmond.jhelm.core.config.JhelmAccessMode#READ_ONLY READ_ONLY}.
+ * Marks a controller endpoint as a cluster-mutating operation. Such endpoints are gated
+ * by the unified {@link org.alexmond.jhelm.core.config.JhelmSecurityPolicy security
+ * policy}: rejected with {@code 403 Forbidden} when mutating operations are disabled
+ * (deny-by-default — {@code jhelm.security.mode} is not {@code FULL} or no
+ * {@code jhelm.security.api-key} is set), and with {@code 401 Unauthorized} when the
+ * request does not carry a valid API key.
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/JhelmRestAutoConfigurationTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/JhelmRestAutoConfigurationTest.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.rest;
 
+import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -12,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class JhelmRestAutoConfigurationTest {
 
 	private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
-		.withConfiguration(AutoConfigurations.of(JhelmRestAutoConfiguration.class));
+		.withConfiguration(AutoConfigurations.of(JhelmCoreAutoConfiguration.class, JhelmRestAutoConfiguration.class));
 
 	@Test
 	void autoConfigurationRegistersProperties() {

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/security/AccessModeInterceptorTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/security/AccessModeInterceptorTest.java
@@ -12,6 +12,8 @@ import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
@@ -29,13 +31,18 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Verifies that {@link AccessModeInterceptor} blocks {@link MutatingOperation} endpoints
- * in {@link JhelmAccessMode#READ_ONLY READ_ONLY} mode while leaving read endpoints (and
- * all endpoints in {@link JhelmAccessMode#FULL FULL} mode) untouched.
+ * Verifies that {@link AccessModeInterceptor} gates {@link MutatingOperation} endpoints
+ * behind the unified {@link JhelmSecurityPolicy} under deny-by-default semantics:
+ * <ul>
+ * <li>READ_ONLY (or FULL without a key) mutating → {@code 403};</li>
+ * <li>FULL + key with a valid {@code X-API-Key} → allowed;</li>
+ * <li>FULL + key with a missing/wrong key → {@code 401};</li>
+ * <li>read endpoints are always allowed.</li>
+ * </ul>
  */
 class AccessModeInterceptorTest {
 
-	private JhelmRestProperties properties;
+	private static final String API_KEY = "test-key";
 
 	private ListAction listAction;
 
@@ -45,7 +52,7 @@ class AccessModeInterceptorTest {
 
 	@BeforeEach
 	void setUp() throws Exception {
-		this.properties = new JhelmRestProperties();
+		JhelmRestProperties properties = new JhelmRestProperties();
 		this.listAction = mock(ListAction.class);
 		StatusAction statusAction = mock(StatusAction.class);
 		GetAction getAction = mock(GetAction.class);
@@ -59,33 +66,58 @@ class AccessModeInterceptorTest {
 		RepoManager repoManager = mock(RepoManager.class);
 		when(this.listAction.list(anyString())).thenReturn(List.of());
 		this.controller = new ReleaseController(this.listAction, statusAction, getAction, historyAction, installAction,
-				upgradeAction, this.uninstallAction, rollbackAction, testAction, chartLoader, repoManager,
-				this.properties);
+				upgradeAction, this.uninstallAction, rollbackAction, testAction, chartLoader, repoManager, properties);
 	}
 
-	private MockMvc mockMvc() {
+	private static JhelmSecurityPolicy policy(JhelmAccessMode mode, String apiKey) {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(mode);
+		props.setApiKey(apiKey);
+		return new JhelmSecurityPolicy(props);
+	}
+
+	private MockMvc mockMvc(JhelmSecurityPolicy policy) {
 		return MockMvcBuilders.standaloneSetup(this.controller)
-			.addInterceptors(new AccessModeInterceptor(this.properties))
+			.addInterceptors(new AccessModeInterceptor(policy))
 			.addPlaceholderValue("jhelm.rest.base-path", "/api/v1")
 			.build();
 	}
 
 	@Test
-	void fullModeAllowsMutatingEndpoint() throws Exception {
-		this.properties.setMode(JhelmAccessMode.FULL);
-		mockMvc().perform(delete("/api/v1/releases/my-release")).andExpect(status().isNoContent());
+	void readOnlyModeBlocksMutatingEndpointWith403() throws Exception {
+		mockMvc(policy(JhelmAccessMode.READ_ONLY, API_KEY)).perform(delete("/api/v1/releases/my-release"))
+			.andExpect(status().isForbidden());
 	}
 
 	@Test
-	void readOnlyModeBlocksMutatingEndpoint() throws Exception {
-		this.properties.setMode(JhelmAccessMode.READ_ONLY);
-		mockMvc().perform(delete("/api/v1/releases/my-release")).andExpect(status().isForbidden());
+	void fullModeWithoutKeyBlocksMutatingEndpointWith403() throws Exception {
+		mockMvc(policy(JhelmAccessMode.FULL, null)).perform(delete("/api/v1/releases/my-release"))
+			.andExpect(status().isForbidden());
 	}
 
 	@Test
-	void readOnlyModeAllowsReadEndpoint() throws Exception {
-		this.properties.setMode(JhelmAccessMode.READ_ONLY);
-		mockMvc().perform(get("/api/v1/releases")).andExpect(status().isOk());
+	void fullModeWithKeyAndValidHeaderAllowsMutatingEndpoint() throws Exception {
+		mockMvc(policy(JhelmAccessMode.FULL, API_KEY))
+			.perform(delete("/api/v1/releases/my-release").header("X-API-Key", API_KEY))
+			.andExpect(status().isNoContent());
+	}
+
+	@Test
+	void fullModeWithKeyAndMissingHeaderRejectsWith401() throws Exception {
+		mockMvc(policy(JhelmAccessMode.FULL, API_KEY)).perform(delete("/api/v1/releases/my-release"))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void fullModeWithKeyAndWrongHeaderRejectsWith401() throws Exception {
+		mockMvc(policy(JhelmAccessMode.FULL, API_KEY))
+			.perform(delete("/api/v1/releases/my-release").header("X-API-Key", "wrong"))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void readEndpointAlwaysAllowed() throws Exception {
+		mockMvc(policy(JhelmAccessMode.READ_ONLY, null)).perform(get("/api/v1/releases")).andExpect(status().isOk());
 	}
 
 }


### PR DESCRIPTION
Closes #538. One shared `jhelm.security.*` policy gates cluster-mutating operations across **jhelm-rest** and **jhelm-mcp** — so you **cannot accidentally start an open cluster-mutation API**.

## Core (`jhelm-core`)
- `JhelmSecurityProperties` (`jhelm.security.{mode,api-key,api-key-header}`); **mode defaults to `READ_ONLY`**.
- `JhelmSecurityPolicy`: `mutatingEnabled()` = `mode==FULL && api-key configured` (**deny-by-default** — FULL without a key does not enable mutation); `validApiKey()` is a **constant-time** compare.
- Startup `ApplicationRunner` logs the security posture (read-only / full+key / full-no-key WARN).

## REST
- `AccessModeInterceptor` now uses the policy: a `@MutatingOperation` request → **403** when mutating is disabled (read-only or no key), **401** on missing/invalid `X-API-Key`, else allowed; reads always allowed. `jhelm.rest.mode` → `jhelm.security.mode`. The stale "NO authentication" WARN is removed (superseded by the accurate core posture log).

## MCP
- `ReleaseMutatingTools` registered only via `OnMutatingEnabledCondition` (`mode=FULL` **AND** api-key set) — no key, no mutating tools.
- `McpApiKeyFilter` requires a valid `X-API-Key` on the MCP HTTP endpoints (`/mcp`, `/sse`) when an api-key is configured; **stdio (local) never hits the servlet**, so the local path is unaffected.

## Samples
rest-sample ships `FULL` + a sample api-key (deny-without-key demo); mcp-sample local read-only. **Spring Security stays a documented upgrade** (a secured combined sample is a follow-up), not baked into the starters.

## Verified
Full reactor **BUILD SUCCESS**; `JhelmSecurityPolicyTest` + reworked `AccessModeInterceptorTest` (deny-by-default 403, 401 on bad key, reads allowed) + MCP gating test (mutating tools only when FULL+key); PMD/Checkstyle clean.

## Follow-up
A secured **combined REST+MCP sample with Spring Security** wired (the production-shaped reference) — distinct, larger addition, tracked under #538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)