### PR TITLE
feat(cli): add `repo update` and `list -o json|yaml` for Helm parity (#607)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
@@ -6,23 +6,41 @@ import org.alexmond.jhelm.core.action.ListAction;
 import org.alexmond.jhelm.core.model.Release;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Implements {@code jhelm list}, printing the releases in a namespace with their
- * revision, status, and chart.
+ * revision, status, and chart. Supports {@code -o table|json|yaml} for machine-readable
+ * output, matching {@code helm list -o}.
  */
 @Component
 @CommandLine.Command(name = "list", mixinStandardHelpOptions = true, description = "List releases")
 @Slf4j
 public class ListCommand implements Runnable {
 
+	private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
+
+	private static final YAMLMapper YAML_MAPPER = YAMLMapper
+		.builder(YAMLFactory.builder().disable(YAMLWriteFeature.WRITE_DOC_START_MARKER).build())
+		.build();
+
 	private final ListAction listAction;
 
 	@CommandLine.Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
 	private String namespace;
+
+	@CommandLine.Option(names = { "-o", "--output" }, defaultValue = "table",
+			description = "output format: table, json, or yaml")
+	private String output;
 
 	/**
 	 * Creates the command.
@@ -48,17 +66,45 @@ public class ListCommand implements Runnable {
 	public void run() {
 		try {
 			List<Release> releases = listAction.list(namespace);
-			CliOutput.printf("%-20s %-10s %-10s %-30s\n", CliOutput.bold("NAME"), CliOutput.bold("REVISION"),
-					CliOutput.bold("STATUS"), CliOutput.bold("CHART"));
-			for (Release r : releases) {
-				String chartInfo = r.getChart().getMetadata().getName() + "-" + r.getChart().getMetadata().getVersion();
-				String status = colorizeStatus(r.getInfo().getStatus().getValue());
-				CliOutput.printf("%-20s %-10d %-10s %-30s\n", r.getName(), r.getVersion(), status, chartInfo);
+			switch (output.toLowerCase(Locale.ROOT)) {
+				case "json" -> System.out.println(JSON_MAPPER.writeValueAsString(toRows(releases)));
+				case "yaml" -> System.out.print(YAML_MAPPER.writeValueAsString(toRows(releases)));
+				default -> printTable(releases);
 			}
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error listing releases: " + ex.getMessage()));
 		}
+	}
+
+	private void printTable(List<Release> releases) {
+		CliOutput.printf("%-20s %-10s %-10s %-30s\n", CliOutput.bold("NAME"), CliOutput.bold("REVISION"),
+				CliOutput.bold("STATUS"), CliOutput.bold("CHART"));
+		for (Release r : releases) {
+			String chartInfo = r.getChart().getMetadata().getName() + "-" + r.getChart().getMetadata().getVersion();
+			String status = colorizeStatus(r.getInfo().getStatus().getValue());
+			CliOutput.printf("%-20s %-10d %-10s %-30s\n", r.getName(), r.getVersion(), status, chartInfo);
+		}
+	}
+
+	// Mirrors the fields Helm emits for `helm list -o json/yaml` (snake_case keys).
+	private List<Map<String, Object>> toRows(List<Release> releases) {
+		List<Map<String, Object>> rows = new ArrayList<>();
+		for (Release r : releases) {
+			Map<String, Object> row = new LinkedHashMap<>();
+			row.put("name", r.getName());
+			row.put("namespace", r.getNamespace());
+			row.put("revision", r.getVersion());
+			row.put("updated", (r.getInfo() != null && r.getInfo().getLastDeployed() != null)
+					? r.getInfo().getLastDeployed().toString() : "");
+			row.put("status",
+					(r.getInfo() != null && r.getInfo().getStatus() != null) ? r.getInfo().getStatus().getValue() : "");
+			row.put("chart", r.getChart().getMetadata().getName() + "-" + r.getChart().getMetadata().getVersion());
+			String appVersion = r.getChart().getMetadata().getAppVersion();
+			row.put("app_version", (appVersion != null) ? appVersion : "");
+			rows.add(row);
+		}
+		return rows;
 	}
 
 }

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoCommand.java
@@ -8,15 +8,16 @@ import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Implements {@code jhelm repo}, managing chart repositories via the {@code add},
- * {@code list}, {@code remove}, and {@code search} subcommands.
+ * {@code list}, {@code remove}, {@code update}, and {@code search} subcommands.
  */
 @Component
 @CommandLine.Command(name = "repo", mixinStandardHelpOptions = true, description = "Manage chart repositories",
 		subcommands = { RepoCommand.AddCommand.class, RepoCommand.ListCommand.class, RepoCommand.RemoveCommand.class,
-				RepoCommand.SearchCommand.class })
+				RepoCommand.UpdateCommand.class, RepoCommand.SearchCommand.class })
 @Slf4j
 public class RepoCommand implements Runnable {
 
@@ -129,6 +130,51 @@ public class RepoCommand implements Runnable {
 			}
 			catch (IOException ex) {
 				CliOutput.errPrintln(CliOutput.error("Error removing repository: " + ex.getMessage()));
+			}
+		}
+
+	}
+
+	/**
+	 * Implements {@code repo update}: refreshes the cached index for one or more chart
+	 * repositories (all of them when no name is given), matching
+	 * {@code helm repo update}.
+	 */
+	@Component
+	@CommandLine.Command(name = "update", aliases = { "up" }, mixinStandardHelpOptions = true,
+			description = "Update the local cache of one or more chart repositories (default: all)")
+	@Slf4j
+	public static class UpdateCommand implements Runnable {
+
+		private final RepoManager repoManager;
+
+		@CommandLine.Parameters(index = "0", arity = "0..*", description = "repositories to update (default: all)")
+		private List<String> names;
+
+		/**
+		 * Creates the command.
+		 * @param repoManager the repository manager that refreshes the repo indexes
+		 */
+		public UpdateCommand(RepoManager repoManager) {
+			this.repoManager = repoManager;
+		}
+
+		@Override
+		public void run() {
+			try {
+				CliOutput.println("Hang tight while we grab the latest from your chart repositories...");
+				if (names == null || names.isEmpty()) {
+					repoManager.updateAll();
+				}
+				else {
+					for (String name : names) {
+						repoManager.updateRepo(name);
+					}
+				}
+				CliOutput.println(CliOutput.success("Update Complete. Happy Helming!"));
+			}
+			catch (IOException ex) {
+				CliOutput.errPrintln(CliOutput.error("Error updating repositories: " + ex.getMessage()));
 			}
 		}
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ListCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ListCommandTest.java
@@ -5,14 +5,19 @@ import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.action.ListAction;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -23,10 +28,24 @@ class ListCommandTest {
 
 	private ListCommand listCommand;
 
+	private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+	private final PrintStream originalOut = System.out;
+
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
 		listCommand = new ListCommand(listAction);
+		System.setOut(new PrintStream(outputStream, true, StandardCharsets.UTF_8));
+	}
+
+	@AfterEach
+	void tearDown() {
+		System.setOut(originalOut);
+	}
+
+	private String captured() {
+		return outputStream.toString(StandardCharsets.UTF_8);
 	}
 
 	@Test
@@ -52,6 +71,32 @@ class ListCommandTest {
 
 		CommandLine cmd = new CommandLine(listCommand);
 		cmd.execute();
+	}
+
+	@Test
+	void testListCommandJsonOutput() throws Exception {
+		when(listAction.list(anyString())).thenReturn(Arrays.asList(createMockRelease("release1", 3)));
+
+		new CommandLine(listCommand).execute("-o", "json");
+
+		String out = captured();
+		// Helm-style snake_case keys, and the release fields
+		assertTrue(out.contains("\"name\":\"release1\""), out);
+		assertTrue(out.contains("\"revision\":3"), out);
+		assertTrue(out.contains("\"status\":\"deployed\""), out);
+		assertTrue(out.contains("\"chart\":\"test-chart-1.0.0\""), out);
+		assertTrue(out.contains("\"app_version\""), out);
+	}
+
+	@Test
+	void testListCommandYamlOutput() throws Exception {
+		when(listAction.list(anyString())).thenReturn(Arrays.asList(createMockRelease("release1", 1)));
+
+		new CommandLine(listCommand).execute("--output", "yaml");
+
+		String out = captured();
+		assertTrue(out.contains("name: \"release1\""), out);
+		assertTrue(out.contains("status: \"deployed\""), out);
 	}
 
 	private Release createMockRelease(String name, int version) {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RepoCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RepoCommandTest.java
@@ -138,6 +138,35 @@ class RepoCommandTest {
 	}
 
 	@Test
+	void testRepoUpdateAllSuccess() throws IOException {
+		doNothing().when(repoManager).updateAll();
+
+		new CommandLine(new RepoCommand.UpdateCommand(repoManager)).execute();
+
+		verify(repoManager).updateAll();
+		assertTrue(outputStream.toString().contains("Update Complete"));
+	}
+
+	@Test
+	void testRepoUpdateNamedRepo() throws IOException {
+		doNothing().when(repoManager).updateRepo(anyString());
+
+		new CommandLine(new RepoCommand.UpdateCommand(repoManager)).execute("bitnami");
+
+		verify(repoManager).updateRepo("bitnami");
+	}
+
+	@Test
+	void testRepoUpdateWithError() throws IOException {
+		doThrow(new IOException("Test error")).when(repoManager).updateAll();
+
+		// covers the error branch; error goes to stderr and is handled without throwing
+		new CommandLine(new RepoCommand.UpdateCommand(repoManager)).execute();
+
+		verify(repoManager).updateAll();
+	}
+
+	@Test
 	void testRepoSearchCommand() {
 		RepoCommand.SearchCommand searchCommand = new RepoCommand.SearchCommand(repoManager);
 		CommandLine cmd = new CommandLine(searchCommand);


### PR DESCRIPTION
First slice of **#607 — CLI options parity** (last #604 gate). Fills the two genuine high-value flag gaps an audit surfaced.

## Context (audit finding)
A full flag audit across all commands showed jhelm is closer to parity than the umbrella assumed: `install`/`upgrade` already have `--wait`/`--timeout`/`--atomic`/`--dry-run`, and `get` already has `-o/--output`. The real gaps a Helm user hits are just two:

## What's added
- **`jhelm repo update [name...]`** — was **missing entirely** despite `RepoManager.updateAll()`/`updateRepo()` already existing in core. Wires the CLI to it: refreshes all repos, or just the named ones.
- **`jhelm list -o table|json|yaml`** — machine-readable output so `helm list -o json` scripts port over. Emits Helm's snake_case keys (`name`, `namespace`, `revision`, `updated`, `status`, `chart`, `app_version`); `table` stays default.

## Tests
`list` json/yaml asserted via captured stdout (snake_case keys, values); `repo update` covers all-repos / named-repo / error branches. Full cli build green (PMD + checkstyle + format).

## Next in #607
The **CLI parity docs reference** — the per-command helm→jhelm flag-mapping table + "porting a helm script" section, marking the genuinely not-yet-supported flags (`--force`, `--wait-for-jobs`, `list -A`, `uninstall --wait`) with reasons rather than leaving silent gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)