### PR TITLE
docs: MCP page, security model, all-surfaces getting-started (#539)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,8 @@
 = jhelm
 :jhelm-version: 0.4.0
 :url-docs: https://www.alexmond.org/jhelm/current/index.html
+:url-docs-mcp: https://www.alexmond.org/jhelm/current/mcp.html
+:url-docs-rest: https://www.alexmond.org/jhelm/current/rest-api.html
 :toc:
 
 image:https://img.shields.io/maven-central/v/org.alexmond/jhelm-core.svg?label=Maven%20Central[Maven Central,link=https://search.maven.org/artifact/org.alexmond/jhelm-core]
@@ -16,11 +18,15 @@ the Go-based Helm binary.
 
 == Why jhelm
 
-* *Helm-faithful rendering* -- jhelm renders chart templates byte-for-byte identically to
-  `helm template` across a continuously-run suite of *346 real-world charts* (Bitnami,
-  Grafana, GitLab, Kubernetes-monitoring, and more). Parity is enforced in CI on every change.
+* *Helm-faithful rendering, in pure Java* -- jhelm renders chart templates byte-for-byte
+  identically to `helm template` across a continuously-run suite of *346 real-world charts*
+  (Bitnami, Grafana, GitLab, Kubernetes-monitoring, and more), with no Go or `helm` binary.
+  Parity is enforced in CI on every change.
 * *Pure JVM, no native binary* -- no `helm` executable, no `exec`, no platform-specific
   distribution. Just a Maven dependency.
+* *MCP-native* -- the same operations are exposed as
+  https://modelcontextprotocol.io[Model Context Protocol] tools, so an AI agent can render
+  charts and manage releases directly. See {url-docs-mcp}[the MCP guide].
 * *Designed to be embedded* -- a clean programmatic API (`TemplateAction`, `InstallAction`,
   …), Spring Boot auto-configuration, and a REST module, in addition to the CLI.
 * *Go template engine on Maven Central* -- the template/Sprig engine is the standalone
@@ -147,10 +153,44 @@ jhelm repo add bitnami https://charts.bitnami.com/bitnami
 jhelm pull bitnami/nginx --untar
 ----
 
+=== As a REST API
+
+Add the `jhelm-rest-starter` to a Spring Boot web application:
+
+[source,xml,subs="attributes"]
+----
+<dependency>
+    <groupId>org.alexmond</groupId>
+    <artifactId>jhelm-rest-starter</artifactId>
+    <version>{jhelm-version}</version>
+</dependency>
+----
+
+The API is read-only by default; cluster-mutating endpoints are deny-by-default behind an
+API key (`jhelm.security.mode=FULL` + `jhelm.security.api-key`). See {url-docs-rest}[the REST
+API guide].
+
+=== As an MCP server
+
+Add the `jhelm-mcp-starter` to expose jhelm operations as MCP tools for AI agents:
+
+[source,xml,subs="attributes"]
+----
+<dependency>
+    <groupId>org.alexmond</groupId>
+    <artifactId>jhelm-mcp-starter</artifactId>
+    <version>{jhelm-version}</version>
+</dependency>
+----
+
+Run it locally (see `jhelm-mcp-sample`) and point an agent at the STREAMABLE HTTP transport.
+See {url-docs-mcp}[the MCP guide].
+
 == Documentation
 
 Full documentation -- getting started, architecture, CLI reference, configuration, the REST
-API, and the Helm function catalogue -- is published at {url-docs}.
+API, the MCP server, the security model, and the Helm function catalogue -- is published at
+{url-docs}.
 
 == Building
 

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -3,8 +3,10 @@
 * xref:architecture.adoc[Architecture]
 * xref:spring-boot-starter.adoc[Library & Spring Boot Starter]
 * xref:rest-api.adoc[REST API]
+* xref:mcp.adoc[MCP Server]
 * xref:cli-reference.adoc[CLI Reference]
 * xref:configuration.adoc[Configuration]
+* xref:security.adoc[Security]
 * xref:core-engine.adoc[Core Engine]
 * Template Functions
 ** xref:helm-functions.adoc[Helm Functions]

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -107,3 +107,88 @@ System.out.println(manifest);
 ----
 
 For Spring Boot integration with auto-configured beans and configuration properties, see the xref:spring-boot-starter.adoc[Spring Boot Starter] guide.
+
+== Using the REST API
+
+Add `jhelm-rest-starter` to a Spring Boot web application to expose Helm operations over HTTP:
+
+[source,xml,subs="attributes"]
+----
+<dependency>
+    <groupId>org.alexmond</groupId>
+    <artifactId>jhelm-rest-starter</artifactId>
+    <version>{jhelm-version}</version>
+</dependency>
+----
+
+Run a minimal Spring Boot application -- the endpoints are auto-configured:
+
+[source,java]
+----
+@SpringBootApplication
+public class MyHelmApp {
+    public static void main(String[] args) {
+        SpringApplication.run(MyHelmApp.class, args);
+    }
+}
+----
+
+Out of the box the API is *read-only* (the default `jhelm.security.mode=READ_ONLY`), so
+template and read endpoints work immediately and safely:
+
+[source,bash]
+----
+curl -X POST http://localhost:8080/api/v1/charts/template \
+  -H 'Content-Type: application/json' \
+  -d '{"chartRef": "bitnami/nginx", "releaseName": "demo", "namespace": "default"}'
+----
+
+Cluster-mutating endpoints (install/upgrade/uninstall/rollback/test) are *deny-by-default*:
+they are enabled only when you set `mode=FULL` *and* configure an API key. Without a key they
+return `403`; with the gate open, a request missing or presenting a bad key returns `401`.
+
+[source,yaml]
+----
+jhelm:
+  security:
+    mode: FULL
+    api-key: changeme
+----
+
+[source,bash]
+----
+curl -X POST http://localhost:8080/api/v1/releases \
+  -H 'X-API-Key: changeme' \
+  -H 'Content-Type: application/json' \
+  -d '{"chartRef": "bitnami/nginx", "releaseName": "demo", "namespace": "default"}'
+----
+
+See the xref:rest-api.adoc[REST API] reference for all endpoints and the
+xref:security.adoc[Security] model for the full gating rules.
+
+== Using the MCP Server
+
+Add `jhelm-mcp-starter` to a Spring Boot application to expose jhelm operations as
+https://modelcontextprotocol.io[Model Context Protocol] tools for AI agents:
+
+[source,xml,subs="attributes"]
+----
+<dependency>
+    <groupId>org.alexmond</groupId>
+    <artifactId>jhelm-mcp-starter</artifactId>
+    <version>{jhelm-version}</version>
+</dependency>
+----
+
+The server is auto-configured and serves the STREAMABLE HTTP MCP transport. Run it locally and
+point your agent at it; the read-only tools are available immediately. The `jhelm-mcp-sample`
+module is a runnable demo:
+
+[source,bash]
+----
+cd jhelm-mcp-sample
+../mvnw spring-boot:run
+----
+
+See the xref:mcp.adoc[MCP Server] guide for the tool catalogue and the local/desktop security
+model.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -4,12 +4,20 @@ jhelm is a native Java implementation of the https://helm.sh[Helm] package manag
 It provides an embeddable library, a Spring Boot starter, a REST API, and a standalone CLI to
 work with Helm charts from the JVM -- without shelling out to the Go-based Helm binary.
 
-== Helm-faithful rendering
+== Helm-faithful rendering, in pure Java
 
-jhelm renders chart templates byte-for-byte identically to `helm template` across a
+jhelm renders chart templates *byte-for-byte identically to `helm template`* across a
 continuously-run suite of *346 real-world charts* (Bitnami, Grafana, GitLab,
-Kubernetes-monitoring, and more). Parity is enforced in CI on every change, so behaviour
-tracks upstream Helm closely rather than approximating it.
+Kubernetes-monitoring, and more) -- in *pure Java, with no Go or `helm` binary*. Parity is
+enforced in CI on every change, so behaviour tracks upstream Helm closely rather than
+approximating it. Rendering is driven by the standalone
+https://github.com/alexmond/gotmpl4j[gotmpl4j] Go-template engine.
+
+== MCP-native
+
+The same operations are exposed as https://modelcontextprotocol.io[Model Context Protocol]
+tools, so an AI agent can render charts, search ArtifactHub, and manage releases directly --
+no shelling out, no glue code. See xref:mcp.adoc[MCP Server].
 
 == Key Features
 
