### PR TITLE
fix(security): RFC-1123 validation of release names + namespaces (#502)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.core.action;
 
+import org.alexmond.jhelm.core.util.ReleaseNames;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -58,6 +59,8 @@ public class InstallAction {
 	 * @throws JhelmException if rendering or a cluster operation fails
 	 */
 	public Release install(InstallOptions options) {
+		ReleaseNames.validateReleaseName(options.getReleaseName());
+		ReleaseNames.validateNamespace(options.getNamespace());
 		Chart chart = options.getChart();
 		if ("library".equals(chart.getMetadata().getType())) {
 			throw new IllegalArgumentException(

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ReleaseNames.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ReleaseNames.java
@@ -1,0 +1,75 @@
+package org.alexmond.jhelm.core.util;
+
+import java.util.regex.Pattern;
+
+/**
+ * RFC-1123 (Kubernetes DNS) validation for Helm release names and namespaces.
+ *
+ * <p>
+ * A release name is embedded in the release-storage Secret name
+ * ({@code sh.helm.release.v1.<name>.v<rev>}) and stamped into resource labels, and a
+ * namespace must be a DNS-1123 label, so both are validated at the action boundary before
+ * any Secret name or label is built — an invalid name would otherwise produce a malformed
+ * Secret name or labels rejected by the Kubernetes API.
+ */
+public final class ReleaseNames {
+
+	/**
+	 * Helm caps release names at 53 characters (leaves room in the 253-char Secret name).
+	 */
+	private static final int MAX_RELEASE_NAME = 53;
+
+	/** Kubernetes namespaces are DNS-1123 labels, capped at 63 characters. */
+	private static final int MAX_NAMESPACE = 63;
+
+	/**
+	 * DNS-1123 subdomain: lowercase alphanumeric, {@code -} or {@code .}, start/end
+	 * alphanumeric.
+	 */
+	private static final Pattern RELEASE_NAME = Pattern.compile("^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$");
+
+	/** DNS-1123 label: lowercase alphanumeric or {@code -}, start/end alphanumeric. */
+	private static final Pattern NAMESPACE = Pattern.compile("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$");
+
+	private ReleaseNames() {
+	}
+
+	/**
+	 * Validates a Helm release name (RFC-1123, &le; 53 chars).
+	 * @param name the release name
+	 * @throws IllegalArgumentException if the name is empty, too long, or not RFC-1123
+	 */
+	public static void validateReleaseName(String name) {
+		if (name == null || name.isBlank()) {
+			throw new IllegalArgumentException("Release name must not be empty");
+		}
+		if (name.length() > MAX_RELEASE_NAME) {
+			throw new IllegalArgumentException(
+					"Release name '" + name + "' exceeds the " + MAX_RELEASE_NAME + "-character limit");
+		}
+		if (!RELEASE_NAME.matcher(name).matches()) {
+			throw new IllegalArgumentException("Invalid release name '" + name
+					+ "': must be a lowercase RFC-1123 name (alphanumeric, '-' or '.', starting and ending "
+					+ "with alphanumeric)");
+		}
+	}
+
+	/**
+	 * Validates a Kubernetes namespace (RFC-1123 label, &le; 63 chars). A {@code null} or
+	 * blank namespace is allowed and means "the default namespace", resolved downstream.
+	 * @param namespace the namespace, or {@code null}/blank for the default
+	 * @throws IllegalArgumentException if a non-blank namespace is too long or not
+	 * RFC-1123
+	 */
+	public static void validateNamespace(String namespace) {
+		if (namespace == null || namespace.isBlank()) {
+			return;
+		}
+		if (namespace.length() > MAX_NAMESPACE || !NAMESPACE.matcher(namespace).matches()) {
+			throw new IllegalArgumentException("Invalid namespace '" + namespace
+					+ "': must be a lowercase RFC-1123 label (alphanumeric or '-', starting and ending with "
+					+ "alphanumeric, at most " + MAX_NAMESPACE + " characters)");
+		}
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ReleaseNamesTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ReleaseNamesTest.java
@@ -1,0 +1,47 @@
+package org.alexmond.jhelm.core.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ReleaseNamesTest {
+
+	@ParameterizedTest
+	@ValueSource(strings = { "myrelease", "release-grafana-grafana", "a", "r1.2.3", "prom-1" })
+	void acceptsValidReleaseNames(String name) {
+		assertDoesNotThrow(() -> ReleaseNames.validateReleaseName(name));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "", " ", "-bad", "bad-", "Upper", "with space", "a/b", "a..b/../c", "name_underscore" })
+	void rejectsInvalidReleaseNames(String name) {
+		assertThrows(IllegalArgumentException.class, () -> ReleaseNames.validateReleaseName(name));
+	}
+
+	@Test
+	void rejectsTooLongReleaseName() {
+		assertThrows(IllegalArgumentException.class, () -> ReleaseNames.validateReleaseName("a".repeat(54)));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "default", "kube-system", "ns1", "a" })
+	void acceptsValidNamespaces(String ns) {
+		assertDoesNotThrow(() -> ReleaseNames.validateNamespace(ns));
+	}
+
+	@Test
+	void allowsBlankNamespaceAsDefault() {
+		assertDoesNotThrow(() -> ReleaseNames.validateNamespace(null));
+		assertDoesNotThrow(() -> ReleaseNames.validateNamespace(""));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "Bad", "ns_1", "a/b", "-ns", "ns-", "with.dot" })
+	void rejectsInvalidNamespaces(String ns) {
+		assertThrows(IllegalArgumentException.class, () -> ReleaseNames.validateNamespace(ns));
+	}
+
+}


### PR DESCRIPTION
Next item from #502 (Security hardening, High).

The release name is embedded in the release-storage Secret name (`sh.helm.release.v1.<name>.v<rev>`) and stamped into resource labels. An unvalidated name (from a CLI/REST/MCP caller) could yield a malformed Secret name or labels the Kubernetes API rejects.

**Fix:** a `ReleaseNames` helper validating release names (DNS-1123 subdomain, ≤53 chars) and namespaces (DNS-1123 label, ≤63 chars; blank = default namespace), enforced at the **install boundary** (`InstallAction`) — where untrusted names first enter. Upgrade/uninstall/rollback inherit the name from the already-validated installed release, so they don't re-validate.

Unit-tested (`ReleaseNamesTest`); the in-build parity-single + full jhelm-core suite stay green (sanitized release names are valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)