### PR TITLE
feat(rest): Bean Validation on request DTOs (#502)

### DIFF
--- a/jhelm-rest/pom.xml
+++ b/jhelm-rest/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandler.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandler.java
@@ -1,11 +1,15 @@
 package org.alexmond.jhelm.rest;
 
 import java.time.Instant;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -26,6 +30,25 @@ public class JhelmRestExceptionHandler {
 	public ProblemDetail handleNotFound(NotFoundException ex) {
 		log.debug("Not found: {}", ex.getMessage());
 		return problem(HttpStatus.NOT_FOUND, ex.getMessage());
+	}
+
+	/**
+	 * Maps Bean Validation failures on a request body to a {@code 400 Bad Request}
+	 * problem response, folding the field messages into the {@code detail}.
+	 * @param ex the validation exception
+	 * @return the problem detail
+	 */
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ProblemDetail handleValidation(MethodArgumentNotValidException ex) {
+		String detail = ex.getBindingResult()
+			.getFieldErrors()
+			.stream()
+			.map(FieldError::getDefaultMessage)
+			.filter(Objects::nonNull)
+			.distinct()
+			.collect(Collectors.joining("; "));
+		log.debug("Validation failed: {}", detail);
+		return problem(HttpStatus.BAD_REQUEST, detail.isEmpty() ? "Validation failed" : detail);
 	}
 
 	/**

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.rest.controller;
 
+import jakarta.validation.Valid;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -82,10 +84,7 @@ public class ChartController {
 	@PostMapping("/template")
 	@Operation(summary = "Render templates",
 			description = "Render chart templates from a repository chart reference with optional value overrides")
-	public ResponseEntity<String> template(@RequestBody TemplateRequest request) throws Exception {
-		if (request.getChartRef() == null || request.getChartRef().isBlank()) {
-			throw new IllegalArgumentException("chartRef is required");
-		}
+	public ResponseEntity<String> template(@Valid @RequestBody TemplateRequest request) throws Exception {
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-template-")) {
 			String chartPath = pullChart(request.getChartRef(), request.getVersion(), tempDir);
 			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
@@ -130,10 +129,7 @@ public class ChartController {
 	@PostMapping("/create")
 	@Operation(summary = "Create a chart",
 			description = "Scaffold a new chart and return it as a .tgz archive download")
-	public ResponseEntity<byte[]> create(@RequestBody CreateRequest request) throws Exception {
-		if (request.getName() == null || request.getName().isBlank()) {
-			throw new IllegalArgumentException("name is required");
-		}
+	public ResponseEntity<byte[]> create(@Valid @RequestBody CreateRequest request) throws Exception {
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-create-")) {
 			Path chartPath = tempDir.sandboxedResolve(request.getName());
 			this.createAction.create(chartPath);

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/DependencyController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/DependencyController.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.rest.controller;
 
+import jakarta.validation.Valid;
+
 import java.util.List;
 import java.util.Map;
 
@@ -66,10 +68,7 @@ public class DependencyController {
 	@PostMapping("/resolve")
 	@Operation(summary = "Resolve dependencies",
 			description = "Resolve chart dependency versions from a repository chart reference and return the Chart.lock content")
-	public ResponseEntity<String> resolve(@RequestBody DependencyResolveRequest request) throws Exception {
-		if (request.getChartRef() == null || request.getChartRef().isBlank()) {
-			throw new IllegalArgumentException("chartRef is required");
-		}
+	public ResponseEntity<String> resolve(@Valid @RequestBody DependencyResolveRequest request) throws Exception {
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-dep-resolve-")) {
 			this.repoManager.pull(request.getChartRef(), request.getVersion(), tempDir.path().toString());
 			Chart chart = this.chartLoader.load(ChartLoader.findChartDir(tempDir.path()).toFile());

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.rest.controller;
 
+import jakarta.validation.Valid;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -169,13 +171,7 @@ public class ReleaseController {
 	@MutatingOperation
 	@Operation(summary = "Install a release",
 			description = "Install a new Helm release from a repository chart reference")
-	public ResponseEntity<ReleaseDto> install(@RequestBody InstallRequest request) throws Exception {
-		if (request.getChartRef() == null || request.getChartRef().isBlank()) {
-			throw new IllegalArgumentException("chartRef is required");
-		}
-		if (request.getReleaseName() == null || request.getReleaseName().isBlank()) {
-			throw new IllegalArgumentException("releaseName is required");
-		}
+	public ResponseEntity<ReleaseDto> install(@Valid @RequestBody InstallRequest request) throws Exception {
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-install-")) {
 			Chart chart = ChartSourceResolver.fromChartRef(request.getChartRef(), request.getVersion(),
 					this.repoManager, this.chartLoader, tempDir);
@@ -204,10 +200,7 @@ public class ReleaseController {
 	@Operation(summary = "Install a release from upload",
 			description = "Install a new Helm release from an uploaded .tgz chart archive")
 	public ResponseEntity<ReleaseDto> installUpload(@RequestPart("chart") MultipartFile chart,
-			@RequestPart("request") InstallUploadRequest request) throws Exception {
-		if (request.getReleaseName() == null || request.getReleaseName().isBlank()) {
-			throw new IllegalArgumentException("releaseName is required");
-		}
+			@Valid @RequestPart("request") InstallUploadRequest request) throws Exception {
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-install-upload-")) {
 			Chart loaded = ChartSourceResolver.fromUpload(chart, this.repoManager, this.chartLoader, tempDir);
 			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
@@ -237,10 +230,7 @@ public class ReleaseController {
 			description = "Upgrade an existing release from a repository chart reference")
 	public ReleaseDto upgrade(@Parameter(description = "Release name") @PathVariable String name,
 			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace,
-			@RequestBody UpgradeRequest request) throws Exception {
-		if (request.getChartRef() == null || request.getChartRef().isBlank()) {
-			throw new IllegalArgumentException("chartRef is required");
-		}
+			@Valid @RequestBody UpgradeRequest request) throws Exception {
 		Release current = this.getAction.getRelease(name, namespace)
 			.orElseThrow(() -> new NotFoundException("Release '" + name + "' not found"));
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-upgrade-")) {
@@ -343,7 +333,7 @@ public class ReleaseController {
 	@Operation(summary = "Rollback a release", description = "Rollback a release to a previous revision")
 	public ResponseEntity<Void> rollback(@Parameter(description = "Release name") @PathVariable String name,
 			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace,
-			@RequestBody RollbackRequest request) throws Exception {
+			@Valid @RequestBody RollbackRequest request) throws Exception {
 		this.rollbackAction.rollback(RollbackOptions.builder()
 			.releaseName(name)
 			.namespace(namespace)

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/RepoController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/RepoController.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.rest.controller;
 
+import jakarta.validation.Valid;
+
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -67,13 +69,7 @@ public class RepoController {
 	 */
 	@PostMapping
 	@Operation(summary = "Add a repository")
-	public ResponseEntity<Void> addRepo(@RequestBody RepoAddRequest request) throws Exception {
-		if (request.getName() == null || request.getName().isBlank()) {
-			throw new IllegalArgumentException("name is required");
-		}
-		if (request.getUrl() == null || request.getUrl().isBlank()) {
-			throw new IllegalArgumentException("url is required");
-		}
+	public ResponseEntity<Void> addRepo(@Valid @RequestBody RepoAddRequest request) throws Exception {
 		this.repoManager.addRepo(request.getName(), request.getUrl());
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
@@ -158,10 +154,7 @@ public class RepoController {
 	@PostMapping("/pull")
 	@Operation(summary = "Pull a chart",
 			description = "Pull a chart from a repository or OCI registry and return it as a .tgz archive")
-	public ResponseEntity<byte[]> pull(@RequestBody PullRequest request) throws Exception {
-		if (request.getChart() == null || request.getChart().isBlank()) {
-			throw new IllegalArgumentException("chart is required");
-		}
+	public ResponseEntity<byte[]> pull(@Valid @RequestBody PullRequest request) throws Exception {
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-pull-")) {
 			this.repoManager.pull(request.getChart(), request.getVersion(), tempDir.path().toString());
 			String fileName = resolveFileName(request.getChart(), request.getVersion());

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/CreateRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/CreateRequest.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.rest.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -12,6 +14,7 @@ public class CreateRequest {
 
 	@Schema(description = "Name of the chart to create", example = "my-chart",
 			requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "name is required")
 	private String name;
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/DependencyResolveRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/DependencyResolveRequest.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.rest.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -12,6 +14,7 @@ public class DependencyResolveRequest {
 
 	@Schema(description = "Chart reference: repo/chart or oci://...", example = "bitnami/nginx",
 			requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "chartRef is required")
 	private String chartRef;
 
 	@Schema(description = "Chart version", example = "18.3.1")

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallRequest.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.rest.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 import java.util.Map;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,12 +16,14 @@ public class InstallRequest {
 
 	@Schema(description = "Chart reference (repo/chart or oci://...)", example = "bitnami/nginx",
 			requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "chartRef is required")
 	private String chartRef;
 
 	@Schema(description = "Chart version", example = "18.3.1")
 	private String version;
 
 	@Schema(description = "Name for the release", example = "my-release", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "releaseName is required")
 	private String releaseName;
 
 	@Schema(description = "Kubernetes namespace", example = "default", defaultValue = "default")

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallUploadRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallUploadRequest.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.rest.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 import java.util.Map;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,6 +15,7 @@ import lombok.Data;
 public class InstallUploadRequest {
 
 	@Schema(description = "Name for the release", example = "my-release", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "releaseName is required")
 	private String releaseName;
 
 	@Schema(description = "Kubernetes namespace", example = "default", defaultValue = "default")

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/PullRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/PullRequest.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.rest.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -12,6 +14,7 @@ public class PullRequest {
 
 	@Schema(description = "Chart reference: repo/chart, repo/chart:version, or oci://...", example = "bitnami/nginx",
 			requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "chart is required")
 	private String chart;
 
 	@Schema(description = "Chart version (required for repo charts, optional for OCI)", example = "18.3.1")

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RepoAddRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RepoAddRequest.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.rest.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -11,10 +13,12 @@ import lombok.Data;
 public class RepoAddRequest {
 
 	@Schema(description = "Repository name", example = "bitnami", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "name is required")
 	private String name;
 
 	@Schema(description = "Repository URL", example = "https://charts.bitnami.com/bitnami",
 			requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "url is required")
 	private String url;
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TemplateRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TemplateRequest.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.rest.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 import java.util.Map;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,6 +16,7 @@ public class TemplateRequest {
 
 	@Schema(description = "Chart reference (repo/chart or oci://...)", example = "bitnami/nginx",
 			requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "chartRef is required")
 	private String chartRef;
 
 	@Schema(description = "Chart version constraint", example = "18.3.1")

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeRequest.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.rest.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 import java.util.Map;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,6 +16,7 @@ public class UpgradeRequest {
 
 	@Schema(description = "Chart reference (repo/chart or oci://...)", example = "bitnami/nginx",
 			requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank(message = "chartRef is required")
 	private String chartRef;
 
 	@Schema(description = "Chart version", example = "18.3.1")

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
@@ -166,6 +166,19 @@ class ReleaseControllerTest {
 	}
 
 	@Test
+	void installRejectsBlankChartRef() throws Exception {
+		// @NotBlank (not merely @NotNull) rejects a whitespace-only value
+		this.mockMvc
+			.perform(post("/api/v1/releases").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartRef": "   ", "releaseName": "my-release"}
+						"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.detail").value("chartRef is required"));
+	}
+
+	@Test
 	void installUploadCreatesRelease() throws Exception {
 		stubUntar();
 		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("1.0.0").build()).build();


### PR DESCRIPTION
Second slice of the #502 Medium (REST maturity) trio (builds on #590's ProblemDetail handler).

Replaces the hand-rolled `if (x == null || x.isBlank()) throw new IllegalArgumentException("x is required")` checks scattered across the controllers with declarative jakarta Bean Validation:

- `@NotBlank` on the required DTO fields (`chartRef`, `releaseName`, `name`, `url`, `chart`).
- `@Valid` on the 9 `@RequestBody` / `@RequestPart` request params.
- A `MethodArgumentNotValidException` handler folds the field messages into the RFC-7807 `ProblemDetail` `detail`, so the **400 bodies are unchanged** (`$.detail` still reads `"chartRef is required"`, etc.).
- Adds `spring-boot-starter-validation`.

The `remote` `@RequestParam` check in `repo push` stays hand-rolled (query param, not a DTO field — out of "Bean Validation on DTOs" scope).

**Tests:** existing "is required" assertions pass unchanged through the new path; adds a blank-value (`"   "`) test proving `@NotBlank` (not merely `@NotNull`) semantics. Full `jhelm-rest` suite green (63 tests + PMD + checkstyle).

Last Medium item after this: actuator + cluster-health + multipart limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)