### PR TITLE
test(parity): register redpanda/redpanda as a known failure (low priority)

### DIFF
--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -33,3 +33,12 @@
 # Diagnostic: render a copy with `{{ .Values.global | toYaml }}` via helm -s and jhelm,
 # diff the dumps.
 gitlab/gitlab,gitlab,https://charts.gitlab.io
+#
+# redpanda (LOW PRIORITY): jhelm rendering aborts in the chart's own _shims.parseResource
+# helper with `invalid Quantity expected string or float64 got: int (5368709120)`. The
+# value is the 5Gi tiered-storage cache size; redpanda's _shims does a Go type-switch that
+# only accepts string/float64. Go Helm represents YAML numbers as float64, so the literal
+# satisfies the switch; jhelm/gotmpl4j keeps integral numbers as int, so it falls through
+# and the chart raises. Root cause is engine-level number typing (how numeric values read
+# from .Values are typed), i.e. a gotmpl4j concern — not fixed here. Deferred low priority.
+redpanda/redpanda,redpanda,https://charts.redpanda.com


### PR DESCRIPTION
## Summary
Records `redpanda/redpanda` in `failed.csv` as a **low-priority known failure**, so the parity suite warns on it without hard-failing — rather than fixing it now.

## Why it fails
jhelm rendering aborts inside the chart's own `_shims.parseResource` helper:

```
invalid Quantity expected string or float64 got: int (5368709120)
```

The value is the 5Gi tiered-storage cache size. redpanda's `_shims` does a Go type-switch that only accepts `string`/`float64`. Go Helm represents YAML numbers as `float64`, so the literal satisfies the switch; **jhelm/gotmpl4j keeps integral numbers as `int`**, so it falls through the switch and the chart raises.

Root cause is **engine-level number typing** (how numeric values read from `.Values` are typed) — a gotmpl4j concern, not a jhelm fix. Deferred at low priority and documented in `failed.csv`.

## Note
`redpanda/console`, `operator`, `connectors`, and `connect` remain passing in `charts.csv`; only the main `redpanda/redpanda` chart hits this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)