### PR TITLE
fix(core): parse YAML 1.1 bare-octal value literals as octal (→529)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesLoader.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.core.util;
 import org.snakeyaml.engine.v2.api.ConstructNode;
 import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.constructor.core.ConstructYamlCoreInt;
 import org.snakeyaml.engine.v2.nodes.Node;
 import org.snakeyaml.engine.v2.nodes.ScalarNode;
 import org.snakeyaml.engine.v2.nodes.Tag;
@@ -63,6 +64,15 @@ public final class ValuesLoader {
 	private static final Pattern YAML11_BOOL = Pattern
 		.compile("^(?:y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)$");
 
+	/**
+	 * YAML 1.1 bare-octal literal: a leading zero followed by octal digits (e.g. file
+	 * modes {@code 0600}, {@code 0755}). Helm loads values via yaml.v2 (YAML 1.1), which
+	 * parses these as octal integers; SnakeYAML Engine's YAML 1.2 core schema would read
+	 * {@code 0600} as decimal 600, so a {@code defaultMode: 0600} diverged from Helm's
+	 * 384.
+	 */
+	private static final Pattern YAML11_OCTAL = Pattern.compile("^0[0-7]+$");
+
 	// Declared after the YAML11_* constants it depends on: static fields initialise in
 	// source order, so createHelmSchema() must not run before those are set.
 	private static final Schema HELM_SCHEMA = createHelmSchema();
@@ -75,10 +85,16 @@ public final class ValuesLoader {
 		resolver.addImplicitResolver(Tag.NULL, CoreScalarResolver.NULL, "~");
 		// Resolve YAML 1.1 boolean tokens (yes/no/on/off/y/n) as booleans like Helm.
 		resolver.addImplicitResolver(Tag.BOOL, YAML11_BOOL, "yYnNtTfFoO");
+		// Resolve YAML 1.1 bare-octal literals (0600, 0755) as integers like Helm.
+		resolver.addImplicitResolver(Tag.INT, YAML11_OCTAL, "0");
 		Map<Tag, ConstructNode> constructors = new HashMap<>(new CoreSchema().getSchemaTagConstructors());
 		// The core BOOL constructor only understands true/false; replace it with one that
 		// also maps the YAML 1.1 tokens this resolver now tags as BOOL.
 		constructors.put(Tag.BOOL, new Yaml11BoolConstructor());
+		// The core INT constructor reads a leading-zero literal as decimal; replace it
+		// with
+		// one that parses YAML 1.1 bare-octal (0600 -> 384) like Helm.
+		constructors.put(Tag.INT, new Yaml11OctalIntConstructor());
 		return new Schema() {
 			@Override
 			public ScalarResolver getScalarResolver() {
@@ -226,6 +242,24 @@ public final class ValuesLoader {
 			}
 			// Should not happen — the resolver only tags the tokens above as BOOL.
 			return Boolean.parseBoolean(value);
+		}
+
+	}
+
+	/**
+	 * Integer constructor that recognises YAML 1.1 bare-octal literals ({@code 0600}) in
+	 * addition to the YAML 1.2 formats handled by {@link ConstructYamlCoreInt}, so a
+	 * leading-zero file mode parses as octal (matching Helm's yaml.v2), not decimal.
+	 */
+	private static final class Yaml11OctalIntConstructor extends ConstructYamlCoreInt {
+
+		@Override
+		public Object construct(Node node) {
+			String value = constructScalar(node);
+			if (value.length() > 1 && value.charAt(0) == '0' && YAML11_OCTAL.matcher(value).matches()) {
+				return createLongOrBigInteger(value.substring(1), 8);
+			}
+			return super.construct(node);
 		}
 
 	}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesLoaderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesLoaderTest.java
@@ -288,6 +288,21 @@ class ValuesLoaderTest {
 		assertEquals("first", first.get("name"));
 	}
 
+	@Test
+	void testBareOctalLiteralsParseAsOctalLikeHelm() throws IOException {
+		// Helm loads values via yaml.v2 (YAML 1.1): a leading-zero literal is octal, so
+		// `defaultMode: 0600` is 384 (not decimal 600). Quoted values stay strings.
+		File file = writeValues("""
+				mode: 0600
+				dir: 0755
+				quoted: "0600"
+				""");
+		Map<String, Object> result = ValuesLoader.load(file);
+		assertEquals(384L, result.get("mode"));
+		assertEquals(493L, result.get("dir"));
+		assertEquals("0600", result.get("quoted"));
+	}
+
 	private File writeValues(String content) throws IOException {
 		Path file = tempDir.resolve("values.yaml");
 		Files.writeString(file, content);

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -526,3 +526,4 @@ signoz/signoz-otel-gateway,signoz,https://charts.signoz.io
 stakater/cerebro,stakater,https://stakater.github.io/stakater-charts
 cetic/fadi,cetic,https://cetic.github.io/helm-charts
 linkerd/linkerd-viz,linkerd,https://helm.linkerd.io/stable
+influxdata/influxdb-enterprise,influxdata,https://helm.influxdata.com


### PR DESCRIPTION
## Summary
Found while applying the pin-where-settable pass — `influxdata/influxdb-enterprise`'s only divergence turned out to be a **real bug**, not a random field.

Helm loads values via `yaml.v2` (YAML 1.1), where a leading-zero integer literal is **octal** — so `defaultMode: 0600` is `384`. jhelm's `ValuesLoader` used SnakeYAML Engine's YAML 1.2 core schema, which read `0600` as **decimal 600**, so secret-volume `defaultMode`s (and any `0NNN` file mode in values) diverged from `helm template`.

## Fix
`ValuesLoader` now adds a YAML 1.1 octal `INT` resolver + constructor — the same one already used for `fromYaml` in `ConversionFunctions` — so `0600` → 384, `0755` → 493; quoted values stay strings.

## Verification
- `influxdata/influxdb-enterprise` (only diffs were `volumes[*].secret.defaultMode` 600 vs 384) now matches `helm template` → added to `charts.csv` (**528 → 529**).
- New `ValuesLoaderTest` octal coverage; regression-checked 18 existing charts (all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)