### PR TITLE
fix(engine): disable subcharts only via Chart.yaml condition, not bare enabled (→523)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -134,28 +134,6 @@ public class Engine {
 		templateCache.put(cacheKey, added);
 	}
 
-	private boolean isTruthy(Object context) {
-		if (context == null) {
-			return false;
-		}
-		if (context instanceof Boolean b) {
-			return b;
-		}
-		if (context instanceof String s) {
-			return !s.isEmpty();
-		}
-		if (context instanceof Iterable i) {
-			return i.iterator().hasNext();
-		}
-		if (context instanceof Map m) {
-			return !m.isEmpty();
-		}
-		if (context instanceof Number n) {
-			return n.doubleValue() != 0;
-		}
-		return true;
-	}
-
 	/**
 	 * Stack size for the render thread. Deeply nested {@code tpl}/{@code include} chains
 	 * — e.g. grafana/loki's {@code configMapOrSecretContentHash} →
@@ -685,13 +663,15 @@ public class Engine {
 						subchartOverrides.get("enabled"));
 			}
 
-			// If subchart is disabled, skip it
-			if (subchartOverrides.containsKey("enabled") && !isTruthy(subchartOverrides.get("enabled"))) {
-				if (log.isDebugEnabled()) {
-					log.debug("Subchart {} is disabled", subchartName);
-				}
-				continue;
-			}
+			// Do NOT skip on a bare `enabled: false` in the merged values. Helm only
+			// disables a subchart through an explicit Chart.yaml `condition` (or tags),
+			// evaluated above — a standalone `<subchart>.enabled` is just an ordinary
+			// value unless a condition references it. Some subcharts ship their own
+			// top-level `enabled` default (e.g. jupyterhub, pulled in by dask/daskhub
+			// with no condition); Helm renders them, so jhelm must too.
+			// mergeSubchartDefaults
+			// folds that default into the slice, which previously tripped a non-Helm
+			// skip.
 
 			// In Helm, global values are deep-merged: parent globals override subchart
 			// globals

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -256,20 +256,50 @@ class EngineTest {
 		Chart subchart = simpleChart("redis", "17.0.0", List.of(tmpl("service.yaml", "kind: Service\nname: redis-svc")),
 				Map.of());
 
+		// Helm disables a subchart only via an explicit Chart.yaml condition, so the
+		// dependency declares condition: redis.enabled.
 		Chart parent = Chart.builder()
-			.metadata(ChartMetadata.builder().name("parent").version("1.0.0").build())
+			.metadata(ChartMetadata.builder()
+				.name("parent")
+				.version("1.0.0")
+				.dependencies(List.of(Dependency.builder().name("redis").condition("redis.enabled").build()))
+				.build())
 			.templates(List.of(tmpl("deploy.yaml", "kind: Deployment\nname: parent-app")))
 			.values(Map.of())
 			.dependencies(List.of(subchart))
 			.build();
 
-		// Disable redis subchart via values
+		// Disable redis subchart via the condition's value
 		Map<String, Object> vals = new HashMap<>();
 		vals.put("redis", new HashMap<>(Map.of("enabled", false)));
 
 		String result = engine.render(parent, vals, releaseInfo());
 		assertTrue(result.contains("name: parent-app"));
 		assertFalse(result.contains("name: redis-svc"));
+	}
+
+	@Test
+	void testBareEnabledFalseWithoutConditionStillRenders() {
+		// Without a Chart.yaml condition, a bare `enabled: false` is just an ordinary
+		// value — Helm renders the subchart regardless (e.g. dask/daskhub pulls in
+		// jupyterhub, whose own values default enabled to false, with no condition).
+		Chart subchart = simpleChart("redis", "17.0.0", List.of(tmpl("service.yaml", "kind: Service\nname: redis-svc")),
+				Map.of("enabled", false));
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder()
+				.name("parent")
+				.version("1.0.0")
+				.dependencies(List.of(Dependency.builder().name("redis").build()))
+				.build())
+			.templates(List.of(tmpl("deploy.yaml", "kind: Deployment\nname: parent-app")))
+			.values(Map.of())
+			.dependencies(List.of(subchart))
+			.build();
+
+		String result = engine.render(parent, new HashMap<>(), releaseInfo());
+		assertTrue(result.contains("name: parent-app"));
+		assertTrue(result.contains("name: redis-svc"), "subchart must render without a disabling condition");
 	}
 
 	// --- .Subcharts context ---

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -520,3 +520,4 @@ stakater/fluentd,stakater,https://stakater.github.io/stakater-charts
 stakater/keycloak,stakater,https://stakater.github.io/stakater-charts
 stakater/chartmuseum-storage,stakater,https://stakater.github.io/stakater-charts
 cetic/pgadmin,cetic,https://cetic.github.io/helm-charts
+dask/daskhub,dask,https://helm.dask.org


### PR DESCRIPTION
## Summary
From the 46-chart triage (`dask/daskhub` — "do desk"). jhelm's subchart render loop skipped any dependency whose merged values contained `enabled: false`, **regardless of whether the parent declared a Chart.yaml `condition`**. That isn't Helm's model: Helm disables a subchart only through an explicit `condition` (or tags), which jhelm already evaluates separately. A bare `<subchart>.enabled` is otherwise just an ordinary value.

## The bug (daskhub)
`dask/daskhub`'s `jupyterhub` dependency has **no condition**, but the jupyterhub subchart ships its own top-level `enabled` default of `false`. `mergeSubchartDefaults` folds that default into the slice, so the non-Helm skip dropped jupyterhub **entirely** — jhelm emitted only dask-gateway (19 resources) while Helm renders 47 (dask-gateway + jupyterhub's 28).

## Fix
- Remove the standalone `enabled`-in-values skip from the subchart loop (and the now-unused `isTruthy` helper). Disabling flows solely through `evaluateDependencyCondition` (Chart.yaml `condition`).
- `EngineTest.testDisabledSubchartIsSkipped` now disables via a real `condition: redis.enabled` (the correct mechanism), and a new `testBareEnabledFalseWithoutConditionStillRenders` covers the daskhub case.
- `dask/daskhub` now matches `helm template` → added to `charts.csv` (**522 → 523**).

## Safety
Regression-checked **17** charts including condition-based umbrellas — `bitnami/wordpress`, `bitnami/kafka`, `bitnami/keycloak`, `kube-prometheus-stack`, `harbor`, `apache-airflow/airflow`, `grafana/k8s-monitoring` — **all still pass** (condition-based disabling is unaffected). Full `jhelm-core install` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)