### PR TITLE
build: adopt gotmpl4j 1.1.3 (from 1.1.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
              dedicated CI job (see .github/workflows/parity.yml). Override with
              -Dsurefire.excludedGroups= -Dgroups=comparison to run only the parity suite. -->
         <surefire.excludedGroups>comparison</surefire.excludedGroups>
-        <gotmpl4j.version>1.1.0</gotmpl4j.version>
+        <gotmpl4j.version>1.1.3</gotmpl4j.version>
         <kubernetes-client.version>26.0.0</kubernetes-client.version>
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>


### PR DESCRIPTION
## Summary
Bumps the Go template engine `gotmpl4j` from **1.1.0 → 1.1.3** (latest release).

The 1.1.0→1.1.3 changes are **pure performance + conformance** — no API or behavior changes:
- −26% render allocation (`floatString` without intermediate substrings, #77)
- −18% render allocation (unsync writer + float-format scratch reuse, #78)
- −16% pipeline allocation (drop per-call subList wrapper, #80)
- `ListNode` backed by `ArrayList` + index-iterated render loops (#67)
- 1,305-case Go/Sprig conformance suite + cross-engine benchmarks

## Verification
- Full `./mvnw clean install` green (all modules/tests).
- Parity smoke sample (20 charts) renders byte-for-byte unchanged vs `helm template` — the perf changes touch float formatting and list iteration, so this confirms no rendering drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)