### PR TITLE
refactor(api)!: RepoManager thread-safety + constructor injection (#500)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -97,15 +97,11 @@ public class JhelmCoreAutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	public RepoManager repoManager(JhelmCoreProperties props) {
+	public RepoManager repoManager(JhelmCoreProperties props, RegistryManager registryManager) {
 		if (props.getConfigPath() != null) {
-			RepoManager rm = new RepoManager(props.getConfigPath());
-			rm.setInsecureSkipTlsVerify(props.isInsecureSkipTlsVerify());
-			return rm;
+			return new RepoManager(props.getConfigPath(), registryManager, props.isInsecureSkipTlsVerify());
 		}
-		RepoManager rm = new RepoManager();
-		rm.setInsecureSkipTlsVerify(props.isInsecureSkipTlsVerify());
-		return rm;
+		return new RepoManager(registryManager, props.isInsecureSkipTlsVerify());
 	}
 
 	/**

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -5,7 +5,6 @@ import tools.jackson.core.StreamReadConstraints;
 import tools.jackson.dataformat.yaml.YAMLFactory;
 import tools.jackson.dataformat.yaml.YAMLMapper;
 import tools.jackson.dataformat.yaml.YAMLWriteFeature;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
@@ -31,7 +30,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -53,19 +52,42 @@ public class RepoManager {
 
 	private OciRegistryClient ociClient;
 
-	@Setter
-	private boolean insecureSkipTlsVerify;
+	private final boolean insecureSkipTlsVerify;
 
-	@Setter
-	private RegistryManager registryManager;
+	private final RegistryManager registryManager;
 
-	private final Map<String, Map<?, ?>> indexCache = new HashMap<>();
+	// Shared across the threads that resolve dependencies concurrently; mutated under no
+	// lock, so a thread-safe map (a stale double-parse is harmless, corruption is not).
+	private final Map<String, Map<?, ?>> indexCache = new ConcurrentHashMap<>();
 
+	/**
+	 * Creates a manager for the default Helm repositories.yaml, no OCI auth, TLS
+	 * verified.
+	 */
 	public RepoManager() {
-		this(resolveDefaultConfigPath());
+		this(resolveDefaultConfigPath(), null, false);
 	}
 
+	/** Creates a manager for the given config path, no OCI auth, TLS verified. */
 	public RepoManager(String configPath) {
+		this(configPath, null, false);
+	}
+
+	/**
+	 * Creates a manager for the default config path with the given OCI auth and TLS
+	 * setting.
+	 */
+	public RepoManager(RegistryManager registryManager, boolean insecureSkipTlsVerify) {
+		this(resolveDefaultConfigPath(), registryManager, insecureSkipTlsVerify);
+	}
+
+	/**
+	 * Creates a repository manager.
+	 * @param configPath path to the Helm repositories.yaml
+	 * @param registryManager OCI registry auth provider (may be {@code null})
+	 * @param insecureSkipTlsVerify whether to skip TLS verification on chart downloads
+	 */
+	public RepoManager(String configPath, RegistryManager registryManager, boolean insecureSkipTlsVerify) {
 		LoadSettings loadSettings = LoadSettings.builder().setCodePointLimit(50_000_000).build();
 		YAMLFactory yamlFactory = YAMLFactory.builder()
 			.disable(YAMLWriteFeature.WRITE_DOC_START_MARKER)
@@ -74,6 +96,8 @@ public class RepoManager {
 			.build();
 		this.yamlMapper = YAMLMapper.builder(yamlFactory).build();
 		this.configPath = configPath;
+		this.registryManager = registryManager;
+		this.insecureSkipTlsVerify = insecureSkipTlsVerify;
 		initHttpClient();
 	}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
@@ -116,8 +116,7 @@ class KpsComparisonTest {
 	}
 
 	private RepoManager createRepoManager() {
-		RepoManager rm = new RepoManager();
-		rm.setInsecureSkipTlsVerify(true);
+		RepoManager rm = new RepoManager(null, true);
 		return rm;
 	}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
@@ -57,8 +57,7 @@ class RepoManagerTest {
 
 	@Test
 	void testGetChartVersionsFromRealRepo() throws IOException {
-		RepoManager repoManager = new RepoManager();
-		repoManager.setInsecureSkipTlsVerify(true);
+		RepoManager repoManager = new RepoManager(null, true);
 
 		// We use a real repo for integration-like test
 		repoManager.addRepo("bitnami-test", "https://charts.bitnami.com/bitnami");


### PR DESCRIPTION
Part of #500. `RepoManager` exposed public `@Setter`s and a plain `HashMap` cache — and two of these were **latent bugs**:
- `registryManager` was **never set** (the auto-config built a `RegistryManager` bean but never wired it) → OCI registry auth was always skipped.
- `insecureSkipTlsVerify` was set via the setter **after** the constructor built the HTTP factory with the default `false` → the flag never took effect.

**Fix:** constructor-inject both (`RepoManager(configPath, registryManager, insecureSkipTlsVerify)` + convenience overloads), fields `final`, set before `initHttpClient` so the factory sees the real TLS setting, index cache → `ConcurrentHashMap` (shared across dependency-resolve threads). Auto-config injects the `RegistryManager` bean. Public `@Setter`s removed.

**⚠️ Breaking:** the `registryManager`/`insecureSkipTlsVerify` setters are removed — pass them to the constructor.

Verified: full affected reactor **BUILD SUCCESS**; RepoManagerTest + jhelm-core green; PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)