### PR TITLE
feat(core): honor Helm's HELM_* config env vars + wire registry-config-path (#606)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -105,12 +105,18 @@ public class JhelmCoreAutoConfiguration {
 	}
 
 	/**
-	 * Provides the OCI registry manager used for OCI-based charts.
+	 * Provides the OCI registry manager used for OCI-based charts. Honors
+	 * {@code jhelm.registry-config-path}, then {@code $HELM_REGISTRY_CONFIG}, then the
+	 * per-OS Helm default.
+	 * @param props the jhelm core configuration properties
 	 * @return the registry manager bean
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	public RegistryManager registryManager() {
+	public RegistryManager registryManager(JhelmCoreProperties props) {
+		if (props.getRegistryConfigPath() != null) {
+			return new RegistryManager(props.getRegistryConfigPath());
+		}
 		return new RegistryManager();
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RegistryManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RegistryManager.java
@@ -27,26 +27,47 @@ public class RegistryManager {
 	private final String configPath;
 
 	public RegistryManager() {
-		String home = System.getProperty("user.home");
-		String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
-		if (os.contains("mac")) {
-			this.configPath = Paths.get(home, "Library/Preferences/helm/registry/config.json").toString();
-		}
-		else if (os.contains("win")) {
-			this.configPath = Paths.get(System.getenv("APPDATA"), "helm/registry/config.json").toString();
-		}
-		else {
-			this.configPath = Paths.get(home, ".config/helm/registry/config.json").toString();
-		}
+		this(resolveDefaultConfigPath());
 	}
 
 	/**
-	 * Creates a manager backed by an explicit config file. Package-private: used by tests
-	 * to point at a temporary file instead of the real per-user helm registry config.
+	 * Creates a manager backed by an explicit config file. Used to honor
+	 * {@code jhelm.registry-config-path} and, in tests, to point at a temporary file
+	 * instead of the real per-user helm registry config.
 	 * @param configPath the path to the registry credentials file
 	 */
