### PR TITLE
ci: align PR coverage thresholds with the 75% gate + widen reporting (#503)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,10 @@ jobs:
           version: v3.14.2
 
       - name: Build with Maven
-        run: ./mvnw clean install -B --fail-at-end
+        # redirectTestOutputToFile keeps the per-chart rendered manifests out of the
+        # surefire system-out (jhelm's tests embed full charts — GBs of XML otherwise),
+        # which is what let the junit upload below widen to every module.
+        run: ./mvnw clean install -B --fail-at-end -DredirectTestOutputToFile=true
 
       - name: Report tests + coverage to UniTrack
         if: always()
@@ -41,12 +44,11 @@ jobs:
           token: ${{ secrets.UNITRACK_TOKEN }}
           # soft-fail: reporting to UniTrack must never fail the build.
           split-by-module: "true"
-          # jhelm's tests embed full rendered charts in surefire system-out — ~GBs of XML,
-          # >100MB even gzipped. Until surefire <redirectTestOutputToFile>true</...> trims that
-          # (or you shard per-module with a shared run-key), upload coverage for everything plus
-          # tests from one small module; widen `junit` to **/ afterwards.
+          # The build runs with -DredirectTestOutputToFile=true, so the per-chart rendered
+          # manifests no longer bloat the surefire system-out — the junit upload can now
+          # cover every module instead of a single small one.
           soft-fail: "true"
-          junit: 'jhelm-gotemplate-helm/**/surefire-reports/TEST-*.xml'
+          junit: '**/surefire-reports/TEST-*.xml'
           jacoco: '**/target/site/jacoco/jacoco.xml'
 
 #      - name: Publish Test Results
@@ -64,10 +66,12 @@ jobs:
             ${{ github.workspace }}/jhelm-core/target/site/jacoco/jacoco.xml,
             ${{ github.workspace }}/jhelm-kube/target/site/jacoco/jacoco.xml,
             ${{ github.workspace }}/jhelm-cli/target/site/jacoco/jacoco.xml,
-            ${{ github.workspace }}/jhelm-gotemplate/target/site/jacoco/jacoco.xml
+            ${{ github.workspace }}/jhelm-rest/target/site/jacoco/jacoco.xml,
+            ${{ github.workspace }}/jhelm-gotemplate-helm/target/site/jacoco/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 40
-          min-coverage-changed-files: 60
+          # Aligned with the JaCoCo build gate (BUNDLE LINE >= 0.75).
+          min-coverage-overall: 75
+          min-coverage-changed-files: 75
 
       - name: Add coverage to PR
         if: ${{ !cancelled() }}
@@ -78,7 +82,8 @@ jobs:
             ${{ github.workspace }}/jhelm-core/target/site/jacoco/jacoco.xml,
             ${{ github.workspace }}/jhelm-kube/target/site/jacoco/jacoco.xml,
             ${{ github.workspace }}/jhelm-cli/target/site/jacoco/jacoco.xml,
-            ${{ github.workspace }}/jhelm-gotemplate/target/site/jacoco/jacoco.xml
+            ${{ github.workspace }}/jhelm-rest/target/site/jacoco/jacoco.xml,
+            ${{ github.workspace }}/jhelm-gotemplate-helm/target/site/jacoco/jacoco.xml
           fail_ci_if_error: true
 
       - name: Upload test results to Codecov


### PR DESCRIPTION
Final Medium item of **0.7.0 test & CI hardening** (#503).

## Problems
- The PR coverage comment used `min-coverage-overall: 40` / `min-coverage-changed-files: 60` — far below the actual JaCoCo build gate (`BUNDLE` `LINE >= 0.75`).
- Both the `madrapps/jacoco-report` and `codecov` steps pointed at `jhelm-gotemplate/target/site/jacoco/jacoco.xml` — a **stale path**: that directory has no `pom` (the base engine is the external gotmpl4j now), so it silently resolved to nothing.
- `jhelm-rest` coverage (un-skipped in #595) wasn't in the reported set at all.

## Changes
- Raise `min-coverage-overall`/`min-coverage-changed-files` **40/60 → 75/75** to match the gate.
- Fix `jhelm-gotemplate` → **`jhelm-gotemplate-helm`** and **add `jhelm-rest`** in both the madrapps and codecov file lists.
- Build with **`-DredirectTestOutputToFile=true`** so the per-chart rendered manifests stay out of the surefire system-out (GBs of XML otherwise); with that trimmed, **widen the UniTrack junit upload** from one small module to every module (`**/surefire-reports/TEST-*.xml`).

## Headroom
Union line coverage across the reported modules is **83.7%** locally (kube ITs skipped without a cluster; higher in CI with the kind cluster) — every module ≥79% — so the 75 floor is comfortable. This PR touches only `build.yml`, so `min-coverage-changed-files` can't block it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)