### PR TITLE
test(core): registry + post-renderer error paths; stop home pollution (#503)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RegistryManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RegistryManager.java
@@ -40,6 +40,15 @@ public class RegistryManager {
 		}
 	}
 
+	/**
+	 * Creates a manager backed by an explicit config file. Package-private: used by tests
+	 * to point at a temporary file instead of the real per-user helm registry config.
+	 * @param configPath the path to the registry credentials file
+	 */
+	RegistryManager(String configPath) {
+		this.configPath = configPath;
+	}
+
 	public void login(String registry, String username, String password) throws IOException {
 		Config config = loadConfig();
 		String auth = Base64.getEncoder().encodeToString((username + ":" + password).getBytes());

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ExternalCommandPostRendererTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ExternalCommandPostRendererTest.java
@@ -52,6 +52,17 @@ class ExternalCommandPostRendererTest {
 	}
 
 	@Test
+	void processIncludesStderrInErrorOnNonZeroExit() throws Exception {
+		// a non-zero exit that also writes to stderr — the error message folds the
+		// captured stderr in (the stderr-non-blank branch)
+		ExternalCommandPostRenderer renderer = new ExternalCommandPostRenderer(
+				List.of("bash", "-c", "echo 'boom happened' >&2; exit 2"));
+		IOException ex = assertThrows(IOException.class, () -> renderer.process("input"));
+		assertTrue(ex.getMessage().contains("boom happened"));
+		assertTrue(ex.getMessage().contains("code 2"));
+	}
+
+	@Test
 	void processThrowsOnTimeout() throws Exception {
 		// Use bash -c to read stdin first (so the process doesn't exit when stdin closes)
 		// then sleep

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RegistryManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RegistryManagerTest.java
@@ -21,21 +21,31 @@ class RegistryManagerTest {
 
 	@BeforeEach
 	void setUp() {
-		registryManager = new RegistryManager();
+		// Back the manager with a temp config file so the login/logout tests below never
+		// touch the developer's real ~/.config/helm/registry/config.json.
+		registryManager = new RegistryManager(tempDir.resolve("registry-config.json").toString());
 	}
 
 	@Test
-	void testConstructorCreatesDefaultConfigPath() {
-		assertNotNull(registryManager);
-		String os = System.getProperty("os.name").toLowerCase();
-		assertNotNull(os);
+	void testDefaultConstructorCreatesConfigPath() {
+		// exercises the OS-specific default path selection without writing anything
+		assertNotNull(new RegistryManager());
 	}
 
 	@Test
-	void testLoadConfigReturnsValidConfig() throws IOException {
+	void testLoadConfigReturnsEmptyConfigWhenFileMissing() throws IOException {
 		RegistryManager.Config config = registryManager.loadConfig();
 		assertNotNull(config);
 		assertNotNull(config.getAuths());
+	}
+
+	@Test
+	void testLoadConfigReadsPersistedFile() throws IOException {
+		// login writes the file; a fresh manager on the same path must read it back
+		// (covers the loadConfig file-exists branch)
+		registryManager.login("ghcr.io", "user", "pass");
+		RegistryManager reopened = new RegistryManager(tempDir.resolve("registry-config.json").toString());
+		assertNotNull(reopened.getAuth("ghcr.io"));
 	}
 
 	@Test


### PR DESCRIPTION
Continues the negative/error-path Medium item of **0.7.0 test & CI hardening** (#503).

## Highlight — a real bug fixed
`RegistryManagerTest`'s login/logout tests ran against a `new RegistryManager()` whose config path is derived from `user.home` — so the suite **wrote credentials into the developer's/CI's actual `~/.config/helm/registry/config.json`** on every run. Added a package-private `RegistryManager(String configPath)` test seam and pointed the tests at a `@TempDir` file. No more home pollution, and a reopen-the-persisted-file test now covers the `loadConfig` file-exists branch. `RegistryManager` BRANCH **60% → 70%**.

## Also
`ExternalCommandPostRenderer` — cover the stderr-non-blank error branch (a non-zero exit that writes to stderr folds it into the exception message). BRANCH **71% → 79%**.

## Scope note
The ticket's "plugin **Mojo** failure cases" doesn't apply: `jhelm-plugin` is the **WASM plugin runtime**, not a Maven Mojo (no `AbstractMojo`/`@Mojo` anywhere in the tree), and it already carries its own test suite (`PluginManagerTest`, `SandboxedExecutorTest`, …). Remaining named class `SignatureService` is already at 82% branch — its residual misses are debug-log guards and deep PGP internals, low ROI.

`mvn -pl jhelm-core -am verify` green; `core/service` branch floor (0.65) holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)