### PR TITLE
test(core): OCI registry auth/error-path tests + ratchet service branch floor (#503)

### DIFF
--- a/jhelm-core/pom.xml
+++ b/jhelm-core/pom.xml
@@ -86,7 +86,7 @@
                 in addition to the parent's BUNDLE LINE >= 0.75 gate. LINE alone is weak
                 for these: a fully-line-covered method can leave half its conditional
                 branches untested. These minimums are ratchet floors set just below the
-                current measured branch coverage (action 76%, service 65%) — they block
+                current measured branch coverage (action 76%, service 66%) — they block
                 regression today and are raised as the negative/error-path tests land.
             -->
             <plugin>
@@ -122,7 +122,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.60</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/OciRegistryClientTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/OciRegistryClientTest.java
@@ -3,17 +3,22 @@ package org.alexmond.jhelm.core.service;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -115,6 +120,148 @@ class OciRegistryClientTest {
 		OciRegistryClient redirectClient = new OciRegistryClient(http);
 		assertThrows(IOException.class, () -> redirectClient.downloadBlob("https://registry.example.com/v2/blob", "tok",
 				tempDir.resolve("b").toFile()));
+	}
+
+	@Test
+	void fetchTokenReturnsTokenFromSuccessBody() throws Exception {
+		OciRegistryClient c = clientReturning(jsonResponse(200, "{\"token\":\"secret-token\"}"));
+		assertEquals("secret-token", c.fetchToken("my.registry.io", "charts/mychart", "dXNlcjpwYXNz", "pull"));
+	}
+
+	@Test
+	void fetchTokenFallsBackToAccessToken() throws Exception {
+		OciRegistryClient c = clientReturning(jsonResponse(200, "{\"access_token\":\"oauth-token\"}"));
+		assertEquals("oauth-token", c.fetchToken("my.registry.io", "charts/mychart", null, "pull"));
+	}
+
+	@Test
+	void fetchTokenReturnsNullWhenBodyHasNoToken() throws Exception {
+		OciRegistryClient c = clientReturning(jsonResponse(200, "{}"));
+		assertNull(c.fetchToken("my.registry.io", "charts/mychart", null, "pull"));
+	}
+
+	@Test
+	void fetchTokenReturnsNullOnNon200() throws Exception {
+		OciRegistryClient c = clientReturning(jsonResponse(401, null));
+		assertNull(c.fetchToken("my.registry.io", "charts/mychart", null, "pull"));
+	}
+
+	@Test
+	void fetchTokenUsesDockerAuthEndpointAndReturnsToken() throws Exception {
+		// registry-1.docker.io routes to the auth.docker.io token service
+		OciRegistryClient c = clientReturning(jsonResponse(200, "{\"token\":\"docker-token\"}"));
+		assertEquals("docker-token", c.fetchToken("registry-1.docker.io", "library/nginx", null, "pull"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void fetchTokenReturnsNullWhenRequestThrows() throws Exception {
+		CloseableHttpClient http = mock(CloseableHttpClient.class);
+		when(http.execute(any(HttpUriRequest.class), any(HttpClientResponseHandler.class)))
+			.thenThrow(new IOException("connection reset"));
+		OciRegistryClient c = new OciRegistryClient(http);
+		assertNull(c.fetchToken("my.registry.io", "charts/mychart", null, "pull"));
+	}
+
+	@Test
+	void getManifestParsesBodyWithTokenAndAccept() throws Exception {
+		OciRegistryClient c = clientReturning(jsonResponse(200, "{\"schemaVersion\":2}"));
+		JsonNode manifest = c.getManifest("https://my.registry.io/v2/charts/mychart/manifests/1.0.0", "bearer",
+				"application/vnd.oci.image.manifest.v1+json");
+		assertEquals(2, manifest.get("schemaVersion").asInt());
+	}
+
+	@Test
+	void getManifestReturnsNullWhenNoEntity() throws Exception {
+		OciRegistryClient c = clientReturning(jsonResponse(200, null));
+		assertNull(c.getManifest("https://my.registry.io/v2/charts/mychart/manifests/1.0.0", null, null));
+	}
+
+	@Test
+	void resolveDigestFromIndexReturnsNullForEmptyManifests() throws Exception {
+		JsonMapper mapper = JsonMapper.builder().build();
+		assertNull(client.resolveDigestFromIndex(mapper.readTree("{\"manifests\":[]}")));
+		assertNull(client.resolveDigestFromIndex(mapper.readTree("{}")));
+	}
+
+	@Test
+	void resolveDigestFromIndexFallsBackToFirstEntry() throws Exception {
+		// no platform-agnostic entry and no linux/amd64 — fall back to the first manifest
+		JsonMapper mapper = JsonMapper.builder().build();
+		JsonNode index = mapper.readTree("""
+				{"manifests":[
+				  {"digest":"sha256:win","platform":{"os":"windows","architecture":"amd64"}},
+				  {"digest":"sha256:arm","platform":{"os":"linux","architecture":"arm64"}}
+				]}
+				""");
+		assertEquals("sha256:win", client.resolveDigestFromIndex(index));
+	}
+
+	@Test
+	void blobExistsTrueOn200() throws Exception {
+		OciRegistryClient c = clientReturning(jsonResponse(200, null));
+		assertTrue(c.blobExists("my.registry.io", "charts/mychart", "bearer", "sha256:abc"));
+	}
+
+	@Test
+	void blobExistsFalseOnNon200() throws Exception {
+		OciRegistryClient c = clientReturning(jsonResponse(404, null));
+		assertFalse(c.blobExists("my.registry.io", "charts/mychart", null, "sha256:abc"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void blobExistsFalseWhenRequestThrows() throws Exception {
+		CloseableHttpClient http = mock(CloseableHttpClient.class);
+		when(http.execute(any(HttpUriRequest.class), any(HttpClientResponseHandler.class)))
+			.thenThrow(new IOException("head failed"));
+		OciRegistryClient c = new OciRegistryClient(http);
+		assertFalse(c.blobExists("my.registry.io", "charts/mychart", null, "sha256:abc"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void downloadBlobFailsWhenRedirectChainExceedsCap() throws Exception {
+		// Every response is a 302 to another valid public host, so the redirect cap
+		// trips.
+		CloseableHttpClient http = mock(CloseableHttpClient.class);
+		ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+		when(response.getCode()).thenReturn(302);
+		when(response.getFirstHeader("Location"))
+			.thenReturn(new BasicHeader("Location", "https://cdn.example.com/next"));
+		when(http.execute(any(HttpUriRequest.class), any(HttpClientResponseHandler.class)))
+			.thenAnswer((inv) -> inv.getArgument(1, HttpClientResponseHandler.class).handleResponse(response));
+		OciRegistryClient c = new OciRegistryClient(http);
+		IOException ex = assertThrows(IOException.class,
+				() -> c.downloadBlob("https://registry.example.com/v2/blob", "tok", tempDir.resolve("b").toFile()));
+		assertTrue(ex.getMessage().contains("Too many redirects"));
+	}
+
+	/** Builds a mocked response with the given status and optional JSON body. */
+	private ClassicHttpResponse jsonResponse(int code, String body) throws Exception {
+		ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+		when(response.getCode()).thenReturn(code);
+		if (body != null) {
+			HttpEntity entity = mock(HttpEntity.class);
+			when(entity.getContent()).thenReturn(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+			when(response.getEntity()).thenReturn(entity);
+		}
+		else {
+			when(response.getEntity()).thenReturn(null);
+		}
+		return response;
+	}
+
+	/**
+	 * Builds a client whose HTTP execute runs the caller's handler against
+	 * {@code response}.
+	 */
+	@SuppressWarnings("unchecked")
+	private OciRegistryClient clientReturning(ClassicHttpResponse response) throws Exception {
+		CloseableHttpClient http = mock(CloseableHttpClient.class);
+		when(http.execute(any(HttpUriRequest.class), any(HttpClientResponseHandler.class)))
+			.thenAnswer((inv) -> inv.getArgument(1, HttpClientResponseHandler.class).handleResponse(response));
+		return new OciRegistryClient(http);
 	}
 
 }


### PR DESCRIPTION
Next slice of **0.7.0 test & CI hardening** (#503) — the "negative/error-path tests for OciRegistryClient auth …" Medium item, which also lets me ratchet the `core/service` branch floor added in #596.

## What
Cover `OciRegistryClient`'s untested auth + error branches using the sanctioned HTTP mock (`CloseableHttpClient`):
- **fetchToken** — success `token`, `access_token` fallback, missing-token → null, non-200 → null, `registry-1.docker.io` auth-endpoint routing, request-throws → null
- **getManifest** — parses body (with token+accept headers), no-entity → null
- **blobExists** — 200 → true, non-200 → false, request-throws → false
- **resolveDigestFromIndex** — empty/absent `manifests` → null, first-entry fallback (no platform-agnostic, no linux/amd64)
- **downloadBlob** — redirect chain exceeding the cap → `IOException("Too many redirects")`

## Result
`OciRegistryClient` BRANCH **51.9% → 69.4%** (+19 branches), lifting `core/service` BRANCH to **66.3%**. Ratchets the service branch floor **0.60 → 0.65** to lock it in. `mvn -pl jhelm-core -am verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)