### PR TITLE
fix(helm): strip inline doc-start marker from toYaml of a root scalar (→524)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -521,3 +521,4 @@ stakater/keycloak,stakater,https://stakater.github.io/stakater-charts
 stakater/chartmuseum-storage,stakater,https://stakater.github.io/stakater-charts
 cetic/pgadmin,cetic,https://cetic.github.io/helm-charts
 dask/daskhub,dask,https://helm.dask.org
+opentelemetry-helm/opentelemetry-ebpf,opentelemetry-helm,https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -229,6 +229,12 @@ public final class ConversionFunctions {
 				if (yaml.startsWith("---\n")) {
 					yaml = yaml.substring(4);
 				}
+				else if (yaml.startsWith("--- ")) {
+					// Jackson emits an inline document-start marker for a ROOT SCALAR
+					// (e.g. toYaml "" -> `--- ""`, toYaml 5 -> `--- 5`); strip it so the
+					// result is the bare scalar Helm's yaml.Marshal produces.
+					yaml = yaml.substring(4);
+				}
 				return removeUnnecessaryQuotes(yaml.trim());
 			}
 			catch (Exception ex) {
@@ -253,6 +259,12 @@ public final class ConversionFunctions {
 			try {
 				String yaml = PRETTY_YAML_MAPPER.get().writeValueAsString(args[0]);
 				if (yaml.startsWith("---\n")) {
+					yaml = yaml.substring(4);
+				}
+				else if (yaml.startsWith("--- ")) {
+					// Jackson emits an inline document-start marker for a ROOT SCALAR
+					// (e.g. toYaml "" -> `--- ""`, toYaml 5 -> `--- 5`); strip it so the
+					// result is the bare scalar Helm's yaml.Marshal produces.
 					yaml = yaml.substring(4);
 				}
 				return removeUnnecessaryQuotes(yaml.trim());
@@ -282,6 +294,12 @@ public final class ConversionFunctions {
 				String yaml = YAML_MAPPER.get().writeValueAsString(args[0]);
 				// Remove document start marker if present
 				if (yaml.startsWith("---\n")) {
+					yaml = yaml.substring(4);
+				}
+				else if (yaml.startsWith("--- ")) {
+					// Jackson emits an inline document-start marker for a ROOT SCALAR
+					// (e.g. toYaml "" -> `--- ""`, toYaml 5 -> `--- 5`); strip it so the
+					// result is the bare scalar Helm's yaml.Marshal produces.
 					yaml = yaml.substring(4);
 				}
 				return removeUnnecessaryQuotes(yaml.trim());

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -315,6 +315,17 @@ class ConversionFunctionsTest {
 	}
 
 	@Test
+	void testToYamlRootScalarHasNoDocMarker() {
+		// Jackson emits an inline document-start marker for a root scalar ("" -> `---
+		// ""`).
+		// Helm's toYaml marshals a bare scalar, so the marker must be stripped.
+		Function toYaml = functions().get("toYaml");
+		assertEquals("\"\"", toYaml.invoke(new Object[] { "" }));
+		assertEquals("5", toYaml.invoke(new Object[] { 5 }));
+		assertEquals("hello", toYaml.invoke(new Object[] { "hello" }));
+	}
+
+	@Test
 	void testToJsonNullReturnsNullString() {
 		Function toJson = functions().get("toJson");
 		assertEquals("null", toJson.invoke(new Object[] {}));


### PR DESCRIPTION
## Summary
From the 46-chart triage. Jackson's `YAMLMapper` emits an **inline document-start marker for a root scalar** — `toYaml ""` produced `--- ""` and `toYaml 5` produced `--- 5` — whereas Helm's `yaml.Marshal` yields the bare scalar (`""` / `5`). The existing strip only handled the block form `---\n`, so a scalar piped through `toYaml` leaked the `--- ` prefix into the rendered value.

In `opentelemetry-helm/opentelemetry-ebpf` this surfaced as empty env values and a ConfigMap label rendering as the literal `--- ""` instead of `""`.

## Fix
`toYaml` / `toYamlPretty` / `mustToYaml` now also strip a leading `--- ` marker (only root scalars produce it; maps start with a key, lists with `-`, and string scalars containing `---` are quoted — so the strip is safe).

## Verification
- `opentelemetry-helm/opentelemetry-ebpf` now matches `helm template` → added to `charts.csv` (**523 → 524**).
- New unit test `testToYamlRootScalarHasNoDocMarker` (`""` → `""`, `5` → `5`, `hello` → `hello`).
- Regression smoke (15 charts incl. ebpf) green; full module build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)