### PR TITLE
perf(engine): skip the redundant render-pass re-parse of define-free templates

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -76,6 +76,11 @@ public class Engine {
 
 	private GoTemplate factory;
 
+	// Per-render record of the text hash last parsed under each template name, so the
+	// render pass can skip re-parsing a template the collect pass already parsed (see
+	// parseWithCache). Reset each render in doRender alongside the factory.
+	private final Map<String, Integer> parsedTextHash = new HashMap<>();
+
 	/**
 	 * Creates an engine with no template cache and no metrics, using a default schema
 	 * validator.
@@ -112,8 +117,26 @@ public class Engine {
 	}
 
 	private void parseWithCache(String name, String text) throws Exception {
+		// The collect pass (collectNamedTemplates) parses every template into the factory
+		// under its helm-style key; the render pass then re-parses the same (name, text)
+		// before executing it — the single hottest render path. When the identical text
+		// is
+		// already parsed under this name AND it declares no `define` block, the re-parse
+		// only
+		// re-creates the identical root node, so skip it. Templates that declare `define`
+		// (which could re-order the global define table) and key collisions (distinct
+		// text
+		// under the same name) still parse, preserving define precedence and collision
+		// resolution. The `define` check is a cheap superset guard: a false positive only
+		// costs a redundant parse, never correctness.
+		Integer prevHash = parsedTextHash.get(name);
+		if (prevHash != null && prevHash == text.hashCode() && !text.contains("define")
+				&& factory.getRootNodes().containsKey(name)) {
+			return;
+		}
 		if (templateCache == null) {
 			factory.parse(name, text);
+			parsedTextHash.put(name, text.hashCode());
 			return;
 		}
 		String cacheKey = name + "|" + text.hashCode();
@@ -132,6 +155,7 @@ public class Engine {
 			}
 		}
 		templateCache.put(cacheKey, added);
+		parsedTextHash.put(name, text.hashCode());
 	}
 
 	/**
@@ -189,6 +213,7 @@ public class Engine {
 	private String doRender(Chart chart, Map<String, Object> values, Map<String, Object> releaseInfo) {
 		namedTemplates.clear();
 		templateVersions.clear();
+		parsedTextHash.clear();
 		// Create a new template for each render to avoid accumulation. Helm renders a
 		// nil/absent value as "" (missingkey=zero), not Go's "<no value>".
 		this.factory = new GoTemplate().option("missingkey=zero");


### PR DESCRIPTION
## Summary
jhelm parses **every template twice per render**: a **collect pass** (`collectNamedTemplates`) parses each template into the factory under its helm-style key to gather `define` blocks, then the **render pass** (`renderChartTemplates`) re-parses the same `(name, text)` before executing it. Because `parseWithCache`'s key includes the name, even a wired `TemplateCache` can't dedupe the two passes *within* a single render — and template parsing is jhelm's single hottest render path (profiled below).

This adds a small per-render `parsedTextHash` memo: when the identical text is already parsed under a name **and it declares no `define` block**, the render-pass re-parse is skipped (it would only re-create the identical root node).

## Why it's safe
- Templates that declare `{{ define }}` — which could re-order the global define table — **still parse**, so define precedence is untouched.
- Key collisions (distinct text under the same helm-style key) **still parse and overwrite**, so collision resolution is untouched.
- The `text.contains("define")` check is a cheap *superset* guard: a false positive only costs a redundant parse, never correctness.
- The memo is reset each render in `doRender` alongside the factory; the `factory.getRootNodes().containsKey(name)` guard makes it robust to the per-render factory swap.

## Measured impact
60-chart render-only batch (jvmlens, live attach), before → after:

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| `parseWithCache` CPU | 42% | 31% | **−28% samples** |
| `parseWithCache` allocation | 2.3 GB | 1.3 GB | **−45%** |
| `Engine.*` total allocation | 3.6 GB | 3.0 GB | **−18%** |
| GC pause | 448 ms | 358 ms | **−20%** |

(Other frames' *shares* rise in the diff purely from share-inversion + more batch rounds completing in the same window — their absolute per-render work is unchanged.)

## Verification
- Full `clean install` green.
- **540/540 parity charts byte-for-byte identical to `helm template`** (0 failures), including the define-precedence-sensitive umbrella charts: gitlab/openbao (#21), druid, redpanda/console, istiod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)