### PR TITLE
fix(core): stringify non-string YAML value keys (Helm parity) + cetic/pgadmin (→522)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesLoader.java
@@ -22,8 +22,10 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -104,7 +106,7 @@ public final class ValuesLoader {
 		try (Reader reader = new FileReader(valuesFile, StandardCharsets.UTF_8)) {
 			for (Object doc : load.loadAllFromReader(reader)) {
 				if (doc instanceof Map) {
-					deepMerge(merged, (Map<String, Object>) doc);
+					deepMerge(merged, (Map<String, Object>) stringifyKeys(doc));
 				}
 			}
 		}
@@ -157,11 +159,39 @@ public final class ValuesLoader {
 		try (Reader reader = new StringReader(body)) {
 			for (Object doc : load.loadAllFromReader(reader)) {
 				if (doc instanceof Map) {
-					deepMerge(merged, (Map<String, Object>) doc);
+					deepMerge(merged, (Map<String, Object>) stringifyKeys(doc));
 				}
 			}
 		}
 		return merged;
+	}
+
+	/**
+	 * Recursively coerces every map key to a {@link String}. Helm loads values via
+	 * sigs.k8s.io/yaml (YAML &rarr; JSON), where object keys are always strings, so a
+	 * YAML mapping key written as a bare integer or boolean (e.g. {@code Servers: { 1:
+	 * ... }}) becomes the string {@code "1"}. SnakeYAML preserves the scalar's native
+	 * type, which would otherwise surface an {@link Integer}/{@link Boolean} key and
+	 * break code that (correctly) assumes string keys.
+	 * @param value the loaded value tree (map, list, or scalar)
+	 * @return the same shape with all map keys stringified
+	 */
+	static Object stringifyKeys(Object value) {
+		if (value instanceof Map<?, ?> map) {
+			Map<String, Object> out = new LinkedHashMap<>();
+			for (Map.Entry<?, ?> entry : map.entrySet()) {
+				out.put(String.valueOf(entry.getKey()), stringifyKeys(entry.getValue()));
+			}
+			return out;
+		}
+		if (value instanceof List<?> list) {
+			List<Object> out = new ArrayList<>(list.size());
+			for (Object item : list) {
+				out.add(stringifyKeys(item));
+			}
+			return out;
+		}
+		return value;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesLoaderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesLoaderTest.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -265,6 +266,26 @@ class ValuesLoaderTest {
 		});
 		server.start();
 		return server;
+	}
+
+	@Test
+	void testNonStringMapKeysAreStringified() throws IOException {
+		// Helm loads values via YAML -> JSON, so a bare integer/boolean mapping key
+		// becomes a string key (e.g. cetic/pgadmin's servers.config.Servers: { 1: ... }).
+		File file = writeValues("""
+				servers:
+				  1:
+				    name: first
+				  true:
+				    name: flag
+				""");
+		Map<String, Object> result = ValuesLoader.load(file);
+		@SuppressWarnings("unchecked")
+		Map<String, Object> servers = (Map<String, Object>) result.get("servers");
+		assertEquals(Set.of("1", "true"), servers.keySet());
+		@SuppressWarnings("unchecked")
+		Map<String, Object> first = (Map<String, Object>) servers.get("1");
+		assertEquals("first", first.get("name"));
 	}
 
 	private File writeValues(String content) throws IOException {

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -519,3 +519,4 @@ stakater/java-app,stakater,https://stakater.github.io/stakater-charts
 stakater/fluentd,stakater,https://stakater.github.io/stakater-charts
 stakater/keycloak,stakater,https://stakater.github.io/stakater-charts
 stakater/chartmuseum-storage,stakater,https://stakater.github.io/stakater-charts
+cetic/pgadmin,cetic,https://cetic.github.io/helm-charts


### PR DESCRIPTION
## Summary
From the 46-chart triage. Helm loads values via `sigs.k8s.io/yaml` (YAML → JSON), so every object key is a **string** — a bare integer or boolean mapping key (e.g. `cetic/pgadmin`'s `servers.config.Servers: { 1: { ... } }`) becomes the string `"1"`. jhelm's SnakeYAML-based `ValuesLoader` preserved the scalar's native type, leaving an `Integer`/`Boolean` key in the values tree, which then crashed `Engine.mergeValues` with `class java.lang.Integer cannot be cast to class java.lang.String`.

This is a **general** bug — any chart with a non-string YAML mapping key in its values crashed jhelm during rendering.

## Fix
`ValuesLoader` now recursively **stringifies map keys** for both file and URL sources (`String.valueOf`, matching Helm's `"1"`/`"true"`). Charts using only string keys are unaffected.

## Changes
- `ValuesLoader.stringifyKeys` + unit coverage for integer/boolean keys.
- `cetic/pgadmin` now renders and matches `helm template` byte-for-byte → added to `charts.csv` (**521 → 522**).

## Safety
Full `./mvnw -pl jhelm-core install` green; a regression sample of existing charts (prometheus, grafana, bitnami ×N) still passes 12/12.

Part of the parity-to-500 follow-up (triaging the 46 charts that diverge from `helm template`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)