### PR TITLE
fix(security): validate OCI blob redirect targets, cap redirect depth (#502)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/OciRegistryClient.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/OciRegistryClient.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -179,10 +181,29 @@ class OciRegistryClient {
 	}
 
 	/**
+	 * Caps the redirect chain when downloading a blob, so a redirect loop can't recurse
+	 * forever.
+	 */
+	private static final int MAX_BLOB_REDIRECTS = 10;
+
+	/**
 	 * Downloads a blob to a local file, following redirects.
 	 */
 	void downloadBlob(String urlStr, String token, File destFile) throws IOException {
+		downloadBlob(urlStr, token, destFile, MAX_BLOB_REDIRECTS);
+	}
+
+	private void downloadBlob(String urlStr, String token, File destFile, int redirectsLeft) throws IOException {
 		destFile.getParentFile().mkdirs();
+
+		// SSRF guard on the initial URL and every redirect target: a registry-controlled
+		// Location could otherwise point at file://, localhost, or the cloud-metadata IP.
+		try {
+			UrlSecurity.validateFetchUrl(new URI(urlStr));
+		}
+		catch (URISyntaxException ex) {
+			throw new IOException("Invalid OCI blob URL '" + urlStr + "': " + ex.getMessage(), ex);
+		}
 
 		HttpGet httpGet = new HttpGet(urlStr);
 		if (token != null) {
@@ -192,8 +213,17 @@ class OciRegistryClient {
 		httpClient.execute(httpGet, (response) -> {
 			int status = response.getCode();
 			if (status == 301 || status == 302 || status == 307 || status == 308) {
-				String newUrl = response.getFirstHeader("Location").getValue();
-				downloadBlob(newUrl, null, destFile);
+				if (redirectsLeft <= 0) {
+					throw new IOException("Too many redirects downloading OCI blob from " + urlStr);
+				}
+				Header location = response.getFirstHeader("Location");
+				if (location == null || location.getValue() == null || location.getValue().isBlank()) {
+					throw new IOException("OCI blob redirect (" + status + ") with no Location header from " + urlStr);
+				}
+				// Drop the bearer token on redirect — the target is often a different
+				// host
+				// (e.g. a signed CDN URL) that must not receive our registry credentials.
+				downloadBlob(location.getValue(), null, destFile, redirectsLeft - 1);
 				return null;
 			}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/OciRegistryClientTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/OciRegistryClientTest.java
@@ -1,6 +1,9 @@
 package org.alexmond.jhelm.core.service;
 
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import tools.jackson.databind.JsonNode;
@@ -13,7 +16,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class OciRegistryClientTest {
 
@@ -82,6 +87,34 @@ class OciRegistryClientTest {
 				]}
 				""");
 		assertEquals("sha256:amd64", client.resolveDigestFromIndex(index));
+	}
+
+	@Test
+	void downloadBlobRejectsInternalInitialUrl() {
+		// SSRF: a blob URL targeting the cloud-metadata IP is refused before any request
+		assertThrows(SecurityException.class,
+				() -> client.downloadBlob("http://169.254.169.254/v2/blob", null, tempDir.resolve("b").toFile()));
+	}
+
+	@Test
+	void downloadBlobRejectsDisallowedScheme() {
+		assertThrows(SecurityException.class,
+				() -> client.downloadBlob("file:///etc/passwd", null, tempDir.resolve("b").toFile()));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void downloadBlobRejectsRedirectWithNoLocation() throws Exception {
+		// A 3xx with a missing Location header must fail cleanly, not NPE
+		CloseableHttpClient http = mock(CloseableHttpClient.class);
+		ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+		when(response.getCode()).thenReturn(302);
+		when(response.getFirstHeader("Location")).thenReturn(null);
+		when(http.execute(any(HttpUriRequest.class), any(HttpClientResponseHandler.class)))
+			.thenAnswer((inv) -> inv.getArgument(1, HttpClientResponseHandler.class).handleResponse(response));
+		OciRegistryClient redirectClient = new OciRegistryClient(http);
+		assertThrows(IOException.class, () -> redirectClient.downloadBlob("https://registry.example.com/v2/blob", "tok",
+				tempDir.resolve("b").toFile()));
 	}
 
 }


### PR DESCRIPTION
Completes the SSRF item on #502 by hardening the one fetch path #587 didn't touch: OCI blob downloads.

`OciRegistryClient.downloadBlob` followed a registry-supplied `Location` header blindly and recursively:
- a malicious registry could redirect a blob fetch at `file://`, `localhost`, or the cloud-metadata IP;
- a 3xx with **no** `Location` NPE'd on `getValue()`;
- a redirect loop recursed until `StackOverflowError`.

**Fix**
- Run the initial URL *and every redirect target* through `UrlSecurity.validateFetchUrl` (scheme allowlist + `localhost` + literal internal IPs). The shared `SsrfGuardingDnsResolver` from #587 still blocks names that *resolve* to internal addresses, so this closes the scheme/literal gap at the redirect boundary.
- Null/blank-check the `Location` header → clean `IOException` instead of NPE.
- Cap the chain at `MAX_BLOB_REDIRECTS` (10).
- Bearer token is still dropped on redirect (unchanged) so a redirected host can't harvest registry credentials.

**Tests** — 3 added: internal initial URL rejected, disallowed scheme rejected, 302-with-no-Location fails cleanly. Full `jhelm-core` validate (PMD + checkstyle) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)