### PR TITLE
fix(security): reject path-traversal repository names (#502)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.Locale;
 import java.util.Map;
 
@@ -170,6 +171,7 @@ public class RepoManager {
 	}
 
 	public void addRepo(String name, String url) throws IOException {
+		validateRepoName(name);
 		RepositoryConfig config = loadConfig();
 		config.getRepositories().removeIf((r) -> r.getName().equals(name));
 		RepositoryConfig.Repository repo = RepositoryConfig.Repository.builder().name(name).url(url).build();
@@ -220,7 +222,22 @@ public class RepoManager {
 		return base;
 	}
 
+	// A repository name is used directly as a filename component for its on-disk index
+	// cache, and repo names are attacker-controllable (e.g. the REST add-repo endpoint).
+	// Restrict them to a single safe path segment so a name like "../../etc/foo" can't
+	// escape the cache directory when the index is written.
+	private static final Pattern SAFE_REPO_NAME = Pattern.compile("^[A-Za-z0-9._-]+$");
+
+	private static void validateRepoName(String repoName) {
+		if (repoName == null || repoName.isBlank() || ".".equals(repoName) || "..".equals(repoName)
+				|| !SAFE_REPO_NAME.matcher(repoName).matches()) {
+			throw new IllegalArgumentException("Invalid repository name '" + repoName
+					+ "': must match [A-Za-z0-9._-]+ and contain no path separators");
+		}
+	}
+
 	private File getIndexCacheFile(String repoName) {
+		validateRepoName(repoName);
 		return new File(getCacheDir(), repoName + "-index.yaml");
 	}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
@@ -15,6 +15,7 @@ import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.stubbing.Answer;
 
@@ -84,6 +85,15 @@ class RepoManagerTest {
 	void testRepoNotFound() {
 		RepoManager repoManager = new RepoManager();
 		assertThrows(IOException.class, () -> repoManager.getChartVersions("non-existent", "nginx"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "../evil", "../../etc/cron.d/x", "a/b", "a\\b", "..", ".", "with space", "name;rm" })
+	void testAddRepoRejectsUnsafeNames(String badName) {
+		RepoManager repoManager = new RepoManager();
+		// validateRepoName runs before any file I/O, so a traversal name can never write
+		// its index cache outside the cache directory.
+		assertThrows(IllegalArgumentException.class, () -> repoManager.addRepo(badName, "https://example.com"));
 	}
 
 	@Test


### PR DESCRIPTION
First concrete item from #502 (Security hardening, High).

## Vulnerability
`RepoManager.getIndexCacheFile(name)` builds `new File(cacheDir, name + "-index.yaml")` with **no sanitization**, and repo names are attacker-controllable (the REST `add-repo` endpoint takes a name). A name like `../../etc/cron.d/x` escapes the cache directory when the downloaded index is written (`new FileOutputStream(getIndexCacheFile(name))`) — an **arbitrary-file-write** primitive.

## Fix
Validate repo names against a single safe path segment (`[A-Za-z0-9._-]+`, rejecting `.`/`..` and anything with a path separator):
- at the **choke point** `getIndexCacheFile` (defense-in-depth — covers every caller), and
- **early in `addRepo`** (before the name is persisted or any file I/O runs).

Real helm repo names (`bitnami`, `prometheus-community`, …) all pass. Added a parameterized test asserting traversal/separator names are rejected before any I/O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)