### PR TITLE
fix(helm): toYaml(nil) renders "null" not empty (Helm parity)

### DIFF
--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -214,8 +214,14 @@ public final class ConversionFunctions {
 	 */
 	private static Function toYaml() {
 		return (args) -> {
-			if (args.length == 0 || args[0] == null) {
+			if (args.length == 0) {
 				return "";
+			}
+			if (args[0] == null) {
+				// Helm's toYaml marshals via sigs.k8s.io/yaml; yaml.Marshal(nil) yields
+				// "null\n" -> trimmed "null". A nil value must render the literal null,
+				// not an empty string (e.g. a ConfigMap data key bound to a nil value).
+				return "null";
 			}
 			try {
 				String yaml = YAML_MAPPER.get().writeValueAsString(args[0]);
@@ -238,8 +244,11 @@ public final class ConversionFunctions {
 	 */
 	private static Function toYamlPretty() {
 		return (args) -> {
-			if (args.length == 0 || args[0] == null) {
+			if (args.length == 0) {
 				return "";
+			}
+			if (args[0] == null) {
+				return "null";
 			}
 			try {
 				String yaml = PRETTY_YAML_MAPPER.get().writeValueAsString(args[0]);
@@ -261,8 +270,13 @@ public final class ConversionFunctions {
 	 */
 	private static Function mustToYaml() {
 		return (args) -> {
-			if (args.length == 0 || args[0] == null) {
+			if (args.length == 0) {
 				throw new FunctionExecutionException("mustToYaml: no value provided");
+			}
+			if (args[0] == null) {
+				// yaml.Marshal(nil) succeeds with "null"; mustToYaml does not error on
+				// nil.
+				return "null";
 			}
 			try {
 				String yaml = YAML_MAPPER.get().writeValueAsString(args[0]);

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -253,7 +253,8 @@ class ConversionFunctionsTest {
 	void testToYamlPrettyNullAndEmpty() {
 		Function toYamlPretty = functions().get("toYamlPretty");
 		assertEquals("", toYamlPretty.invoke(new Object[] {}));
-		assertEquals("", toYamlPretty.invoke(new Object[] { null }));
+		// Helm's toYamlPretty(nil) marshals to the literal "null" (yaml.Marshal(nil)).
+		assertEquals("null", toYamlPretty.invoke(new Object[] { null }));
 	}
 
 	@ParameterizedTest
@@ -307,7 +308,9 @@ class ConversionFunctionsTest {
 	void testToYamlNullAndEmpty() {
 		Function toYaml = functions().get("toYaml");
 		assertEquals("", toYaml.invoke(new Object[] {}));
-		assertEquals("", toYaml.invoke(new Object[] { null }));
+		// Helm's toYaml(nil) marshals to the literal "null" (yaml.Marshal(nil) ->
+		// "null\n").
+		assertEquals("null", toYaml.invoke(new Object[] { null }));
 	}
 
 	@Test
@@ -494,10 +497,11 @@ class ConversionFunctionsTest {
 	// must* variants throw on null/empty
 
 	@Test
-	void testMustToYamlThrowsOnNull() {
+	void testMustToYamlNullAndEmpty() {
 		Function fn = functions().get("mustToYaml");
 		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] {}));
-		assertThrows(RuntimeException.class, () -> fn.invoke(new Object[] { null }));
+		// mustToYaml(nil) does not error in Helm; yaml.Marshal(nil) succeeds with "null".
+		assertEquals("null", fn.invoke(new Object[] { null }));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
Found while triaging the 46 charts that diverge from `helm template`. Helm's `toYaml` marshals via `sigs.k8s.io/yaml`, so `toYaml(nil)` = `yaml.Marshal(nil)` = `"null\n"` → trimmed **`"null"`**. jhelm returned an empty string for a nil argument, and `mustToYaml(nil)` *threw* instead of returning `"null"` (Helm's `yaml.Marshal(nil)` succeeds).

A ConfigMap data key bound to a nil value therefore rendered empty in jhelm but `null` in Helm — and that difference **cascades into `checksum/*` annotations** that hash the rendered content.

## Changes
- `toYaml(nil)` / `toYamlPretty(nil)` → `"null"` (was `""`)
- `mustToYaml(nil)` → `"null"` (was: threw `"no value provided"`)
- no-argument case unchanged (`toYaml` → `""`, `mustToYaml` → throws)
- updated the three tests that codified the old (incorrect) behavior

## Verification
Against `helm template` (kube v1.35.0): **`bitnami/metallb`** and **`nfd/node-feature-discovery`** now match byte-for-byte. Full reactor `./mvnw install` green (no regressions).

Part of the #501-adjacent parity-to-500 follow-up: triaging the 46 new charts that diverge. This is the first shared-root-cause fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)