### PR TITLE
test(rest): remove JaCoCo skip + cover the exception handler (#503)

### DIFF
--- a/jhelm-rest/pom.xml
+++ b/jhelm-rest/pom.xml
@@ -58,16 +58,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandlerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandlerTest.java
@@ -1,0 +1,99 @@
+package org.alexmond.jhelm.rest;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link JhelmRestExceptionHandler}, exercising every handler and the
+ * {@code problem()} helper's edge branches directly (the controller {@code @WebMvcTest}
+ * classes cover the happy 404/400 paths through MVC; this pins the 500 path and the
+ * null-message / no-field-error fallbacks that MVC doesn't reach).
+ */
+class JhelmRestExceptionHandlerTest {
+
+	private final JhelmRestExceptionHandler handler = new JhelmRestExceptionHandler();
+
+	@Test
+	void notFoundMapsTo404WithDetailAndTimestamp() {
+		ProblemDetail problem = this.handler.handleNotFound(new NotFoundException("Release 'x' not found"));
+
+		assertEquals(HttpStatus.NOT_FOUND.value(), problem.getStatus());
+		assertEquals("Release 'x' not found", problem.getDetail());
+		assertNotNull(problem.getProperties());
+		assertNotNull(problem.getProperties().get("timestamp"));
+	}
+
+	@Test
+	void illegalArgumentMapsTo400() {
+		ProblemDetail problem = this.handler.handleBadRequest(new IllegalArgumentException("bad input"));
+
+		assertEquals(HttpStatus.BAD_REQUEST.value(), problem.getStatus());
+		assertEquals("bad input", problem.getDetail());
+	}
+
+	@Test
+	void validationFoldsFieldMessagesIntoDetail() throws Exception {
+		BeanPropertyBindingResult binding = new BeanPropertyBindingResult(new Object(), "request");
+		binding.addError(new FieldError("request", "chartRef", "chartRef is required"));
+		binding.addError(new FieldError("request", "name", "name is required"));
+
+		ProblemDetail problem = this.handler.handleValidation(methodArgNotValid(binding));
+
+		assertEquals(HttpStatus.BAD_REQUEST.value(), problem.getStatus());
+		assertEquals("chartRef is required; name is required", problem.getDetail());
+	}
+
+	@Test
+	void validationWithNoFieldErrorsFallsBackToGenericMessage() throws Exception {
+		BeanPropertyBindingResult binding = new BeanPropertyBindingResult(new Object(), "request");
+
+		ProblemDetail problem = this.handler.handleValidation(methodArgNotValid(binding));
+
+		assertEquals(HttpStatus.BAD_REQUEST.value(), problem.getStatus());
+		assertEquals("Validation failed", problem.getDetail());
+	}
+
+	@Test
+	void unhandledExceptionMapsTo500() {
+		ProblemDetail problem = this.handler.handleInternalError(new RuntimeException("boom"));
+
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), problem.getStatus());
+		assertEquals("boom", problem.getDetail());
+	}
+
+	@Test
+	void nullMessageFallsBackToUnknownError() {
+		ProblemDetail problem = this.handler.handleInternalError(new RuntimeException());
+
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), problem.getStatus());
+		assertEquals("Unknown error", problem.getDetail());
+		assertTrue(problem.getProperties().containsKey("timestamp"));
+	}
+
+	private MethodArgumentNotValidException methodArgNotValid(BeanPropertyBindingResult binding) throws Exception {
+		Method method = Target.class.getDeclaredMethod("handle", String.class);
+		MethodParameter parameter = new MethodParameter(method, 0);
+		return new MethodArgumentNotValidException(parameter, binding);
+	}
+
+	/** Reflection target providing a real {@link MethodParameter} for the test. */
+	private static final class Target {
+
+		void handle(String body) {
+		}
+
+	}
+
+}


### PR DESCRIPTION
First slice of the **0.7.0 test & CI hardening** milestone (#503).

## What
- Remove the `jhelm-rest` JaCoCo exemption (`<skip>true</skip>`) — the module now inherits the parent's `BUNDLE` `LINE >= 0.75` coverage gate, so REST error-path regressions can no longer merge uncovered.
- Add `JhelmRestExceptionHandlerTest` — a direct unit test (real objects, no mocks) covering all four handlers and the branches the controller `@WebMvcTest` classes don't reach:
  - `NotFoundException` → 404 (detail + timestamp property)
  - `IllegalArgumentException` → 400
  - `MethodArgumentNotValidException` → 400, folding field messages into `detail`, **and** the no-field-error "Validation failed" fallback
  - `Exception` → 500, **and** the null-message "Unknown error" fallback

## Result
`jhelm-rest` LINE coverage **91.5%** (gate 75%); `mvn -pl jhelm-rest -am verify` green with the check enforced.

## #503 reconciliation
While picking this up I found the tracker stale and corrected it: the **rollback-on-kind** blocker and the **`@KubeClusterAvailable`** high item are already done (0.5.0 conformance suite + the existing condition annotation), and the **parity-subset** blocker's premise is obsolete (`parity.yml` already gates PRs). Those are now checked off in #503; this PR clears the next open High item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)