### PR TITLE
fix(kube)!: core-group apply/delete via DynamicKubernetesApi + e2e lifecycle conformance (#501)

### DIFF
--- a/jhelm-kube/pom.xml
+++ b/jhelm-kube/pom.xml
@@ -62,6 +62,29 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <!--
+                Integration tests (*IntegrationTest) drive the real action layer against a
+                live cluster and are owned by failsafe, not surefire. They self-skip via
+                @KubeClusterAvailable when no cluster is reachable, so a normal local
+                `mvn install` (no cluster) stays green while CI's kind cluster runs them.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*IntegrationTest.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/HelmKubeService.java
@@ -8,7 +8,6 @@ import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1DaemonSet;
 import io.kubernetes.client.openapi.models.V1Deployment;
@@ -21,8 +20,11 @@ import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretList;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
-import io.kubernetes.client.util.PatchUtils;
 import io.kubernetes.client.util.Yaml;
+import io.kubernetes.client.util.generic.KubernetesApiResponse;
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi;
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
+import io.kubernetes.client.util.generic.options.PatchOptions;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.exception.ReleaseStorageException;
@@ -339,20 +341,18 @@ public class HelmKubeService implements KubeService {
 		}
 
 		V1Patch patch = new V1Patch(Yaml.dump(obj));
-		CustomObjectsApi api = new CustomObjectsApi(apiClient);
-
-		PatchUtils.patch(Object.class, () -> {
-			if (namespace != null && !namespace.isEmpty()) {
-				return api.patchNamespacedCustomObject(group, version, namespace, plural, name, patch)
-					.fieldManager("helm")
-					.force(true)
-					.buildCall(null);
-			}
-			return api.patchClusterCustomObject(group, version, plural, name, patch)
-				.fieldManager("helm")
-				.force(true)
-				.buildCall(null);
-		}, V1Patch.PATCH_FORMAT_APPLY_YAML, apiClient);
+		PatchOptions options = new PatchOptions();
+		options.setFieldManager("helm");
+		options.setForce(true);
+		// DynamicKubernetesApi resolves the request path from the group, so core-group
+		// resources (empty group, e.g. Service/ConfigMap/Secret) hit /api/<version>
+		// while named groups hit /apis/<group>/<version>. CustomObjectsApi always emits
+		// /apis/<group>/... and 404s on the core group.
+		DynamicKubernetesApi api = new DynamicKubernetesApi(group, version, plural, apiClient);
+		KubernetesApiResponse<DynamicKubernetesObject> response = (namespace != null && !namespace.isEmpty())
+				? api.patch(namespace, name, V1Patch.PATCH_FORMAT_APPLY_YAML, patch, options)
+				: api.patch(name, V1Patch.PATCH_FORMAT_APPLY_YAML, patch, options);
+		response.throwsApiException();
 	}
 
 	/**
@@ -387,19 +387,15 @@ public class HelmKubeService implements KubeService {
 			log.info("Deleting {} {} in namespace {}", kind, name, namespace);
 		}
 
-		CustomObjectsApi api = new CustomObjectsApi(apiClient);
-		try {
-			if (namespace != null && !namespace.isEmpty()) {
-				api.deleteNamespacedCustomObject(group, version, namespace, plural, name).execute();
-			}
-			else {
-				api.deleteClusterCustomObject(group, version, plural, name).execute();
-			}
-		}
-		catch (Exception ex) {
-			if (!(ex instanceof ApiException ae && ae.getCode() == 404)) {
-				throw ex;
-			}
+		// As with apply, DynamicKubernetesApi targets /api/<version> for the core group;
+		// CustomObjectsApi 404s there, which previously made core-resource deletes
+		// silently
+		// no-op (the 404 was swallowed below as "already gone").
+		DynamicKubernetesApi api = new DynamicKubernetesApi(group, version, plural, apiClient);
+		KubernetesApiResponse<DynamicKubernetesObject> response = (namespace != null && !namespace.isEmpty())
+				? api.delete(namespace, name) : api.delete(name);
+		if (!response.isSuccess() && response.getHttpStatusCode() != 404) {
+			response.throwsApiException();
 		}
 	}
 

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmFullFlowIntegrationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmFullFlowIntegrationTest.java
@@ -14,6 +14,7 @@ import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.alexmond.jhelm.core.CoreConfig;
+import org.alexmond.jhelm.kube.KubeClusterAvailable;
 import org.alexmond.jhelm.kube.KubernetesConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 
 @SpringBootTest(classes = { KubernetesConfig.class, HelmKubeService.class, CoreConfig.class })
+@KubeClusterAvailable
 @Slf4j
 class HelmFullFlowIntegrationTest {
 

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmIntegrationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmIntegrationTest.java
@@ -6,6 +6,7 @@ import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.CoreConfig;
+import org.alexmond.jhelm.kube.KubeClusterAvailable;
 import org.alexmond.jhelm.kube.KubernetesConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashMap;
 
 @SpringBootTest(classes = { KubernetesConfig.class, HelmKubeService.class, CoreConfig.class })
+@KubeClusterAvailable
 class HelmIntegrationTest {
 
 	@Autowired

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceIntegrationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.alexmond.jhelm.kube.KubeClusterAvailable;
 import org.alexmond.jhelm.kube.KubernetesConfig;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -15,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest(classes = { KubernetesConfig.class, HelmKubeService.class })
+@KubeClusterAvailable
 class HelmKubeServiceIntegrationTest {
 
 	@Autowired

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmKubeServiceTest.java
@@ -6,7 +6,6 @@ import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1DaemonSet;
 import io.kubernetes.client.openapi.models.V1DaemonSetStatus;
@@ -22,7 +21,10 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretList;
-import io.kubernetes.client.util.PatchUtils;
+import io.kubernetes.client.util.generic.KubernetesApiResponse;
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi;
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
+import io.kubernetes.client.util.generic.options.PatchOptions;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.exception.ReleaseStorageException;
 import org.alexmond.jhelm.core.exception.WaitTimeoutException;
@@ -35,9 +37,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
-import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
 import java.io.ByteArrayOutputStream;
@@ -62,7 +64,6 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mockConstruction;
-import static org.mockito.Mockito.mockStatic;
 
 class HelmKubeServiceTest {
 
@@ -77,17 +78,13 @@ class HelmKubeServiceTest {
 
 	private MockedConstruction<CoreV1Api> coreV1ApiConstruction;
 
-	private MockedConstruction<CustomObjectsApi> customObjectsApiConstruction;
-
-	private MockedStatic<PatchUtils> patchUtilsMock;
+	private MockedConstruction<DynamicKubernetesApi> dynamicApiConstruction;
 
 	private CoreV1Api mockCoreV1Api;
 
-	private CustomObjectsApi mockCustomObjectsApi;
+	private DynamicKubernetesApi mockDynamicApi;
 
-	private CustomObjectsApi.APIpatchNamespacedCustomObjectRequest mockPatchRequest;
-
-	private CustomObjectsApi.APIpatchClusterCustomObjectRequest mockClusterPatchRequest;
+	private List<Object> lastDynamicApiCtorArgs;
 
 	@BeforeEach
 	void setUp() {
@@ -103,11 +100,8 @@ class HelmKubeServiceTest {
 		if (coreV1ApiConstruction != null) {
 			coreV1ApiConstruction.close();
 		}
-		if (customObjectsApiConstruction != null) {
-			customObjectsApiConstruction.close();
-		}
-		if (patchUtilsMock != null) {
-			patchUtilsMock.close();
+		if (dynamicApiConstruction != null) {
+			dynamicApiConstruction.close();
 		}
 	}
 
@@ -157,28 +151,18 @@ class HelmKubeServiceTest {
 	}
 
 	private void setupSsaMock() {
-		customObjectsApiConstruction = mockConstruction(CustomObjectsApi.class, (mock, ctx) -> {
-			mockCustomObjectsApi = mock;
-
-			mockPatchRequest = mock(CustomObjectsApi.APIpatchNamespacedCustomObjectRequest.class);
-			when(mockPatchRequest.fieldManager(anyString())).thenReturn(mockPatchRequest);
-			when(mockPatchRequest.force(any(Boolean.class))).thenReturn(mockPatchRequest);
-			when(mockPatchRequest.buildCall(any())).thenReturn(null);
-			when(mock.patchNamespacedCustomObject(any(), any(), any(), any(), any(), any()))
-				.thenReturn(mockPatchRequest);
-
-			mockClusterPatchRequest = mock(CustomObjectsApi.APIpatchClusterCustomObjectRequest.class);
-			when(mockClusterPatchRequest.fieldManager(anyString())).thenReturn(mockClusterPatchRequest);
-			when(mockClusterPatchRequest.force(any(Boolean.class))).thenReturn(mockClusterPatchRequest);
-			when(mockClusterPatchRequest.buildCall(any())).thenReturn(null);
-			when(mock.patchClusterCustomObject(any(), any(), any(), any(), any())).thenReturn(mockClusterPatchRequest);
-		});
-
-		patchUtilsMock = mockStatic(PatchUtils.class);
-		patchUtilsMock.when(() -> PatchUtils.patch(any(), any(), anyString(), any())).thenAnswer((invocation) -> {
-			PatchUtils.PatchCallFunc func = invocation.getArgument(1);
-			func.getCall();
-			return null;
+		dynamicApiConstruction = mockConstruction(DynamicKubernetesApi.class, (mock, ctx) -> {
+			mockDynamicApi = mock;
+			lastDynamicApiCtorArgs = new ArrayList<>(ctx.arguments());
+			@SuppressWarnings("unchecked")
+			KubernetesApiResponse<DynamicKubernetesObject> resp = mock(KubernetesApiResponse.class);
+			when(resp.throwsApiException()).thenReturn(resp);
+			when(resp.isSuccess()).thenReturn(true);
+			when(mock.patch(anyString(), anyString(), anyString(), any(V1Patch.class), any(PatchOptions.class)))
+				.thenReturn(resp);
+			when(mock.patch(anyString(), anyString(), any(V1Patch.class), any(PatchOptions.class))).thenReturn(resp);
+			when(mock.delete(anyString(), anyString())).thenReturn(resp);
+			when(mock.delete(anyString())).thenReturn(resp);
 		});
 	}
 
@@ -492,10 +476,15 @@ class HelmKubeServiceTest {
 		setupSsaMock();
 		kubeService.apply("default", yaml);
 
-		verify(mockCustomObjectsApi).patchNamespacedCustomObject(eq("apps"), eq("v1"), eq("default"), eq("deployments"),
-				eq("my-deploy"), any(V1Patch.class));
-		verify(mockPatchRequest).fieldManager("helm");
-		verify(mockPatchRequest).force(true);
+		assertEquals("apps", lastDynamicApiCtorArgs.get(0));
+		assertEquals("v1", lastDynamicApiCtorArgs.get(1));
+		assertEquals("deployments", lastDynamicApiCtorArgs.get(2));
+
+		ArgumentCaptor<PatchOptions> optionsCaptor = ArgumentCaptor.forClass(PatchOptions.class);
+		verify(mockDynamicApi).patch(eq("default"), eq("my-deploy"), eq(V1Patch.PATCH_FORMAT_APPLY_YAML),
+				any(V1Patch.class), optionsCaptor.capture());
+		assertEquals("helm", optionsCaptor.getValue().getFieldManager());
+		assertEquals(Boolean.TRUE, optionsCaptor.getValue().getForce());
 	}
 
 	@Test
@@ -513,10 +502,12 @@ class HelmKubeServiceTest {
 		setupSsaMock();
 		kubeService.apply("default", yaml);
 
-		verify(mockCustomObjectsApi).patchNamespacedCustomObject(eq(""), eq("v1"), eq("default"), eq("configmaps"),
-				eq("my-config"), any(V1Patch.class));
-		verify(mockPatchRequest).fieldManager("helm");
-		verify(mockPatchRequest).force(true);
+		assertEquals("", lastDynamicApiCtorArgs.get(0));
+		assertEquals("v1", lastDynamicApiCtorArgs.get(1));
+		assertEquals("configmaps", lastDynamicApiCtorArgs.get(2));
+
+		verify(mockDynamicApi).patch(eq("default"), eq("my-config"), eq(V1Patch.PATCH_FORMAT_APPLY_YAML),
+				any(V1Patch.class), any(PatchOptions.class));
 	}
 
 	@Test
@@ -531,10 +522,12 @@ class HelmKubeServiceTest {
 		setupSsaMock();
 		kubeService.apply("", yaml);
 
-		verify(mockCustomObjectsApi).patchClusterCustomObject(eq(""), eq("v1"), eq("namespaces"), eq("my-ns"),
-				any(V1Patch.class));
-		verify(mockClusterPatchRequest).fieldManager("helm");
-		verify(mockClusterPatchRequest).force(true);
+		assertEquals("", lastDynamicApiCtorArgs.get(0));
+		assertEquals("v1", lastDynamicApiCtorArgs.get(1));
+		assertEquals("namespaces", lastDynamicApiCtorArgs.get(2));
+
+		verify(mockDynamicApi).patch(eq("my-ns"), eq(V1Patch.PATCH_FORMAT_APPLY_YAML), any(V1Patch.class),
+				any(PatchOptions.class));
 	}
 
 	@Test
@@ -547,19 +540,13 @@ class HelmKubeServiceTest {
 				  namespace: default
 				""";
 
-		customObjectsApiConstruction = mockConstruction(CustomObjectsApi.class, (mock, ctx) -> {
-			var patchReq = mock(CustomObjectsApi.APIpatchNamespacedCustomObjectRequest.class);
-			when(patchReq.fieldManager(anyString())).thenReturn(patchReq);
-			when(patchReq.force(any(Boolean.class))).thenReturn(patchReq);
-			when(patchReq.buildCall(any())).thenThrow(new ApiException(500, "Server error"));
-			when(mock.patchNamespacedCustomObject(any(), any(), any(), any(), any(), any())).thenReturn(patchReq);
-		});
-
-		patchUtilsMock = mockStatic(PatchUtils.class);
-		patchUtilsMock.when(() -> PatchUtils.patch(any(), any(), anyString(), any())).thenAnswer((invocation) -> {
-			PatchUtils.PatchCallFunc func = invocation.getArgument(1);
-			func.getCall();
-			return null;
+		dynamicApiConstruction = mockConstruction(DynamicKubernetesApi.class, (mock, ctx) -> {
+			mockDynamicApi = mock;
+			@SuppressWarnings("unchecked")
+			KubernetesApiResponse<DynamicKubernetesObject> resp = mock(KubernetesApiResponse.class);
+			when(resp.throwsApiException()).thenThrow(new ApiException(500, "Server error"));
+			when(mock.patch(anyString(), anyString(), anyString(), any(V1Patch.class), any(PatchOptions.class)))
+				.thenReturn(resp);
 		});
 
 		assertThrows(KubernetesOperationException.class, () -> kubeService.apply("default", yaml));
@@ -577,17 +564,13 @@ class HelmKubeServiceTest {
 				  namespace: default
 				""";
 
-		customObjectsApiConstruction = mockConstruction(CustomObjectsApi.class, (mock, ctx) -> {
-			mockCustomObjectsApi = mock;
-			var deleteReq = mock(CustomObjectsApi.APIdeleteNamespacedCustomObjectRequest.class);
-			when(deleteReq.execute()).thenReturn(new Object());
-			when(mock.deleteNamespacedCustomObject(eq("apps"), eq("v1"), eq("default"), eq("deployments"),
-					eq("my-deploy")))
-				.thenReturn(deleteReq);
-		});
-
+		setupSsaMock();
 		kubeService.delete("default", yaml);
-		verify(mockCustomObjectsApi).deleteNamespacedCustomObject("apps", "v1", "default", "deployments", "my-deploy");
+
+		assertEquals("apps", lastDynamicApiCtorArgs.get(0));
+		assertEquals("v1", lastDynamicApiCtorArgs.get(1));
+		assertEquals("deployments", lastDynamicApiCtorArgs.get(2));
+		verify(mockDynamicApi).delete("default", "my-deploy");
 	}
 
 	@Test
@@ -600,11 +583,13 @@ class HelmKubeServiceTest {
 				  namespace: default
 				""";
 
-		customObjectsApiConstruction = mockConstruction(CustomObjectsApi.class, (mock, ctx) -> {
-			var deleteReq = mock(CustomObjectsApi.APIdeleteNamespacedCustomObjectRequest.class);
-			when(deleteReq.execute()).thenThrow(new ApiException(404, "Not found"));
-			when(mock.deleteNamespacedCustomObject(anyString(), anyString(), anyString(), anyString(), anyString()))
-				.thenReturn(deleteReq);
+		dynamicApiConstruction = mockConstruction(DynamicKubernetesApi.class, (mock, ctx) -> {
+			mockDynamicApi = mock;
+			@SuppressWarnings("unchecked")
+			KubernetesApiResponse<DynamicKubernetesObject> resp = mock(KubernetesApiResponse.class);
+			when(resp.isSuccess()).thenReturn(false);
+			when(resp.getHttpStatusCode()).thenReturn(404);
+			when(mock.delete(anyString(), anyString())).thenReturn(resp);
 		});
 
 		// Should not throw on 404
@@ -621,11 +606,14 @@ class HelmKubeServiceTest {
 				  namespace: default
 				""";
 
-		customObjectsApiConstruction = mockConstruction(CustomObjectsApi.class, (mock, ctx) -> {
-			var deleteReq = mock(CustomObjectsApi.APIdeleteNamespacedCustomObjectRequest.class);
-			when(deleteReq.execute()).thenThrow(new ApiException(500, "Server error"));
-			when(mock.deleteNamespacedCustomObject(anyString(), anyString(), anyString(), anyString(), anyString()))
-				.thenReturn(deleteReq);
+		dynamicApiConstruction = mockConstruction(DynamicKubernetesApi.class, (mock, ctx) -> {
+			mockDynamicApi = mock;
+			@SuppressWarnings("unchecked")
+			KubernetesApiResponse<DynamicKubernetesObject> resp = mock(KubernetesApiResponse.class);
+			when(resp.isSuccess()).thenReturn(false);
+			when(resp.getHttpStatusCode()).thenReturn(500);
+			when(resp.throwsApiException()).thenThrow(new ApiException(500, "Server error"));
+			when(mock.delete(anyString(), anyString())).thenReturn(resp);
 		});
 
 		assertThrows(KubernetesOperationException.class, () -> kubeService.delete("default", yaml));
@@ -640,16 +628,13 @@ class HelmKubeServiceTest {
 				  name: test-ns
 				""";
 
-		customObjectsApiConstruction = mockConstruction(CustomObjectsApi.class, (mock, ctx) -> {
-			mockCustomObjectsApi = mock;
-			var deleteReq = mock(CustomObjectsApi.APIdeleteClusterCustomObjectRequest.class);
-			when(deleteReq.execute()).thenReturn(new Object());
-			when(mock.deleteClusterCustomObject(eq(""), eq("v1"), eq("namespaces"), eq("test-ns")))
-				.thenReturn(deleteReq);
-		});
-
+		setupSsaMock();
 		kubeService.delete("", yaml);
-		verify(mockCustomObjectsApi).deleteClusterCustomObject("", "v1", "namespaces", "test-ns");
+
+		assertEquals("", lastDynamicApiCtorArgs.get(0));
+		assertEquals("v1", lastDynamicApiCtorArgs.get(1));
+		assertEquals("namespaces", lastDynamicApiCtorArgs.get(2));
+		verify(mockDynamicApi).delete("test-ns");
 	}
 
 	// --- ensureNamespace ---

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmLifecycleConformanceIntegrationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/HelmLifecycleConformanceIntegrationTest.java
@@ -1,0 +1,195 @@
+package org.alexmond.jhelm.kube.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.CoreConfig;
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
+import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.RollbackOptions;
+import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UninstallOptions;
+import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.action.UpgradeOptions;
+import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
+import org.alexmond.jhelm.kube.KubeClusterAvailable;
+import org.alexmond.jhelm.kube.KubernetesConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end lifecycle conformance against a live cluster (kind in CI): drives the full
+ * Helm day-2 flow install → upgrade → rollback → uninstall through the real action layer
+ * and asserts the resulting revision numbers and release statuses, plus the
+ * {@code --keep-history} uninstall variant. Skipped automatically when no cluster is
+ * reachable (see {@link KubeClusterAvailable}).
+ */
+@SpringBootTest(classes = { KubernetesConfig.class, HelmKubeService.class, CoreConfig.class })
+@KubeClusterAvailable
+@Slf4j
+class HelmLifecycleConformanceIntegrationTest {
+
+	private static final String NAMESPACE = "default";
+
+	@Autowired
+	private HelmKubeService helmKubeService;
+
+	@Autowired
+	private InstallAction installAction;
+
+	@Autowired
+	private UpgradeAction upgradeAction;
+
+	@Autowired
+	private RollbackAction rollbackAction;
+
+	@Autowired
+	private UninstallAction uninstallAction;
+
+	@Test
+	void testInstallUpgradeRollbackUninstall() {
+		String releaseName = "conformance-iur";
+		Chart chart = nginxChart();
+		try {
+			// Install — revision 1, deployed.
+			Release installed = installAction.install(InstallOptions.builder()
+				.chart(chart)
+				.releaseName(releaseName)
+				.namespace(NAMESPACE)
+				.values(Map.of("replicaCount", 1))
+				.revision(1)
+				.dryRun(false)
+				.build());
+			assertNotNull(installed);
+			assertReleaseAt(releaseName, 1, ReleaseStatus.DEPLOYED);
+
+			// Upgrade — revision 2, deployed.
+			Release current = helmKubeService.getRelease(releaseName, NAMESPACE).orElseThrow();
+			Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
+				.currentRelease(current)
+				.newChart(chart)
+				.values(Map.of("replicaCount", 2))
+				.valueStrategy(UpgradeValueStrategy.DEFAULT)
+				.dryRun(false)
+				.build());
+			assertEquals(2, upgraded.getVersion());
+			assertReleaseAt(releaseName, 2, ReleaseStatus.DEPLOYED);
+
+			// Rollback to revision 1 — produces a new revision 3, deployed.
+			Release rolledBack = rollbackAction
+				.rollback(RollbackOptions.builder().releaseName(releaseName).namespace(NAMESPACE).revision(1).build());
+			assertNotNull(rolledBack);
+			assertEquals(3, rolledBack.getVersion());
+			assertEquals(ReleaseStatus.DEPLOYED, rolledBack.getInfo().getStatus());
+			assertReleaseAt(releaseName, 3, ReleaseStatus.DEPLOYED);
+
+			// History retains all three revisions.
+			List<Integer> versions = helmKubeService.getReleaseHistory(releaseName, NAMESPACE)
+				.stream()
+				.map(Release::getVersion)
+				.toList();
+			assertTrue(versions.containsAll(List.of(1, 2, 3)), "history versions: " + versions);
+
+			// Uninstall (default) — release record is removed.
+			uninstallAction.uninstall(UninstallOptions.builder().releaseName(releaseName).namespace(NAMESPACE).build());
+			assertFalse(helmKubeService.getRelease(releaseName, NAMESPACE).isPresent());
+		}
+		finally {
+			cleanup(releaseName, chart);
+		}
+	}
+
+	@Test
+	void testUninstallKeepHistory() {
+		String releaseName = "conformance-keep";
+		Chart chart = nginxChart();
+		try {
+			installAction.install(InstallOptions.builder()
+				.chart(chart)
+				.releaseName(releaseName)
+				.namespace(NAMESPACE)
+				.values(Map.of("replicaCount", 1))
+				.revision(1)
+				.dryRun(false)
+				.build());
+			assertReleaseAt(releaseName, 1, ReleaseStatus.DEPLOYED);
+
+			// --keep-history retains the record and flips its status to uninstalled.
+			uninstallAction.uninstall(
+					UninstallOptions.builder().releaseName(releaseName).namespace(NAMESPACE).keepHistory(true).build());
+			Optional<Release> kept = helmKubeService.getRelease(releaseName, NAMESPACE);
+			assertTrue(kept.isPresent(), "release history should be retained");
+			assertEquals(ReleaseStatus.UNINSTALLED, kept.get().getInfo().getStatus());
+		}
+		finally {
+			cleanup(releaseName, chart);
+		}
+	}
+
+	private void assertReleaseAt(String releaseName, int version, ReleaseStatus status) {
+		Release stored = helmKubeService.getRelease(releaseName, NAMESPACE).orElseThrow();
+		assertEquals(version, stored.getVersion());
+		assertEquals(status, stored.getInfo().getStatus());
+	}
+
+	/**
+	 * Best-effort teardown so a failed assertion never leaks cluster state into the next
+	 * run.
+	 */
+	private void cleanup(String releaseName, Chart chart) {
+		try {
+			helmKubeService.deleteReleaseHistory(releaseName, NAMESPACE);
+		}
+		catch (Exception ex) {
+			log.debug("cleanup deleteReleaseHistory({}) ignored: {}", releaseName, ex.getMessage());
+		}
+	}
+
+	private Chart nginxChart() {
+		return Chart.builder()
+			.metadata(ChartMetadata.builder().name("nginx").version("1.0.0").build())
+			.templates(new ArrayList<>(List.of(Chart.Template.builder().name("deployment.yaml").data("""
+					apiVersion: apps/v1
+					kind: Deployment
+					metadata:
+					  name: {{ .Release.Name }}-nginx
+					spec:
+					  replicas: {{ .Values.replicaCount }}
+					  selector:
+					    matchLabels:
+					      app: nginx
+					  template:
+					    metadata:
+					      labels:
+					        app: nginx
+					    spec:
+					      containers:
+					      - name: nginx
+					        image: nginx:latest
+					""").build(), Chart.Template.builder().name("configmap.yaml").data("""
+					apiVersion: v1
+					kind: ConfigMap
+					metadata:
+					  name: {{ .Release.Name }}-nginx
+					data:
+					  replicas: "{{ .Values.replicaCount }}"
+					""").build())))
+			.values(Map.of("replicaCount", 1))
+			.build();
+	}
+
+}


