### PR TITLE
docs: prep 0.4.1 + exclude sample modules from Central (#560)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 = jhelm
-:jhelm-version: 0.4.0
+:jhelm-version: 0.4.1
 :url-docs: https://www.alexmond.org/jhelm/current/index.html
 :url-docs-mcp: https://www.alexmond.org/jhelm/current/mcp.html
 :url-docs-rest: https://www.alexmond.org/jhelm/current/rest-api.html

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -4,7 +4,7 @@ version: master
 start_page: ROOT:index.adoc
 asciidoc:
   attributes:
-    jhelm-version: 0.4.0
+    jhelm-version: 0.4.1
     toc: left
     sectnums: ''
     keywords: 'Helm, Java, Kubernetes, Spring Boot, Chart management, Template engine'

--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,15 @@
                         <publishingServerId>central</publishingServerId>
                         <autoPublish>true</autoPublish>
                         <waitUntil>published</waitUntil>
+                        <!-- The sample/demo modules are apps, not libraries — keep them out
+                             of the Central bundle. central-publishing ignores
+                             maven.deploy.skip, so excludeArtifacts on the aggregator config
+                             is the safe lever (drops just these artifactIds). (#560) -->
+                        <excludeArtifacts>
+                            <excludeArtifact>jhelm-sample</excludeArtifact>
+                            <excludeArtifact>jhelm-rest-sample</excludeArtifact>
+                            <excludeArtifact>jhelm-mcp-sample</excludeArtifact>
+                        </excludeArtifacts>
                     </configuration>
                 </plugin>
                 <!-- Generate JavaDoc JAR -->


### PR DESCRIPTION
Release prep for **0.4.1**:
- Bump `jhelm-version` (docs/antora.yml + README.adoc) `0.4.0 → 0.4.1` so the install snippets match the release.
- **Fixes #560** — exclude `jhelm-sample`, `jhelm-rest-sample`, `jhelm-mcp-sample` from the Central bundle via `central-publishing` `excludeArtifacts` (they're demo apps, not libraries; the plugin ignores `maven.deploy.skip`).

Full `clean install` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)