### PR TITLE
fix(helm): toYaml quotes leading-# strings (nordmart) + aws-iam checksum ignore (→537)

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -78,6 +78,14 @@ jhelmtest:
       - resource: "ConfigMap/*"
         path: "data.flow.xml"
         reason: "flow.xml ids come from `default uuidv4` (not settable); regenerated per render"
+    "[fairwinds/aws-iam-authenticator]":
+      # The DaemonSet's checksum/config hashes the inlined ConfigMap via include|sha256sum;
+      # the ConfigMap itself renders byte-for-byte identical to Helm, so the hash differs
+      # only by intermediate toYaml serialization (#237). The _global rule covers
+      # spec.template.* checksums; this chart puts it at the top-level metadata.
+      - resource: "DaemonSet/*"
+        path: "metadata.annotations.checksum/config"
+        reason: "checksum of an inlined ConfigMap that matches Helm byte-for-byte; differs only by toYaml serialization (#237)"
     "[timescale/timescaledb-single]":
       # The certificate Secret holds a genSignedCert TLS cert/key and the credentials
       # Secret holds randAlphaNum passwords — both regenerated per render.

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -533,3 +533,5 @@ bitnami/chainloop,bitnami,https://charts.bitnami.com/bitnami
 mongodb/atlas-basic,mongodb,https://mongodb.github.io/helm-charts
 mongodb/atlas-advanced,mongodb,https://mongodb.github.io/helm-charts
 wiremind/druid,wiremind,https://wiremind.github.io/wiremind-helm-charts
+stakater/nordmart-review-instance,stakater,https://stakater.github.io/stakater-charts
+fairwinds/aws-iam-authenticator,fairwinds,https://charts.fairwinds.com/stable

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -892,9 +892,11 @@ public final class ConversionFunctions {
 			return false;
 		}
 		char first = s.charAt(0);
-		// Must not start with YAML indicators
+		// Must not start with YAML indicators. '#' starts a comment (Go's yaml.Marshal
+		// quotes a leading-'#' string, e.g. stakater nordmart's slack channel '#alerts';
+		// left plain it reads back as a comment and the value is lost).
 		if (first == '[' || first == '{' || first == '!' || first == '&' || first == '*' || first == '|' || first == '>'
-				|| first == '%' || first == '@' || first == '`' || first == '\'' || first == '"') {
+				|| first == '%' || first == '@' || first == '`' || first == '\'' || first == '"' || first == '#') {
 			return false;
 		}
 		// Must not start with - or ? followed by space

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctionsTest.java
@@ -144,6 +144,21 @@ class ConversionFunctionsTest {
 	}
 
 	@Test
+	void testToYamlQuotesLeadingHashStrings() {
+		// A value starting with '#' is a YAML comment indicator; Go's yaml.Marshal
+		// single-quotes it (stakater nordmart's slack channel '#alerts'). Left plain it
+		// reads back as a comment and the value is lost.
+		Map<String, Object> data = new LinkedHashMap<>();
+		data.put("channel", "#nordmart-gabbar-application-alerts");
+		String result = (String) functions().get("toYaml").invoke(new Object[] { data });
+		assertTrue(result.contains("channel: '#nordmart-gabbar-application-alerts'"),
+				"leading-# value must be single-quoted: " + result);
+		Object back = functions().get("fromYaml").invoke(new Object[] { result });
+		assertInstanceOf(Map.class, back);
+		assertEquals("#nordmart-gabbar-application-alerts", ((Map<?, ?>) back).get("channel"));
+	}
+
+	@Test
 	void testToYamlQuotesTrailingColonStrings() {
 		// A value ending in ':' (e.g. a Prometheus recording-rule name) would otherwise
 		// be


### PR DESCRIPTION
## Summary
The two charts you asked for, from the 46-chart triage.

### nordmart — real `toYaml` bug
`toYaml` emitted a string starting with `#` as a **plain** scalar (`channel: #alerts`), but YAML reads `: #` as a **comment**, so the value was lost on re-parse — `stakater/nordmart-review-instance`'s slack `channel: '#nordmart-...'` rendered as `null`. `canBePlainScalar` now rejects a leading `#` (a comment indicator), so `toYaml` single-quotes it like Go's `yaml.Marshal`. New unit test round-trips the value back to the string.

### aws-iam — not a bug → ignore
`fairwinds/aws-iam-authenticator`'s DaemonSet `checksum/config` hashes the **inlined** ConfigMap via `include | sha256sum`. The ConfigMap renders **byte-for-byte identical** to Helm (verified), so the hash differs only by intermediate `toYaml` serialization — the #237 class already ignored globally for `spec.template` checksums; this chart puts it at the DaemonSet's top-level `metadata`. Added a chart-specific ignore.

## Verification
- Both now match `helm template` → added to `charts.csv` (**535 → 537**).
- Regression-checked 16 charts (`toYaml` is a hot path) + the gotemplate-helm unit suite — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)