### PR TITLE
feat(core): delete orphaned resources on upgrade (#501)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -22,6 +22,7 @@ import org.alexmond.jhelm.core.service.LifecyclePhase;
 import org.alexmond.jhelm.core.service.PostRenderProcessor;
 import org.alexmond.jhelm.core.util.HookExecutor;
 import org.alexmond.jhelm.core.util.HookParser;
+import org.alexmond.jhelm.core.util.ManifestDiff;
 import org.alexmond.jhelm.core.util.ValuesLoader;
 
 @RequiredArgsConstructor
@@ -101,31 +102,45 @@ public class UpgradeAction {
 		newRelease = newRelease.toBuilder().manifest(manifest).build();
 
 		if (kubeService != null && !options.isDryRun()) {
-			boolean noHooks = options.isNoHooks();
-			fireLifecycleEvent(LifecyclePhase.PRE_UPGRADE, newRelease.getName(), newRelease.getNamespace());
-			String regularManifest = HookParser.stripHooks(manifest);
-			List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(manifest);
-			HookExecutor hookExecutor = noHooks ? null : new HookExecutor(kubeService);
-			if (!noHooks) {
-				runHooks(hookExecutor, newRelease.getNamespace(), hooks, "pre-upgrade");
-			}
-			kubeService.apply(newRelease.getNamespace(), regularManifest);
-			try {
-				kubeService.storeRelease(newRelease);
-			}
-			catch (Exception ex) {
-				reapplyPreviousRelease(currentRelease);
-				throw new DeploymentFailedException("Failed to store release after apply; previous release re-applied",
-						ex, regularManifest);
-			}
-			kubeService.pruneReleaseHistory(newRelease.getName(), newRelease.getNamespace(), options.getMaxHistory());
-			if (!noHooks) {
-				runHooks(hookExecutor, newRelease.getNamespace(), hooks, "post-upgrade");
-			}
-			fireLifecycleEvent(LifecyclePhase.POST_UPGRADE, newRelease.getName(), newRelease.getNamespace());
+			applyRelease(options, currentRelease, newRelease, manifest);
 		}
 
 		return newRelease;
+	}
+
+	/**
+	 * Applies a non-dry-run upgrade to the cluster: runs pre-upgrade hooks, applies the
+	 * hook-stripped manifest, stores the release, prunes history, deletes orphaned
+	 * resources and runs post-upgrade hooks.
+	 * @param options the upgrade options
+	 * @param currentRelease the previous release
+	 * @param newRelease the new release being applied
+	 * @param manifest the full rendered manifest (hooks not yet stripped)
+	 */
+	private void applyRelease(UpgradeOptions options, Release currentRelease, Release newRelease, String manifest) {
+		boolean noHooks = options.isNoHooks();
+		fireLifecycleEvent(LifecyclePhase.PRE_UPGRADE, newRelease.getName(), newRelease.getNamespace());
+		String regularManifest = HookParser.stripHooks(manifest);
+		List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(manifest);
+		HookExecutor hookExecutor = noHooks ? null : new HookExecutor(kubeService);
+		if (!noHooks) {
+			runHooks(hookExecutor, newRelease.getNamespace(), hooks, "pre-upgrade");
+		}
+		kubeService.apply(newRelease.getNamespace(), regularManifest);
+		try {
+			kubeService.storeRelease(newRelease);
+		}
+		catch (Exception ex) {
+			reapplyPreviousRelease(currentRelease);
+			throw new DeploymentFailedException("Failed to store release after apply; previous release re-applied", ex,
+					regularManifest);
+		}
+		kubeService.pruneReleaseHistory(newRelease.getName(), newRelease.getNamespace(), options.getMaxHistory());
+		deleteOrphanedResources(currentRelease, regularManifest, newRelease.getNamespace());
+		if (!noHooks) {
+			runHooks(hookExecutor, newRelease.getNamespace(), hooks, "post-upgrade");
+		}
+		fireLifecycleEvent(LifecyclePhase.POST_UPGRADE, newRelease.getName(), newRelease.getNamespace());
 	}
 
 	/**
@@ -210,6 +225,36 @@ public class UpgradeAction {
 		catch (Exception rollbackEx) {
 			if (log.isErrorEnabled()) {
 				log.error("Failed to re-apply previous release: {}", rollbackEx.getMessage(), rollbackEx);
+			}
+		}
+	}
+
+	/**
+	 * Deletes resources the previous release contained that the new revision no longer
+	 * renders. Orphans are the old−new manifest difference (both hooks-stripped). Matches
+	 * Helm's best-effort cleanup: a failed delete is logged and the upgrade continues.
+	 * @param currentRelease the previous release (its manifest provides the old
+	 * resources)
+	 * @param regularManifest the new hooks-stripped manifest
+	 * @param namespace the release namespace
+	 */
+	private void deleteOrphanedResources(Release currentRelease, String regularManifest, String namespace) {
+		String oldManifest = currentRelease.getManifest();
+		if (oldManifest == null || oldManifest.isBlank()) {
+			return;
+		}
+		String oldRegular = HookParser.stripHooks(oldManifest);
+		// Orphans = resources present in the old manifest but not the new one.
+		String orphans = ManifestDiff.orphanedResources(oldRegular, regularManifest);
+		if (orphans.isBlank()) {
+			return;
+		}
+		try {
+			kubeService.delete(namespace, orphans);
+		}
+		catch (Exception ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("Failed to delete orphaned resources during upgrade: {}", ex.getMessage(), ex);
 			}
 		}
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ManifestDiff.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ManifestDiff.java
@@ -1,0 +1,95 @@
+package org.alexmond.jhelm.core.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+/**
+ * Computes the set of resources that exist in an old rendered manifest but no longer
+ * exist in a new one. Mirrors Helm's upgrade behaviour, which deletes resources that a
+ * previous release contained but the new revision no longer renders.
+ */
+public final class ManifestDiff {
+
+	private static final YAMLMapper YAML_MAPPER = YAMLMapper.builder().build();
+
+	private ManifestDiff() {
+	}
+
+	/**
+	 * Returns the documents from {@code oldManifest} whose resource identity is not
+	 * present in {@code newManifest}, rejoined with {@code ---} the same way
+	 * {@link HookParser#stripHooks(String)} joins documents.
+	 * <p>
+	 * Each manifest is split on {@code ---} and every non-blank document is parsed into a
+	 * map. A document is skipped when it is blank, parses to {@code null}, has no
+	 * {@code kind}, or has no {@code metadata.name}. The identity of a resource is
+	 * {@code apiVersion + "|" + kind + "|" + namespace + "|" + name}, where
+	 * {@code namespace} is {@code metadata.namespace} or the empty string when absent.
+	 * The original document text is preserved verbatim for each old resource so that
+	 * orphans can be deleted exactly as they were applied.
+	 * @param oldManifest the previous revision's manifest (may be {@code null} or blank)
+	 * @param newManifest the new revision's manifest (may be {@code null} or blank)
+	 * @return the orphaned documents rejoined with {@code ---}, or an empty string when
+	 * there are no orphans
+	 */
+	public static String orphanedResources(String oldManifest, String newManifest) {
+		Map<String, String> oldResources = parse(oldManifest);
+		if (oldResources.isEmpty()) {
+			return "";
+		}
+		Map<String, String> newResources = parse(newManifest);
+
+		StringBuilder result = new StringBuilder();
+		for (Map.Entry<String, String> entry : oldResources.entrySet()) {
+			if (!newResources.containsKey(entry.getKey())) {
+				result.append("---\n").append(entry.getValue().trim()).append('\n');
+			}
+		}
+		return result.toString();
+	}
+
+	/**
+	 * Parses a manifest into a map of resource identity to the original document text.
+	 * @param manifest the manifest to parse (may be {@code null} or blank)
+	 * @return a map from resource identity to verbatim document text
+	 */
+	@SuppressWarnings("unchecked")
+	private static Map<String, String> parse(String manifest) {
+		Map<String, String> resources = new LinkedHashMap<>();
+		if (manifest == null || manifest.isBlank()) {
+			return resources;
+		}
+
+		String[] docs = manifest.split("---");
+		for (String doc : docs) {
+			if (doc.isBlank()) {
+				continue;
+			}
+			try {
+				Map<String, Object> parsed = YAML_MAPPER.readValue(doc, Map.class);
+				if (parsed == null) {
+					continue;
+				}
+				String kind = (String) parsed.get("kind");
+				if (kind == null) {
+					continue;
+				}
+				Map<String, Object> metadata = (Map<String, Object>) parsed.get("metadata");
+				String name = (metadata != null) ? (String) metadata.get("name") : null;
+				if (name == null) {
+					continue;
+				}
+				String apiVersion = (String) parsed.get("apiVersion");
+				String namespace = (metadata.get("namespace") != null) ? metadata.get("namespace").toString() : "";
+				String identity = apiVersion + "|" + kind + "|" + namespace + "|" + name;
+				resources.put(identity, doc);
+			}
+			catch (Exception ignored) {
+			}
+		}
+		return resources;
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -12,8 +12,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -346,6 +348,110 @@ class UpgradeActionTest {
 		// Regular manifest is still applied and the release stored
 		verify(kubeService).apply("default", strippedManifest);
 		verify(kubeService).storeRelease(any(Release.class));
+	}
+
+	@Test
+	void testUpgradeDeletesOrphanedResources() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("2.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		// Previous release rendered a Service and a ConfigMap; the new chart only
+		// renders the Service, so the ConfigMap is orphaned and must be deleted.
+		String previousManifest = """
+				---
+				apiVersion: v1
+				kind: Service
+				metadata:
+				  name: myapp-svc
+				---
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: myapp-config
+				""";
+
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status(ReleaseStatus.DEPLOYED)
+			.build();
+
+		Release currentRelease = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.manifest(previousManifest)
+			.info(info)
+			.build();
+
+		String newManifest = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: myapp-svc\n";
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(newManifest);
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(chart)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.build());
+
+		ArgumentCaptor<String> orphanCaptor = ArgumentCaptor.forClass(String.class);
+		verify(kubeService).delete(eq("default"), orphanCaptor.capture());
+		String orphans = orphanCaptor.getValue();
+		assertTrue(orphans.contains("kind: ConfigMap"));
+		assertTrue(orphans.contains("name: myapp-config"));
+		assertFalse(orphans.contains("kind: Service"));
+	}
+
+	@Test
+	void testUpgradeNoOrphansSkipsDelete() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("2.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		String previousManifest = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: myapp-svc\n";
+
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status(ReleaseStatus.DEPLOYED)
+			.build();
+
+		Release currentRelease = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.manifest(previousManifest)
+			.info(info)
+			.build();
+
+		// New manifest still renders the Service (plus an added ConfigMap) — nothing
+		// dropped.
+		String newManifest = """
+				---
+				apiVersion: v1
+				kind: Service
+				metadata:
+				  name: myapp-svc
+				---
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: myapp-config
+				""";
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(newManifest);
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(chart)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.build());
+
+		verify(kubeService, never()).delete(anyString(), anyString());
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ManifestDiffTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ManifestDiffTest.java
@@ -1,0 +1,122 @@
+package org.alexmond.jhelm.core.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ManifestDiffTest {
+
+	private static final String DEPLOYMENT_FOO = """
+			apiVersion: apps/v1
+			kind: Deployment
+			metadata:
+			  name: foo
+			""";
+
+	private static final String SERVICE_FOO = """
+			apiVersion: v1
+			kind: Service
+			metadata:
+			  name: foo
+			""";
+
+	private static final String CONFIGMAP_BAR = """
+			apiVersion: v1
+			kind: ConfigMap
+			metadata:
+			  name: bar
+			""";
+
+	private static String manifest(String... docs) {
+		StringBuilder sb = new StringBuilder();
+		for (String doc : docs) {
+			sb.append("---\n").append(doc.trim()).append('\n');
+		}
+		return sb.toString();
+	}
+
+	@Test
+	void testDroppedResourceIsOrphan() {
+		String oldManifest = manifest(DEPLOYMENT_FOO, SERVICE_FOO);
+		String newManifest = manifest(DEPLOYMENT_FOO, CONFIGMAP_BAR);
+
+		String orphans = ManifestDiff.orphanedResources(oldManifest, newManifest);
+
+		assertTrue(orphans.contains("kind: Service"), "orphan output should contain the dropped Service");
+		assertTrue(orphans.contains("name: foo"), "orphan output should contain the Service name");
+		assertFalse(orphans.contains("kind: Deployment"), "retained Deployment must not be an orphan");
+	}
+
+	@Test
+	void testIdenticalManifestsHaveNoOrphans() {
+		String oldManifest = manifest(DEPLOYMENT_FOO, SERVICE_FOO);
+
+		String orphans = ManifestDiff.orphanedResources(oldManifest, oldManifest);
+
+		assertTrue(orphans.isEmpty(), "identical manifests should yield no orphans");
+	}
+
+	@Test
+	void testNewSupersetHasNoOrphans() {
+		String oldManifest = manifest(DEPLOYMENT_FOO);
+		String newManifest = manifest(DEPLOYMENT_FOO, SERVICE_FOO, CONFIGMAP_BAR);
+
+		String orphans = ManifestDiff.orphanedResources(oldManifest, newManifest);
+
+		assertTrue(orphans.isEmpty(), "a superset new manifest should yield no orphans");
+	}
+
+	@Test
+	void testChangedFieldsSameIdentityIsNotOrphan() {
+		String oldDeployment = """
+				apiVersion: apps/v1
+				kind: Deployment
+				metadata:
+				  name: foo
+				spec:
+				  replicas: 1
+				""";
+		String newDeployment = """
+				apiVersion: apps/v1
+				kind: Deployment
+				metadata:
+				  name: foo
+				spec:
+				  replicas: 3
+				""";
+
+		String orphans = ManifestDiff.orphanedResources(manifest(oldDeployment), manifest(newDeployment));
+
+		assertTrue(orphans.isEmpty(), "same identity with changed fields is not an orphan");
+	}
+
+	@Test
+	void testNamespaceIsPartOfIdentity() {
+		String oldService = """
+				apiVersion: v1
+				kind: Service
+				metadata:
+				  name: foo
+				  namespace: alpha
+				""";
+		String newService = """
+				apiVersion: v1
+				kind: Service
+				metadata:
+				  name: foo
+				  namespace: beta
+				""";
+
+		String orphans = ManifestDiff.orphanedResources(manifest(oldService), manifest(newService));
+
+		assertTrue(orphans.contains("namespace: alpha"), "same kind/name in a different namespace should be an orphan");
+	}
+
+	@Test
+	void testEmptyOldManifestYieldsNoOrphans() {
+		String orphans = ManifestDiff.orphanedResources("", manifest(SERVICE_FOO));
+		assertTrue(orphans.isEmpty(), "blank old manifest yields no orphans");
+	}
+
+}


### PR DESCRIPTION
Part of #501. When an upgrade renders a chart that no longer contains a resource the previous revision had, Helm **deletes the orphan**; jhelm left it lingering.

- New **`ManifestDiff.orphanedResources(old, new)`** — parses both manifests (mirrors `HookParser`'s doc split), keys resources by `apiVersion|kind|namespace|name`, returns the old docs whose identity is absent from the new manifest (verbatim).
- `UpgradeAction` runs the diff after apply/store/prune, before post-upgrade hooks: `orphans = stripHooks(oldManifest) − newManifest`; if any → `kubeService.delete(namespace, orphans)`. **Best-effort** — a delete failure logs at warn and doesn't fail the upgrade (matching Helm).

Verified: full reactor **BUILD SUCCESS**; `ManifestDiffTest` (dropped→orphan, changed-fields-not-orphan, namespace-in-identity, superset/empty→none) + `UpgradeActionTest` (deletes the dropped resource; never when superset); PMD/Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)