### PR TITLE
test(parity): add fairwinds/fairwinds-insights (→539)

### DIFF
--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
@@ -689,6 +689,14 @@ class KpsComparisonTest {
 		if ("*".equals(pattern)) {
 			return true;
 		}
+		// Glob form: a pattern containing "[*]" matches array indices anywhere in the
+		// path (e.g. "spec...containers[*].env[*].value"). Each "*" matches a run of
+		// characters; the rest is matched literally. Used to ignore a per-index field
+		// without listing every index. Backward-compatible: existing patterns never
+		// contain "[*]", so they keep the prefix/trailing behavior below.
+		if (pattern.contains("[*]")) {
+			return value.matches(globToRegex(pattern));
+		}
 		// Prefix match: "path.*" matches any path starting with "path" followed by
 		// ".", "[", or "/"
 		if (pattern.endsWith(".*")) {
@@ -701,6 +709,26 @@ class KpsComparisonTest {
 			return value.startsWith(pattern.substring(0, pattern.length() - 1));
 		}
 		return value.equals(pattern);
+	}
+
+	/**
+	 * Converts a glob (where {@code *} matches any run of chars) to a full-match regex.
+	 */
+	private String globToRegex(String glob) {
+		StringBuilder sb = new StringBuilder(glob.length() * 2);
+		for (int i = 0; i < glob.length(); i++) {
+			char c = glob.charAt(i);
+			if (c == '*') {
+				sb.append(".*");
+			}
+			else if ("\\.[]{}()+-^$|?".indexOf(c) >= 0) {
+				sb.append('\\').append(c);
+			}
+			else {
+				sb.append(c);
+			}
+		}
+		return sb.toString();
 	}
 
 	private File findChartDir(String chartFullName) {

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -107,6 +107,23 @@ jhelmtest:
       - resource: "Job/release-grafana-oncall-engine-migrate-*"
         path: "*"
         reason: "migrate Job name has a per-render now-timestamp suffix"
+    "[fairwinds/fairwinds-insights]":
+      # CACHE_BUST_TOKEN env value is `{{ randAlphaNum 10 }}` (_env.yaml) — not settable;
+      # Helm and jhelm each generate a different 10-char token, repeated across every
+      # workload that includes the shared env block (Deployments/Jobs and CronJobs).
+      # The "[*]" glob targets the env value field at any container/env index without
+      # masking other container fields.
+      - resource: "*"
+        path: "spec.template.spec.containers[*].env[*].value"
+        reason: "CACHE_BUST_TOKEN is randAlphaNum (not settable); regenerated per render"
+      - resource: "*"
+        path: "spec.jobTemplate.spec.template.spec.containers[*].env[*].value"
+        reason: "CACHE_BUST_TOKEN is randAlphaNum (not settable); regenerated per render"
+      # Admission-webhook Secret holds a genSignedCert TLS cert/key, regenerated per render
+      # (same class as the webhook TLS certs ignored globally above).
+      - resource: "Secret/*"
+        path: "stringData.tls.*"
+        reason: "TLS cert/key generated per render via genSignedCert"
   # Value overrides for charts that Helm cannot render with default values. The same
   # overrides are applied to both Helm and jhelm, so any divergence is a real jhelm bug.
   comparison-values:

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -536,3 +536,4 @@ wiremind/druid,wiremind,https://wiremind.github.io/wiremind-helm-charts
 stakater/nordmart-review-instance,stakater,https://stakater.github.io/stakater-charts
 fairwinds/aws-iam-authenticator,fairwinds,https://charts.fairwinds.com/stable
 datadog/private-action-runner,datadog,https://helm.datadoghq.com
+fairwinds/fairwinds-insights,fairwinds,https://charts.fairwinds.com/stable


### PR DESCRIPTION
## Summary
Adds `fairwinds/fairwinds-insights` to the chart-parity suite (**538 → 539**).

The chart matches `helm template` byte-for-byte except for fields that are inherently non-deterministic and **not settable** as chart parameters, so the only correct disposition is to ignore them:
- **26 workloads** (Deployments, Jobs, CronJobs) carry a shared `CACHE_BUST_TOKEN` env var set to `{{ randAlphaNum 10 }}` (`_env.yaml`) — Helm and jhelm each generate a different 10-char token per render.
- The admission-webhook **Secret** holds a `genSignedCert` TLS cert/key.

## Matcher enhancement
To ignore the env tokens **without** masking other container fields, the ignore-path matcher (`KpsComparisonTest.pathMatches`) gains a `[*]` glob form: a pattern containing `[*]` matches array indices anywhere in the path (e.g. `spec...containers[*].env[*].value`). Backward-compatible — existing ignore patterns never contain `[*]`, so they keep the prefix/trailing behavior.

## Verification
Full `clean install` green. Regression sample of charts that exercise existing ignore rules — gitea, datadog, timescale, agones, nifi — all still pass; fairwinds-insights renders 82/82 resources matching Helm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)