### PR TITLE
test(parity): add ot-helm/otel-operator (→540)

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -107,6 +107,14 @@ jhelmtest:
       - resource: "Job/release-grafana-oncall-engine-migrate-*"
         path: "*"
         reason: "migrate Job name has a per-render now-timestamp suffix"
+    "[ot-helm/otel-operator]":
+      # The opentelemetrycollectors CRD's conversion-webhook caBundle is a
+      # genCA/genSignedCert TLS cert (admissionWebhooks.autoGenerateCert, _helpers.tpl),
+      # regenerated per render with no value to pin it — same class as the agones
+      # APIService caBundle and the global webhook TLS certs.
+      - resource: "CustomResourceDefinition/*"
+        path: "spec.conversion.webhook.clientConfig.caBundle"
+        reason: "caBundle is a genCA/genSignedCert TLS cert regenerated per render (not settable)"
     "[fairwinds/fairwinds-insights]":
       # CACHE_BUST_TOKEN env value is `{{ randAlphaNum 10 }}` (_env.yaml) — not settable;
       # Helm and jhelm each generate a different 10-char token, repeated across every

--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -537,3 +537,4 @@ stakater/nordmart-review-instance,stakater,https://stakater.github.io/stakater-c
 fairwinds/aws-iam-authenticator,fairwinds,https://charts.fairwinds.com/stable
 datadog/private-action-runner,datadog,https://helm.datadoghq.com
 fairwinds/fairwinds-insights,fairwinds,https://charts.fairwinds.com/stable
+ot-helm/otel-operator,ot-helm,https://ot-container-kit.github.io/helm-charts


### PR DESCRIPTION
## Summary
Adds `ot-helm/otel-operator` to the chart-parity suite (**539 → 540**).

The chart matches `helm template` byte-for-byte except for one field: the `opentelemetrycollectors` CRD's conversion-webhook `caBundle`. That value is a `genCA`/`genSignedCert` TLS cert (`admissionWebhooks.autoGenerateCert`, generated in the bundled `opentelemetry-operator` subchart's `_helpers.tpl`), regenerated per render with **no value to pin it** — the same class as the agones `APIService` caBundle and the global webhook TLS certs already ignored. Disposition: scoped ignore on `CustomResourceDefinition` `spec.conversion.webhook.clientConfig.caBundle`.

(`ot-helm/opentelemetry-operator` is only published as a subchart, not a standalone chart, so it isn't addable.)

## Verification
Full `clean install` green; otel-operator renders all resources matching Helm apart from the ignored genCA caBundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)