### PR TITLE
feat(cli): install/upgrade from .tgz + --verify provenance (#502)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ChartResolver.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ChartResolver.java
@@ -1,0 +1,110 @@
+package org.alexmond.jhelm.app.command;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.action.VerifyAction;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves a chart source given on the command line — either an unpacked chart directory
+ * or a packaged {@code .tgz} archive — into a loaded {@link Chart}, optionally verifying
+ * the archive's PGP provenance first.
+ *
+ * <p>
+ * When {@code verify} is requested the source must be a {@code .tgz} (a directory has no
+ * {@code .prov} provenance file); verification runs before the archive is extracted, so a
+ * chart that fails verification is never loaded or installed.
+ */
+@Slf4j
+@Component
+public class ChartResolver {
+
+	private final ChartLoader chartLoader;
+
+	private final RepoManager repoManager;
+
+	private final VerifyAction verifyAction;
+
+	/**
+	 * Creates the resolver.
+	 * @param chartLoader loads a chart from an unpacked directory
+	 * @param repoManager provides the archive-extraction ({@code untar}) utility
+	 * @param verifyAction verifies a packaged chart's PGP provenance
+	 */
+	public ChartResolver(ChartLoader chartLoader, RepoManager repoManager, VerifyAction verifyAction) {
+		this.chartLoader = chartLoader;
+		this.repoManager = repoManager;
+		this.verifyAction = verifyAction;
+	}
+
+	/**
+	 * Resolves {@code chartPath} to a loaded chart.
+	 * @param chartPath a chart directory or a packaged {@code .tgz} archive
+	 * @param verify whether to verify the archive's provenance before loading
+	 * @param keyring path to the PGP public keyring, or {@code null} for the default
+	 * @return the loaded chart
+	 * @throws IOException if the archive cannot be extracted
+	 * @throws IllegalArgumentException if the path is missing, or {@code verify} is set
+	 * for a directory
+	 */
+	public Chart resolve(String chartPath, boolean verify, String keyring) throws IOException {
+		File source = new File(chartPath);
+		if (!source.exists()) {
+			throw new IllegalArgumentException("Chart path not found: " + chartPath);
+		}
+		if (source.isDirectory()) {
+			if (verify) {
+				throw new IllegalArgumentException(
+						"--verify requires a packaged .tgz chart; a chart directory has no provenance file");
+			}
+			return chartLoader.load(source);
+		}
+		if (verify) {
+			// Aborts with a SignatureException before extraction if verification fails.
+			verifyAction.verify(chartPath, (keyring != null) ? keyring : defaultKeyringPath());
+		}
+		Path workDir = Files.createTempDirectory("jhelm-chart-");
+		try {
+			repoManager.untar(source, workDir.toFile());
+			Path chartDir = ChartLoader.findChartDir(workDir);
+			// load() reads the whole chart into memory, so the temp dir can be removed
+			// after.
+			return chartLoader.load(chartDir.toFile());
+		}
+		finally {
+			deleteRecursively(workDir);
+		}
+	}
+
+	private static String defaultKeyringPath() {
+		return System.getProperty("user.home") + "/.gnupg/pubring.gpg";
+	}
+
+	private static void deleteRecursively(Path dir) {
+		try (var paths = Files.walk(dir)) {
+			paths.sorted(Comparator.reverseOrder()).forEach((p) -> {
+				try {
+					Files.deleteIfExists(p);
+				}
+				catch (IOException ex) {
+					throw new UncheckedIOException(ex);
+				}
+			});
+		}
+		catch (IOException | UncheckedIOException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("Failed to clean up temp chart dir {}: {}", dir, ex.getMessage());
+			}
+		}
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -1,6 +1,5 @@
 package org.alexmond.jhelm.app.command;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -13,7 +12,6 @@ import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
-import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.util.ValuesOverrides;
@@ -37,13 +35,19 @@ public class InstallCommand implements Runnable {
 
 	private final KubeService kubeService;
 
-	private final ChartLoader chartLoader;
+	private final ChartResolver chartResolver;
 
 	@CommandLine.Parameters(index = "0", description = "release name")
 	private String name;
 
 	@CommandLine.Parameters(index = "1", description = "chart path")
 	private String chartPath;
+
+	@Option(names = { "--verify" }, description = "verify the packaged chart's provenance before installing")
+	private boolean verify;
+
+	@Option(names = { "--keyring" }, description = "path to the PGP public keyring file (for --verify)")
+	private String keyring;
 
 	@CommandLine.Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
 	private String namespace;
@@ -89,20 +93,21 @@ public class InstallCommand implements Runnable {
 	 * @param installAction the action that performs the install
 	 * @param uninstallAction the action used to roll back when {@code --atomic} is set
 	 * @param kubeService the Kubernetes service used to wait for resource readiness
-	 * @param chartLoader the loader that reads the chart from disk
+	 * @param chartResolver resolves the chart source (directory or {@code .tgz}), with
+	 * optional provenance verification
 	 */
 	public InstallCommand(InstallAction installAction, UninstallAction uninstallAction, KubeService kubeService,
-			ChartLoader chartLoader) {
+			ChartResolver chartResolver) {
 		this.installAction = installAction;
 		this.uninstallAction = uninstallAction;
 		this.kubeService = kubeService;
-		this.chartLoader = chartLoader;
+		this.chartResolver = chartResolver;
 	}
 
 	@Override
 	public void run() {
 		try {
-			Chart chart = chartLoader.load(new File(chartPath));
+			Chart chart = chartResolver.resolve(chartPath, verify, keyring);
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
 					setFileValues, setJsonValues);
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -1,6 +1,5 @@
 package org.alexmond.jhelm.app.command;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -19,7 +18,6 @@ import org.alexmond.jhelm.core.action.UpgradeOptions;
 import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
-import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.util.ValuesOverrides;
@@ -47,13 +45,19 @@ public class UpgradeCommand implements Runnable {
 
 	private final RollbackAction rollbackAction;
 
-	private final ChartLoader chartLoader;
+	private final ChartResolver chartResolver;
 
 	@CommandLine.Parameters(index = "0", description = "release name")
 	private String name;
 
 	@CommandLine.Parameters(index = "1", description = "chart path")
 	private String chartPath;
+
+	@Option(names = { "--verify" }, description = "verify the packaged chart's provenance before upgrading")
+	private boolean verify;
+
+	@Option(names = { "--keyring" }, description = "path to the PGP public keyring file (for --verify)")
+	private String keyring;
 
 	@CommandLine.Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
 	private String namespace;
@@ -120,16 +124,17 @@ public class UpgradeCommand implements Runnable {
 	 * @param upgradeAction the action that performs the upgrade
 	 * @param rollbackAction the action used to roll back to the previous revision on
 	 * atomic failure
-	 * @param chartLoader the loader that reads the chart from disk
+	 * @param chartResolver resolves the chart source (directory or {@code .tgz}), with
+	 * optional provenance verification
 	 */
 	public UpgradeCommand(KubeService kubeService, InstallAction installAction, UninstallAction uninstallAction,
-			UpgradeAction upgradeAction, RollbackAction rollbackAction, ChartLoader chartLoader) {
+			UpgradeAction upgradeAction, RollbackAction rollbackAction, ChartResolver chartResolver) {
 		this.kubeService = kubeService;
 		this.installAction = installAction;
 		this.uninstallAction = uninstallAction;
 		this.upgradeAction = upgradeAction;
 		this.rollbackAction = rollbackAction;
-		this.chartLoader = chartLoader;
+		this.chartResolver = chartResolver;
 	}
 
 	@Override
@@ -138,7 +143,7 @@ public class UpgradeCommand implements Runnable {
 		boolean wasInstall = false;
 		try {
 			Optional<Release> currentReleaseOpt = kubeService.getRelease(name, namespace);
-			Chart chart = chartLoader.load(new File(chartPath));
+			Chart chart = chartResolver.resolve(chartPath, verify, keyring);
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
 					setFileValues, setJsonValues);
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ChartResolverTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ChartResolverTest.java
@@ -1,0 +1,86 @@
+package org.alexmond.jhelm.app.command;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.alexmond.jhelm.core.action.PackageAction;
+import org.alexmond.jhelm.core.action.VerifyAction;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.core.service.SignatureService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ChartResolverTest {
+
+	private final ChartLoader chartLoader = new ChartLoader();
+
+	private final SignatureService signatureService = new SignatureService();
+
+	private final ChartResolver resolver = new ChartResolver(chartLoader, new RepoManager(),
+			new VerifyAction(signatureService));
+
+	@TempDir
+	Path tempDir;
+
+	private File chartDir;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		chartDir = tempDir.resolve("test-chart").toFile();
+		chartDir.mkdirs();
+		Files.writeString(chartDir.toPath().resolve("Chart.yaml"), """
+				apiVersion: v2
+				name: test-chart
+				version: 1.0.0
+				""");
+	}
+
+	@Test
+	void resolvesChartDirectory() throws Exception {
+		Chart chart = resolver.resolve(chartDir.getAbsolutePath(), false, null);
+		assertEquals("test-chart", chart.getMetadata().getName());
+	}
+
+	@Test
+	void resolvesPackagedTgz() throws Exception {
+		File tgz = packageChart();
+		Chart chart = resolver.resolve(tgz.getAbsolutePath(), false, null);
+		assertEquals("test-chart", chart.getMetadata().getName());
+	}
+
+	@Test
+	void verifyOnDirectoryIsRejected() {
+		// a directory has no provenance file, so --verify cannot apply
+		assertThrows(IllegalArgumentException.class, () -> resolver.resolve(chartDir.getAbsolutePath(), true, null));
+	}
+
+	@Test
+	void verifyAbortsWhenProvenanceMissing() throws Exception {
+		// an unsigned .tgz has no .prov, so verification aborts before the chart is
+		// loaded
+		File tgz = packageChart();
+		assertThrows(IllegalArgumentException.class,
+				() -> resolver.resolve(tgz.getAbsolutePath(), true, tempDir.resolve("keyring.gpg").toString()));
+	}
+
+	@Test
+	void missingPathIsRejected() {
+		assertThrows(IllegalArgumentException.class,
+				() -> resolver.resolve(tempDir.resolve("does-not-exist").toString(), false, null));
+	}
+
+	private File packageChart() {
+		PackageAction packageAction = new PackageAction(chartLoader, signatureService);
+		packageAction.setDestination(tempDir.toFile());
+		return packageAction.packageChart(chartDir.getAbsolutePath());
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -1,7 +1,6 @@
 package org.alexmond.jhelm.app.command;
 
 import org.alexmond.jhelm.core.model.Chart;
-import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.model.Release;
@@ -24,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -42,7 +42,7 @@ class InstallCommandTest {
 	private KubeService kubeService;
 
 	@Mock
-	private ChartLoader chartLoader;
+	private ChartResolver chartResolver;
 
 	private InstallCommand installCommand;
 
@@ -56,8 +56,8 @@ class InstallCommandTest {
 			.metadata(ChartMetadata.builder().name("test-chart").version("1.0.0").build())
 			.values(new HashMap<>())
 			.build();
-		when(chartLoader.load(any(File.class))).thenReturn(defaultChart);
-		installCommand = new InstallCommand(installAction, uninstallAction, kubeService, chartLoader);
+		when(chartResolver.resolve(anyString(), anyBoolean(), any())).thenReturn(defaultChart);
+		installCommand = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver);
 	}
 
 	@Test

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -1,7 +1,6 @@
 package org.alexmond.jhelm.app.command;
 
 import org.alexmond.jhelm.core.model.Chart;
-import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ReleaseStatus;
@@ -27,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -51,7 +51,7 @@ class UpgradeCommandTest {
 	private RollbackAction rollbackAction;
 
 	@Mock
-	private ChartLoader chartLoader;
+	private ChartResolver chartResolver;
 
 	private UpgradeCommand upgradeCommand;
 
@@ -65,9 +65,9 @@ class UpgradeCommandTest {
 			.metadata(ChartMetadata.builder().name("test-chart").version("1.0.0").build())
 			.values(new HashMap<>())
 			.build();
-		when(chartLoader.load(any(File.class))).thenReturn(defaultChart);
+		when(chartResolver.resolve(anyString(), anyBoolean(), any())).thenReturn(defaultChart);
 		upgradeCommand = new UpgradeCommand(kubeService, installAction, uninstallAction, upgradeAction, rollbackAction,
-				chartLoader);
+				chartResolver);
 	}
 
 	@Test


### PR DESCRIPTION
Closes the last remaining **#502 blocker** — `install --verify` enforcement — plus its prerequisite (packaged-`.tgz` install support).

**Before:** CLI `install`/`upgrade` loaded only an unpacked chart *directory*, so a packaged chart couldn't be installed and there was no `.prov` to verify.

**Now:** a new `ChartResolver` loads a chart from **either a directory or a `.tgz`** (extract via `RepoManager.untar` → `findChartDir` → `load`). `install` and `upgrade` accept a `.tgz` and gain:
- `--verify` — checks the archive's PGP provenance (`VerifyAction`) **before extraction**, so a chart that fails verification is never loaded or applied.
- `--keyring` — public keyring path (default `~/.gnupg/pubring.gpg`, matching the standalone `verify` command).
- `--verify` against a directory is rejected (a directory has no provenance).

Wraps the existing, already-tested verify engine (`VerifyAction`/`SignatureService`) — **no new crypto**.

**Tests:** `ChartResolverTest` (dir load, `.tgz` load, dir+`--verify` rejected, `.tgz`+`--verify` aborts when provenance missing, missing-path rejected); `Install`/`UpgradeCommandTest` updated to the resolver. Full `jhelm-cli` build green (context loads, PMD + checkstyle).

With this merged, **#502 (0.6.0 — Security hardening) is complete** — every box checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)