### PR DESCRIPTION
## TL;DR
Wiring the #501 lifecycle conformance suite immediately caught a **P0**: jhelm could not apply **any core/v1 resource** (Service, ConfigMap, Secret, Pod, PVC, ServiceAccount, Namespace) — real installs of normal charts were broken. Fixed here, and locked in by the new e2e suite. Verified against a live k3s cluster.

## The bug
`HelmKubeService.apply`/`delete` built requests via `CustomObjectsApi`, which always targets `/apis/<group>/<version>/...`. For the **core group** (`apiVersion: v1`, empty group) that becomes `/apis//v1/...`, which the apiserver returns `404 page not found` for. Consequences:
- **apply** of any core/v1 resource threw `Failed to apply manifest` (404).
- **delete** of any core/v1 resource **silently no-oped** — the 404 was swallowed as "already gone", so uninstall never removed core resources.

Named groups (`apps/v1`, `batch/v1`, …) worked, which is why Deployments installed and the gap went unnoticed — the e2e tests that would have caught it were excluded from the build (see below).

## The fix
Route apply/delete through `DynamicKubernetesApi`, which derives the path from the group: `/api/<version>` for the core group, `/apis/<group>/<version>` for named groups. Server-side apply semantics (`fieldManager=helm`, `force=true`) are preserved; delete keeps 404-as-success but now actually reaches core resources.

