### PR TITLE
feat(rest): RFC-7807 ProblemDetail errors + NotFoundException 404 (#502)

### DIFF
--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandler.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandler.java
@@ -1,50 +1,60 @@
 package org.alexmond.jhelm.rest;
 
 import java.time.Instant;
-import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 /**
- * Global error handler for the jhelm REST API. Converts exceptions into structured JSON
- * error responses.
+ * Global error handler for the jhelm REST API. Converts exceptions into RFC&nbsp;7807
+ * {@code application/problem+json} responses.
  */
 @Slf4j
 @RestControllerAdvice(basePackages = "org.alexmond.jhelm.rest")
 public class JhelmRestExceptionHandler {
 
 	/**
-	 * Maps invalid input to a {@code 400 Bad Request} JSON error response.
-	 * @param ex the rejected-argument exception
-	 * @return the structured error response
+	 * Maps a missing resource to a {@code 404 Not Found} problem response.
+	 * @param ex the not-found exception
+	 * @return the problem detail
 	 */
-	@ExceptionHandler(IllegalArgumentException.class)
-	public ResponseEntity<Map<String, Object>> handleBadRequest(IllegalArgumentException ex) {
-		log.debug("Bad request: {}", ex.getMessage());
-		return errorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+	@ExceptionHandler(NotFoundException.class)
+	public ProblemDetail handleNotFound(NotFoundException ex) {
+		log.debug("Not found: {}", ex.getMessage());
+		return problem(HttpStatus.NOT_FOUND, ex.getMessage());
 	}
 
 	/**
-	 * Maps any unhandled exception to a {@code 500 Internal Server Error} JSON error
-	 * response.
-	 * @param ex the unhandled exception
-	 * @return the structured error response
+	 * Maps invalid input to a {@code 400 Bad Request} problem response.
+	 * @param ex the rejected-argument exception
+	 * @return the problem detail
 	 */
-	@ExceptionHandler(Exception.class)
-	public ResponseEntity<Map<String, Object>> handleInternalError(Exception ex) {
-		log.error("Internal error", ex);
-		return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ProblemDetail handleBadRequest(IllegalArgumentException ex) {
+		log.debug("Bad request: {}", ex.getMessage());
+		return problem(HttpStatus.BAD_REQUEST, ex.getMessage());
 	}
 
-	private ResponseEntity<Map<String, Object>> errorResponse(HttpStatus status, String message) {
-		Map<String, Object> body = Map.of("status", status.value(), "error", status.getReasonPhrase(), "message",
-				(message != null) ? message : "Unknown error", "timestamp", Instant.now().toString());
-		return ResponseEntity.status(status).body(body);
+	/**
+	 * Maps any unhandled exception to a {@code 500 Internal Server Error} problem
+	 * response.
+	 * @param ex the unhandled exception
+	 * @return the problem detail
+	 */
+	@ExceptionHandler(Exception.class)
+	public ProblemDetail handleInternalError(Exception ex) {
+		log.error("Internal error", ex);
+		return problem(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+	}
+
+	private ProblemDetail problem(HttpStatus status, String message) {
+		ProblemDetail problem = ProblemDetail.forStatusAndDetail(status, (message != null) ? message : "Unknown error");
+		problem.setProperty("timestamp", Instant.now().toString());
+		return problem;
 	}
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/NotFoundException.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/NotFoundException.java
@@ -1,0 +1,18 @@
+package org.alexmond.jhelm.rest;
+
+/**
+ * Thrown when a requested resource (typically a release) does not exist, so the REST
+ * layer can map it to {@code 404 Not Found} rather than the {@code 400} that a generic
+ * {@link IllegalArgumentException} would produce.
+ */
+public class NotFoundException extends RuntimeException {
+
+	/**
+	 * Creates the exception.
+	 * @param message the human-readable detail describing what was not found
+	 */
+	public NotFoundException(String message) {
+		super(message);
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
@@ -28,6 +28,7 @@ import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.core.util.HookParser;
+import org.alexmond.jhelm.rest.NotFoundException;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
 import org.alexmond.jhelm.rest.security.MutatingOperation;
 import org.alexmond.jhelm.rest.dto.HelmHookDto;
@@ -241,7 +242,7 @@ public class ReleaseController {
 			throw new IllegalArgumentException("chartRef is required");
 		}
 		Release current = this.getAction.getRelease(name, namespace)
-			.orElseThrow(() -> new IllegalArgumentException("Release '" + name + "' not found"));
+			.orElseThrow(() -> new NotFoundException("Release '" + name + "' not found"));
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-upgrade-")) {
 			Chart chart = ChartSourceResolver.fromChartRef(request.getChartRef(), request.getVersion(),
 					this.repoManager, this.chartLoader, tempDir);
@@ -279,7 +280,7 @@ public class ReleaseController {
 			@RequestPart("chart") MultipartFile chart, @RequestPart("request") UpgradeUploadRequest request)
 			throws Exception {
 		Release current = this.getAction.getRelease(name, namespace)
-			.orElseThrow(() -> new IllegalArgumentException("Release '" + name + "' not found"));
+			.orElseThrow(() -> new NotFoundException("Release '" + name + "' not found"));
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-upgrade-upload-")) {
 			Chart loaded = ChartSourceResolver.fromUpload(chart, this.repoManager, this.chartLoader, tempDir);
 			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ChartControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ChartControllerTest.java
@@ -80,7 +80,7 @@ class ChartControllerTest {
 						{"releaseName": "my-release"}
 						"""))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("chartRef is required"));
+			.andExpect(jsonPath("$.detail").value("chartRef is required"));
 	}
 
 	@Test
@@ -122,7 +122,7 @@ class ChartControllerTest {
 				.accept(MediaType.APPLICATION_JSON)
 				.content("{}"))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("name is required"));
+			.andExpect(jsonPath("$.detail").value("name is required"));
 	}
 
 	@Test

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/DependencyControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/DependencyControllerTest.java
@@ -59,7 +59,7 @@ class DependencyControllerTest {
 				.accept(MediaType.APPLICATION_JSON)
 				.content("{}"))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("chartRef is required"));
+			.andExpect(jsonPath("$.detail").value("chartRef is required"));
 	}
 
 	@Test

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
@@ -162,7 +162,7 @@ class ReleaseControllerTest {
 						{"releaseName": "my-release"}
 						"""))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("chartRef is required"));
+			.andExpect(jsonPath("$.detail").value("chartRef is required"));
 	}
 
 	@Test
@@ -201,6 +201,20 @@ class ReleaseControllerTest {
 						"""))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.version").value(2));
+	}
+
+	@Test
+	void upgradeMissingReleaseReturnsNotFound() throws Exception {
+		when(this.getAction.getRelease("missing", "default")).thenReturn(Optional.empty());
+
+		this.mockMvc
+			.perform(put("/api/v1/releases/missing").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartRef": "bitnami/nginx", "version": "2.0.0"}
+						"""))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.detail").value("Release 'missing' not found"));
 	}
 
 	@Test

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/RepoControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/RepoControllerTest.java
@@ -63,7 +63,7 @@ class RepoControllerTest {
 						{"url": "https://charts.bitnami.com/bitnami"}
 						"""))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("name is required"));
+			.andExpect(jsonPath("$.detail").value("name is required"));
 	}
 
 	@Test
@@ -157,7 +157,7 @@ class RepoControllerTest {
 				.accept(MediaType.APPLICATION_JSON)
 				.content("{}"))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("chart is required"));
+			.andExpect(jsonPath("$.detail").value("chart is required"));
 	}
 
 	@Test
@@ -186,7 +186,7 @@ class RepoControllerTest {
 
 		this.mockMvc.perform(multipart("/api/v1/repos/push").file(chartFile).param("remote", ""))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("remote is required"));
+			.andExpect(jsonPath("$.detail").value("remote is required"));
 	}
 
 }


### PR DESCRIPTION
First slice of the #502 Medium (REST maturity) trio.

**Fixes a status-code bug + modernizes error bodies.**
- Error responses were an ad-hoc `{status, error, message, timestamp}` map. They're now RFC-7807 `ProblemDetail` (`application/problem+json`), the Spring-native shape (`type`/`title`/`status`/`detail` + a `timestamp` extension).
- A missing release on **upgrade** threw `IllegalArgumentException` → surfaced as **400**. Added `NotFoundException` mapped to **404** and threw it from the `upgrade` / `upgrade-upload` not-found paths in `ReleaseController`.

**Test impact:** error assertions move from `$.message` to the standard `$.detail` (7 updated), plus a new `upgrade → 404` test. Full `jhelm-rest` suite green (62 tests + PMD + checkstyle).

Remaining Medium items (follow-up PRs): Bean Validation on DTOs (`@Valid`/`@NotBlank`), and actuator + cluster-health + multipart limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)