### PR TITLE
feat(rest): actuator + Kubernetes health indicator + multipart cap (#502)

### DIFF
--- a/jhelm-kube/pom.xml
+++ b/jhelm-kube/pom.xml
@@ -41,6 +41,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.RetryTemplate;
 import java.time.Duration;
@@ -114,22 +115,6 @@ public class JhelmKubeAutoConfiguration {
 		return service;
 	}
 
-	/**
-	 * Registers a Kubernetes connectivity
-	 * {@link org.springframework.boot.health.contributor.HealthIndicator} when Spring
-	 * Boot Actuator is on the classpath. Reports {@code UP}/{@code DOWN} based on
-	 * reaching the cluster {@code /version} endpoint.
-	 * @param kubeClient the client wrapper to probe
-	 * @return the health indicator bean
-	 */
-	@Bean
-	@ConditionalOnClass(HealthIndicator.class)
-	@ConditionalOnBean(KubeClient.class)
-	@ConditionalOnMissingBean(KubernetesHealthIndicator.class)
-	public KubernetesHealthIndicator kubernetesHealthIndicator(KubeClient kubeClient) {
-		return new KubernetesHealthIndicator(kubeClient);
-	}
-
 	private RetryTemplate buildRetryTemplate(JhelmKubernetesProperties.Retry config) {
 		RetryPolicy policy = RetryPolicy.builder()
 			// maxRetries excludes the initial call, so subtract one to preserve the
@@ -143,6 +128,32 @@ public class JhelmKubeAutoConfiguration {
 			.predicate(RetryableKubeService::isTransient)
 			.build();
 		return new RetryTemplate(policy);
+	}
+
+	/**
+	 * Kubernetes health-indicator configuration, isolated in a nested class guarded by
+	 * {@link ConditionalOnClass} so the actuator {@code HealthIndicator} type is only
+	 * referenced when Spring Boot Actuator is on the classpath. This keeps the enclosing
+	 * {@link JhelmKubeAutoConfiguration} introspectable by consumers (e.g. the CLI) that
+	 * do not depend on actuator.
+	 */
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(HealthIndicator.class)
+	static class KubernetesHealthContributorConfiguration {
+
+		/**
+		 * Registers a Kubernetes connectivity health indicator reporting up/down based on
+		 * reaching the cluster {@code /version} endpoint.
+		 * @param kubeClient the client wrapper to probe
+		 * @return the health indicator bean
+		 */
+		@Bean
+		@ConditionalOnBean(KubeClient.class)
+		@ConditionalOnMissingBean(KubernetesHealthIndicator.class)
+		KubernetesHealthIndicator kubernetesHealthIndicator(KubeClient kubeClient) {
+			return new KubernetesHealthIndicator(kubeClient);
+		}
+
 	}
 
 }

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
@@ -13,10 +13,14 @@ import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
 import org.alexmond.jhelm.kube.service.AsyncHelmKubeService;
 import org.alexmond.jhelm.kube.service.KubeClient;
+import org.alexmond.jhelm.kube.service.KubernetesHealthIndicator;
 import org.alexmond.jhelm.kube.service.ObservableKubeService;
 import org.alexmond.jhelm.kube.service.RetryableKubeService;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -108,6 +112,22 @@ public class JhelmKubeAutoConfiguration {
 			service = new ObservableKubeService(service, metrics);
 		}
 		return service;
+	}
+
+	/**
+	 * Registers a Kubernetes connectivity
+	 * {@link org.springframework.boot.health.contributor.HealthIndicator} when Spring
+	 * Boot Actuator is on the classpath. Reports {@code UP}/{@code DOWN} based on
+	 * reaching the cluster {@code /version} endpoint.
+	 * @param kubeClient the client wrapper to probe
+	 * @return the health indicator bean
+	 */
+	@Bean
+	@ConditionalOnClass(HealthIndicator.class)
+	@ConditionalOnBean(KubeClient.class)
+	@ConditionalOnMissingBean(KubernetesHealthIndicator.class)
+	public KubernetesHealthIndicator kubernetesHealthIndicator(KubeClient kubeClient) {
+		return new KubernetesHealthIndicator(kubeClient);
 	}
 
 	private RetryTemplate buildRetryTemplate(JhelmKubernetesProperties.Retry config) {

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/KubernetesHealthIndicator.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/KubernetesHealthIndicator.java
@@ -1,0 +1,39 @@
+package org.alexmond.jhelm.kube.service;
+
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.VersionApi;
+import io.kubernetes.client.openapi.models.VersionInfo;
+
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+
+/**
+ * Reports Kubernetes API-server connectivity as a Spring Boot health contributor: it
+ * queries the cluster {@code /version} endpoint (the cheapest authenticated round-trip)
+ * and reports {@code UP} with the server version when reachable, {@code DOWN} otherwise.
+ * Registered only when Spring Boot Actuator is on the classpath.
+ */
+public class KubernetesHealthIndicator implements HealthIndicator {
+
+	private final KubeClient kubeClient;
+
+	/**
+	 * Creates the indicator.
+	 * @param kubeClient the wrapper holding the Kubernetes API client to probe
+	 */
+	public KubernetesHealthIndicator(KubeClient kubeClient) {
+		this.kubeClient = kubeClient;
+	}
+
+	@Override
+	public Health health() {
+		try {
+			VersionInfo version = new VersionApi(this.kubeClient.apiClient()).getCode().execute();
+			return Health.up().withDetail("version", version.getGitVersion()).build();
+		}
+		catch (ApiException | RuntimeException ex) {
+			return Health.down(ex).build();
+		}
+	}
+
+}

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/KubernetesHealthIndicatorTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/KubernetesHealthIndicatorTest.java
@@ -1,0 +1,27 @@
+package org.alexmond.jhelm.kube.service;
+
+import io.kubernetes.client.openapi.ApiClient;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class KubernetesHealthIndicatorTest {
+
+	@Test
+	void reportsDownWhenClusterUnreachable() {
+		// point at a port with nothing listening → the /version probe fails fast
+		ApiClient client = new ApiClient();
+		client.setBasePath("http://127.0.0.1:1");
+		client.setConnectTimeout(500);
+		client.setReadTimeout(500);
+		KubernetesHealthIndicator indicator = new KubernetesHealthIndicator(new KubeClient(client));
+
+		Health health = indicator.health();
+
+		assertEquals(Status.DOWN, health.getStatus());
+	}
+
+}

--- a/jhelm-rest/pom.xml
+++ b/jhelm-rest/pom.xml
@@ -26,6 +26,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -26,11 +26,13 @@ import org.alexmond.jhelm.rest.controller.HubController;
 import org.alexmond.jhelm.rest.controller.ReleaseController;
 import org.alexmond.jhelm.rest.controller.RepoController;
 import org.alexmond.jhelm.rest.security.AccessModeInterceptor;
+import jakarta.servlet.MultipartConfigElement;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.servlet.MultipartConfigFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -48,7 +50,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * key is the floor; wire Spring Security in the application for real multi-user auth. The
  * startup security posture is logged by the core module.
  */
-@AutoConfiguration(after = JhelmCoreAutoConfiguration.class)
+@AutoConfiguration(after = JhelmCoreAutoConfiguration.class,
+		beforeName = "org.springframework.boot.servlet.autoconfigure.MultipartAutoConfiguration")
 @ConditionalOnWebApplication
 @EnableConfigurationProperties(JhelmRestProperties.class)
 public class JhelmRestAutoConfiguration {
@@ -61,6 +64,23 @@ public class JhelmRestAutoConfiguration {
 	@ConditionalOnMissingBean
 	public JhelmRestExceptionHandler jhelmRestExceptionHandler() {
 		return new JhelmRestExceptionHandler();
+	}
+
+	/**
+	 * Caps multipart uploads (chart archives) at
+	 * {@link JhelmRestProperties#getMaxUploadSize()}, registered before Spring Boot's own
+	 * so the module default applies unless the application defines its own
+	 * {@link MultipartConfigElement}.
+	 * @param properties REST module configuration providing the upload cap
+	 * @return the multipart configuration bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public MultipartConfigElement multipartConfigElement(JhelmRestProperties properties) {
+		MultipartConfigFactory factory = new MultipartConfigFactory();
+		factory.setMaxFileSize(properties.getMaxUploadSize());
+		factory.setMaxRequestSize(properties.getMaxUploadSize());
+		return factory.createMultipartConfig();
 	}
 
 	/**

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/config/JhelmRestProperties.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/config/JhelmRestProperties.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.unit.DataSize;
 
 /**
  * Configuration properties for the jhelm REST API module.
@@ -28,6 +29,12 @@ public class JhelmRestProperties {
 	 * Base directory for temporary files. Defaults to the system temp directory.
 	 */
 	private Path tempDir;
+
+	/**
+	 * Maximum size of an uploaded chart archive (applied to both the multipart file and
+	 * the whole request), capping upload-based resource use. Defaults to 100 MB.
+	 */
+	private DataSize maxUploadSize = DataSize.ofMegabytes(100);
 
 	/**
 	 * Returns the configured temp directory, or the system default if not set. The


### PR DESCRIPTION
Final slice of the #502 Medium (REST maturity) trio — completes the Medium tier.

- **Actuator**: adds `spring-boot-starter-actuator` to `jhelm-rest` so the server exposes the actuator endpoints.
- **Cluster-connectivity health indicator**: `KubernetesHealthIndicator` (in `jhelm-kube`) probes the cluster `/version` endpoint and reports `UP` (with the server git version) / `DOWN`. Registered only when Actuator is on the classpath (`@ConditionalOnClass`) and a `KubeClient` bean exists; actuator is an **optional** dependency of `jhelm-kube`, so non-actuator consumers (e.g. the CLI) are unaffected.
- **Multipart cap**: uploads are capped at `jhelm.rest.max-upload-size` (default **100 MB**) via a `MultipartConfigElement` registered before Boot's `MultipartAutoConfiguration`, bounding upload-based resource use.

Boot 4.0 relocated the health (`org.springframework.boot.health.contributor.*`) and servlet (`org.springframework.boot.servlet.*`) packages — imports target the new locations.

**Tests:** health indicator DOWN-on-unreachable test; both module auto-config context-load tests pass (wiring + multipart ordering load cleanly). Full `jhelm-kube` + `jhelm-rest` reactor green (PMD + checkstyle included).

With this, the #502 Medium tier is done; only the prerequisite-blocked `install --verify` remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)