### PR TITLE
feat(kube): deepen --wait readiness to Helm parity (#501)

### DIFF
--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
@@ -10,8 +10,10 @@ import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1DaemonSet;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1ReplicaSet;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
@@ -428,6 +430,8 @@ public class HelmKubeService implements KubeService {
 		try {
 			return switch (kind) {
 				case "Deployment" -> checkDeployment(namespace, name);
+				case "ReplicaSet" -> checkReplicaSet(namespace, name);
+				case "DaemonSet" -> checkDaemonSet(namespace, name);
 				case "StatefulSet" -> checkStatefulSet(namespace, name);
 				case "Job" -> checkJob(namespace, name);
 				case "Pod" -> checkPod(namespace, name);
@@ -455,10 +459,13 @@ public class HelmKubeService implements KubeService {
 		AppsV1Api api = new AppsV1Api(apiClient);
 		V1Deployment dep = api.readNamespacedDeployment(name, namespace).execute();
 		int desired = (dep.getSpec().getReplicas() != null) ? dep.getSpec().getReplicas() : 1;
-		int ready = (dep.getStatus().getReadyReplicas() != null) ? dep.getStatus().getReadyReplicas() : 0;
-		int updated = (dep.getStatus().getUpdatedReplicas() != null) ? dep.getStatus().getUpdatedReplicas() : 0;
-		boolean isReady = (ready >= desired) && (updated >= desired);
-		String message = isReady ? "ready" : String.format("%d/%d replicas ready", ready, desired);
+		int ready = nz(dep.getStatus().getReadyReplicas());
+		int updated = nz(dep.getStatus().getUpdatedReplicas());
+		int available = nz(dep.getStatus().getAvailableReplicas());
+		boolean observed = observedCurrent(generationOf(dep.getMetadata()), dep.getStatus().getObservedGeneration());
+		boolean isReady = observed && (updated >= desired) && (ready >= desired) && (available >= desired);
+		String message = isReady ? "ready"
+				: !observed ? "waiting for rollout" : String.format("%d/%d replicas ready", ready, desired);
 		return ResourceStatus.builder()
 			.kind("Deployment")
 			.name(name)
@@ -466,6 +473,66 @@ public class HelmKubeService implements KubeService {
 			.ready(isReady)
 			.message(message)
 			.build();
+	}
+
+	private ResourceStatus checkReplicaSet(String namespace, String name) throws ApiException {
+		AppsV1Api api = new AppsV1Api(apiClient);
+		V1ReplicaSet rs = api.readNamespacedReplicaSet(name, namespace).execute();
+		int desired = (rs.getSpec().getReplicas() != null) ? rs.getSpec().getReplicas() : 1;
+		int ready = nz(rs.getStatus().getReadyReplicas());
+		boolean observed = observedCurrent(generationOf(rs.getMetadata()), rs.getStatus().getObservedGeneration());
+		boolean isReady = observed && (ready >= desired);
+		String message = isReady ? "ready"
+				: !observed ? "waiting for rollout" : String.format("%d/%d replicas ready", ready, desired);
+		return ResourceStatus.builder()
+			.kind("ReplicaSet")
+			.name(name)
+			.namespace(namespace)
+			.ready(isReady)
+			.message(message)
+			.build();
+	}
+
+	private ResourceStatus checkDaemonSet(String namespace, String name) throws ApiException {
+		AppsV1Api api = new AppsV1Api(apiClient);
+		V1DaemonSet ds = api.readNamespacedDaemonSet(name, namespace).execute();
+		int desiredScheduled = nz(ds.getStatus().getDesiredNumberScheduled());
+		int updatedScheduled = nz(ds.getStatus().getUpdatedNumberScheduled());
+		int numberReady = nz(ds.getStatus().getNumberReady());
+		boolean observed = observedCurrent(generationOf(ds.getMetadata()), ds.getStatus().getObservedGeneration());
+		boolean isReady = observed && (updatedScheduled >= desiredScheduled) && (numberReady >= desiredScheduled);
+		String message = isReady ? "ready"
+				: !observed ? "waiting for rollout" : String.format("%d/%d ready", numberReady, desiredScheduled);
+		return ResourceStatus.builder()
+			.kind("DaemonSet")
+			.name(name)
+			.namespace(namespace)
+			.ready(isReady)
+			.message(message)
+			.build();
+	}
+
+	/** Null-safe count: treats {@code null} as 0. */
+	private static int nz(Integer value) {
+		return (value != null) ? value : 0;
+	}
+
+	/**
+	 * Null-safe read of {@code metadata.generation}, returning {@code null} if absent.
+	 */
+	private static Long generationOf(V1ObjectMeta metadata) {
+		return (metadata != null) ? metadata.getGeneration() : null;
+	}
+
+	/**
+	 * Returns {@code true} when the controller has observed the latest spec, i.e.
+	 * {@code status.observedGeneration >= metadata.generation} (both null-safe as 0).
+	 * This guards against a mid-rollout false-ready before the controller has reconciled.
+	 */
+	private static boolean observedCurrent(Long generation, Long observedGeneration) {
+		long gen = (generation != null) ? generation : 0L;
+		long observed = (observedGeneration != null) ? observedGeneration : 0L;
+		return observed >= gen;
 	}
 
 	private ResourceStatus checkStatefulSet(String namespace, String name) throws ApiException {

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
@@ -8,10 +8,15 @@ import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1DaemonSet;
+import io.kubernetes.client.openapi.models.V1DaemonSetStatus;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1DeploymentSpec;
 import io.kubernetes.client.openapi.models.V1DeploymentStatus;
 import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1ReplicaSet;
+import io.kubernetes.client.openapi.models.V1ReplicaSetSpec;
+import io.kubernetes.client.openapi.models.V1ReplicaSetStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
@@ -807,8 +812,12 @@ class HelmKubeServiceTest {
 				""";
 
 		appsV1ApiConstruction = mockConstruction(AppsV1Api.class, (mock, ctx) -> {
-			V1Deployment dep = new V1Deployment().spec(new V1DeploymentSpec().replicas(2))
-				.status(new V1DeploymentStatus().readyReplicas(2).updatedReplicas(2));
+			V1Deployment dep = new V1Deployment().metadata(new V1ObjectMeta().generation(2L))
+				.spec(new V1DeploymentSpec().replicas(2))
+				.status(new V1DeploymentStatus().observedGeneration(2L)
+					.readyReplicas(2)
+					.updatedReplicas(2)
+					.availableReplicas(2));
 			var readReq = mock(AppsV1Api.APIreadNamespacedDeploymentRequest.class);
 			when(readReq.execute()).thenReturn(dep);
 			when(mock.readNamespacedDeployment(eq("my-deploy"), eq("default"))).thenReturn(readReq);
@@ -819,6 +828,178 @@ class HelmKubeServiceTest {
 		assertEquals(1, statuses.size());
 		assertEquals("Deployment", statuses.get(0).getKind());
 		assertTrue(statuses.get(0).isReady());
+	}
+
+	@Test
+	void testGetResourceStatusesDeploymentNotReadyWhenObservedGenerationStale() throws Exception {
+		// Replicas all look ready, but the controller has not yet observed the latest
+		// spec (observedGeneration < generation): this guards a mid-rollout false-ready.
+		String manifest = """
+				apiVersion: apps/v1
+				kind: Deployment
+				metadata:
+				  name: my-deploy
+				  namespace: default
+				""";
+
+		appsV1ApiConstruction = mockConstruction(AppsV1Api.class, (mock, ctx) -> {
+			V1Deployment dep = new V1Deployment().metadata(new V1ObjectMeta().generation(3L))
+				.spec(new V1DeploymentSpec().replicas(2))
+				.status(new V1DeploymentStatus().observedGeneration(2L)
+					.readyReplicas(2)
+					.updatedReplicas(2)
+					.availableReplicas(2));
+			var readReq = mock(AppsV1Api.APIreadNamespacedDeploymentRequest.class);
+			when(readReq.execute()).thenReturn(dep);
+			when(mock.readNamespacedDeployment(eq("my-deploy"), eq("default"))).thenReturn(readReq);
+		});
+
+		List<ResourceStatus> statuses = kubeService.getResourceStatuses("default", manifest);
+
+		assertEquals(1, statuses.size());
+		assertFalse(statuses.get(0).isReady());
+		assertEquals("waiting for rollout", statuses.get(0).getMessage());
+	}
+
+	@Test
+	void testGetResourceStatusesDeploymentNotReadyWhenUnavailable() throws Exception {
+		// observedGeneration is current and ready/updated meet desired, but available
+		// replicas lag: Helm treats this as not ready.
+		String manifest = """
+				apiVersion: apps/v1
+				kind: Deployment
+				metadata:
+				  name: my-deploy
+				  namespace: default
+				""";
+
+		appsV1ApiConstruction = mockConstruction(AppsV1Api.class, (mock, ctx) -> {
+			V1Deployment dep = new V1Deployment().metadata(new V1ObjectMeta().generation(1L))
+				.spec(new V1DeploymentSpec().replicas(2))
+				.status(new V1DeploymentStatus().observedGeneration(1L)
+					.readyReplicas(2)
+					.updatedReplicas(2)
+					.availableReplicas(1));
+			var readReq = mock(AppsV1Api.APIreadNamespacedDeploymentRequest.class);
+			when(readReq.execute()).thenReturn(dep);
+			when(mock.readNamespacedDeployment(eq("my-deploy"), eq("default"))).thenReturn(readReq);
+		});
+
+		List<ResourceStatus> statuses = kubeService.getResourceStatuses("default", manifest);
+
+		assertEquals(1, statuses.size());
+		assertFalse(statuses.get(0).isReady());
+		assertEquals("2/2 replicas ready", statuses.get(0).getMessage());
+	}
+
+	@Test
+	void testGetResourceStatusesReplicaSetReady() throws Exception {
+		String manifest = """
+				apiVersion: apps/v1
+				kind: ReplicaSet
+				metadata:
+				  name: my-rs
+				  namespace: default
+				""";
+
+		appsV1ApiConstruction = mockConstruction(AppsV1Api.class, (mock, ctx) -> {
+			V1ReplicaSet rs = new V1ReplicaSet().metadata(new V1ObjectMeta().generation(1L))
+				.spec(new V1ReplicaSetSpec().replicas(3))
+				.status(new V1ReplicaSetStatus().observedGeneration(1L).readyReplicas(3));
+			var readReq = mock(AppsV1Api.APIreadNamespacedReplicaSetRequest.class);
+			when(readReq.execute()).thenReturn(rs);
+			when(mock.readNamespacedReplicaSet(eq("my-rs"), eq("default"))).thenReturn(readReq);
+		});
+
+		List<ResourceStatus> statuses = kubeService.getResourceStatuses("default", manifest);
+
+		assertEquals(1, statuses.size());
+		assertEquals("ReplicaSet", statuses.get(0).getKind());
+		assertTrue(statuses.get(0).isReady());
+	}
+
+	@Test
+	void testGetResourceStatusesReplicaSetNotReady() throws Exception {
+		String manifest = """
+				apiVersion: apps/v1
+				kind: ReplicaSet
+				metadata:
+				  name: my-rs
+				  namespace: default
+				""";
+
+		appsV1ApiConstruction = mockConstruction(AppsV1Api.class, (mock, ctx) -> {
+			V1ReplicaSet rs = new V1ReplicaSet().metadata(new V1ObjectMeta().generation(1L))
+				.spec(new V1ReplicaSetSpec().replicas(3))
+				.status(new V1ReplicaSetStatus().observedGeneration(1L).readyReplicas(1));
+			var readReq = mock(AppsV1Api.APIreadNamespacedReplicaSetRequest.class);
+			when(readReq.execute()).thenReturn(rs);
+			when(mock.readNamespacedReplicaSet(eq("my-rs"), eq("default"))).thenReturn(readReq);
+		});
+
+		List<ResourceStatus> statuses = kubeService.getResourceStatuses("default", manifest);
+
+		assertEquals(1, statuses.size());
+		assertEquals("ReplicaSet", statuses.get(0).getKind());
+		assertFalse(statuses.get(0).isReady());
+		assertEquals("1/3 replicas ready", statuses.get(0).getMessage());
+	}
+
+	@Test
+	void testGetResourceStatusesDaemonSetReady() throws Exception {
+		String manifest = """
+				apiVersion: apps/v1
+				kind: DaemonSet
+				metadata:
+				  name: my-ds
+				  namespace: default
+				""";
+
+		appsV1ApiConstruction = mockConstruction(AppsV1Api.class, (mock, ctx) -> {
+			V1DaemonSet ds = new V1DaemonSet().metadata(new V1ObjectMeta().generation(1L))
+				.status(new V1DaemonSetStatus().observedGeneration(1L)
+					.desiredNumberScheduled(3)
+					.updatedNumberScheduled(3)
+					.numberReady(3));
+			var readReq = mock(AppsV1Api.APIreadNamespacedDaemonSetRequest.class);
+			when(readReq.execute()).thenReturn(ds);
+			when(mock.readNamespacedDaemonSet(eq("my-ds"), eq("default"))).thenReturn(readReq);
+		});
+
+		List<ResourceStatus> statuses = kubeService.getResourceStatuses("default", manifest);
+
+		assertEquals(1, statuses.size());
+		assertEquals("DaemonSet", statuses.get(0).getKind());
+		assertTrue(statuses.get(0).isReady());
+	}
+
+	@Test
+	void testGetResourceStatusesDaemonSetNotReady() throws Exception {
+		String manifest = """
+				apiVersion: apps/v1
+				kind: DaemonSet
+				metadata:
+				  name: my-ds
+				  namespace: default
+				""";
+
+		appsV1ApiConstruction = mockConstruction(AppsV1Api.class, (mock, ctx) -> {
+			V1DaemonSet ds = new V1DaemonSet().metadata(new V1ObjectMeta().generation(1L))
+				.status(new V1DaemonSetStatus().observedGeneration(1L)
+					.desiredNumberScheduled(3)
+					.updatedNumberScheduled(2)
+					.numberReady(1));
+			var readReq = mock(AppsV1Api.APIreadNamespacedDaemonSetRequest.class);
+			when(readReq.execute()).thenReturn(ds);
+			when(mock.readNamespacedDaemonSet(eq("my-ds"), eq("default"))).thenReturn(readReq);
+		});
+
+		List<ResourceStatus> statuses = kubeService.getResourceStatuses("default", manifest);
+
+		assertEquals(1, statuses.size());
+		assertEquals("DaemonSet", statuses.get(0).getKind());
+		assertFalse(statuses.get(0).isReady());
+		assertEquals("1/3 ready", statuses.get(0).getMessage());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
Strengthens the `--wait` resource-readiness checks in `HelmKubeService` to match Helm's criteria (part of #501, 0.5.0 Lifecycle).

Two gaps closed:
- **ReplicaSet and DaemonSet were never checked** — they fell through the `switch(kind)` to `ready=true`, so `--wait` returned immediately for them.
- **Deployment could report ready mid-rollout** — the old check compared only `readyReplicas`/`updatedReplicas` to the desired count, ignoring the observed generation and available replicas.

## Changes
- `checkDeployment`: now requires `observedGeneration >= metadata.generation` **and** `updated/ready/available >= desired`.
- `checkReplicaSet` (new): `observedGeneration` current **and** `readyReplicas >= desired`.
- `checkDaemonSet` (new): `observedGeneration` current **and** `updated/ready scheduled >= desiredNumberScheduled`.
- Dispatch: `case "ReplicaSet"` / `case "DaemonSet"` wired into `switch(kind)`.
- Null-safe helpers (`nz`/`generationOf`/`observedCurrent`).

## Tests
+7 `HelmKubeServiceTest` cases (module total 204, all green), incl. the Deployment `observedGeneration < generation` false-ready guard, and ReplicaSet/DaemonSet ready & not-ready paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)