### PR TITLE
feat(lifecycle): rollback --wait, uninstall --keep-history, hook-failed policy (#501)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
@@ -4,6 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.RollbackAction;
 import org.alexmond.jhelm.core.action.RollbackOptions;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.KubeService;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
@@ -18,6 +20,8 @@ import picocli.CommandLine;
 public class RollbackCommand implements Runnable {
 
 	private final RollbackAction rollbackAction;
+
+	private final KubeService kubeService;
 
 	@CommandLine.Parameters(index = "0", description = "release name")
 	private String name;
@@ -35,18 +39,27 @@ public class RollbackCommand implements Runnable {
 			description = "limit the maximum number of revisions saved per release (0 = no limit)")
 	private int historyMax;
 
+	@CommandLine.Option(names = { "--wait" }, description = "wait until all resources are ready")
+	private boolean wait;
+
+	@CommandLine.Option(names = { "--timeout" }, defaultValue = "300",
+			description = "timeout in seconds for --wait (default 300)")
+	private int timeout;
+
 	/**
 	 * Creates the command.
 	 * @param rollbackAction the action that performs the rollback
+	 * @param kubeService the Kubernetes service used to wait for resource readiness
 	 */
-	public RollbackCommand(RollbackAction rollbackAction) {
+	public RollbackCommand(RollbackAction rollbackAction, KubeService kubeService) {
 		this.rollbackAction = rollbackAction;
+		this.kubeService = kubeService;
 	}
 
 	@Override
 	public void run() {
 		try {
-			rollbackAction.rollback(RollbackOptions.builder()
+			Release release = rollbackAction.rollback(RollbackOptions.builder()
 				.releaseName(name)
 				.namespace(namespace)
 				.revision(revision)
@@ -54,6 +67,9 @@ public class RollbackCommand implements Runnable {
 				.maxHistory(historyMax)
 				.build());
 			CliOutput.println(CliOutput.success("Rollback was a success! Happy Helming!"));
+			if (wait) {
+				kubeService.waitForReady(namespace, release.getManifest(), timeout);
+			}
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error during rollback: " + ex.getMessage()));

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
@@ -27,6 +27,10 @@ public class UninstallCommand implements Runnable {
 	@CommandLine.Option(names = { "--no-hooks" }, description = "prevent hooks from running during this operation")
 	private boolean noHooks;
 
+	@CommandLine.Option(names = { "--keep-history" },
+			description = "remove all associated resources and mark the release as deleted, but retain the release history")
+	private boolean keepHistory;
+
 	/**
 	 * Creates the command.
 	 * @param uninstallAction the action that uninstalls the release
@@ -38,8 +42,12 @@ public class UninstallCommand implements Runnable {
 	@Override
 	public void run() {
 		try {
-			uninstallAction
-				.uninstall(UninstallOptions.builder().releaseName(name).namespace(namespace).noHooks(noHooks).build());
+			uninstallAction.uninstall(UninstallOptions.builder()
+				.releaseName(name)
+				.namespace(namespace)
+				.noHooks(noHooks)
+				.keepHistory(keepHistory)
+				.build());
 			CliOutput.println(CliOutput.success("release \"" + name + "\" uninstalled"));
 		}
 		catch (Exception ex) {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RollbackCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RollbackCommandTest.java
@@ -2,6 +2,8 @@ package org.alexmond.jhelm.app.command;
 
 import org.alexmond.jhelm.core.action.RollbackAction;
 import org.alexmond.jhelm.core.action.RollbackOptions;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.KubeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -9,25 +11,29 @@ import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
 class RollbackCommandTest {
 
 	@Mock
 	private RollbackAction rollbackAction;
 
+	@Mock
+	private KubeService kubeService;
+
 	private RollbackCommand rollbackCommand;
 
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		rollbackCommand = new RollbackCommand(rollbackAction);
+		rollbackCommand = new RollbackCommand(rollbackAction, kubeService);
 	}
 
 	@Test
 	void testRollbackCommandSuccess() throws Exception {
-		doNothing().when(rollbackAction).rollback(any(RollbackOptions.class));
+		Release release = Release.builder().name("my-release").namespace("default").manifest("---\n").build();
+		when(rollbackAction.rollback(any(RollbackOptions.class))).thenReturn(release);
 
 		CommandLine cmd = new CommandLine(rollbackCommand);
 		cmd.execute("my-release", "1", "-n", "default");
@@ -35,7 +41,8 @@ class RollbackCommandTest {
 
 	@Test
 	void testRollbackCommandDefaultNamespace() throws Exception {
-		doNothing().when(rollbackAction).rollback(any(RollbackOptions.class));
+		Release release = Release.builder().name("my-release").namespace("default").manifest("---\n").build();
+		when(rollbackAction.rollback(any(RollbackOptions.class))).thenReturn(release);
 
 		CommandLine cmd = new CommandLine(rollbackCommand);
 		cmd.execute("my-release", "2");

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
@@ -28,8 +28,9 @@ public class RollbackAction {
 	 * revisions.
 	 * @param options the rollback options (release name, namespace, target revision,
 	 * no-hooks flag and the history cap)
+	 * @return the newly created {@link Release} representing the rolled-back revision
 	 */
-	public void rollback(RollbackOptions options) {
+	public Release rollback(RollbackOptions options) {
 		String name = options.getReleaseName();
 		String namespace = options.getNamespace();
 		int revision = options.getRevision();
@@ -75,6 +76,7 @@ public class RollbackAction {
 		if (!noHooks) {
 			runHooks(hookExecutor, namespace, hooks, "post-rollback");
 		}
+		return newRelease;
 	}
 
 	private void runHooks(HookExecutor hookExecutor, String namespace, List<HelmHook> hooks, String phase) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.core.action;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -9,6 +10,7 @@ import org.alexmond.jhelm.core.exception.JhelmException;
 import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.util.HookExecutor;
 import org.alexmond.jhelm.core.util.HookParser;
@@ -44,7 +46,30 @@ public class UninstallAction {
 		if (!noHooks) {
 			runHooks(hookExecutor, namespace, hooks, "post-delete");
 		}
-		kubeService.deleteReleaseHistory(releaseName, namespace);
+		if (options.isKeepHistory()) {
+			kubeService.storeRelease(markUninstalled(release));
+		}
+		else {
+			kubeService.deleteReleaseHistory(releaseName, namespace);
+		}
+	}
+
+	private Release markUninstalled(Release release) {
+		Release.ReleaseInfo previousInfo = release.getInfo();
+		OffsetDateTime firstDeployed = (previousInfo != null) ? previousInfo.getFirstDeployed() : null;
+		return Release.builder()
+			.name(release.getName())
+			.namespace(release.getNamespace())
+			.version(release.getVersion())
+			.chart(release.getChart())
+			.manifest(release.getManifest())
+			.info(Release.ReleaseInfo.builder()
+				.firstDeployed(firstDeployed)
+				.lastDeployed(OffsetDateTime.now())
+				.status(ReleaseStatus.UNINSTALLED)
+				.description("Uninstallation complete")
+				.build())
+			.build();
 	}
 
 	private void runHooks(HookExecutor hookExecutor, String namespace, List<HelmHook> hooks, String phase) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallOptions.java
@@ -26,4 +26,10 @@ public final class UninstallOptions {
 	 */
 	private final boolean noHooks;
 
+	/**
+	 * When {@code true}, retain the release history and mark the release uninstalled
+	 * instead of deleting its history. Defaults to {@code false}.
+	 */
+	private final boolean keepHistory;
+
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/HookExecutor.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/HookExecutor.java
@@ -48,7 +48,23 @@ public class HookExecutor {
 			}
 
 			kubeService.apply(namespace, hook.getYaml());
-			kubeService.waitForReady(namespace, hook.getYaml(), timeoutSeconds);
+			try {
+				kubeService.waitForReady(namespace, hook.getYaml(), timeoutSeconds);
+			}
+			catch (Exception ex) {
+				if (policy != null && policy.contains("hook-failed")) {
+					try {
+						kubeService.delete(namespace, hook.getYaml());
+					}
+					catch (Exception deleteEx) {
+						if (log.isDebugEnabled()) {
+							log.debug("hook-failed delete of hook {}/{} failed (ignored): {}", hook.getKind(),
+									hook.getName(), deleteEx.getMessage());
+						}
+					}
+				}
+				throw ex;
+			}
 
 			if (policy != null && policy.contains("hook-succeeded")) {
 				kubeService.delete(namespace, hook.getYaml());

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
@@ -11,6 +11,7 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -256,6 +257,53 @@ class RollbackActionTest {
 		// Regular manifest is still applied and the release stored
 		verify(kubeService).apply("default", strippedManifest);
 		verify(kubeService).storeRelease(any(Release.class));
+	}
+
+	@Test
+	void testRollbackReturnsNewRelease() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).build();
+
+		Release.ReleaseInfo info1 = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(2))
+			.lastDeployed(OffsetDateTime.now().minusDays(2))
+			.status(ReleaseStatus.DEPLOYED)
+			.build();
+
+		Release.ReleaseInfo info2 = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(2))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status(ReleaseStatus.DEPLOYED)
+			.build();
+
+		Release v1 = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.manifest("---\nv1 manifest")
+			.info(info1)
+			.build();
+
+		Release v2 = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(2)
+			.chart(chart)
+			.manifest("---\nv2 manifest")
+			.info(info2)
+			.build();
+
+		when(kubeService.getReleaseHistory(anyString(), anyString())).thenReturn(Arrays.asList(v2, v1));
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		Release result = rollbackAction
+			.rollback(RollbackOptions.builder().releaseName("myapp").namespace("default").revision(1).build());
+
+		assertNotNull(result);
+		assertEquals(3, result.getVersion());
+		assertEquals(ReleaseStatus.DEPLOYED, result.getInfo().getStatus());
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UninstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UninstallActionTest.java
@@ -2,13 +2,17 @@ package org.alexmond.jhelm.core.action;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -19,6 +23,7 @@ import static org.mockito.Mockito.anyString;
 import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.util.HookParser;
 
@@ -152,6 +157,60 @@ class UninstallActionTest {
 		// Only ConfigMap should be deleted — PVC with resource-policy: keep is preserved
 		String deletedManifest = HookParser.stripKeptResources(HookParser.stripHooks(fullManifest));
 		verify(kubeService).delete("default", deletedManifest);
+	}
+
+	@Test
+	void testUninstallKeepHistoryStoresUninstalledReleaseAndKeepsHistory() throws Exception {
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status(ReleaseStatus.DEPLOYED)
+			.build();
+		Release release = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.manifest("---\nkind: Service\n")
+			.info(info)
+			.build();
+
+		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		uninstallAction
+			.uninstall(UninstallOptions.builder().releaseName("myapp").namespace("default").keepHistory(true).build());
+
+		ArgumentCaptor<Release> releaseCaptor = ArgumentCaptor.forClass(Release.class);
+		verify(kubeService).storeRelease(releaseCaptor.capture());
+		assertEquals(ReleaseStatus.UNINSTALLED, releaseCaptor.getValue().getInfo().getStatus());
+		assertEquals("Uninstallation complete", releaseCaptor.getValue().getInfo().getDescription());
+		verify(kubeService, never()).deleteReleaseHistory(anyString(), anyString());
+	}
+
+	@Test
+	void testUninstallWithoutKeepHistoryDeletesHistoryAndDoesNotStore() throws Exception {
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status(ReleaseStatus.DEPLOYED)
+			.build();
+		Release release = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.manifest("---\nkind: Service\n")
+			.info(info)
+			.build();
+
+		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).deleteReleaseHistory(anyString(), anyString());
+
+		uninstallAction.uninstall(UninstallOptions.builder().releaseName("myapp").namespace("default").build());
+
+		verify(kubeService).deleteReleaseHistory("myapp", "default");
+		verify(kubeService, never()).storeRelease(any(Release.class));
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/HookExecutorTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/HookExecutorTest.java
@@ -9,6 +9,8 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -162,6 +164,39 @@ class HookExecutorTest {
 		hookExecutor.run("default", List.of(hook), "pre-install", 120);
 
 		verify(kubeService).waitForReady("default", hook.getYaml(), 120);
+	}
+
+	@Test
+	void testHookFailedDeletesHookAndRethrowsOnWaitFailure() throws Exception {
+		HelmHook hook = hookWithWeight("my-hook", "pre-install", 0, List.of("hook-failed"));
+
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doThrow(new RuntimeException("hook timed out")).when(kubeService)
+			.waitForReady(anyString(), anyString(), anyInt());
+		doNothing().when(kubeService).delete(anyString(), anyString());
+
+		RuntimeException ex = assertThrows(RuntimeException.class,
+				() -> hookExecutor.run("default", List.of(hook), "pre-install", 300));
+		assertEquals("hook timed out", ex.getMessage());
+
+		verify(kubeService).delete("default", hook.getYaml());
+	}
+
+	@Test
+	void testWaitFailureWithoutHookFailedPolicyDoesNotDeleteButRethrows() throws Exception {
+		HelmHook hook = hookWithWeight("my-hook", "pre-install", 0, List.of("hook-succeeded"));
+
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doThrow(new RuntimeException("hook timed out")).when(kubeService)
+			.waitForReady(anyString(), anyString(), anyInt());
+
+		RuntimeException ex = assertThrows(RuntimeException.class,
+				() -> hookExecutor.run("default", List.of(hook), "pre-install", 300));
+		assertEquals("hook timed out", ex.getMessage());
+
+		// No before-hook-creation policy and no hook-failed policy: delete is never
+		// called.
+		verify(kubeService, never()).delete(anyString(), anyString());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
Completes the remaining Helm lifecycle flags for 0.5.0 (#501).

### `rollback --wait`
`--wait` is wired at the CLI layer (the command calls `kubeService.waitForReady` on the resulting manifest), but `RollbackAction.rollback` returned `void`, so the command had nothing to wait on. It now **returns the new `Release`** (mirroring `InstallAction.install`/`UpgradeAction.upgrade`; source-compatible for existing call-sites). `RollbackCommand` gains `--wait`/`--timeout` options and a `KubeService` dependency.

### `uninstall --keep-history`
New `UninstallOptions.keepHistory`. When set, the release history is **retained** and the last release is re-stored with status `UNINSTALLED` ("Uninstallation complete") instead of deleting the history. `UninstallCommand` gains `--keep-history`.

### `hook-failed` delete-policy
`HookExecutor` now honours the `hook-failed` delete-policy: if a hook's readiness wait fails and its policy contains `hook-failed`, the hook is deleted (best-effort, like `before-hook-creation`) before the original failure is rethrown. The existing `hook-succeeded` post-success delete is unchanged.

## Tests
- `RollbackActionTest`: `rollback` returns a non-null `Release` at the next revision with status `DEPLOYED`.
- `UninstallActionTest`: keep-history → `storeRelease` with `UNINSTALLED` and **no** `deleteReleaseHistory`; default → `deleteReleaseHistory` and no store.
- `HookExecutorTest`: `hook-failed` policy deletes the hook on wait failure (and rethrows); absent policy does not delete.
- All existing core/cli/rest tests green (clean reactor build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)