### PR TITLE
build: adopt gotmpl4j 1.1.5 + datadog/private-action-runner (→538)

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -535,3 +535,4 @@ mongodb/atlas-advanced,mongodb,https://mongodb.github.io/helm-charts
 wiremind/druid,wiremind,https://wiremind.github.io/wiremind-helm-charts
 stakater/nordmart-review-instance,stakater,https://stakater.github.io/stakater-charts
 fairwinds/aws-iam-authenticator,fairwinds,https://charts.fairwinds.com/stable
+datadog/private-action-runner,datadog,https://helm.datadoghq.com

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
              dedicated CI job (see .github/workflows/parity.yml). Override with
              -Dsurefire.excludedGroups= -Dgroups=comparison to run only the parity suite. -->
         <surefire.excludedGroups>comparison</surefire.excludedGroups>
-        <gotmpl4j.version>1.1.4</gotmpl4j.version>
+        <gotmpl4j.version>1.1.5</gotmpl4j.version>
         <kubernetes-client.version>26.0.0</kubernetes-client.version>
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>


### PR DESCRIPTION
## Summary
Bumps the engine to **gotmpl4j 1.1.5** and adds `datadog/private-action-runner` (**537 → 538**).

gotmpl4j 1.1.5 fixes sprig `substr` with a **negative end index** (the fix for [gotmpl4j #85](https://github.com/alexmond/gotmpl4j/issues/85), filed from this suite): `substr 1 -1 "pod"` now returns `"od"` (slice-to-end) instead of `""`, matching Masterminds/sprig.

That unblocks `datadog/private-action-runner`: its `actionsAllowlist` is built with `... {{ substr 1 -1 (include "chart.k8sResourceSingular" $resourceType) }}`, so `getPod`/`listPod` previously rendered as `getP`/`listP`. With 1.1.5 the chart matches `helm template` byte-for-byte.

## Verification
Full `clean install` green; `datadog/private-action-runner` passes + 15-chart regression sample clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)