Marked `!` (behavioral fix): uninstall now genuinely deletes core/v1 resources it previously left orphaned.

## Conformance suite (the #501 item that found this)
- **New `HelmLifecycleConformanceIntegrationTest`** — install → upgrade → rollback → uninstall, asserting revisions (1/2/3) and `DEPLOYED` status, plus `uninstall --keep-history` → `UNINSTALLED`. Includes a core/v1 ConfigMap so the suite itself locks in the apply fix.
- **Failsafe wiring** — `maven-failsafe-plugin` in `jhelm-kube` (`integration-test`/`verify`, `includes=**/*IntegrationTest.java`). The `*IntegrationTest` classes were excluded from surefire with **no failsafe/profile running them** — effectively dead despite CI provisioning a kind cluster. They now run, gated by the existing `@KubeClusterAvailable` so they self-skip with no cluster (local `mvn install` stays green) and execute against CI's kind.
- **Unit tests** — `HelmKubeServiceTest` apply/delete rewritten to mock `DynamicKubernetesApi` (core/named/cluster paths, SSA options, 404 handling).

## Verification
Run against a live **k3s** cluster locally — all four integration classes green:
- `HelmFullFlowIntegrationTest` 2/2 (was failing: Service apply 404)
- `HelmIntegrationTest` 1/1 (was failing: ConfigMap apply 404)
- `HelmKubeServiceIntegrationTest` 2/2
- `HelmLifecycleConformanceIntegrationTest` 2/2 (rollback + keep-history + core ConfigMap)

Full reactor `clean install` green; `HelmKubeServiceTest` 56/56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)