### PR TITLE
feat(core): make the release payload byte-schema-compatible with Helm (#605)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Release.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Release.java
@@ -3,13 +3,27 @@ package org.alexmond.jhelm.core.model;
 import java.time.OffsetDateTime;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import tools.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
 import lombok.Value;
 
+/**
+ * A Helm release record. Serializes to Helm's on-cluster release JSON schema (the payload
+ * stored inside the {@code sh.helm.release.v1.*} Secret) so that {@code helm} and
+ * {@code jhelm} can read each other's releases: nulls are omitted ({@code omitempty}),
+ * unknown fields Helm writes but jhelm does not model (e.g. {@code hooks},
+ * {@code labels}) are tolerated on read, and field names match Helm's wire format.
+ */
 @JsonDeserialize(builder = Release.ReleaseBuilder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Builder(toBuilder = true)
 @Value
 public class Release {
@@ -39,12 +53,16 @@ public class Release {
 	}
 
 	@JsonDeserialize(builder = ReleaseInfo.ReleaseInfoBuilder.class)
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	@Builder
 	@Value
 	public static class ReleaseInfo {
 
+		@JsonProperty("first_deployed")
 		private OffsetDateTime firstDeployed;
 
+		@JsonProperty("last_deployed")
 		private OffsetDateTime lastDeployed;
 
 		private OffsetDateTime deleted;
@@ -62,16 +80,30 @@ public class Release {
 
 	}
 
-	@JsonDeserialize(builder = MapConfig.MapConfigBuilder.class)
 	@Builder
 	@Value
 	public static class MapConfig {
 
 		private Map<String, Object> values;
 
-		@JsonPOJOBuilder(withPrefix = "")
-		public static class MapConfigBuilder {
+		/**
+		 * Serializes as Helm's bare {@code config} map — the user-supplied values
+		 * directly, not wrapped in a {@code values} object.
+		 * @return the values map
+		 */
+		@JsonValue
+		public Map<String, Object> jsonValue() {
+			return this.values;
+		}
 
+		/**
+		 * Deserializes from Helm's bare {@code config} map.
+		 * @param values the values map from the release payload
+		 * @return the wrapped config
+		 */
+		@JsonCreator
+		static MapConfig fromJson(Map<String, Object> values) {
+			return MapConfig.builder().values(values).build();
 		}
 
 	}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/model/ReleaseHelmInteropTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/model/ReleaseHelmInteropTest.java
@@ -1,0 +1,106 @@
+package org.alexmond.jhelm.core.model;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the on-cluster release payload to Helm's JSON schema so `helm` and `jhelm` can
+ * read each other's releases (the payload inside the {@code sh.helm.release.v1.*} Secret,
+ * not just the Secret envelope). Uses the same mapper configuration as the storage layer.
+ */
+class ReleaseHelmInteropTest {
+
+	// Same configuration as the storage layer (HelmKubeService).
+	private final JsonMapper mapper = JsonMapper.builder().build();
+
+	@Test
+	void serializesInfoTimestampsAsHelmSnakeCase() {
+		String json = this.mapper.writeValueAsString(sampleRelease());
+		assertTrue(json.contains("\"first_deployed\""), json);
+		assertTrue(json.contains("\"last_deployed\""), json);
+		assertFalse(json.contains("firstDeployed"), json);
+		assertFalse(json.contains("lastDeployed"), json);
+	}
+
+	@Test
+	void serializesConfigAsABareMapLikeHelm() {
+		ObjectNode root = (ObjectNode) this.mapper.readTree(this.mapper.writeValueAsString(sampleRelease()));
+		// Helm stores user values directly under "config", not wrapped in a "values"
+		// object
+		assertEquals(2, root.get("config").get("replicaCount").asInt());
+		assertFalse(root.get("config").has("values"), root.get("config").toString());
+	}
+
+	@Test
+	void omitsNullFieldsLikeHelmOmitempty() {
+		String json = this.mapper.writeValueAsString(sampleRelease());
+		assertFalse(json.contains("null"), json);
+	}
+
+	@Test
+	void serializesStatusAsHelmWireString() {
+		String json = this.mapper.writeValueAsString(sampleRelease());
+		assertTrue(json.contains("\"status\":\"deployed\""), json);
+	}
+
+	@Test
+	void readsAHelmShapedReleaseIncludingUnknownFields() {
+		// A payload as the Helm CLI writes it: snake_case info, bare config, and fields
+		// jhelm
+		// does not model (hooks, labels). jhelm must read it without throwing.
+		String helmJson = """
+				{
+				  "name": "wordpress",
+				  "namespace": "default",
+				  "version": 3,
+				  "info": {
+				    "first_deployed": "2026-01-01T00:00:00Z",
+				    "last_deployed": "2026-01-03T00:00:00Z",
+				    "deleted": "",
+				    "description": "Upgrade complete",
+				    "status": "deployed",
+				    "notes": "hello"
+				  },
+				  "config": { "replicaCount": 5, "image": { "tag": "1.2.3" } },
+				  "manifest": "apiVersion: v1",
+				  "hooks": [ { "name": "pre-install", "kind": "Job" } ],
+				  "labels": { "owner": "helm" }
+				}
+				""";
+		Release r = this.mapper.readValue(helmJson, Release.class);
+		assertEquals("wordpress", r.getName());
+		assertEquals(3, r.getVersion());
+		assertNotNull(r.getInfo());
+		assertEquals(OffsetDateTime.parse("2026-01-01T00:00:00Z"), r.getInfo().getFirstDeployed());
+		assertEquals(OffsetDateTime.parse("2026-01-03T00:00:00Z"), r.getInfo().getLastDeployed());
+		assertEquals(ReleaseStatus.DEPLOYED, r.getInfo().getStatus());
+		assertNotNull(r.getConfig());
+		assertEquals(5, r.getConfig().getValues().get("replicaCount"));
+	}
+
+	private Release sampleRelease() {
+		return Release.builder()
+			.name("demo")
+			.namespace("default")
+			.version(1)
+			.manifest("apiVersion: v1")
+			.config(Release.MapConfig.builder().values(Map.of("replicaCount", 2)).build())
+			.info(Release.ReleaseInfo.builder()
+				.firstDeployed(OffsetDateTime.parse("2026-01-01T00:00:00Z"))
+				.lastDeployed(OffsetDateTime.parse("2026-01-02T00:00:00Z"))
+				.status(ReleaseStatus.DEPLOYED)
+				.description("Install complete")
+				.build())
+			.build();
+	}
+
+}

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,7 @@
+# Stop Lombok config lookup here (project root).
+config.stopBubbling = true
+
+# Copy Jackson's @JsonProperty from a field onto the generated @Builder setter, so
+# builder-based deserialization honors custom/snake_case wire names (e.g. Helm's
+# release payload uses first_deployed / last_deployed).
+lombok.copyableAnnotations += com.fasterxml.jackson.annotation.JsonProperty


### PR DESCRIPTION
First slice of **#605 — release-storage interoperability** (under the #604 interop umbrella, a 1.0.0 gate).

## The gap this closes
The audit confirmed the Secret **envelope** (name `sh.helm.release.v1.*`, type `helm.sh/release.v1`, `owner=helm` labels) already matches Helm — so `helm list` sees jhelm's releases. But the **JSON payload inside** did not match Helm's release schema, so `helm get` and cross-tool upgrades (which parse the payload) would mis-read it:

| | jhelm (before) | Helm |
|---|---|---|
| info timestamps | `firstDeployed` / `lastDeployed` | `first_deployed` / `last_deployed` |
| `config` | wrapped: `{"values":{…}}` | bare map: `{…}` |
| empty fields | `"chart":null,…` | omitempty (absent) |
| unknown fields (`hooks`,`labels`) | would choke on read | present |

## Fix (in the `Release` model — `HelmKubeService`'s mapper picks it up)
- `ReleaseInfo` → `@JsonProperty("first_deployed"/"last_deployed")`
- `MapConfig` serializes/reads as Helm's bare `config` map (`@JsonValue` + `@JsonCreator`), **keeping `getConfig().getValues()` unchanged** at all call sites
- `@JsonInclude(NON_NULL)` (omitempty) + `@JsonIgnoreProperties(ignoreUnknown=true)` (tolerate Helm's richer payload)
- root `lombok.config` copies `@JsonProperty` onto the generated builder setters so builder-based **deserialization** honors the snake_case names

`ReleaseStatus` was already Helm-wire-compatible (`deployed`, `pending-install`, …).

## Verification
New `ReleaseHelmInteropTest` (5 cases, no cluster needed) pins the contract: snake_case timestamps, bare config, null-omission, Helm-wire status, and **reading a real Helm-shaped payload** including unknown `hooks`/`labels`. Full `core,kube,rest,cli` build green — no existing test regressed.

## Next in #605
The cluster-based **two-way interop test suite** (install with one tool, manage with the other, on kind), and a deeper audit of the nested chart/hooks schema, then the docs page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)