### PR TITLE
test(parity): expand kind:List in comparison + add 5 stakater charts (→521)

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
@@ -562,18 +562,35 @@ class KpsComparisonTest {
 		Map<String, JsonNode> map = new HashMap<>();
 
 		for (JsonNode doc : docs) {
-			String kind = doc.has("kind") ? doc.get("kind").asString() : "Unknown";
-			String name = "unnamed";
-
-			if (doc.has("metadata") && doc.get("metadata").has("name")) {
-				name = doc.get("metadata").get("name").asString();
-			}
-
-			String key = kind + "/" + name;
-			map.put(key, doc);
+			addResourceToMap(map, doc);
 		}
 
 		return map;
+	}
+
+	private void addResourceToMap(Map<String, JsonNode> map, JsonNode doc) {
+		String kind = doc.has("kind") ? doc.get("kind").asString() : "Unknown";
+
+		// A `kind: List` document is just a container (Helm emits these, e.g. the
+		// stakater storage charts). Expand it and key each item by its own kind/name —
+		// otherwise multiple unnamed List documents all collide under "List/unnamed" and
+		// get compared against each other, producing spurious diffs even when every
+		// contained resource matches Helm byte-for-byte.
+		if ("List".equals(kind) && doc.has("items") && doc.get("items").isArray()) {
+			for (JsonNode item : doc.get("items")) {
+				if (item != null && item.isObject()) {
+					addResourceToMap(map, item);
+				}
+			}
+			return;
+		}
+
+		String name = "unnamed";
+		if (doc.has("metadata") && doc.get("metadata").has("name")) {
+			name = doc.get("metadata").get("name").asString();
+		}
+
+		map.put(kind + "/" + name, doc);
 	}
 
 	private List<Diff> computeDiffs(JsonNode expected, JsonNode actual, String path) {

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -514,3 +514,8 @@ linkerd/linkerd-failover,linkerd,https://helm.linkerd.io/stable
 nats/nats-operator,nats,https://nats-io.github.io/k8s/helm/charts
 ory/hydra-maester,ory,https://k8s.ory.sh/helm/charts
 timescale/parca-server,timescale,https://charts.timescale.com
+stakater/keycloak-db-storage,stakater,https://stakater.github.io/stakater-charts
+stakater/java-app,stakater,https://stakater.github.io/stakater-charts
+stakater/fluentd,stakater,https://stakater.github.io/stakater-charts
+stakater/keycloak,stakater,https://stakater.github.io/stakater-charts
+stakater/chartmuseum-storage,stakater,https://stakater.github.io/stakater-charts


### PR DESCRIPTION
## Summary
From the 46-chart triage. The parity comparison keyed every resource by `kind/name`, so multiple `kind: List` documents (no `metadata.name`) all collided under `List/unnamed` and were compared against **each other** — a PV-List diffed against a PVC-List — producing spurious failures even when every contained resource matched Helm byte-for-byte.

`buildResourceMap` now **expands a `kind: List` into its items**, keying each by its own `kind/name` (same key format, so ignore rules are unaffected). A List is just a container; this is the semantically correct comparison.

## Not a jhelm rendering bug
Confirmed jhelm renders these charts correctly — expanding both sides' Lists and comparing item-by-item, every resource is **byte-for-byte identical** to `helm template`. The failure was purely a comparison-keying artifact.

## Payoff
The five stakater charts that use `kind: List` now pass and are added to `charts.csv` (**516 → 521**): `chartmuseum-storage`, `keycloak-db-storage`, `java-app`, `fluentd`, `keycloak`.

## Safety
Charts that currently pass are unaffected: a `List` that previously matched as one blob still matches item-by-item. No ignore rule references `List/`. jhelm-core compiles; full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)