### PR TITLE
feat(core): store the embedded chart in Helm's release format (#605)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/HelmReleaseCodec.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/HelmReleaseCodec.java
@@ -1,0 +1,161 @@
+package org.alexmond.jhelm.core.model;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.function.Consumer;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * Encodes and decodes a {@link Release} to Helm's on-cluster release JSON at the storage
+ * boundary (the payload stored, gzipped, inside the {@code sh.helm.release.v1.*} Secret).
+ *
+ * <p>
+ * The top-level release schema is already Helm-compatible via annotations on
+ * {@link Release} (snake_case info timestamps, bare {@code config} map,
+ * {@code omitempty}, unknown-field tolerance). The embedded {@code chart} needs a further
+ * transform that must <em>not</em> touch the in-memory {@link Chart} model — the
+ * rendering engine reads template/file content as raw text, and the REST API serializes
+ * charts in readable form — so it is applied here, on the JSON tree, only for storage:
+ * </p>
+ * <ul>
+ * <li>{@code templates[].data} is base64-encoded (Helm stores chart file bytes
+ * base64);</li>
+ * <li>{@code files} is converted between jhelm's {@code {name: content}} map and Helm's
+ * {@code [{name, data}]} array with base64 content;</li>
+ * <li>the values schema is moved between jhelm's raw {@code valuesSchema} and Helm's
+ * base64 {@code schema};</li>
+ * <li>subchart {@code dependencies} are transformed recursively.</li>
+ * </ul>
+ */
+public final class HelmReleaseCodec {
+
+	private final JsonMapper mapper = JsonMapper.builder().build();
+
+	/**
+	 * Serializes a release to Helm's release-payload JSON.
+	 * @param release the release to encode
+	 * @return the Helm-shaped JSON bytes
+	 */
+	public byte[] toJson(Release release) {
+		ObjectNode root = (ObjectNode) this.mapper.valueToTree(release);
+		if (root.get("chart") instanceof ObjectNode chart) {
+			chartToHelm(chart);
+		}
+		return this.mapper.writeValueAsBytes(root);
+	}
+
+	/**
+	 * Deserializes a Helm-shaped release payload (as written by {@code helm} or by
+	 * {@link #toJson(Release)}) back into a {@link Release}.
+	 * @param json the release-payload JSON bytes
+	 * @return the decoded release
+	 */
+	public Release fromJson(byte[] json) {
+		JsonNode tree = this.mapper.readTree(json);
+		if (tree instanceof ObjectNode root && root.get("chart") instanceof ObjectNode chart) {
+			chartFromHelm(chart);
+		}
+		return this.mapper.treeToValue(tree, Release.class);
+	}
+
+	private void chartToHelm(ObjectNode chart) {
+		base64DataItems(chart, "templates");
+		renameAndBase64(chart, "valuesSchema", "schema");
+		filesMapToArray(chart);
+		forEachDependency(chart, this::chartToHelm);
+	}
+
+	private void chartFromHelm(ObjectNode chart) {
+		decodeDataItems(chart, "templates");
+		renameAndDecode(chart, "schema", "valuesSchema");
+		filesArrayToMap(chart);
+		forEachDependency(chart, this::chartFromHelm);
+	}
+
+	private void base64DataItems(ObjectNode chart, String field) {
+		if (chart.get(field) instanceof ArrayNode items) {
+			for (JsonNode item : items) {
+				if (item instanceof ObjectNode node && node.get("data") != null && !node.get("data").isNull()) {
+					node.put("data", encode(node.get("data").asString()));
+				}
+			}
+		}
+	}
+
+	private void decodeDataItems(ObjectNode chart, String field) {
+		if (chart.get(field) instanceof ArrayNode items) {
+			for (JsonNode item : items) {
+				if (item instanceof ObjectNode node && node.get("data") != null && !node.get("data").isNull()) {
+					node.put("data", decode(node.get("data").asString()));
+				}
+			}
+		}
+	}
+
+	private void renameAndBase64(ObjectNode chart, String from, String to) {
+		JsonNode value = chart.get(from);
+		if (value != null && !value.isNull()) {
+			chart.put(to, encode(value.asString()));
+		}
+		chart.remove(from);
+	}
+
+	private void renameAndDecode(ObjectNode chart, String from, String to) {
+		JsonNode value = chart.get(from);
+		if (value != null && !value.isNull()) {
+			chart.put(to, decode(value.asString()));
+		}
+		chart.remove(from);
+	}
+
+	private void filesMapToArray(ObjectNode chart) {
+		if (chart.get("files") instanceof ObjectNode files) {
+			ArrayNode array = this.mapper.createArrayNode();
+			for (String name : files.propertyNames()) {
+				JsonNode content = files.get(name);
+				ObjectNode entry = this.mapper.createObjectNode();
+				entry.put("name", name);
+				entry.put("data", content.isNull() ? "" : encode(content.asString()));
+				array.add(entry);
+			}
+			chart.set("files", array);
+		}
+	}
+
+	private void filesArrayToMap(ObjectNode chart) {
+		if (chart.get("files") instanceof ArrayNode files) {
+			ObjectNode map = this.mapper.createObjectNode();
+			for (JsonNode item : files) {
+				if (item instanceof ObjectNode node && node.get("name") != null) {
+					JsonNode data = node.get("data");
+					map.put(node.get("name").asString(),
+							(data == null || data.isNull()) ? "" : decode(data.asString()));
+				}
+			}
+			chart.set("files", map);
+		}
+	}
+
+	private void forEachDependency(ObjectNode chart, Consumer<ObjectNode> transform) {
+		if (chart.get("dependencies") instanceof ArrayNode dependencies) {
+			for (JsonNode dependency : dependencies) {
+				if (dependency instanceof ObjectNode node) {
+					transform.accept(node);
+				}
+			}
+		}
+	}
+
+	private String encode(String raw) {
+		return Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private String decode(String base64) {
+		return new String(Base64.getDecoder().decode(base64), StandardCharsets.UTF_8);
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/model/ReleaseHelmInteropTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/model/ReleaseHelmInteropTest.java
@@ -1,6 +1,10 @@
 package org.alexmond.jhelm.core.model;
 
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -85,6 +89,78 @@ class ReleaseHelmInteropTest {
 		assertEquals(ReleaseStatus.DEPLOYED, r.getInfo().getStatus());
 		assertNotNull(r.getConfig());
 		assertEquals(5, r.getConfig().getValues().get("replicaCount"));
+	}
+
+	@Test
+	void encodesChartTemplatesAndFilesInHelmFormat() {
+		HelmReleaseCodec codec = new HelmReleaseCodec();
+		ObjectNode root = (ObjectNode) this.mapper.readTree(codec.toJson(sampleReleaseWithChart()));
+		ObjectNode chart = (ObjectNode) root.get("chart");
+		// Helm stores chart file bytes base64-encoded
+		String expectedTemplate = Base64.getEncoder()
+			.encodeToString("apiVersion: apps/v1".getBytes(StandardCharsets.UTF_8));
+		assertEquals(expectedTemplate, chart.get("templates").get(0).get("data").asString());
+		// files: Helm uses an array of {name, data(base64)}, not jhelm's map
+		assertTrue(chart.get("files").isArray(), chart.get("files").toString());
+		assertEquals("NOTES.txt", chart.get("files").get(0).get("name").asString());
+		// values schema: Helm's field is "schema" (base64), not "valuesSchema"
+		assertFalse(chart.has("valuesSchema"), chart.toString());
+		assertEquals(Base64.getEncoder().encodeToString("{}".getBytes(StandardCharsets.UTF_8)),
+				chart.get("schema").asString());
+	}
+
+	@Test
+	void roundTripsChartThroughHelmStorageFormat() {
+		HelmReleaseCodec codec = new HelmReleaseCodec();
+		Release back = codec.fromJson(codec.toJson(sampleReleaseWithChart()));
+		Chart chart = back.getChart();
+		assertNotNull(chart);
+		// raw text is restored for the in-memory model the engine renders from
+		assertEquals("apiVersion: apps/v1", chart.getTemplates().get(0).getData());
+		assertEquals("templates/deployment.yaml", chart.getTemplates().get(0).getName());
+		assertEquals("hello", chart.getFiles().get("NOTES.txt"));
+		assertEquals("{}", chart.getValuesSchema());
+	}
+
+	@Test
+	void readsAHelmShapedChartPayload() {
+		// A chart embedded as the Helm CLI writes it: base64 template/file data, files as
+		// an
+		// array, schema base64. jhelm must decode it back to raw text.
+		String rawTemplate = "kind: Deployment";
+		String helmChartJson = """
+				{
+				  "name": "app", "namespace": "default", "version": 1,
+				  "chart": {
+				    "metadata": { "name": "app", "version": "1.0.0", "apiVersion": "v2" },
+				    "templates": [ { "name": "templates/deployment.yaml", "data": "%s" } ],
+				    "files": [ { "name": "README.md", "data": "%s" } ],
+				    "schema": "%s"
+				  }
+				}
+				""".formatted(b64(rawTemplate), b64("readme body"), b64("{\"type\":\"object\"}"));
+		Release r = new HelmReleaseCodec().fromJson(helmChartJson.getBytes(StandardCharsets.UTF_8));
+		assertEquals(rawTemplate, r.getChart().getTemplates().get(0).getData());
+		assertEquals("readme body", r.getChart().getFiles().get("README.md"));
+		assertEquals("{\"type\":\"object\"}", r.getChart().getValuesSchema());
+	}
+
+	private static String b64(String raw) {
+		return Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private Release sampleReleaseWithChart() {
+		Map<String, String> files = new LinkedHashMap<>();
+		files.put("NOTES.txt", "hello");
+		Chart chart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("demo").version("1.0.0").apiVersion("v2").build())
+			.templates(List
+				.of(Chart.Template.builder().name("templates/deployment.yaml").data("apiVersion: apps/v1").build()))
+			.values(Map.of("replicaCount", 2))
+			.valuesSchema("{}")
+			.files(files)
+			.build();
+		return sampleRelease().toBuilder().chart(chart).build();
 	}
 
 	private Release sampleRelease() {

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
@@ -1,6 +1,5 @@
 package org.alexmond.jhelm.kube.service.internal;
 
-import tools.jackson.databind.json.JsonMapper;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
@@ -30,6 +29,7 @@ import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.exception.ReleaseStorageException;
 import org.alexmond.jhelm.core.exception.WaitTimeoutException;
 import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.core.model.HelmReleaseCodec;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import java.io.ByteArrayInputStream;
@@ -64,7 +64,7 @@ public class HelmKubeService implements KubeService {
 	/** Configured Kubernetes API client used for all cluster operations. */
 	private final ApiClient apiClient;
 
-	private final JsonMapper objectMapper = JsonMapper.builder().build();
+	private final HelmReleaseCodec releaseCodec = new HelmReleaseCodec();
 
 	private ResourcePluralizer pluralizer;
 
@@ -635,7 +635,7 @@ public class HelmKubeService implements KubeService {
 			// The k8s client auto-decodes the outer base64, so raw is the inner base64
 			byte[] gzipped = Base64.getDecoder().decode(raw);
 			byte[] json = gunzip(gzipped);
-			return objectMapper.readValue(json, Release.class);
+			return releaseCodec.fromJson(json);
 		}
 		catch (Exception ex) {
 			throw new ReleaseStorageException("Failed to decode release from Secret: " + secret.getMetadata().getName(),
@@ -644,7 +644,7 @@ public class HelmKubeService implements KubeService {
 	}
 
 	private byte[] encodeRelease(Release release) throws Exception {
-		byte[] json = objectMapper.writeValueAsBytes(release);
+		byte[] json = releaseCodec.toJson(release);
 		byte[] gzipped = gzip(json);
 		String b64 = Base64.getEncoder().encodeToString(gzipped);
 		return b64.getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
Second slice of **#605 — release-storage interoperability** (1.0.0 gate, under #604). Follows #608 (top-level payload).

## The gap this closes
#608 made the release payload Helm-compatible, but the **chart embedded inside it** — which `helm get all` dumps and which `helm` re-renders from on **rollback/upgrade** of a jhelm-installed release — still diverged from Helm's chart JSON:

| | jhelm (before) | Helm |
|---|---|---|
| `templates[].data`, file content | raw text | **base64** |
| `files` | `{name: content}` map | `[{name, data}]` **array** |
| values schema | `valuesSchema` (raw) | `schema` (base64) |

Helm's Go `json.Unmarshal` fails on the map-typed `files` and mis-decodes raw template bytes — so real `helm` **could not read a jhelm-stored chart**.

## Why a storage-boundary codec (not model annotations)
The transform must **not** touch the in-memory `Chart`: the rendering `Engine` reads `template.getData()` as **raw text**, and the REST `ChartController` serializes charts in **readable** form. Annotating the model would break both.

So `HelmReleaseCodec` rewrites the `chart` subtree of the release **JSON tree**, applied only in `HelmKubeService.encodeRelease`/`decodeRelease`:
- base64 `templates[].data` (decode on read)
- `files` map ⇄ Helm's `[{name, data(base64)}]` array
- `valuesSchema` ⇄ Helm's base64 `schema`
- recurses into subchart `dependencies`

The in-memory model, the engine, and the REST API are untouched.

## Verification
`ReleaseHelmInteropTest` +3 chart cases (no cluster): encodes to Helm's shape, round-trips back to raw in-memory text, and reads a Helm-shaped chart payload. All 8 pass; full `core,kube,rest,cli` build green.

## Next in #605
Cluster-based **two-way interop suite** (kind + real `helm`: install with one tool, rollback/upgrade/uninstall with the other), then the "Interoperability with Helm" docs page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)