### PR TITLE
refactor(api)!: typed ReleaseContext replaces the magic releaseInfo map (#500)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -13,6 +13,7 @@ import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
@@ -87,15 +88,15 @@ public class InstallAction {
 				.build())
 			.build();
 
-		Map<String, Object> releaseData = new HashMap<>();
-		releaseData.put("Name", options.getReleaseName());
-		releaseData.put("Namespace", options.getNamespace());
-		releaseData.put("Service", "Helm");
-		releaseData.put("IsInstall", true);
-		releaseData.put("IsUpgrade", false);
-		releaseData.put("Revision", release.getVersion());
+		ReleaseContext releaseContext = ReleaseContext.builder()
+			.name(options.getReleaseName())
+			.namespace(options.getNamespace())
+			.install(true)
+			.upgrade(false)
+			.revision(release.getVersion())
+			.build();
 
-		String manifest = runPostRenderProcessors(engine.render(chart, values, releaseData));
+		String manifest = runPostRenderProcessors(engine.render(chart, values, releaseContext));
 
 		release = release.toBuilder().manifest(manifest).build();
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/LintAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/LintAction.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.SchemaValidationException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.SchemaValidator;
@@ -101,16 +102,16 @@ public class LintAction {
 			ValuesLoader.deepMerge(values, overrideValues);
 		}
 
-		Map<String, Object> releaseData = new HashMap<>();
-		releaseData.put("Name", "RELEASE-NAME");
-		releaseData.put("Namespace", "default");
-		releaseData.put("Service", "Helm");
-		releaseData.put("IsInstall", true);
-		releaseData.put("IsUpgrade", false);
-		releaseData.put("Revision", 1);
+		ReleaseContext releaseContext = ReleaseContext.builder()
+			.name("RELEASE-NAME")
+			.namespace("default")
+			.install(true)
+			.upgrade(false)
+			.revision(1)
+			.build();
 
 		try {
-			engine.render(chart, values, releaseData);
+			engine.render(chart, values, releaseContext);
 		}
 		catch (Exception ex) {
 			errors.add("template rendering failed: " + ex.getMessage());

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.PostRenderProcessor;
@@ -33,15 +34,15 @@ public class TemplateAction {
 		Map<String, Object> values = new HashMap<>(chart.getValues());
 		ValuesLoader.deepMerge(values, overrides);
 
-		Map<String, Object> releaseData = new HashMap<>();
-		releaseData.put("Name", releaseName);
-		releaseData.put("Namespace", namespace);
-		releaseData.put("Service", "Helm");
-		releaseData.put("IsInstall", true);
-		releaseData.put("IsUpgrade", false);
-		releaseData.put("Revision", 1);
+		ReleaseContext releaseContext = ReleaseContext.builder()
+			.name(releaseName)
+			.namespace(namespace)
+			.install(true)
+			.upgrade(false)
+			.revision(1)
+			.build();
 
-		String manifest = engine.render(chart, values, releaseData);
+		String manifest = engine.render(chart, values, releaseContext);
 
 		for (PostRenderProcessor processor : postRenderProcessors) {
 			try {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -13,6 +13,7 @@ import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
@@ -78,15 +79,15 @@ public class UpgradeAction {
 			.config(Release.MapConfig.builder().values(configValues).build())
 			.build();
 
-		Map<String, Object> releaseData = new HashMap<>();
-		releaseData.put("Name", newRelease.getName());
-		releaseData.put("Namespace", newRelease.getNamespace());
-		releaseData.put("Service", "Helm");
-		releaseData.put("IsInstall", false);
-		releaseData.put("IsUpgrade", true);
-		releaseData.put("Revision", newRelease.getVersion());
+		ReleaseContext releaseContext = ReleaseContext.builder()
+			.name(newRelease.getName())
+			.namespace(newRelease.getNamespace())
+			.install(false)
+			.upgrade(true)
+			.revision(newRelease.getVersion())
+			.build();
 
-		String manifest = engine.render(newChart, renderValues, releaseData);
+		String manifest = engine.render(newChart, renderValues, releaseContext);
 
 		for (PostRenderProcessor processor : postRenderProcessors) {
 			try {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ReleaseContext.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ReleaseContext.java
@@ -1,0 +1,70 @@
+package org.alexmond.jhelm.core.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Helm's {@code .Release} built-in object, exposed to chart templates during rendering.
+ *
+ * <p>
+ * This immutable value type captures the release metadata that templates can reference as
+ * {@code .Release.Name}, {@code .Release.Namespace}, {@code .Release.IsInstall}, and so
+ * on. {@link #toMap()} produces the wire form consumed by the template engine — a
+ * {@link LinkedHashMap} whose keys, value types, and ordering match exactly what the
+ * actions historically built by hand, so template resolution stays byte-identical.
+ */
+@Getter
+@Builder
+public final class ReleaseContext {
+
+	/** The release name, exposed as {@code .Release.Name}. */
+	private final String name;
+
+	/** The target namespace, exposed as {@code .Release.Namespace}. */
+	private final String namespace;
+
+	/**
+	 * The rendering service, always {@code "Helm"}, exposed as {@code .Release.Service}.
+	 */
+	@Builder.Default
+	private final String service = "Helm";
+
+	/**
+	 * Whether this render is part of an install, exposed as {@code .Release.IsInstall}.
+	 */
+	private final boolean install;
+
+	/**
+	 * Whether this render is part of an upgrade, exposed as {@code .Release.IsUpgrade}.
+	 */
+	private final boolean upgrade;
+
+	/** The release revision number, exposed as {@code .Release.Revision}. */
+	private final int revision;
+
+	/**
+	 * Builds the {@code .Release} map in the exact form the template engine consumes.
+	 *
+	 * <p>
+	 * The returned {@link LinkedHashMap} preserves the historical key order
+	 * ({@code Name}, {@code Namespace}, {@code Service}, {@code IsInstall},
+	 * {@code IsUpgrade}, {@code Revision}) and value types ({@code IsInstall}/
+	 * {@code IsUpgrade} as booleans, {@code Revision} as an int), guaranteeing
+	 * byte-identical template output.
+	 * @return the {@code .Release} map exposed to templates
+	 */
+	public Map<String, Object> toMap() {
+		Map<String, Object> map = new LinkedHashMap<>();
+		map.put("Name", name);
+		map.put("Namespace", namespace);
+		map.put("Service", service);
+		map.put("IsInstall", install);
+		map.put("IsUpgrade", upgrade);
+		map.put("Revision", revision);
+		return map;
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartFiles;
 import org.alexmond.jhelm.core.model.Dependency;
+import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.alexmond.jhelm.core.model.Values;
 import org.alexmond.jhelm.core.model.VersionSet;
 
@@ -172,14 +173,15 @@ public class Engine {
 	 * @param chart the chart to render
 	 * @param values the user-supplied values merged over the chart defaults, exposed as
 	 * {@code .Values}
-	 * @param releaseInfo the release context exposed as {@code .Release} (name,
-	 * namespace, revision, etc.)
+	 * @param release the release context exposed as {@code .Release} (name, namespace,
+	 * revision, etc.)
 	 * @return the rendered manifests joined into one document
 	 * @throws TemplateRenderException if a template fails to parse or execute
 	 * @throws SchemaValidationException if the values violate the chart's JSON schema
 	 */
 	@SneakyThrows
-	public String render(Chart chart, Map<String, Object> values, Map<String, Object> releaseInfo) {
+	public String render(Chart chart, Map<String, Object> values, ReleaseContext release) {
+		Map<String, Object> releaseInfo = release.toMap();
 		long startNanos = System.nanoTime();
 		try {
 			AtomicReference<String> result = new AtomicReference<>();

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
@@ -26,6 +26,7 @@ import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
@@ -53,7 +54,7 @@ class InstallActionTest {
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
 
 		String manifest = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(manifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(manifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
@@ -79,7 +80,7 @@ class InstallActionTest {
 	void testInstallPersistsUserValuesAsConfig() throws Exception {
 		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("---\n");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("---\n");
 		Map<String, Object> overrides = Map.of("replicaCount", 3, "image", Map.of("tag", "v2"));
 
 		Release release = installAction.install(InstallOptions.builder()
@@ -101,7 +102,7 @@ class InstallActionTest {
 		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
 
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("---\nkind: ConfigMap\n");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("---\nkind: ConfigMap\n");
 
 		Release release = installAction.install(InstallOptions.builder()
 			.chart(chart)
@@ -138,7 +139,7 @@ class InstallActionTest {
 		String regularYaml = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
 		String fullManifest = "---\n" + hookYaml + regularYaml;
 
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(fullManifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(fullManifest);
 		doNothing().when(kubeService).delete(anyString(), anyString());
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
@@ -182,7 +183,7 @@ class InstallActionTest {
 		String regularYaml = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
 		String fullManifest = "---\n" + hookYaml + regularYaml;
 
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(fullManifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(fullManifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
@@ -210,7 +211,7 @@ class InstallActionTest {
 		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
 
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("---\nkind: ConfigMap\n");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("---\nkind: ConfigMap\n");
 
 		Release release = noKubeInstall.install(InstallOptions.builder()
 			.chart(chart)
@@ -229,7 +230,7 @@ class InstallActionTest {
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
 
 		String manifest = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(manifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(manifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doThrow(new RuntimeException("storage failed")).when(kubeService).storeRelease(any(Release.class));
 		doNothing().when(kubeService).delete(anyString(), anyString());
@@ -257,7 +258,7 @@ class InstallActionTest {
 			.crds(List.of(Chart.Crd.builder().name("foos.yaml").data(crdYaml).build()))
 			.build();
 
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("---\nkind: ConfigMap\n");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("---\nkind: ConfigMap\n");
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
@@ -280,7 +281,7 @@ class InstallActionTest {
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
 
 		String manifest = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(manifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(manifest);
 		doNothing().when(kubeService).ensureNamespace(anyString());
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
@@ -305,7 +306,7 @@ class InstallActionTest {
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
 
 		String manifest = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(manifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(manifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/TemplateActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/TemplateActionTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.when;
 import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.alexmond.jhelm.core.service.Engine;
 
 class TemplateActionTest {
@@ -46,7 +47,7 @@ class TemplateActionTest {
 		Files.writeString(chartDir.resolve("Chart.yaml"), chartYaml);
 
 		String manifest = "---\nkind: Service\nmetadata:\n  name: myservice";
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(manifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(manifest);
 
 		String result = templateAction.render(chartDir.toString(), "myrelease", "default");
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -35,6 +35,7 @@ import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
@@ -82,7 +83,7 @@ class UpgradeActionTest {
 		Chart newChart = Chart.builder().metadata(newMetadata).values(newValues).build();
 
 		String renderedManifest = "---\napiVersion: v1\nkind: Service";
-		when(engine.render(eq(newChart), anyMap(), anyMap())).thenReturn(renderedManifest);
+		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class))).thenReturn(renderedManifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
@@ -107,11 +108,10 @@ class UpgradeActionTest {
 		// The 5-arg overload defaults to Helm's --history-max default of 10.
 		verify(kubeService).pruneReleaseHistory("myapp", "default", 10);
 
-		@SuppressWarnings("unchecked")
-		ArgumentCaptor<Map<String, Object>> releaseDataCaptor = ArgumentCaptor.forClass(Map.class);
+		ArgumentCaptor<ReleaseContext> releaseDataCaptor = ArgumentCaptor.forClass(ReleaseContext.class);
 		verify(engine).render(eq(newChart), anyMap(), releaseDataCaptor.capture());
 
-		Map<String, Object> releaseData = releaseDataCaptor.getValue();
+		Map<String, Object> releaseData = releaseDataCaptor.getValue().toMap();
 		assertEquals("myapp", releaseData.get("Name"));
 		assertEquals("default", releaseData.get("Namespace"));
 		assertEquals(false, releaseData.get("IsInstall"));
@@ -144,7 +144,7 @@ class UpgradeActionTest {
 		Map<String, Object> overrideValues = new HashMap<>();
 		overrideValues.put("replicaCount", 5);
 
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
 
 		upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(currentRelease)
@@ -155,7 +155,7 @@ class UpgradeActionTest {
 
 		@SuppressWarnings("unchecked")
 		ArgumentCaptor<Map<String, Object>> valuesCaptor = ArgumentCaptor.forClass(Map.class);
-		verify(engine).render(eq(chart), valuesCaptor.capture(), anyMap());
+		verify(engine).render(eq(chart), valuesCaptor.capture(), any(ReleaseContext.class));
 
 		Map<String, Object> mergedValues = valuesCaptor.getValue();
 		assertEquals(5, mergedValues.get("replicaCount"));
@@ -181,7 +181,7 @@ class UpgradeActionTest {
 			.info(info)
 			.build();
 
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("dry-run-manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("dry-run-manifest");
 
 		Release upgradedRelease = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(currentRelease)
@@ -218,7 +218,7 @@ class UpgradeActionTest {
 			.info(info)
 			.build();
 
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
@@ -271,7 +271,7 @@ class UpgradeActionTest {
 		String regularYaml = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: myapp-svc\n";
 		String fullManifest = "---\n" + hookYaml + regularYaml;
 
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(fullManifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(fullManifest);
 		doNothing().when(kubeService).delete(anyString(), anyString());
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
@@ -327,7 +327,7 @@ class UpgradeActionTest {
 		String regularYaml = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: myapp-svc\n";
 		String fullManifest = "---\n" + hookYaml + regularYaml;
 
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(fullManifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(fullManifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
@@ -367,7 +367,7 @@ class UpgradeActionTest {
 			.info(info)
 			.build();
 
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
 
 		Release upgradedRelease = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(currentRelease)
@@ -401,7 +401,7 @@ class UpgradeActionTest {
 			.build();
 
 		String newManifest = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: new-svc\n";
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn(newManifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(newManifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doThrow(new RuntimeException("storage failed")).when(kubeService).storeRelease(any(Release.class));
 
@@ -478,7 +478,7 @@ class UpgradeActionTest {
 	@SuppressWarnings("unchecked")
 	private Map<String, Object> renderValuesFor(Release upgraded) {
 		ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
-		verify(engine).render(any(Chart.class), captor.capture(), anyMap());
+		verify(engine).render(any(Chart.class), captor.capture(), any(ReleaseContext.class));
 		return captor.getValue();
 	}
 
@@ -486,7 +486,7 @@ class UpgradeActionTest {
 	void testDefaultNoOverridesReusesPriorConfig() {
 		Release current = currentReleaseWithPrior();
 		Chart newChart = newChartWithChangedDefault();
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
 
 		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(current)
@@ -509,7 +509,7 @@ class UpgradeActionTest {
 		Chart newChart = newChartWithChangedDefault();
 		Map<String, Object> overrides = new HashMap<>();
 		overrides.put("extra", "x");
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
 
 		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(current)
@@ -535,7 +535,7 @@ class UpgradeActionTest {
 		Chart newChart = newChartWithChangedDefault();
 		Map<String, Object> overrides = new HashMap<>();
 		overrides.put("extra", "x");
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
 
 		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(current)
@@ -559,7 +559,7 @@ class UpgradeActionTest {
 		Chart newChart = newChartWithChangedDefault();
 		Map<String, Object> overrides = new HashMap<>();
 		overrides.put("extra", "x");
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
 
 		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(current)
@@ -586,7 +586,7 @@ class UpgradeActionTest {
 		Chart newChart = newChartWithChangedDefault();
 		Map<String, Object> overrides = new HashMap<>();
 		overrides.put("extra", "x");
-		when(engine.render(any(Chart.class), anyMap(), anyMap())).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
 
 		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(current)

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/model/ReleaseContextTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/model/ReleaseContextTest.java
@@ -1,0 +1,76 @@
+package org.alexmond.jhelm.core.model;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReleaseContextTest {
+
+	@Test
+	void testToMapProducesExactReleaseWireForm() {
+		ReleaseContext release = ReleaseContext.builder()
+			.name("my-release")
+			.namespace("prod")
+			.install(true)
+			.upgrade(false)
+			.revision(7)
+			.build();
+
+		Map<String, Object> map = release.toMap();
+
+		assertEquals("my-release", map.get("Name"));
+		assertEquals("prod", map.get("Namespace"));
+		assertEquals("Helm", map.get("Service"));
+		assertEquals(true, map.get("IsInstall"));
+		assertEquals(false, map.get("IsUpgrade"));
+		assertEquals(7, map.get("Revision"));
+	}
+
+	@Test
+	void testServiceDefaultsToHelm() {
+		ReleaseContext release = ReleaseContext.builder().name("r").namespace("ns").build();
+
+		assertEquals("Helm", release.getService());
+		assertEquals("Helm", release.toMap().get("Service"));
+	}
+
+	@Test
+	void testToMapHasExactKeysAndTypes() {
+		ReleaseContext release = ReleaseContext.builder()
+			.name("r")
+			.namespace("ns")
+			.install(false)
+			.upgrade(true)
+			.revision(1)
+			.build();
+
+		Map<String, Object> map = release.toMap();
+
+		assertEquals(6, map.size());
+		assertTrue(map.containsKey("Name"));
+		assertTrue(map.containsKey("Namespace"));
+		assertTrue(map.containsKey("Service"));
+		assertTrue(map.containsKey("IsInstall"));
+		assertTrue(map.containsKey("IsUpgrade"));
+		assertTrue(map.containsKey("Revision"));
+
+		// Types must match the hand-built maps the engine historically consumed.
+		assertInstanceOf(Boolean.class, map.get("IsInstall"));
+		assertInstanceOf(Boolean.class, map.get("IsUpgrade"));
+		assertInstanceOf(Integer.class, map.get("Revision"));
+	}
+
+	@Test
+	void testToMapPreservesInsertionOrder() {
+		ReleaseContext release = ReleaseContext.builder().name("r").namespace("ns").revision(1).build();
+
+		assertEquals(List.of("Name", "Namespace", "Service", "IsInstall", "IsUpgrade", "Revision"),
+				List.copyOf(release.toMap().keySet()));
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineCacheTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineCacheTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.alexmond.jhelm.core.cache.TemplateCache;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -16,8 +17,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EngineCacheTest {
 
-	private static final Map<String, Object> RELEASE_INFO = Map.of("Name", "test-release", "Namespace", "default",
-			"IsInstall", true, "IsUpgrade", false, "Revision", 1);
+	private static final ReleaseContext RELEASE_INFO = ReleaseContext.builder()
+		.name("test-release")
+		.namespace("default")
+		.install(true)
+		.upgrade(false)
+		.revision(1)
+		.build();
 
 	private ChartLoader chartLoader;
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -11,6 +11,7 @@ import org.alexmond.jhelm.core.exception.TemplateRenderException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Dependency;
+import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,14 +53,14 @@ class EngineTest {
 			.build();
 	}
 
-	private Map<String, Object> releaseInfo() {
-		Map<String, Object> info = new HashMap<>();
-		info.put("Name", "test-release");
-		info.put("Namespace", "default");
-		info.put("IsInstall", true);
-		info.put("IsUpgrade", false);
-		info.put("Revision", 1);
-		return info;
+	private ReleaseContext releaseInfo() {
+		return ReleaseContext.builder()
+			.name("test-release")
+			.namespace("default")
+			.install(true)
+			.upgrade(false)
+			.revision(1)
+			.build();
 	}
 
 	// --- basic rendering ---


### PR DESCRIPTION
Part of #500. `Engine.render` + the actions used a hand-built `Map<String,Object>` with magic `Name`/`Namespace`/`IsInstall`/… keys as the template `.Release` object. Replaced with an immutable **`ReleaseContext`** (name/namespace/service/install/upgrade/revision).

**Parity-safe:** `ReleaseContext.toMap()` reproduces the exact `{Name, Namespace, Service, IsInstall, IsUpgrade, Revision}` map; `Engine.render`'s first line converts to it, so the template engine sees an identical `.Release` — rendering is **byte-identical** (DefineOrder/NestedSubchart/Engine render tests pass unchanged). Actions build it via the builder.

**⚠️ Breaking:** `Engine.render`'s third parameter is `ReleaseContext`, not `Map`.

Verified: full reactor **BUILD SUCCESS**; new `ReleaseContextTest` + all render/parity tests green; PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)