### PR TITLE
build: adopt gotmpl4j 1.2.0 (from 1.1.5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
              dedicated CI job (see .github/workflows/parity.yml). Override with
              -Dsurefire.excludedGroups= -Dgroups=comparison to run only the parity suite. -->
         <surefire.excludedGroups>comparison</surefire.excludedGroups>
-        <gotmpl4j.version>1.1.5</gotmpl4j.version>
+        <gotmpl4j.version>1.2.0</gotmpl4j.version>
         <kubernetes-client.version>26.0.0</kubernetes-client.version>
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>


### PR DESCRIPTION
## Summary
Bumps the template engine to **gotmpl4j 1.2.0** (from 1.1.5).

For jhelm's dependencies (`gotmpl4j-core` + `gotmpl4j-sprig`), 1.2.0 brings the **lexer/parse-path perf work** that came directly out of profiling jhelm's chart-render path ([gotmpl4j #95](https://github.com/alexmond/gotmpl4j/issues/95) → #96 startsWith-based lexer scans, #97 ArrayList parse nodes + presized token list). The release's other addition — a new `gotmpl4j-spring` module — is not consumed by jhelm.

## Verification
- Full `clean install` green against the released 1.2.0 artifacts from Central.
- **540/540 chart parity byte-for-byte identical to `helm template`** (0 failures).
- Compatibility was also pre-confirmed on the 1.1.6-SNAPSHOT that preceded the release (same core/sprig changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)