### PR TITLE
build: adopt gotmpl4j 1.1.4 + signoz-otel-gateway (→525)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -522,3 +522,4 @@ stakater/chartmuseum-storage,stakater,https://stakater.github.io/stakater-charts
 cetic/pgadmin,cetic,https://cetic.github.io/helm-charts
 dask/daskhub,dask,https://helm.dask.org
 opentelemetry-helm/opentelemetry-ebpf,opentelemetry-helm,https://open-telemetry.github.io/opentelemetry-helm-charts
+signoz/signoz-otel-gateway,signoz,https://charts.signoz.io

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
              dedicated CI job (see .github/workflows/parity.yml). Override with
              -Dsurefire.excludedGroups= -Dgroups=comparison to run only the parity suite. -->
         <surefire.excludedGroups>comparison</surefire.excludedGroups>
-        <gotmpl4j.version>1.1.3</gotmpl4j.version>
+        <gotmpl4j.version>1.1.4</gotmpl4j.version>
         <kubernetes-client.version>26.0.0</kubernetes-client.version>
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>


### PR DESCRIPTION
## Summary
Bumps the template engine to **gotmpl4j 1.1.4** and adds `signoz/signoz-otel-gateway` to the parity suite (**524 → 525**).

## Why
gotmpl4j 1.1.4 fixes Go's **`printf "%T"`** verb — it now returns the argument's *type name* (`string`, `map[string]interface {}`, `int`, `float64`, `bool`, `[]interface {}`, `<nil>`) instead of its value — plus the pre-compiled printf regex perf work.

That was the root cause of the signoz divergence (from the 46-chart triage): signoz's `renderEnv` helper type-switches on `eq (printf "%T" $v) "string"` to decide whether to splice a `valueFrom:` block or emit a plain `value:`. With `%T` returning the value, jhelm collapsed every `valueFrom` env var into a quoted string in `value:` (20+ diffs across its Deployment/DaemonSet/ConfigMap).

## Verification
- Full `./mvnw clean install` green on 1.1.4.
- `signoz/signoz-otel-gateway` now matches `helm template` byte-for-byte (1/1) → added to `charts.csv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)