### PR TITLE
fix(security): SSRF guard on chart/index HTTP fetches (#502)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
@@ -96,6 +96,7 @@ final class RepoHttpClientFactory {
 					: new DefaultClientTlsStrategy(sslContext);
 			HttpClientConnectionManager connManager = PoolingHttpClientConnectionManagerBuilder.create()
 				.setTlsSocketStrategy(tlsStrategy)
+				.setDnsResolver(new SsrfGuardingDnsResolver())
 				.build();
 			return HttpClients.custom().setConnectionManager(connManager).build();
 		}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.core.service;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -61,6 +62,12 @@ final class RepoHttpClientFactory {
 
 	<T> T executeGet(HttpGet request, RepositoryConfig.Repository repo, HttpClientResponseHandler<T> handler)
 			throws IOException {
+		try {
+			UrlSecurity.validateFetchUrl(request.getUri());
+		}
+		catch (URISyntaxException ex) {
+			throw new IOException("Invalid request URI: " + ex.getMessage(), ex);
+		}
 		configureAuth(request, repo);
 		if (needsCustomTls(repo)) {
 			try (CloseableHttpClient client = buildTlsClient(repo)) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -11,6 +11,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.core5.http.HttpEntity;
 
 import java.io.BufferedInputStream;
@@ -134,15 +135,16 @@ public class RepoManager {
 	}
 
 	private void initHttpClient() {
-		try {
-			httpClient = HttpClients.createDefault();
-		}
-		catch (Exception ex) {
-			if (log.isErrorEnabled()) {
-				log.error("Failed to initialize HTTP client", ex);
-			}
-			httpClient = HttpClients.createDefault();
-		}
+		// SSRF-validating DNS resolver: a host resolving to loopback/cloud-metadata is
+		// refused at connect time and the connection is pinned to the validated addresses
+		// (no rebinding window). The client owns and closes the connection manager.
+		// Shared
+		// with the OCI client below.
+		httpClient = HttpClients.custom()
+			.setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create()
+				.setDnsResolver(new SsrfGuardingDnsResolver())
+				.build())
+			.build();
 		httpClientFactory = new RepoHttpClientFactory(httpClient, insecureSkipTlsVerify);
 		ociClient = new OciRegistryClient(httpClient);
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SsrfGuardingDnsResolver.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SsrfGuardingDnsResolver.java
@@ -1,0 +1,35 @@
+package org.alexmond.jhelm.core.service;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.apache.hc.client5.http.SystemDefaultDnsResolver;
+
+/**
+ * A {@link org.apache.hc.client5.http.DnsResolver} that refuses to hand back any address
+ * pointing at a non-routable/internal target, closing the SSRF gap a URL-only check
+ * can't: a host given as a DNS <em>name</em> that resolves to loopback or the
+ * cloud-metadata range ({@code 169.254.169.254}) is rejected here. Because resolution
+ * happens once in the resolver and the connection is pinned to the exact addresses it
+ * returns, there is no resolve-then-reconnect (DNS-rebinding/TOCTOU) window.
+ *
+ * <p>
+ * This is the resolution the HTTP client already performs at connect time, so it adds no
+ * extra lookup; {@link UrlSecurity} still rejects bad schemes, {@code localhost} and
+ * literal internal IPs up front before a connection is ever opened.
+ */
+final class SsrfGuardingDnsResolver extends SystemDefaultDnsResolver {
+
+	@Override
+	public InetAddress[] resolve(String host) throws UnknownHostException {
+		InetAddress[] addresses = super.resolve(host);
+		for (InetAddress address : addresses) {
+			if (UrlSecurity.isInternalAddress(address)) {
+				throw new SecurityException("Refusing to connect to non-routable/internal address ("
+						+ address.getHostAddress() + ") resolved from host '" + host + "'");
+			}
+		}
+		return addresses;
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/UrlSecurity.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/UrlSecurity.java
@@ -46,7 +46,10 @@ public final class UrlSecurity {
 			addresses = InetAddress.getAllByName(host);
 		}
 		catch (UnknownHostException ex) {
-			throw new SecurityException("Refusing to fetch URL with unresolvable host '" + host + "': " + uri);
+			// A host that doesn't resolve can't reach anything internal, so it's not an
+			// SSRF risk — let the HTTP layer fail the connection naturally rather than
+			// turning a (possibly transient) DNS miss into a security rejection.
+			return;
 		}
 		for (InetAddress address : addresses) {
 			if (isBlocked(address)) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/UrlSecurity.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/UrlSecurity.java
@@ -1,0 +1,66 @@
+package org.alexmond.jhelm.core.service;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * SSRF guard for outbound fetches (chart archives, repo indexes). It rejects URLs whose
+ * scheme isn't HTTP(S)/OCI and whose host resolves to an address that is never a
+ * legitimate chart repository — loopback, link-local (the cloud-metadata {@code
+ * 169.254.0.0/16} range), the wildcard address, or multicast.
+ *
+ * <p>
+ * Private/site-local ranges ({@code 10/8}, {@code 172.16/12}, {@code 192.168/16}) are
+ * <em>not</em> blocked by default so a CLI pull from a private/internal repo still works;
+ * blocking those too is a stricter server-mode policy left for a follow-up.
+ */
+public final class UrlSecurity {
+
+	private static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https", "oci");
+
+	private UrlSecurity() {
+	}
+
+	/**
+	 * Validates that {@code uri} is safe to fetch, throwing {@link SecurityException}
+	 * (unchecked, so it aborts the fetch) when it is not.
+	 * @param uri the URI about to be fetched
+	 */
+	public static void validateFetchUrl(URI uri) {
+		if (uri == null) {
+			throw new SecurityException("Refusing to fetch a null URL");
+		}
+		String scheme = uri.getScheme();
+		if (scheme == null || !ALLOWED_SCHEMES.contains(scheme.toLowerCase(Locale.ROOT))) {
+			throw new SecurityException("Refusing to fetch URL with disallowed scheme '" + scheme + "': " + uri);
+		}
+		String host = uri.getHost();
+		if (host == null || host.isBlank()) {
+			throw new SecurityException("Refusing to fetch URL with no host: " + uri);
+		}
+		InetAddress[] addresses;
+		try {
+			addresses = InetAddress.getAllByName(host);
+		}
+		catch (UnknownHostException ex) {
+			throw new SecurityException("Refusing to fetch URL with unresolvable host '" + host + "': " + uri);
+		}
+		for (InetAddress address : addresses) {
+			if (isBlocked(address)) {
+				throw new SecurityException("Refusing to fetch URL resolving to a non-routable/internal address ("
+						+ address.getHostAddress() + "): " + uri);
+			}
+		}
+	}
+
+	private static boolean isBlocked(InetAddress address) {
+		// Loopback (127/8, ::1), link-local (169.254/16 cloud metadata, fe80::/10), the
+		// wildcard (0.0.0.0, ::) and multicast are never a real chart repo.
+		return address.isLoopbackAddress() || address.isLinkLocalAddress() || address.isAnyLocalAddress()
+				|| address.isMulticastAddress();
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/UrlSecurity.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/UrlSecurity.java
@@ -15,18 +15,19 @@ import java.util.regex.Pattern;
  * multicast.
  *
  * <p>
- * The guard deliberately does <em>not</em> resolve DNS names. An eager lookup on the
- * fetch hot path is an unbounded blocking call (a hang/DoS risk with no socket timeout),
- * and because the HTTP client resolves the host independently when it connects, a lookup
- * here can't reliably close the DNS-rebinding hole anyway — only pinning the resolved
- * address at connection time would, which is a stricter server-mode policy left for a
- * follow-up. So a host given as a literal internal IP is blocked, but a <em>name</em>
- * that resolves to one is left for the HTTP layer.
+ * This URL-level check deliberately does <em>not</em> resolve DNS names — an eager lookup
+ * on the fetch hot path is an unbounded blocking call, and a lookup here couldn't close
+ * the DNS-rebinding hole anyway (the HTTP client resolves independently when it
+ * connects). The case of a <em>name</em> that resolves to an internal address is instead
+ * handled at connection time by {@link SsrfGuardingDnsResolver}, which validates the
+ * addresses the client actually resolves and pins the connection to them, leaving no
+ * resolve-then- reconnect window. So between the two: a literal internal IP is rejected
+ * here up front, and a name resolving to one is rejected at connect time.
  *
  * <p>
  * Private/site-local ranges ({@code 10/8}, {@code 172.16/12}, {@code 192.168/16}) are
- * also <em>not</em> blocked by default so a CLI pull from a private/internal repo still
- * works; blocking those too is part of the same stricter server-mode policy.
+ * <em>not</em> blocked by default so a CLI pull from a private/internal repo still works;
+ * blocking those too is a stricter server-mode policy left for a follow-up.
  */
 public final class UrlSecurity {
 
@@ -62,7 +63,7 @@ public final class UrlSecurity {
 			throw new SecurityException("Refusing to fetch URL targeting localhost: " + uri);
 		}
 		InetAddress literal = parseIpLiteral(host);
-		if (literal != null && isBlocked(literal)) {
+		if (literal != null && isInternalAddress(literal)) {
 			throw new SecurityException("Refusing to fetch URL targeting a non-routable/internal address ("
 					+ literal.getHostAddress() + "): " + uri);
 		}
@@ -116,9 +117,15 @@ public final class UrlSecurity {
 		return true;
 	}
 
-	private static boolean isBlocked(InetAddress address) {
-		// Loopback (127/8, ::1), link-local (169.254/16 cloud metadata, fe80::/10), the
-		// wildcard (0.0.0.0, ::) and multicast are never a real chart repo.
+	/**
+	 * Whether {@code address} is one a chart repository should never resolve to —
+	 * loopback (127/8, ::1), link-local (169.254/16 cloud metadata, fe80::/10), the
+	 * wildcard (0.0.0.0, ::) or multicast. Shared with {@link SsrfGuardingDnsResolver},
+	 * which applies it to the addresses a DNS <em>name</em> actually resolves to.
+	 * @param address a resolved or literal address
+	 * @return {@code true} if the address is internal/non-routable
+	 */
+	static boolean isInternalAddress(InetAddress address) {
 		return address.isLoopbackAddress() || address.isLinkLocalAddress() || address.isAnyLocalAddress()
 				|| address.isMulticastAddress();
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/UrlSecurity.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/UrlSecurity.java
@@ -5,21 +5,37 @@ import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * SSRF guard for outbound fetches (chart archives, repo indexes). It rejects URLs whose
- * scheme isn't HTTP(S)/OCI and whose host resolves to an address that is never a
- * legitimate chart repository — loopback, link-local (the cloud-metadata {@code
- * 169.254.0.0/16} range), the wildcard address, or multicast.
+ * scheme isn't HTTP(S)/OCI, that target {@code localhost}, or whose host is a numeric IP
+ * literal in a range that never names a legitimate chart repository — loopback,
+ * link-local (the cloud-metadata {@code 169.254.0.0/16} range), the wildcard address, or
+ * multicast.
+ *
+ * <p>
+ * The guard deliberately does <em>not</em> resolve DNS names. An eager lookup on the
+ * fetch hot path is an unbounded blocking call (a hang/DoS risk with no socket timeout),
+ * and because the HTTP client resolves the host independently when it connects, a lookup
+ * here can't reliably close the DNS-rebinding hole anyway — only pinning the resolved
+ * address at connection time would, which is a stricter server-mode policy left for a
+ * follow-up. So a host given as a literal internal IP is blocked, but a <em>name</em>
+ * that resolves to one is left for the HTTP layer.
  *
  * <p>
  * Private/site-local ranges ({@code 10/8}, {@code 172.16/12}, {@code 192.168/16}) are
- * <em>not</em> blocked by default so a CLI pull from a private/internal repo still works;
- * blocking those too is a stricter server-mode policy left for a follow-up.
+ * also <em>not</em> blocked by default so a CLI pull from a private/internal repo still
+ * works; blocking those too is part of the same stricter server-mode policy.
  */
 public final class UrlSecurity {
 
 	private static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https", "oci");
+
+	/**
+	 * IPv6 literals are the only hostnames made up purely of hex digits, colons and dots.
+	 */
+	private static final Pattern IPV6_LITERAL_CHARS = Pattern.compile("^[0-9A-Fa-f:.]+$");
 
 	private UrlSecurity() {
 	}
@@ -41,22 +57,63 @@ public final class UrlSecurity {
 		if (host == null || host.isBlank()) {
 			throw new SecurityException("Refusing to fetch URL with no host: " + uri);
 		}
-		InetAddress[] addresses;
+		String lower = host.toLowerCase(Locale.ROOT);
+		if (lower.equals("localhost") || lower.endsWith(".localhost")) {
+			throw new SecurityException("Refusing to fetch URL targeting localhost: " + uri);
+		}
+		InetAddress literal = parseIpLiteral(host);
+		if (literal != null && isBlocked(literal)) {
+			throw new SecurityException("Refusing to fetch URL targeting a non-routable/internal address ("
+					+ literal.getHostAddress() + "): " + uri);
+		}
+	}
+
+	/**
+	 * Parses {@code host} as a numeric IP literal without any network lookup, returning
+	 * {@code null} when it is a DNS name (which is intentionally not resolved here).
+	 * @param host the URI host, possibly bracketed for IPv6
+	 * @return the parsed address, or {@code null} if {@code host} is not an IP literal
+	 */
+	private static InetAddress parseIpLiteral(String host) {
+		String h = host;
+		if (h.length() > 1 && h.charAt(0) == '[' && h.charAt(h.length() - 1) == ']') {
+			h = h.substring(1, h.length() - 1);
+		}
+		boolean ipv6 = h.indexOf(':') >= 0 && IPV6_LITERAL_CHARS.matcher(h).matches();
+		if (!ipv6 && !isIpv4Literal(h)) {
+			return null;
+		}
 		try {
-			addresses = InetAddress.getAllByName(host);
+			// Safe: a syntactically valid IP literal is parsed by getByName with no DNS
+			// query.
+			return InetAddress.getByName(h);
 		}
 		catch (UnknownHostException ex) {
-			// A host that doesn't resolve can't reach anything internal, so it's not an
-			// SSRF risk — let the HTTP layer fail the connection naturally rather than
-			// turning a (possibly transient) DNS miss into a security rejection.
-			return;
+			return null;
 		}
-		for (InetAddress address : addresses) {
-			if (isBlocked(address)) {
-				throw new SecurityException("Refusing to fetch URL resolving to a non-routable/internal address ("
-						+ address.getHostAddress() + "): " + uri);
+	}
+
+	private static boolean isIpv4Literal(String h) {
+		String[] parts = h.split("\\.", -1);
+		if (parts.length != 4) {
+			return false;
+		}
+		for (String part : parts) {
+			if (part.isEmpty() || part.length() > 3) {
+				return false;
+			}
+			int value;
+			try {
+				value = Integer.parseInt(part);
+			}
+			catch (NumberFormatException ex) {
+				return false;
+			}
+			if (value < 0 || value > 255) {
+				return false;
 			}
 		}
+		return true;
 	}
 
 	private static boolean isBlocked(InetAddress address) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/SsrfGuardingDnsResolverTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/SsrfGuardingDnsResolverTest.java
@@ -1,0 +1,32 @@
+package org.alexmond.jhelm.core.service;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SsrfGuardingDnsResolverTest {
+
+	private final SsrfGuardingDnsResolver resolver = new SsrfGuardingDnsResolver();
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			// resolves to loopback via /etc/hosts; literal loopback / metadata / wildcard
+			"localhost", "127.0.0.1", "169.254.169.254", "0.0.0.0" })
+	void refusesInternalTargets(String host) {
+		assertThrows(SecurityException.class, () -> resolver.resolve(host));
+	}
+
+	@Test
+	void allowsPublicLiteral() throws UnknownHostException {
+		// a public IP literal is parsed without a network lookup and passes through
+		InetAddress[] addresses = resolver.resolve("203.0.113.7");
+		assertTrue(addresses.length >= 1);
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/UrlSecurityTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/UrlSecurityTest.java
@@ -11,8 +11,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class UrlSecurityTest {
 
 	@ParameterizedTest
-	@ValueSource(
-			strings = { "https://charts.bitnami.com/bitnami/index.yaml", "http://example.com/charts/app-1.0.0.tgz" })
+	@ValueSource(strings = { "https://charts.bitnami.com/bitnami/index.yaml", "http://example.com/charts/app-1.0.0.tgz",
+			// a DNS name is NOT resolved here (no network lookup), even an all-hex-ish
+			// one,
+			// so any name is allowed and the HTTP layer connects normally; a public
+			// literal
+			// IP is allowed too
+			"https://cafe.example.com/x", "https://203.0.113.7/charts/index.yaml" })
 	void allowsPublicHttpUrls(String url) {
 		assertDoesNotThrow(() -> UrlSecurity.validateFetchUrl(URI.create(url)));
 	}
@@ -21,7 +26,9 @@ class UrlSecurityTest {
 	@ValueSource(strings = {
 			// cloud metadata (link-local), localhost (loopback), wildcard
 			"http://169.254.169.254/latest/meta-data/", "http://127.0.0.1:8080/admin", "https://localhost/index.yaml",
-			"http://0.0.0.0/x",
+			"https://sub.localhost/index.yaml", "http://0.0.0.0/x",
+			// IPv6 literals: loopback and link-local
+			"http://[::1]/x", "http://[fe80::1]/x",
 			// disallowed schemes
 			"file:///etc/passwd", "ftp://example.com/x", "gopher://example.com/x" })
 	void blocksSsrfTargetsAndBadSchemes(String url) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/UrlSecurityTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/UrlSecurityTest.java
@@ -1,0 +1,31 @@
+package org.alexmond.jhelm.core.service;
+
+import java.net.URI;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UrlSecurityTest {
+
+	@ParameterizedTest
+	@ValueSource(
+			strings = { "https://charts.bitnami.com/bitnami/index.yaml", "http://example.com/charts/app-1.0.0.tgz" })
+	void allowsPublicHttpUrls(String url) {
+		assertDoesNotThrow(() -> UrlSecurity.validateFetchUrl(URI.create(url)));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			// cloud metadata (link-local), localhost (loopback), wildcard
+			"http://169.254.169.254/latest/meta-data/", "http://127.0.0.1:8080/admin", "https://localhost/index.yaml",
+			"http://0.0.0.0/x",
+			// disallowed schemes
+			"file:///etc/passwd", "ftp://example.com/x", "gopher://example.com/x" })
+	void blocksSsrfTargetsAndBadSchemes(String url) {
+		assertThrows(SecurityException.class, () -> UrlSecurity.validateFetchUrl(URI.create(url)));
+	}
+
+}


### PR DESCRIPTION
#502 (Security hardening, High) — SSRF guards.

Outbound chart-archive and repo-index fetches had **no destination checks**, so a caller-influenced URL (via REST/MCP) could make jhelm request internal targets — most dangerously the **cloud-metadata endpoint** (`169.254.169.254`, which hands out IAM credentials) or `localhost`/internal services.

**Fix:** a `UrlSecurity` guard at the HTTP choke point (`RepoHttpClientFactory.executeGet`, which every index + chart GET flows through):
- allow only `http`/`https`/`oci` schemes;
- reject hosts resolving to **loopback, link-local (cloud metadata), wildcard, or multicast** addresses.

Private/site-local ranges (`10/8`, `172.16/12`, `192.168/16`) are **intentionally not blocked by default** so a CLI pull from a private/internal repo still works — a stricter server-mode "block private too" policy is a follow-up, as is the OCI redirect-follow path (`OciRegistryClient`).

Unit-tested (`UrlSecurityTest`, 9 cases: public URLs pass; metadata/localhost/wildcard + bad schemes rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)