### PR TITLE
test(core): BRANCH coverage floors for action + service (#503)

### DIFF
--- a/jhelm-core/pom.xml
+++ b/jhelm-core/pom.xml
@@ -78,4 +78,59 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+                Branch-coverage floors for the mutation-heavy action + service packages,
+                in addition to the parent's BUNDLE LINE >= 0.75 gate. LINE alone is weak
+                for these: a fully-line-covered method can leave half its conditional
+                branches untested. These minimums are ratchet floors set just below the
+                current measured branch coverage (action 76%, service 65%) — they block
+                regression today and are raised as the negative/error-path tests land.
+            -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-branch-coverage</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <includes>
+                                        <include>org.alexmond.jhelm.core.action</include>
+                                    </includes>
+                                    <limits>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <includes>
+                                        <include>org.alexmond.jhelm.core.service</include>
+                                    </includes>
+                                    <limits>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.60</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Next slice of the **0.7.0 test & CI hardening** milestone (#503) — the "add a BRANCH gate for `core/action` + `core/service`" High item.

## Why
The parent's single `BUNDLE` `LINE >= 0.75` gate is weak for the mutation-heavy action/service packages: a fully **line**-covered method can still leave half its conditional **branches** untested.

## What
A second jacoco `check` execution on jhelm-core (additive to the inherited LINE gate) with per-package `BRANCH` `COVEREDRATIO` floors:

| package | current BRANCH | floor |
|---|---|---|
| `core.action` | 76.1% | **≥ 0.75** |
| `core.service` | 64.8% | **≥ 0.60** |

These are **ratchet floors** set just below current coverage — they block regression today and get raised as the negative/error-path tests (RegistryManager / OciRegistryClient / SignatureService, the #503 Medium item) land and lift `service` toward 0.75.

## Verification
Proved the rules aren't vacuous: an impossible `0.99` floor **fails** the build on `check-branch-coverage` for `core.service`; the real `0.75`/`0.60` floors **pass** (`mvn -pl jhelm-core -am verify` green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)