-	RegistryManager(String configPath) {
+	public RegistryManager(String configPath) {
 		this.configPath = configPath;
+	}
+
+	/**
+	 * Resolves the registry config.json path the way Helm does:
+	 * {@code $HELM_REGISTRY_CONFIG} when set, otherwise the per-OS Helm default
+	 * (docker-style credentials, shared with {@code helm registry login}).
+	 * Package-private for testing.
+	 * @param helmRegistryConfig the value of {@code $HELM_REGISTRY_CONFIG} (may be
+	 * {@code null})
+	 * @param home the user home directory
+	 * @param osName the OS name
+	 * @return the resolved registry config.json path
+	 */
+	static String resolveConfigPath(String helmRegistryConfig, String home, String osName) {
+		if (helmRegistryConfig != null && !helmRegistryConfig.isBlank()) {
+			return helmRegistryConfig;
+		}
+		String os = osName.toLowerCase(Locale.ROOT);
+		if (os.contains("mac")) {
+			return Paths.get(home, "Library/Preferences/helm/registry/config.json").toString();
+		}
+		if (os.contains("win")) {
+			return Paths.get(System.getenv("APPDATA"), "helm/registry/config.json").toString();
+		}
+		return Paths.get(home, ".config/helm/registry/config.json").toString();
+	}
+
+	private static String resolveDefaultConfigPath() {
+		return resolveConfigPath(System.getenv("HELM_REGISTRY_CONFIG"), System.getProperty("user.home"),
+				System.getProperty("os.name"));
 	}
 
 	public void login(String registry, String username, String password) throws IOException {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -123,8 +123,25 @@ public class RepoManager {
 	}
 
 	private static String resolveDefaultConfigPath() {
-		String home = System.getProperty("user.home");
-		String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+		return resolveConfigPath(System.getenv("HELM_REPOSITORY_CONFIG"), System.getProperty("user.home"),
+				System.getProperty("os.name"));
+	}
+
+	/**
+	 * Resolves the repositories.yaml path the way Helm does:
+	 * {@code $HELM_REPOSITORY_CONFIG} when set, otherwise the per-OS Helm default.
+	 * Package-private for testing.
+	 * @param helmRepositoryConfig the value of {@code $HELM_REPOSITORY_CONFIG} (may be
+	 * {@code null})
+	 * @param home the user home directory
+	 * @param osName the OS name
+	 * @return the resolved repositories.yaml path
+	 */
+	static String resolveConfigPath(String helmRepositoryConfig, String home, String osName) {
+		if (helmRepositoryConfig != null && !helmRepositoryConfig.isBlank()) {
+			return helmRepositoryConfig;
+		}
+		String os = osName.toLowerCase(Locale.ROOT);
 		if (os.contains("mac")) {
 			return Paths.get(home, "Library/Preferences/helm/repositories.yaml").toString();
 		}
@@ -208,20 +225,34 @@ public class RepoManager {
 	}
 
 	private File getCacheDir() {
-		String home = System.getProperty("user.home");
-		String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
-		File base;
-		if (os.contains("mac")) {
-			base = Paths.get(home, "Library/Caches/jhelm/repository").toFile();
-		}
-		else if (os.contains("win")) {
-			base = Paths.get(System.getenv("LOCALAPPDATA"), "jhelm/repository").toFile();
-		}
-		else {
-			base = Paths.get(home, ".cache/jhelm/repository").toFile();
-		}
+		File base = resolveCacheDir(System.getenv("HELM_REPOSITORY_CACHE"), System.getProperty("user.home"),
+				System.getProperty("os.name"));
 		base.mkdirs();
 		return base;
+	}
+
+	/**
+	 * Resolves the repository index cache directory: {@code $HELM_REPOSITORY_CACHE} when
+	 * set (so it can be shared with Helm), otherwise a per-OS jhelm-native default.
+	 * Package-private for testing.
+	 * @param helmRepositoryCache the value of {@code $HELM_REPOSITORY_CACHE} (may be
+	 * {@code null})
+	 * @param home the user home directory
+	 * @param osName the OS name
+	 * @return the resolved cache directory
+	 */
+	static File resolveCacheDir(String helmRepositoryCache, String home, String osName) {
+		if (helmRepositoryCache != null && !helmRepositoryCache.isBlank()) {
+			return Paths.get(helmRepositoryCache).toFile();
+		}
+		String os = osName.toLowerCase(Locale.ROOT);
+		if (os.contains("mac")) {
+			return Paths.get(home, "Library/Caches/jhelm/repository").toFile();
+		}
+		if (os.contains("win")) {
+			return Paths.get(System.getenv("LOCALAPPDATA"), "jhelm/repository").toFile();
+		}
+		return Paths.get(home, ".cache/jhelm/repository").toFile();
 	}
 
 	// A repository name is used directly as a filename component for its on-disk index

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/HelmEnvConfigResolutionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/HelmEnvConfigResolutionTest.java
@@ -2,9 +2,12 @@ package org.alexmond.jhelm.core.service;
 
 import java.nio.file.Paths;
 
+import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
+import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -51,6 +54,23 @@ class HelmEnvConfigResolutionTest {
 	void registryConfigFallsBackToHelmOsDefault() {
 		assertEquals(Paths.get("/home/u", ".config/helm/registry/config.json").toString(),
 				RegistryManager.resolveConfigPath(null, "/home/u", "Linux"));
+	}
+
+	@Test
+	void defaultConstructorsResolveAgainstTheCurrentEnvironment() {
+		// exercises the default-path resolution wrappers (System.getenv/getProperty)
+		assertNotNull(new RegistryManager());
+		assertNotNull(new RepoManager());
+	}
+
+	@Test
+	void autoConfigRegistryManagerHonorsRegistryConfigPathProperty() {
+		JhelmCoreAutoConfiguration autoConfig = new JhelmCoreAutoConfiguration();
+		JhelmCoreProperties withPath = new JhelmCoreProperties();
+		withPath.setRegistryConfigPath("/tmp/jhelm-test/registry/config.json");
+		assertNotNull(autoConfig.registryManager(withPath));
+		// null property -> default resolution branch
+		assertNotNull(autoConfig.registryManager(new JhelmCoreProperties()));
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/HelmEnvConfigResolutionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/HelmEnvConfigResolutionTest.java
@@ -45,6 +45,16 @@ class HelmEnvConfigResolutionTest {
 	}
 
 	@Test
+	void resolvesTheMacOsHelmLocations() {
+		assertEquals(Paths.get("/home/u", "Library/Preferences/helm/repositories.yaml").toString(),
+				RepoManager.resolveConfigPath(null, "/home/u", "Mac OS X"));
+		assertEquals(Paths.get("/home/u", "Library/Caches/jhelm/repository").toFile(),
+				RepoManager.resolveCacheDir(null, "/home/u", "Mac OS X"));
+		assertEquals(Paths.get("/home/u", "Library/Preferences/helm/registry/config.json").toString(),
+				RegistryManager.resolveConfigPath(null, "/home/u", "Mac OS X"));
+	}
+
+	@Test
 	void registryConfigHonorsHelmRegistryConfig() {
 		assertEquals("/custom/registry.json",
 				RegistryManager.resolveConfigPath("/custom/registry.json", "/home/u", "Linux"));

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/HelmEnvConfigResolutionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/HelmEnvConfigResolutionTest.java
@@ -1,0 +1,56 @@
+package org.alexmond.jhelm.core.service;
+
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies jhelm resolves Helm's config-file locations the way Helm does — honoring the
+ * {@code HELM_*} environment variables so a Helm user's environment drops in — with the
+ * per-OS Helm default as the fallback (#606). The OS name is passed explicitly to keep
+ * the assertions platform-independent.
+ */
+class HelmEnvConfigResolutionTest {
+
+	@Test
+	void repositoriesConfigHonorsHelmRepositoryConfig() {
+		assertEquals("/custom/repositories.yaml",
+				RepoManager.resolveConfigPath("/custom/repositories.yaml", "/home/u", "Linux"));
+	}
+
+	@Test
+	void repositoriesConfigFallsBackToHelmOsDefault() {
+		assertEquals(Paths.get("/home/u", ".config/helm/repositories.yaml").toString(),
+				RepoManager.resolveConfigPath(null, "/home/u", "Linux"));
+		// blank env is treated as unset
+		assertTrue(RepoManager.resolveConfigPath("  ", "/home/u", "Linux").endsWith("repositories.yaml"));
+	}
+
+	@Test
+	void repositoryCacheHonorsHelmRepositoryCache() {
+		assertEquals(Paths.get("/shared/helm/repository").toFile(),
+				RepoManager.resolveCacheDir("/shared/helm/repository", "/home/u", "Linux"));
+	}
+
+	@Test
+	void repositoryCacheFallsBackToJhelmDefault() {
+		assertEquals(Paths.get("/home/u", ".cache/jhelm/repository").toFile(),
+				RepoManager.resolveCacheDir(null, "/home/u", "Linux"));
+	}
+
+	@Test
+	void registryConfigHonorsHelmRegistryConfig() {
+		assertEquals("/custom/registry.json",
+				RegistryManager.resolveConfigPath("/custom/registry.json", "/home/u", "Linux"));
+	}
+
+	@Test
+	void registryConfigFallsBackToHelmOsDefault() {
+		assertEquals(Paths.get("/home/u", ".config/helm/registry/config.json").toString(),
+				RegistryManager.resolveConfigPath(null, "/home/u", "Linux"));
+	}
+
+}


### PR DESCRIPTION
First slice of **#606 — configuration parity** (under #604). The "small code changes to honor Helm's paths/env" so jhelm drops into a Helm user's environment.

## What changed
jhelm now resolves the shared config locations the way Helm does — so `helm repo add` / `helm registry login`, or a `HELM_*`-driven setup, is picked up by jhelm with no extra config:

| Surface | Now honors | Resolution order |
|---|---|---|
| `repositories.yaml` | `$HELM_REPOSITORY_CONFIG` | `jhelm.config-path` > env > per-OS default |
| repo index cache | `$HELM_REPOSITORY_CACHE` | env > per-OS default |
| `registry/config.json` | `$HELM_REGISTRY_CONFIG` | `jhelm.registry-config-path` > env > per-OS default |

## Also fixes a latent gap
`jhelm.registry-config-path` was **documented but never wired** — `registryManager()` always used the default path. It now honors the property (the `RegistryManager(String)` ctor is promoted to public).

## Tests
Path resolution is extracted into package-private static helpers (`resolveConfigPath`/`resolveCacheDir`) so `HelmEnvConfigResolutionTest` covers the env-honored and default branches for all three surfaces **without mutating process env**. Full core/kube/cli/rest/mcp build green.

## Next in #606
The "Configuration parity" docs guide (helm file/env ↔ jhelm property/env mapping, drop-in vs jhelm-native).

🤖 Generated with [Claude Code](https://claude.com/claude-code)