### PR TITLE
perf(gotemplate-helm): tpl reuses the parent factory for define-free strings

### DIFF
--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctions.java
@@ -15,6 +15,11 @@ import org.alexmond.gotmpl4j.FunctionExecutionException;
  */
 public final class TemplateFunctions {
 
+	// Reserved root-node key under which the tpl fast path parses an inline string in the
+	// parent factory. Chosen so it can't collide with a chart's template path or define
+	// name.
+	private static final String TPL_INLINE_NAME = "__jhelm_tpl_inline__";
+
 	private TemplateFunctions() {
 	}
 
@@ -119,7 +124,32 @@ public final class TemplateFunctions {
 	 * @return the rendered output
 	 */
 	private static String renderInline(GoTemplate factory, String text, Object data) throws Exception {
-		// Match Helm's missingkey=zero: a nil/absent value renders "" inside tpl too.
+		StringWriter writer = new StringWriter();
+		// Fast path: a tpl string that declares no `define` contributes only its own
+		// body, so
+		// parse and execute it directly in the parent factory under a reserved name. This
+		// reuses the factory's already-built function registry and named templates
+		// instead of
+		// constructing a fresh GoTemplate per call — which re-runs ServiceLoader function
+		// discovery and copies the entire root-node table on every tpl invocation. The
+		// factory
+		// is already missingkey=zero (set per render, the same option the slow path
+		// applies),
+		// the reserved name can't collide with a chart template/define, and it is
+		// overwritten
+		// on each call; execute() resolves its node at entry, so nested tpl calls stay
+		// correct.
+		if (!text.contains("define")) {
+			factory.parse(TPL_INLINE_NAME, text);
+			factory.execute(TPL_INLINE_NAME, data, writer);
+			return writer.toString();
+		}
+		// Slow path: the tpl string declares templates — isolate the parse in a child so
+		// its
+		// defines merge into the parent without overwriting existing ones (putIfAbsent),
+		// which
+		// matches Helm where a template defined within a tpl string joins the global
+		// namespace.
 		GoTemplate tplTemplate = new GoTemplate(factory.getFunctions()).option("missingkey=zero");
 		tplTemplate.getRootNodes().putAll(factory.getRootNodes());
 		tplTemplate.parse("inline", text);
@@ -128,7 +158,6 @@ public final class TemplateFunctions {
 				factory.getRootNodes().putIfAbsent(entry.getKey(), entry.getValue());
 			}
 		}
-		StringWriter writer = new StringWriter();
 		tplTemplate.execute("inline", data, writer);
 		return writer.toString();
 	}


### PR DESCRIPTION
## Summary
`tpl`/`mustTpl` built a **fresh `GoTemplate` on every call** (`new GoTemplate(factory.getFunctions())`) and then `putAll`-copied the **entire root-node table** into it. Two per-call costs, both on the hot path for tpl-heavy charts (grafana/loki et al.):
1. the public `GoTemplate` constructor re-runs `ServiceLoader` `FunctionProvider` discovery and **rebuilds the whole Sprig+Helm function registry**, and
2. the root-node `putAll` is **O(named-templates)**.

A `tpl` string that declares no `define` contributes only its own body, so it can parse and execute **directly in the parent factory** under a reserved name — reusing the already-built functions and named templates, with no fresh `GoTemplate`, no `ServiceLoader`, and no copy.

## Why it's safe
- The factory is already `missingkey=zero` (the same option the old path set explicitly).
- The reserved name (`__jhelm_tpl_inline__`) can't collide with a chart template path or define name, and is overwritten per call; `execute()` resolves its node at entry, so **nested `tpl` calls stay correct**.
- Strings that declare `{{ define }}` keep the **isolated-child path**, so their defines still merge into the parent via `putIfAbsent` (Helm's global-namespace behaviour) — unchanged.

## Measured impact
60-chart render-only batch (jvmlens diff, vs the post-#573 baseline):

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| `renderInline` CPU | 5% | **GONE** | eliminated |
| `renderInline` allocation | 639 MB | **GONE** | eliminated |
| `TemplateFunctions.*` allocation | 2.1 GB | 1.5 GB | **−26%** |
| Total allocation | 7.5 GB | 7.1 GB | −6% |
| GC pause | 358 ms | 322 ms | −10% |

## Verification
- Full `clean install` green.
- **540/540 parity charts byte-for-byte identical to `helm template`** (0 failures), including tpl-heavy charts and define-inside-tpl charts (which exercise the preserved slow path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)