### PR TITLE
refactor(api): inject ChartLoader; RepositoryConfig fields camelCase (#500)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -180,9 +180,9 @@ public class JhelmCoreAutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	public TemplateAction templateAction(Engine engine,
+	public TemplateAction templateAction(Engine engine, ChartLoader chartLoader,
 			ObjectProvider<List<PostRenderProcessor>> postRenderProcessors) {
-		TemplateAction action = new TemplateAction(engine);
+		TemplateAction action = new TemplateAction(engine, chartLoader);
 		List<PostRenderProcessor> processors = postRenderProcessors.getIfAvailable();
 		if (processors != null) {
 			action.setPostRenderProcessors(processors);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
@@ -20,6 +20,8 @@ public class TemplateAction {
 
 	private final Engine engine;
 
+	private final ChartLoader chartLoader;
+
 	@Setter
 	private List<PostRenderProcessor> postRenderProcessors = List.of();
 
@@ -28,8 +30,7 @@ public class TemplateAction {
 	}
 
 	public String render(String chartPath, String releaseName, String namespace, Map<String, Object> overrides) {
-		ChartLoader loader = new ChartLoader();
-		Chart chart = loader.load(new File(chartPath));
+		Chart chart = this.chartLoader.load(new File(chartPath));
 
 		Map<String, Object> values = new HashMap<>(chart.getValues());
 		ValuesLoader.deepMerge(values, overrides);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/RepositoryConfig.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/RepositoryConfig.java
@@ -2,6 +2,8 @@ package org.alexmond.jhelm.core.model;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -39,9 +41,11 @@ public class RepositoryConfig {
 
 		private String caFile;
 
-		private boolean insecure_skip_tls_verify;
+		@JsonProperty("insecure_skip_tls_verify")
+		private boolean insecureSkipTlsVerify;
 
-		private boolean pass_credentials_all;
+		@JsonProperty("pass_credentials_all")
+		private boolean passCredentialsAll;
 
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
@@ -76,13 +76,13 @@ final class RepoHttpClientFactory {
 		}
 		boolean hasTls = (repo.getCertFile() != null && !repo.getCertFile().isEmpty())
 				|| (repo.getCaFile() != null && !repo.getCaFile().isEmpty());
-		boolean skipVerify = repo.isInsecure_skip_tls_verify() || globalInsecureSkipTls;
+		boolean skipVerify = repo.isInsecureSkipTlsVerify() || globalInsecureSkipTls;
 		return hasTls || skipVerify;
 	}
 
 	private CloseableHttpClient buildTlsClient(RepositoryConfig.Repository repo) throws IOException {
 		try {
-			boolean skipVerify = repo.isInsecure_skip_tls_verify() || globalInsecureSkipTls;
+			boolean skipVerify = repo.isInsecureSkipTlsVerify() || globalInsecureSkipTls;
 			SSLContext sslContext = buildSslContext(repo, skipVerify);
 			TlsSocketStrategy tlsStrategy = skipVerify
 					? new DefaultClientTlsStrategy(sslContext, NoopHostnameVerifier.INSTANCE)

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/TemplateActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/TemplateActionTest.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.core.action;
 
+import org.alexmond.jhelm.core.service.ChartLoader;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -30,7 +32,7 @@ class TemplateActionTest {
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		templateAction = new TemplateAction(engine);
+		templateAction = new TemplateAction(engine, new ChartLoader());
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/model/RepositoryConfigTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/model/RepositoryConfigTest.java
@@ -1,0 +1,41 @@
+package org.alexmond.jhelm.core.model;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RepositoryConfigTest {
+
+	private final YAMLMapper mapper = YAMLMapper.builder().build();
+
+	@Test
+	void testSnakeCaseWireKeysParseIntoCamelCaseFields() {
+		String yaml = """
+				name: myrepo
+				url: https://example.com
+				insecure_skip_tls_verify: true
+				pass_credentials_all: true
+				""";
+		RepositoryConfig.Repository repo = mapper.readValue(yaml, RepositoryConfig.Repository.class);
+		assertTrue(repo.isInsecureSkipTlsVerify());
+		assertTrue(repo.isPassCredentialsAll());
+	}
+
+	@Test
+	void testSerializesBackToHelmSnakeCaseKeys() {
+		RepositoryConfig.Repository repo = RepositoryConfig.Repository.builder()
+			.name("myrepo")
+			.url("https://example.com")
+			.insecureSkipTlsVerify(true)
+			.passCredentialsAll(false)
+			.build();
+		String yaml = mapper.writeValueAsString(repo);
+		assertTrue(yaml.contains("insecure_skip_tls_verify:"), yaml);
+		assertTrue(yaml.contains("pass_credentials_all:"), yaml);
+		assertFalse(yaml.contains("insecureSkipTlsVerify"), yaml);
+	}
+
+}


### PR DESCRIPTION
The final two #500 API-freeze cleanups.

- **TemplateAction** injects `ChartLoader` (constructor) instead of `new ChartLoader()` per render; the auto-config passes the shared bean.
- **RepositoryConfig.Repository**'s two snake_case fields → camelCase (`insecureSkipTlsVerify`, `passCredentialsAll`) with **`@JsonProperty` preserving the Helm `repositories.yaml` wire keys** (`insecure_skip_tls_verify`, `pass_credentials_all`). New `RepositoryConfigTest` pins the wire round-trip (parse + serialize unchanged).

Verified: full affected reactor green; PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)