### PR TITLE
test(parity): pin settable random fields (cerebro/linkerd-viz), ignore only fadi (→528)

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -72,6 +72,12 @@ jhelmtest:
       - resource: "APIService/*"
         path: "spec.caBundle"
         reason: "caBundle is a generated TLS cert that differs every render"
+    "[cetic/fadi]":
+      # nifi flow.xml ids are `{{ default uuidv4 }}` — generated per render with no value
+      # to pin them, so the only option is to ignore the field.
+      - resource: "ConfigMap/*"
+        path: "data.flow.xml"
+        reason: "flow.xml ids come from `default uuidv4` (not settable); regenerated per render"
     "[timescale/timescaledb-single]":
       # The certificate Secret holds a genSignedCert TLS cert/key and the credentials
       # Secret holds randAlphaNum passwords — both regenerated per render.
@@ -96,6 +102,22 @@ jhelmtest:
   # Value overrides for charts that Helm cannot render with default values. The same
   # overrides are applied to both Helm and jhelm, so any divergence is a real jhelm bug.
   comparison-values:
+    # cerebro generates `secret = randAlphaNum 64` only when config.secret is empty;
+    # pinning it makes the application.conf ConfigMap deterministic (and validated).
+    "[stakater/cerebro]":
+      config:
+        secret: parity-fixed-cerebro-secret
+    # linkerd-viz's tap APIService caBundle is genSelfSignedCert unless tap.caBundle is
+    # set; pinning it renders a stable caBundle (the per-render tls.crt/key stay in a
+    # Secret, which is ignored globally).
+    "[linkerd/linkerd-viz]":
+      tap:
+        # caBundle requires externalSecret (the chart rejects caBundle without it).
+        externalSecret: true
+        caBundle: |
+          -----BEGIN CERTIFICATE-----
+          MIIBparityfixedcabundleforcomparisononlynotarealcertificateAAAAAA
+          -----END CERTIFICATE-----
     "[aws/aws-load-balancer-controller]":
       clusterName: test-cluster
     "[rancher-stable/rancher]":

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -523,3 +523,6 @@ cetic/pgadmin,cetic,https://cetic.github.io/helm-charts
 dask/daskhub,dask,https://helm.dask.org
 opentelemetry-helm/opentelemetry-ebpf,opentelemetry-helm,https://open-telemetry.github.io/opentelemetry-helm-charts
 signoz/signoz-otel-gateway,signoz,https://charts.signoz.io
+stakater/cerebro,stakater,https://stakater.github.io/stakater-charts
+cetic/fadi,cetic,https://cetic.github.io/helm-charts
+linkerd/linkerd-viz,linkerd,https://helm.linkerd.io/stable


### PR DESCRIPTION
## Summary
Three charts from the 46-chart triage diverge only on per-render random fields. Per review feedback, **prefer pinning the field via `comparison-values`** — passed to *both* `helm template` and jhelm, so the field renders deterministically **and is validated** — and only fall back to an ignore rule when the value isn't settable.

| Chart | Field | Resolution |
|---|---|---|
| `stakater/cerebro` | `application.conf` `secret` (`randAlphaNum 64` when `config.secret` empty) | **pin** `config.secret` |
| `linkerd/linkerd-viz` | tap APIService `caBundle` (`genSelfSignedCert` unless `tap.caBundle` set) | **pin** `tap.caBundle` + `tap.externalSecret: true` |
| `cetic/fadi` | nifi `flow.xml` ids (`{{ default uuidv4 }}` — no value to pin) | **ignore** `data.flow.xml` (only non-settable case) |

cerebro's `application.conf` and linkerd-viz's `caBundle` are now fully validated against a fixed value rather than skipped. Adds the three charts to `charts.csv` (**525 → 528**). Verified 3/3 pass (0 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)