### PR TITLE
docs: parity number 346 → 540 (README/index/roadmap)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ the Go-based Helm binary.
 == Why jhelm
 
 * *Helm-faithful rendering, in pure Java* -- jhelm renders chart templates byte-for-byte
-  identically to `helm template` across a continuously-run suite of *346 real-world charts*
+  identically to `helm template` across a continuously-run suite of *540+ real-world charts*
   (Bitnami, Grafana, GitLab, Kubernetes-monitoring, and more), with no Go or `helm` binary.
   Parity is enforced in CI on every change.
 * *Pure JVM, no native binary* -- no `helm` executable, no `exec`, no platform-specific

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -7,7 +7,7 @@ work with Helm charts from the JVM -- without shelling out to the Go-based Helm 
 == Helm-faithful rendering, in pure Java
 
 jhelm renders chart templates *byte-for-byte identically to `helm template`* across a
-continuously-run suite of *346 real-world charts* (Bitnami, Grafana, GitLab,
+continuously-run suite of *540+ real-world charts* (Bitnami, Grafana, GitLab,
 Kubernetes-monitoring, and more) -- in *pure Java, with no Go or `helm` binary*. Parity is
 enforced in CI on every change, so behaviour tracks upstream Helm closely rather than
 approximating it. Rendering is driven by the standalone

--- a/docs/modules/ROOT/pages/roadmap.adoc
+++ b/docs/modules/ROOT/pages/roadmap.adoc
@@ -19,13 +19,13 @@ extraction-ready engine*. The release is cut via `maven_release.yml`
 | *≥ 300 charts* render byte-identical to `helm template` in CI (the `KpsComparisonTest`
   suite, `charts.csv`), order-independent and with only the documented comparison-ignores
   (random/timestamp names, generated secrets/certs).
-| ✅ 346 / 346
+| ✅ 540 / 540
 
 | Engine maturity
 | The Go template + Sprig engine ships as the standalone
   https://github.com/alexmond/gotmpl4j[gotmpl4j] library on Maven Central; jhelm consumes it
-  as a dependency (`gotmpl4j 1.1.0`). The 346-chart suite is its de-facto conformance test.
-| ✅ Extracted — gotmpl4j on Maven Central; 346-chart suite green
+  as a dependency (`gotmpl4j 1.2.0`). The 540-chart suite is its de-facto conformance test.
+| ✅ Extracted — gotmpl4j on Maven Central; 540-chart suite green
 
 | Supported surface
 | All modules ship as supported: `gotemplate`/`sprig`/`helm` (engine), `core` (chart
@@ -53,13 +53,13 @@ extraction-ready engine*. The release is cut via `maven_release.yml`
 
 The Go template engine has been extracted into the standalone
 https://github.com/alexmond/gotmpl4j[gotmpl4j] library, published to Maven Central
-(`org.alexmond:gotmpl4j-core`, `gotmpl4j-sprig`, plus a Spring Boot starter; `gotmpl4j 1.1.0`).
+(`org.alexmond:gotmpl4j-core`, `gotmpl4j-sprig`, plus a Spring Boot starter; `gotmpl4j 1.2.0`).
 jhelm consumes
 it as an ordinary dependency, keeping only the Helm-specific function layer
 (`jhelm-gotemplate-helm`) in this repository. The extraction holds the properties that made it
 mechanical rather than a redesign:
 
-* *Correctness* — no known rendering gaps; the 346-chart parity suite is the conformance
+* *Correctness* — no known rendering gaps; the 540-chart parity suite is the conformance
   bar.
 * *Clean boundary* — the engine has zero dependencies on Sprig, Helm, or `core`; Sprig
   (priority 100) and Helm (priority 200) functions load only via `ServiceLoader`.


### PR DESCRIPTION
performance.adoc cites the grown corpus (540/540 byte-identical), but README/index/roadmap still said 346. Unifies the headline to 540+ before 1.0.0, and bumps the roadmap's stale `gotmpl4j 1.1.0` → `1.2.0`. Closes #551.