### PR TITLE
fix(engine): don't collect named templates from condition-disabled subcharts (→535)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -197,8 +197,10 @@ public class Engine {
 		// subchart .Chart.Name and template registration keys use the alias consistently.
 		applyAliasesFromMetadata(chart);
 
-		// Collect all named templates (define blocks) first
-		collectNamedTemplates(chart);
+		// Collect all named templates (define blocks) first. Pass the render values so
+		// templates from condition-disabled subcharts are pruned (as Helm does) and don't
+		// pollute the global define namespace.
+		collectNamedTemplates(chart, values);
 
 		try {
 			// Using a shared set for the whole rendering process to avoid redundant work
@@ -276,7 +278,7 @@ public class Engine {
 		return true;
 	}
 
-	private void collectNamedTemplates(Chart chart) {
+	private void collectNamedTemplates(Chart chart, Map<String, Object> values) {
 		// First pass: collect all templates without parsing, to have them available for
 		// definitions
 		// Also track which chart each template belongs to for proper namespacing
@@ -289,7 +291,8 @@ public class Engine {
 		// two subcharts define the same named template the last one in that order wins.
 		// Parsing in the same order makes jhelm's define resolution match Helm's.
 		Map<String, String> templateFullPath = new HashMap<>();
-		collectAllTemplates(chart, allTemplates, templateToChartName, templateFullPath, chart.getMetadata().getName());
+		collectAllTemplates(chart, allTemplates, templateToChartName, templateFullPath, chart.getMetadata().getName(),
+				values);
 
 		// Second pass: parse each template. Helper files (.tpl) are parsed first so their
 		// defines are present; within each group templates are parsed in Helm's full-path
@@ -396,13 +399,15 @@ public class Engine {
 	}
 
 	private void collectAllTemplates(Chart chart, Map<String, String> templates,
-			Map<String, String> templateToChartName, Map<String, String> templateFullPath, String rootChartName) {
-		collectAllTemplates(chart, templates, templateToChartName, templateFullPath, rootChartName, rootChartName);
+			Map<String, String> templateToChartName, Map<String, String> templateFullPath, String rootChartName,
+			Map<String, Object> values) {
+		collectAllTemplates(chart, templates, templateToChartName, templateFullPath, rootChartName, rootChartName,
+				values);
 	}
 
 	private void collectAllTemplates(Chart chart, Map<String, String> templates,
 			Map<String, String> templateToChartName, Map<String, String> templateFullPath, String rootChartName,
-			String pathPrefix) {
+			String pathPrefix, Map<String, Object> inheritedValues) {
 		String chartName = chart.getMetadata().getName();
 		String chartVersion = chart.getMetadata().getVersion();
 
@@ -443,9 +448,31 @@ public class Engine {
 			}
 		}
 
+		// Merged values at this level, used to evaluate subchart conditions so a
+		// condition-disabled subchart's templates are NOT collected. Helm prunes disabled
+		// subcharts from the tree before loading templates; jhelm previously collected
+		// them
+		// anyway, so a stale same-named define from a disabled library chart could win
+		// the
+		// global define collision (e.g. dask/druid's disabled mysql common overriding
+		// postgresql's common.affinities.pods.soft, dropping `namespaces`).
+		Map<String, Object> chartDefaults = (chart.getValues() != null) ? chart.getValues() : new HashMap<>();
+		Map<String, Object> merged = mergeValues(chartDefaults, inheritedValues);
+		List<Dependency> depMeta = (chart.getMetadata() != null) ? chart.getMetadata().getDependencies() : null;
 		for (Chart subchart : chart.getDependencies()) {
+			String subchartName = (subchart.getAlias() != null) ? subchart.getAlias()
+					: subchart.getMetadata().getName();
+			Dependency depEntry = findDependencyMetadata(depMeta, subchart);
+			if (depEntry != null && depEntry.getCondition() != null && !depEntry.getCondition().isEmpty()
+					&& !evaluateDependencyCondition(depEntry.getCondition(), merged)) {
+				continue;
+			}
+			Object sliced = merged.get(subchartName);
+			@SuppressWarnings("unchecked")
+			Map<String, Object> subchartValues = (sliced instanceof Map) ? (Map<String, Object>) sliced
+					: new HashMap<>();
 			collectAllTemplates(subchart, templates, templateToChartName, templateFullPath, rootChartName,
-					pathPrefix + "/charts/" + subchart.getMetadata().getName());
+					pathPrefix + "/charts/" + subchart.getMetadata().getName(), subchartValues);
 		}
 	}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -279,6 +279,33 @@ class EngineTest {
 	}
 
 	@Test
+	void testDisabledSubchartDefinesDoNotPolluteNamedTemplates() {
+		// A condition-disabled subchart must contribute no named templates: its define
+		// must not win the global collision over an enabled subchart's. "omega" sorts
+		// last (so it would win without pruning); disabling it must let "alpha" win.
+		Chart enabled = simpleChart("alpha", "1.0.0",
+				List.of(tmpl("_helpers.tpl", "{{- define \"common.greet\" -}}from-alpha{{- end -}}")), Map.of());
+		Chart disabled = simpleChart("omega", "1.0.0",
+				List.of(tmpl("_helpers.tpl", "{{- define \"common.greet\" -}}from-omega{{- end -}}")), Map.of());
+
+		Chart parent = Chart.builder()
+			.metadata(ChartMetadata.builder()
+				.name("parent")
+				.version("1.0.0")
+				.dependencies(List.of(Dependency.builder().name("alpha").build(),
+						Dependency.builder().name("omega").condition("omega.enabled").build()))
+				.build())
+			.templates(List.of(tmpl("cm.yaml", "data: {{ include \"common.greet\" . }}")))
+			.values(new HashMap<>(Map.of("omega", new HashMap<>(Map.of("enabled", false)))))
+			.dependencies(List.of(enabled, disabled))
+			.build();
+
+		String result = engine.render(parent, new HashMap<>(), releaseInfo());
+		assertTrue(result.contains("from-alpha"), result);
+		assertFalse(result.contains("from-omega"), result);
+	}
+
+	@Test
 	void testBareEnabledFalseWithoutConditionStillRenders() {
 		// Without a Chart.yaml condition, a bare `enabled: false` is just an ordinary
 		// value — Helm renders the subchart regardless (e.g. dask/daskhub pulls in

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -532,3 +532,4 @@ mongodb/atlas-cluster,mongodb,https://mongodb.github.io/helm-charts
 bitnami/chainloop,bitnami,https://charts.bitnami.com/bitnami
 mongodb/atlas-basic,mongodb,https://mongodb.github.io/helm-charts
 mongodb/atlas-advanced,mongodb,https://mongodb.github.io/helm-charts
+wiremind/druid,wiremind,https://wiremind.github.io/wiremind-helm-charts


### PR DESCRIPTION
## Summary
A real engine bug from the 46-chart triage (`wiremind/druid`). Helm prunes condition-disabled subcharts from the chart tree **before** loading templates, so their `define`s never enter the global named-template namespace. jhelm's `collectAllTemplates` walked **every** dependency regardless of its Chart.yaml condition, so a disabled subchart's named templates were still registered — and a stale same-named define from a disabled library chart could win the global collision.

## The bug (druid)
`wiremind/druid` bundles a **disabled** `mysql` subchart whose older bitnami `common` (v1.16.0) defines `common.affinities.pods.soft` **without** the `namespaces:` block. jhelm collected it and it won over postgresql's newer common, so the postgresql StatefulSet's `podAntiAffinity` dropped `namespaces: ["default"]`.

## Fix
`collectAllTemplates` now threads the merged values and **skips a subchart whose dependency condition evaluates false** — reusing `findDependencyMetadata` / `evaluateDependencyCondition`, the same gate `renderWithSubcharts` already applies to rendering. Enabled-subchart collision ordering (#18 / #21 / redpanda) is untouched.

## Verification
- `wiremind/druid` now matches `helm template` → added to `charts.csv` (**534 → 535**).
- `EngineTest`: new test — a disabled subchart's define must not win the global collision (the disabled chart is named to sort last, so it would win without pruning).
- Regression-checked **39** charts including umbrellas (wordpress, kafka, keycloak, kube-prometheus-stack, harbor, airflow, k8s-monitoring) — all still pass. Full `jhelm-core install` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)