### PR TITLE
feat(cli): registry login --password-stdin + interactive prompt (#502)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RegistryCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RegistryCommand.java
@@ -6,7 +6,9 @@ import org.alexmond.jhelm.core.service.RegistryManager;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+import java.io.Console;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Implements {@code jhelm registry}, managing authentication to OCI registries via the
@@ -46,8 +48,11 @@ public class RegistryCommand implements Runnable {
 		@CommandLine.Option(names = { "-u", "--username" }, description = "registry username", required = true)
 		private String username;
 
-		@CommandLine.Option(names = { "-p", "--password" }, description = "registry password", required = true)
+		@CommandLine.Option(names = { "-p", "--password" }, description = "registry password")
 		private String password;
+
+		@CommandLine.Option(names = "--password-stdin", description = "take the password from stdin")
+		private boolean passwordStdin;
 
 		/**
 		 * Creates the command.
@@ -60,12 +65,49 @@ public class RegistryCommand implements Runnable {
 		@Override
 		public void run() {
 			try {
-				registryManager.login(server, username, password);
+				registryManager.login(server, username, resolvePassword());
 				CliOutput.println(CliOutput.success("Login Succeeded"));
+			}
+			catch (IllegalArgumentException ex) {
+				CliOutput.errPrintln(CliOutput.error(ex.getMessage()));
 			}
 			catch (IOException ex) {
 				CliOutput.errPrintln(CliOutput.error("Error logging in: " + ex.getMessage()));
 			}
+		}
+
+		/**
+		 * Resolves the password, keeping it off the command line where possible: from
+		 * {@code --password-stdin} (piped), else {@code -p}, else an interactive hidden
+		 * prompt. {@code --password-stdin} and {@code -p} are mutually exclusive.
+		 * @return the resolved password
+		 * @throws IOException if reading stdin fails
+		 * @throws IllegalArgumentException if the options conflict or no password is
+		 * given
+		 */
+		private String resolvePassword() throws IOException {
+			if (passwordStdin) {
+				if (password != null) {
+					throw new IllegalArgumentException("--password and --password-stdin are mutually exclusive");
+				}
+				String fromStdin = new String(System.in.readAllBytes(), StandardCharsets.UTF_8).replaceAll("[\\r\\n]+$",
+						"");
+				if (fromStdin.isEmpty()) {
+					throw new IllegalArgumentException("No password supplied on stdin");
+				}
+				return fromStdin;
+			}
+			if (password != null) {
+				return password;
+			}
+			Console console = System.console();
+			if (console != null) {
+				char[] entered = console.readPassword("Password: ");
+				if (entered != null && entered.length > 0) {
+					return new String(entered);
+				}
+			}
+			throw new IllegalArgumentException("No password supplied; use -p, --password-stdin, or run interactively");
 		}
 
 	}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RegistryCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RegistryCommandTest.java
@@ -7,11 +7,17 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 class RegistryCommandTest {
 
@@ -43,6 +49,37 @@ class RegistryCommandTest {
 
 		CommandLine cmd = new CommandLine(loginCommand);
 		cmd.execute("registry.example.com", "-u", "user", "-p", "pass");
+	}
+
+	@Test
+	void testLoginReadsPasswordFromStdin() throws IOException {
+		doNothing().when(registryManager).login(anyString(), anyString(), anyString());
+		InputStream original = System.in;
+		try {
+			System.setIn(new ByteArrayInputStream("s3cret\n".getBytes(StandardCharsets.UTF_8)));
+			CommandLine cmd = new CommandLine(loginCommand);
+			cmd.execute("registry.example.com", "-u", "user", "--password-stdin");
+		}
+		finally {
+			System.setIn(original);
+		}
+		// trailing newline is stripped; the secret never appears on the command line
+		verify(registryManager).login(eq("registry.example.com"), eq("user"), eq("s3cret"));
+	}
+
+	@Test
+	void testLoginRejectsPasswordAndStdinTogether() throws IOException {
+		CommandLine cmd = new CommandLine(loginCommand);
+		cmd.execute("registry.example.com", "-u", "user", "-p", "pass", "--password-stdin");
+		verify(registryManager, never()).login(anyString(), anyString(), anyString());
+	}
+
+	@Test
+	void testLoginWithNoPasswordFails() throws IOException {
+		// no -p, no --password-stdin, and no console under test → clean failure, no login
+		CommandLine cmd = new CommandLine(loginCommand);
+		cmd.execute("registry.example.com", "-u", "user");
+		verify(registryManager, never()).login(anyString(), anyString(), anyString());
 	}
 
 	@Test


### PR DESCRIPTION
Closes the `--password-stdin`/prompt sub-item under #502 (the OCI-creds line; the `0600` half landed in #586).

`registry login` required `--password` as a flag, so the secret was exposed in shell history and the process list (`ps aux`). This mirrors `helm registry login`:

- `-p/--password` is now **optional**.
- `--password-stdin` reads the password from piped stdin (trailing newline stripped): `echo "$TOKEN" | jhelm registry login -u user --password-stdin reg.example.com`.
- With neither flag, a **hidden interactive prompt** (`Console.readPassword`) is used when a TTY is present.
- `-p` and `--password-stdin` are **mutually exclusive**; a missing password fails cleanly without calling `login`.

**Tests** — 3 added (stdin read + newline strip, mutual exclusion, no-password). Full `jhelm-cli` build green (tests + PMD + checkstyle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)