@@ -39,8 +47,10 @@ tracks upstream Helm closely rather than approximating it.
 * xref:getting-started.adoc[Getting Started] -- build, run the CLI, or add jhelm as a library
 * xref:spring-boot-starter.adoc[Spring Boot Starter] -- programmatic API with auto-configured beans and code samples
 * xref:rest-api.adoc[REST API] -- HTTP endpoints and OpenAPI documentation
+* xref:mcp.adoc[MCP Server] -- jhelm operations as Model Context Protocol tools for AI agents
 * xref:cli-reference.adoc[CLI Reference] -- all commands, options, and examples
 * xref:configuration.adoc[Configuration] -- `jhelm.*` properties reference
+* xref:security.adoc[Security] -- the unified `jhelm.security.*` model for REST and MCP
 * xref:architecture.adoc[Architecture] -- module structure and design
 * xref:helm-functions.adoc[Helm Functions] -- the Helm-specific template function catalogue
 * xref:roadmap.adoc[Roadmap] -- planned features and compatibility matrix

--- a/docs/modules/ROOT/pages/mcp.adoc
+++ b/docs/modules/ROOT/pages/mcp.adoc
@@ -1,0 +1,106 @@
+= MCP Server
+
+`jhelm-mcp` exposes jhelm's Helm operations as https://modelcontextprotocol.io[Model Context
+Protocol] (MCP) tools, so an AI agent can render charts, search ArtifactHub, and manage
+releases by calling tools rather than shelling out to a binary. It is built on Spring AI 2.0
+and serves the STREAMABLE HTTP MCP transport (Spring MVC / webmvc).
+
+The same operations available over the xref:rest-api.adoc[REST API] are surfaced here as MCP
+tools, and both share the unified xref:security.adoc[security model].
+
+== Running it
+
+`jhelm-mcp` ships as a pure library plus a `jhelm-mcp-starter` that auto-configures the MCP
+server. Add the starter to a Spring Boot application:
+
+[source,xml,subs="attributes"]
+----
+<dependency>
+    <groupId>org.alexmond</groupId>
+    <artifactId>jhelm-mcp-starter</artifactId>
+    <version>{jhelm-version}</version>
+</dependency>
+----
+
+With the starter on the classpath, the MCP server is auto-configured and serves the
+STREAMABLE HTTP transport. The `jhelm-mcp-sample` module is a ready-to-run demo:
+
+[source,bash]
+----
+cd jhelm-mcp-sample
+../mvnw spring-boot:run
+----
+
+=== Local / desktop model
+
+MCP is designed to run local-first: you launch the server on the same machine as the agent,
+and the agent connects to it. In that local / stdio / localhost arrangement the transport is
+already inside the trust boundary, so no API key is required.
+
+The API key matters only when you *expose the MCP server over the network*. Once exposed, set
+`jhelm.security.api-key` and the HTTP endpoints (`/mcp`, `/sse`) require a valid `X-API-Key`
+header. See <<security>> below.
+
+== Tools
+
+The server exposes 16 tools. Read-only tools are always available; the cluster-mutating tools
+are registered only when `jhelm.security.mode=FULL` *and* an `api-key` is configured (see
+<<security>>).
+
+[cols="2,3,1"]
+|===
+| Tool | Description | Mutating
+
+| `helm_template`     | Render chart templates from a chart reference | No
+| `helm_show_chart`   | Show `Chart.yaml` metadata | No
+| `helm_show_values`  | Show default `values.yaml` | No
+| `helm_show_readme`  | Show the chart README | No
+| `helm_lint`         | Lint a chart | No
+| `helm_search_hub`   | Search ArtifactHub for charts | No
+| `helm_list`         | List releases in a namespace | No
+| `helm_status`       | Get release status | No
+| `helm_history`      | Get release revision history | No
+| `helm_get_values`   | Get the values of a release | No
+| `helm_get_manifest` | Get the rendered manifest of a release | No
+| `helm_install`      | Install a release into a cluster | *Yes*
+| `helm_upgrade`      | Upgrade an existing release | *Yes*
+| `helm_uninstall`    | Uninstall a release | *Yes*
+| `helm_rollback`     | Roll a release back to a previous revision | *Yes*
+| `helm_test`         | Run a release's test hooks | *Yes*
+|===
+
+The tools group naturally into:
+
+* *Chart* -- `helm_template`, `helm_show_chart`, `helm_show_values`, `helm_show_readme`,
+  `helm_lint`
+* *Hub* -- `helm_search_hub`
+* *Release (read)* -- `helm_list`, `helm_status`, `helm_history`, `helm_get_values`,
+  `helm_get_manifest`
+* *Release (mutating)* -- `helm_install`, `helm_upgrade`, `helm_uninstall`, `helm_rollback`,
+  `helm_test`
+
+NOTE: The mutating tools require `jhelm-kube` on the classpath (Kubernetes client). When the
+mutating gate is closed they are not registered, so an agent never sees them.
+
+[#security]
+== Security
+
+The MCP server uses the unified xref:security.adoc[`jhelm.security.*` model]:
+
+* *Tool gating* -- the mutating tools are registered only when `mode=FULL` and an `api-key`
+  is set. Otherwise they do not exist.
+* *HTTP filter* -- when an `api-key` is configured, the MCP HTTP endpoints (`/mcp`, `/sse`)
+  require a valid `X-API-Key` header.
+* *stdio / local bypass* -- a locally launched server never hits the servlet filter, so a
+  trusted localhost launch is not forced to present a key.
+
+[source,yaml,subs="attributes"]
+----
+jhelm:
+  security:
+    mode: FULL          # READ_ONLY (default) or FULL
+    api-key: changeme   # required to register + reach the mutating tools
+----
+
+For real multi-user authentication (OAuth, mTLS, gateway), layer Spring Security on top -- see
+the xref:security.adoc#spring-security[security upgrade path].

--- a/docs/modules/ROOT/pages/rest-api.adoc
+++ b/docs/modules/ROOT/pages/rest-api.adoc
@@ -50,9 +50,13 @@ Open http://localhost:8080/swagger-ui.html to see all endpoints.
 |===
 | Property | Default | Description
 
-| `jhelm.rest.mode`
-| `FULL`
-| Access mode. `READ_ONLY` disables the cluster-mutating endpoints (install/upgrade/uninstall/rollback/test, repo add/remove/push); `FULL` enables them.
+| `jhelm.security.mode`
+| `READ_ONLY`
+| Shared access mode (also used by the MCP server). `READ_ONLY` disables the cluster-mutating endpoints (install/upgrade/uninstall/rollback/test, repo add/remove/push); `FULL` enables them — but only together with an API key (deny-by-default).
+
+| `jhelm.security.api-key`
+| _(none)_
+| API key required on mutating requests via the `X-API-Key` header. With no key set, mutating operations stay disabled even in `FULL` mode.
 
 | `jhelm.rest.base-path`
 | `/api/v1`
@@ -66,15 +70,18 @@ Open http://localhost:8080/swagger-ui.html to see all endpoints.
 [source,yaml]
 ----
 jhelm:
+  security:
+    mode: FULL                 # READ_ONLY (default) or FULL
+    api-key: change-me         # required to enable mutating endpoints
   rest:
-    mode: FULL
     base-path: /api/v1
     temp-dir: /var/lib/jhelm/tmp
 ----
 
-NOTE: Authentication and authorization are the embedding application's responsibility
-(e.g. Spring Security). `jhelm.rest.mode` is a coarse mutating/read-only gate, not an auth
-mechanism.
+A mutating endpoint returns `403` when mutation is disabled (read-only, or no key), `401`
+on a missing/invalid key, and otherwise proceeds. See xref:security.adoc[Security] for the
+full model. The built-in key is the floor; wire Spring Security in your application for real
+multi-user auth.
 
 == Auto-Configuration
 
@@ -585,15 +592,18 @@ Add `jhelm-mcp-starter` to a Spring Boot application for the auto-configured ser
 </dependency>
 ----
 
-Like the REST starter, the MCP server has a `READ_ONLY`/`FULL` access mode. It defaults to
-`READ_ONLY`, so only the non-mutating tools are exposed unless you opt in:
+The MCP server shares the same `jhelm.security.*` gate as the REST API. It defaults to
+`READ_ONLY`, so only the non-mutating tools are registered; the mutating tools appear only
+in `FULL` mode with an API key set (deny-by-default):
 
 [source,yaml]
 ----
 jhelm:
-  mcp:
+  security:
     mode: READ_ONLY   # READ_ONLY (default) or FULL
+    api-key: change-me
 ----
 
-NOTE: As with the REST API, authentication is the embedding application's responsibility;
-`jhelm.mcp.mode` is a coarse mutating/read-only gate.
+When an API key is set, the MCP HTTP endpoints (`/mcp`, `/sse`) require it; a locally
+launched server over stdio is not forced to present one. See xref:mcp.adoc[MCP Server] and
+xref:security.adoc[Security].

--- a/docs/modules/ROOT/pages/security.adoc
+++ b/docs/modules/ROOT/pages/security.adoc
@@ -1,0 +1,116 @@
+= Security Model
+
+jhelm exposes Helm operations over two network surfaces -- the xref:rest-api.adoc[REST API]
+and the xref:mcp.adoc[MCP server] -- and both share a single, unified security model under
+`jhelm.security.*`.
+
+The design in one line: *MCP runs local-first, the REST API is deny-by-default behind an API
+key, read-only is the default everywhere, and Spring Security is the bring-your-own upgrade
+path for real auth.*
+
+== Principles
+
+* *Read-only by default.* Out of the box, only non-mutating operations (template, show, lint,
+  list, status, history, get) are available. They are safe to expose and never touch a cluster.
+* *Deny-by-default for mutating operations.* Cluster-mutating operations (install, upgrade,
+  uninstall, rollback, test) are enabled *only* when both conditions hold: `mode=FULL` *and* an
+  `api-key` is configured. `FULL` without a key leaves mutating operations disabled.
+* *The API key is the floor, not the ceiling.* The built-in key protects the
+  network-exposed HTTP transport. For real multi-user auth (OAuth, mTLS, an upstream gateway),
+  layer Spring Security on top -- see <<spring-security>>.
+
+== Configuration (`jhelm.security.*`)
+
+[cols="2,1,4"]
+|===
+| Property | Default | Description
+
+| `jhelm.security.mode`
+| `READ_ONLY`
+| Access mode. `READ_ONLY` exposes only non-mutating operations. `FULL` enables the
+  cluster-mutating operations -- but only when an `api-key` is also set (deny-by-default).
+
+| `jhelm.security.api-key`
+| _(none)_
+| Shared secret required to call mutating operations. With no key set, mutating operations
+  stay disabled regardless of `mode`.
+
+| `jhelm.security.api-key-header`
+| `X-API-Key`
+| Name of the HTTP header that carries the API key.
+|===
+
+[source,yaml]
+----
+jhelm:
+  security:
+    mode: FULL          # READ_ONLY (default) or FULL
+    api-key: changeme   # required to actually enable mutating operations
+    api-key-header: X-API-Key
+----
+
+[NOTE]
+====
+The mutating gate is the logical AND of both settings:
+
+[cols="1,1,2"]
+|===
+| `mode` | `api-key` | Mutating operations
+
+| `READ_ONLY` (default) | _any_ | Disabled
+| `FULL` | not set | Disabled
+| `FULL` | set | *Enabled*
+|===
+====
+
+== REST behaviour
+
+The REST API always serves read-only endpoints. For a mutating endpoint, the outcome depends
+on the gate and the request's API-key header:
+
+[cols="1,3"]
+|===
+| Status | When
+
+| `403 Forbidden`
+| Mutating is disabled -- `mode=READ_ONLY`, or `mode=FULL` with no `api-key` configured. The
+  operation is not available at all.
+
+| `401 Unauthorized`
+| Mutating is enabled, but the request is missing the `X-API-Key` header or presents an
+  invalid value.
+
+| _proceeds_
+| Mutating is enabled and a valid `X-API-Key` header is present.
+|===
+
+Read-only endpoints are always allowed and never require a key.
+
+== MCP behaviour
+
+The MCP server applies the same model, with two transport-aware twists:
+
+* *Tool gating.* The cluster-mutating tools (`helm_install`, `helm_upgrade`,
+  `helm_uninstall`, `helm_rollback`, `helm_test`) are only *registered* when `mode=FULL` and an
+  `api-key` is set. When the gate is closed they do not exist at all -- an agent never sees them.
+* *HTTP filter.* When an `api-key` is configured, an HTTP filter requires a valid
+  `X-API-Key` header on the MCP HTTP endpoints (`/mcp`, `/sse`).
+* *stdio / local bypass.* A locally launched MCP server (stdio / localhost) never passes
+  through the servlet filter, so it is not forced to present a key. The key protects the
+  *network-exposed* HTTP transport, not a trusted local launch.
+
+This matches how MCP is normally used: the server runs on the same machine as the agent, and
+the key only matters once the transport is exposed over the network. See the
+xref:mcp.adoc#security[MCP security section] for details.
+
+[#spring-security]
+== Upgrade path: Spring Security
+
+The built-in API key is a deliberately simple floor. For production multi-user authentication
+and authorization -- OAuth2 / OIDC, mTLS, or delegating to an upstream API gateway -- wire
+https://spring.io/projects/spring-security[Spring Security] into your application. Because both
+the REST and MCP surfaces are ordinary Spring MVC / web endpoints, standard Spring Security
+configuration applies on top of them.
+
+NOTE: Spring Security is configured in the embedding application, not baked into the starters.
+A fully secured sample is forthcoming.


### PR DESCRIPTION
Closes #539. The pre-public-release documentation pass.

- **NEW `mcp.adoc`** — what jhelm-mcp is, how to run it (`jhelm-mcp-starter`, STREAMABLE HTTP, the sample), the **16-tool table** (read + gated mutating), the local/desktop model.
- **NEW `security.adoc`** — the unified model as a feature: *MCP local · REST deny-by-default key · read-only default · bring-your-own Spring Security*. `jhelm.security.*` config, REST **403/401** table, MCP tool gating + HTTP filter + **stdio bypass**.
- **getting-started.adoc** — all four surfaces (library / CLI / REST / MCP) with the read-only default + deny-by-default key shown.
- **index.adoc / README.adoc** — surface the credible claims (byte-for-byte parity across **346 charts in pure Java**, **MCP-native**) + links to the new pages.
- **rest-api.adoc** — reconciled the stale `jhelm.rest.mode`/`jhelm.mcp.mode` to the unified `jhelm.security.*` model (#538).
- **nav.adoc** — MCP Server + Security entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)