### PR TITLE
ci(parity): weekly semi-autonomous chart-version upgrade bot

### DIFF
--- a/.github/workflows/upgrade-charts.yml
+++ b/.github/workflows/upgrade-charts.yml
@@ -1,0 +1,79 @@
+name: Chart Version Upgrade
+
+# Semi-autonomous chart-version updater. Weekly, it resolves the latest upstream
+# version of every pinned chart in charts.csv, renders parity at it, and bumps the pin
+# only for versions that still match `helm template` byte-for-byte. Diverging newer
+# versions keep their old pin and are reported (job summary) for a human to investigate.
+# A review PR is opened only when at least one pin actually changes — never auto-merged.
+
+on:
+  schedule:
+    # Mondays 04:23 UTC — off-peak, after the nightly parity run.
+    - cron: '23 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: chart-upgrade
+  cancel-in-progress: true
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Create Kubernetes Cluster (Kind)
+        uses: helm/kind-action@v1.12.0
+        with:
+          cluster_name: kind
+
+      # Match the helm version jhelm emulates (.Capabilities.HelmVersion in Engine.java),
+      # so version-gated templates (e.g. bitnami common) compare apples-to-apples.
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.0
+
+      # Resolve latest versions, render parity at each, rewrite charts.csv pins for the
+      # ones that still match. Output redirected to files (large per-chart output would
+      # otherwise buffer in the fork's heap).
+      - name: Resolve + validate chart-version upgrades
+        run: >
+          ./mvnw -B -pl jhelm-core -am test
+          -Dtest=KpsComparisonTest#upgradePins
+          -Dsurefire.excludedGroups=
+          -Dgroups=comparison
+          -Dsurefire.failIfNoSpecifiedTests=false
+          -DredirectTestOutputToFile=true
+
+      # Always surface the report (bumped / held-diverging / errors) on the run, even when
+      # nothing bumped — so diverging newer versions are visible without a PR.
+      - name: Publish upgrade report to run summary
+        if: ${{ !cancelled() }}
+        run: cat jhelm-core/target/upgrade-report.md >> "$GITHUB_STEP_SUMMARY" || true
+
+      # Open a review PR only when at least one pin changed. peter-evans/create-pull-request
+      # no-ops when there is no diff, so a week with only held/error charts opens no PR.
+      - name: Open upgrade PR
+        if: ${{ !cancelled() }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/chart-version-upgrade
+          delete-branch: true
+          add-paths: jhelm-core/src/test/resources/charts.csv
+          commit-message: "chore(parity): bump pinned chart versions (still byte-for-byte vs helm)"
+          title: "chore(parity): weekly chart-version upgrade"
+          body-path: jhelm-core/target/upgrade-report.md
+          labels: chart-upgrade

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/KpsComparisonTest.java
@@ -38,6 +38,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -219,6 +220,128 @@ class KpsComparisonTest {
 		compareChart(chartName, "release-" + chartName, repoId, repoUrl, version);
 	}
 
+	/**
+	 * Semi-autonomous chart-version upgrade bot (run on demand by the weekly
+	 * upgrade-charts workflow, never in the normal build). For each pinned chart it
+	 * resolves the latest upstream version and, if newer, renders parity at it: a version
+	 * that still matches Helm byte-for-byte gets its pin bumped in charts.csv; one that
+	 * diverges keeps its current pin and is reported for a human to investigate. Writes a
+	 * markdown summary to target/upgrade-report.md (used as the PR body).
+	 */
+	@Tag("comparison")
+	@Test
+	void upgradePins() throws Exception {
+		Path csv = Path.of("src/test/resources/charts.csv");
+		List<String> lines = Files.readAllLines(csv);
+		List<String> out = new ArrayList<>();
+		List<String> bumped = new ArrayList<>();
+		List<String> held = new ArrayList<>();
+		List<String> errors = new ArrayList<>();
+		for (String line : lines) {
+			String[] p = line.split(",", 4);
+			if (line.isBlank() || line.startsWith("#") || p.length < 4) {
+				out.add(line);
+				continue;
+			}
+			String chart = p[0];
+			String repoId = p[1];
+			String repoUrl = p[2];
+			String pinned = p[3];
+			String newVersion = pinned;
+			try {
+				newVersion = tryUpgrade(chart, repoId, repoUrl, pinned, bumped, held, errors);
+			}
+			catch (Exception ex) {
+				errors.add(chart + ": " + ex.getMessage());
+			}
+			out.add(String.join(",", chart, repoId, repoUrl, newVersion));
+		}
+		Files.writeString(csv, String.join("\n", out) + "\n");
+		writeUpgradeReport(bumped, held, errors);
+		log.info("upgradePins: bumped={} held={} errors={}", bumped.size(), held.size(), errors.size());
+	}
+
+	/**
+	 * Resolves the latest version of one chart and bumps its pin if it still matches
+	 * Helm.
+	 */
+	private String tryUpgrade(String chart, String repoId, String repoUrl, String pinned, List<String> bumped,
+			List<String> held, List<String> errors) throws Exception {
+		if (isSkipped(chart)) {
+			return pinned;
+		}
+		String shortName = chart.contains("/") ? chart.substring(chart.indexOf('/') + 1) : chart;
+		String effectiveRepoUrl = REPO_URL_OVERRIDES.getOrDefault(repoUrl.replaceAll("/+$", ""), repoUrl);
+		addHelmRepo(repoId, effectiveRepoUrl);
+		List<RepoManager.ChartVersion> versions = repoManager.getChartVersions(repoId, shortName);
+		if (versions.isEmpty()) {
+			errors.add(chart + ": no versions found");
+			return pinned;
+		}
+		String latest = versions.getFirst().getChartVersion();
+		if (latest.equals(pinned)) {
+			return pinned;
+		}
+		String releaseName = sanitizeReleaseName("release-" + chart);
+		Map<String, Object> overrides = testProperties.getComparisonValues().getOrDefault(chart, Map.of());
+		fetchFromHelmRepo(chart, latest);
+		File dir = findChartDir(chart, latest);
+		if (dir == null) {
+			errors.add(chart + " " + latest + ": fetch failed");
+			return pinned;
+		}
+		String helm = runHelmInstallDryRun(dir, releaseName, "default", overrides);
+		if (helm == null) {
+			errors.add(chart + " " + latest + ": helm template failed");
+			return pinned;
+		}
+		Chart loaded = chartLoader.load(dir);
+		String jhelm = installAction
+			.install(InstallOptions.builder()
+				.chart(loaded)
+				.releaseName(releaseName)
+				.namespace("default")
+				.values(overrides)
+				.revision(1)
+				.dryRun(true)
+				.build())
+			.getManifest();
+		List<String> fails = computeManifestFailures(chart, jhelm, helm);
+		if (fails.isEmpty()) {
+			bumped.add(chart + ": " + pinned + " -> " + latest);
+			return latest;
+		}
+		held.add(chart + ": " + pinned + " held (latest " + latest + " diverges in " + fails.size() + " resource(s))");
+		return pinned;
+	}
+
+	private void writeUpgradeReport(List<String> bumped, List<String> held, List<String> errors) throws IOException {
+		StringBuilder r = new StringBuilder();
+		r.append("## Chart version upgrade\n\n");
+		r.append("Bumped **")
+			.append(bumped.size())
+			.append("**, held **")
+			.append(held.size())
+			.append("** (diverge), errors **")
+			.append(errors.size())
+			.append("**.\n\n");
+		appendSection(r, "Bumped — still byte-for-byte vs Helm at the new version", bumped);
+		appendSection(r, "Held — newer version diverges, kept old pin (needs investigation)", held);
+		appendSection(r, "Could not check (resolve/fetch/helm error)", errors);
+		Files.writeString(Path.of("target/upgrade-report.md"), r.toString());
+	}
+
+	private void appendSection(StringBuilder r, String title, List<String> items) {
+		if (items.isEmpty()) {
+			return;
+		}
+		r.append("### ").append(title).append("\n\n");
+		for (String item : items) {
+			r.append("- ").append(item).append('\n');
+		}
+		r.append('\n');
+	}
+
 	private List<String[]> readFailedCsv() throws Exception {
 		try (InputStream is = getClass().getResourceAsStream("/failed.csv")) {
 			if (is == null) {
@@ -297,20 +420,7 @@ class KpsComparisonTest {
 
 		// Sanitize release name to be valid for Helm (alphanumeric and hyphens only, no
 		// slashes)
-		String sanitizedReleaseName = releaseName.replaceAll("[^a-z0-9-]", "-").replaceAll("-+", "-");
-		if (sanitizedReleaseName.startsWith("-")) {
-			sanitizedReleaseName = "r" + sanitizedReleaseName;
-		}
-		// Helm rejects release names longer than 53 characters — truncate (charts with
-		// long repo/name combos like prometheus-community/prometheus-blackbox-exporter).
-		// Applied to both Helm and jhelm, so resource names stay consistent.
-		if (sanitizedReleaseName.length() > 53) {
-			sanitizedReleaseName = sanitizedReleaseName.substring(0, 53);
-		}
-		if (sanitizedReleaseName.endsWith("-")) {
-			sanitizedReleaseName = sanitizedReleaseName.substring(0, sanitizedReleaseName.length() - 1);
-		}
-
+		String sanitizedReleaseName = sanitizeReleaseName(releaseName);
 		log.info("Using sanitized release name: {} (from {})", sanitizedReleaseName, releaseName);
 
 		String sanitizedName = chartName.replace("/", "_");
@@ -433,6 +543,32 @@ class KpsComparisonTest {
 
 	private void compareManifests(String chartName, String repoId, String repoUrl, String jhelm, String helm)
 			throws Exception {
+		List<String> failures = computeManifestFailures(chartName, jhelm, helm);
+		if (failures.isEmpty()) {
+			log.info("{} - All resources match Helm output!", chartName);
+			return;
+		}
+		StringBuilder msg = new StringBuilder();
+		msg.append(chartName).append(" - ").append(failures.size()).append(" comparison failure(s):\n");
+		for (String f : failures) {
+			msg.append("  - ").append(f).append('\n');
+		}
+		msg.append("  failed.csv: ")
+			.append(chartName)
+			.append(',')
+			.append(repoId)
+			.append(',')
+			.append(repoUrl)
+			.append('\n');
+		fail(msg.toString());
+	}
+
+	/**
+	 * Renders the per-resource diff between jhelm and helm output and returns the list of
+	 * un-ignored comparison failures (empty when they match). Shared by the asserting
+	 * comparison and the version-upgrade bot, which needs the result without failing.
+	 */
+	private List<String> computeManifestFailures(String chartName, String jhelm, String helm) throws Exception {
 		// Parse both manifests into YAML documents
 		List<JsonNode> jhelmDocs = parseYamlDocuments(jhelm);
 		List<JsonNode> helmDocs = parseYamlDocuments(helm);
@@ -499,24 +635,7 @@ class KpsComparisonTest {
 			}
 		}
 
-		if (failures.isEmpty()) {
-			log.info("{} - All resources match Helm output!", chartName);
-		}
-		else {
-			StringBuilder msg = new StringBuilder();
-			msg.append(chartName).append(" - ").append(failures.size()).append(" comparison failure(s):\n");
-			for (String f : failures) {
-				msg.append("  - ").append(f).append('\n');
-			}
-			msg.append("  failed.csv: ")
-				.append(chartName)
-				.append(',')
-				.append(repoId)
-				.append(',')
-				.append(repoUrl)
-				.append('\n');
-			fail(msg.toString());
-		}
+		return failures;
 	}
 
 	private List<JsonNode> parseYamlDocuments(String yaml) throws Exception {
@@ -730,6 +849,24 @@ class KpsComparisonTest {
 			}
 		}
 		return sb.toString();
+	}
+
+	/**
+	 * Sanitize a release name to Helm's rules (alphanumeric/hyphen, leading char,
+	 * &le;53).
+	 */
+	private String sanitizeReleaseName(String releaseName) {
+		String name = releaseName.replaceAll("[^a-z0-9-]", "-").replaceAll("-+", "-");
+		if (name.startsWith("-")) {
+			name = "r" + name;
+		}
+		if (name.length() > 53) {
+			name = name.substring(0, 53);
+		}
+		if (name.endsWith("-")) {
+			name = name.substring(0, name.length() - 1);
+		}
+		return name;
 	}
 
 	private File findChartDir(String chartFullName, String version) {


### PR DESCRIPTION
## Summary
Phase 2 of the reproducible-parity plan (Phase 1 = version pinning, #580). A weekly bot keeps the pins fresh **without** reintroducing drift.

For each pinned chart, `upgradePins` resolves the latest upstream version and, if newer, **renders parity at it**:
- still byte-for-byte vs `helm template` → **bump the pin** in `charts.csv`.
- diverges → **keep the old pin** and report it (never silently bumped).

It writes `target/upgrade-report.md` (bumped / held-diverging / errors).

## The workflow (`upgrade-charts.yml`, Mondays)
1. Runs `upgradePins` with helm pinned to jhelm's emulated **v3.16.0** (apples-to-apples).
2. **Always** publishes the report to the run summary — so diverging newer versions are visible even on a week with no bumps.
3. Opens a **review PR** (`peter-evans/create-pull-request`) only when a pin actually changes — **never auto-merged** (your "semi-autonomous, keep-old-pin-and-report" choice).

## Code
- Refactors `compareManifests` to delegate to a returning `computeManifestFailures` (shared by the asserting comparison and the bot); extracts `sanitizeReleaseName`.
- `upgradePins` is `@Tag("comparison")` so it never runs in the normal build.

## Verification
`upgradePins` bumps a passing newer version (grafana `10.5.14 → 10.5.15`, rendered + matched) and leaves current pins untouched; the asserting comparison path is unchanged (redis-ha still matches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)