### PR TITLE
test(parity): pin atlas passwords + chainloop passphrase (→534)

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -118,6 +118,36 @@ jhelmtest:
           -----BEGIN CERTIFICATE-----
           MIIBparityfixedcabundleforcomparisononlynotarealcertificateAAAAAA
           -----END CERTIFICATE-----
+    # mongodb atlas charts render `password | default (randAlphaNum 32 | b64enc)`;
+    # pinning the password makes the admin-user Secret deterministic (and validated).
+    "[mongodb/atlas-basic]":
+      dbUser:
+        password: parity-fixed-atlas-password
+    "[mongodb/atlas-advanced]":
+      dbUser:
+        password: parity-fixed-atlas-password
+    "[mongodb/atlas-deployment]":
+      users:
+        - username: admin-user
+          databaseName: admin
+          password: parity-fixed-atlas-password
+          roles:
+            - databaseName: admin
+              roleName: atlasAdmin
+    "[mongodb/atlas-cluster]":
+      users:
+        - username: admin-user
+          databaseName: admin
+          password: parity-fixed-atlas-password
+          roles:
+            - databaseName: admin
+              roleName: atlasAdmin
+    # chainloop's generated_jws_hmac_secret derives from controlplane.auth.passphrase
+    # (common.secrets.passwords.manage providedValues); pinning it makes the Secret stable.
+    "[bitnami/chainloop]":
+      controlplane:
+        auth:
+          passphrase: parity-fixed-chainloop-passphrase
     "[aws/aws-load-balancer-controller]":
       clusterName: test-cluster
     "[rancher-stable/rancher]":

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -527,3 +527,8 @@ stakater/cerebro,stakater,https://stakater.github.io/stakater-charts
 cetic/fadi,cetic,https://cetic.github.io/helm-charts
 linkerd/linkerd-viz,linkerd,https://helm.linkerd.io/stable
 influxdata/influxdb-enterprise,influxdata,https://helm.influxdata.com
+mongodb/atlas-deployment,mongodb,https://mongodb.github.io/helm-charts
+mongodb/atlas-cluster,mongodb,https://mongodb.github.io/helm-charts
+bitnami/chainloop,bitnami,https://charts.bitnami.com/bitnami
+mongodb/atlas-basic,mongodb,https://mongodb.github.io/helm-charts
+mongodb/atlas-advanced,mongodb,https://mongodb.github.io/helm-charts


### PR DESCRIPTION
## Summary
Continuing the pin-where-settable pass on the 46-chart triage. Five charts diverge only on a per-render generated secret that **is settable via a chart value**, so pin it via `comparison-values` (rendered by both `helm template` and jhelm → deterministic **and validated**) instead of ignoring.

| Chart | Pinned value |
|---|---|
| `mongodb/atlas-basic`, `atlas-advanced` | `dbUser.password` |
| `mongodb/atlas-deployment`, `atlas-cluster` | `users[0].password` (full admin-user entry replicated so only the password changes) |
| `bitnami/chainloop` | `controlplane.auth.passphrase` (drives `generated_jws_hmac_secret`) |

Adds the five charts to `charts.csv` (**529 → 534**); 5/5 pass.

## Not pinned (follow-up)
`kong/kong-operator` and `ot-helm/otel-operator` use multiple `genCA`/`genSignedCert` with no single value to pin — those need ignore rules or full cert-chain values, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)