### PR TITLE
docs: API documentation index + javadoc.io links per artifact (#594)

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -5,6 +5,12 @@ start_page: ROOT:index.adoc
 asciidoc:
   attributes:
     jhelm-version: 0.6.0
+    api-core: 'https://javadoc.io/page/org.alexmond/jhelm-core'
+    api-gotemplate-helm: 'https://javadoc.io/page/org.alexmond/jhelm-gotemplate-helm'
+    api-kube: 'https://javadoc.io/page/org.alexmond/jhelm-kube'
+    api-rest: 'https://javadoc.io/page/org.alexmond/jhelm-rest'
+    api-mcp: 'https://javadoc.io/page/org.alexmond/jhelm-mcp'
+    api-plugin: 'https://javadoc.io/page/org.alexmond/jhelm-plugin'
     toc: left
     sectnums: ''
     keywords: 'Helm, Java, Kubernetes, Spring Boot, Chart management, Template engine'

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,6 +2,7 @@
 * xref:getting-started.adoc[Getting Started]
 * xref:architecture.adoc[Architecture]
 * xref:spring-boot-starter.adoc[Library & Spring Boot Starter]
+* xref:api.adoc[API Documentation]
 * xref:api-surface.adoc[API Surface & Stability]
 * xref:rest-api.adoc[REST API]
 * xref:mcp.adoc[MCP Server]

--- a/docs/modules/ROOT/pages/api.adoc
+++ b/docs/modules/ROOT/pages/api.adoc
@@ -1,0 +1,67 @@
+= API Documentation
+
+jhelm's library artifacts publish versioned Javadoc to https://javadoc.io[javadoc.io], which
+serves it automatically from Maven Central — no build or hosting required. The links below track
+the {jhelm-version} release.
+
+* For how to add these as dependencies and worked usage examples, see
+  xref:spring-boot-starter.adoc[Library & Spring Boot Starter].
+* For which types are supported API versus internal implementation, see
+  xref:api-surface.adoc[API Surface & Stability].
+
+== Javadoc per artifact
+
+[cols="1,2"]
+|===
+| Artifact | Javadoc
+
+| `jhelm-core` — chart model, rendering engine, action layer, repositories
+| {api-core}/{jhelm-version}/index.html[browse^]
+
+| `jhelm-gotemplate-helm` — Helm template functions
+| {api-gotemplate-helm}/{jhelm-version}/index.html[browse^]
+
+| `jhelm-kube` — Kubernetes install / upgrade / rollback / uninstall
+| {api-kube}/{jhelm-version}/index.html[browse^]
+
+| `jhelm-rest` — REST API and controllers
+| {api-rest}/{jhelm-version}/index.html[browse^]
+
+| `jhelm-mcp` — MCP server tools
+| {api-mcp}/{jhelm-version}/index.html[browse^]
+
+| `jhelm-plugin` — WASM plugin runtime
+| {api-plugin}/{jhelm-version}/index.html[browse^]
+|===
+
+[NOTE]
+====
+`jhelm-rest-starter` and `jhelm-mcp-starter` are dependency-only starters — they pull in and
+auto-configure `jhelm-rest` / `jhelm-mcp` and carry no code of their own, so their API is the
+Javadoc of `jhelm-rest` / `jhelm-mcp` above. The `jhelm-cli` application and the sample modules
+are not published to Maven Central.
+====
+
+== Key public types
+
+*Core engine and model* (`jhelm-core`)
+
+* {api-core}/{jhelm-version}/org/alexmond/jhelm/core/service/Engine.html[Engine^] — renders a chart to Kubernetes manifests
+* {api-core}/{jhelm-version}/org/alexmond/jhelm/core/model/Chart.html[Chart^] — the in-memory chart model
+* {api-core}/{jhelm-version}/org/alexmond/jhelm/core/service/ChartLoader.html[ChartLoader^] — loads a chart from a directory or archive
+* {api-core}/{jhelm-version}/org/alexmond/jhelm/core/service/RepoManager.html[RepoManager^] — chart repositories and pulls
+* {api-core}/{jhelm-version}/org/alexmond/jhelm/core/service/KubeService.html[KubeService^] — the cluster-operations SPI
+
+*Action layer* (`jhelm-core`, package `org.alexmond.jhelm.core.action`)
+
+* {api-core}/{jhelm-version}/org/alexmond/jhelm/core/action/InstallAction.html[InstallAction^], with the sibling `UpgradeAction`, `UninstallAction`, `RollbackAction`, `ListAction`, `StatusAction`, `HistoryAction`, `GetAction`, and `TemplateAction` in the same package.
+
+*Helm template functions* (`jhelm-gotemplate-helm`)
+
+* {api-gotemplate-helm}/{jhelm-version}/org/alexmond/jhelm/gotemplate/helm/HelmFunctions.html[HelmFunctions^] — the Helm function provider. The Go template engine itself is the external https://github.com/alexmond/gotmpl4j[gotmpl4j] library, which publishes its own Javadoc.
+
+*Spring Boot auto-configuration entry points*
+
+* {api-kube}/{jhelm-version}/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.html[JhelmKubeAutoConfiguration^]
+* {api-rest}/{jhelm-version}/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.html[JhelmRestAutoConfiguration^]
+* {api-mcp}/{jhelm-version}/org/alexmond/jhelm/mcp/JhelmMcpAutoConfiguration.html[JhelmMcpAutoConfiguration^]

--- a/docs/modules/ROOT/pages/spring-boot-starter.adoc
+++ b/docs/modules/ROOT/pages/spring-boot-starter.adoc
@@ -4,6 +4,9 @@ jhelm is designed to be embedded. Its modules are Spring Boot starters: adding t
 to your classpath auto-configures every bean you need to render templates and manage Helm
 charts and releases programmatically -- no CLI, no `helm` binary.
 
+TIP: For the published Javadoc of every artifact and deep links to the key public types, see
+xref:api.adoc[API Documentation].
+
 == Module Selection
 
 [cols="1,3,2"]


### PR DESCRIPTION
Delivers the concrete **#594** items (a 1.0.0 gate from #504): the `api-*` attributes and an "API documentation" index page.

## What's added
- **`api-*` attributes** in `docs/antora.yml` — one per published library artifact that ships Javadoc: `jhelm-core`, `jhelm-gotemplate-helm`, `jhelm-kube`, `jhelm-rest`, `jhelm-mcp`, `jhelm-plugin`. Version kept out of the base, composed in pages as `{api-x}/{jhelm-version}/...`.
- **New "API Documentation" page** — a per-artifact Javadoc table + deep links to the key public types (`Engine`, `Chart`, `ChartLoader`, `RepoManager`, `KubeService`, the action layer, `HelmFunctions`, and the kube/rest/mcp auto-config entry points).

## Accuracy (verified, not assumed)
- Found that **`jhelm-rest-starter` / `jhelm-mcp-starter` have no `-javadoc.jar` on Central (404)** — they're code-less dependency starters — so they're excluded from the Javadoc index with a note pointing to `jhelm-rest` / `jhelm-mcp`.
- Every artifact index and **every deep-link class path was verified against the published 0.6.0 `-javadoc.jar`** on Central, then confirmed to resolve **200 on javadoc.io** (primed past the lazy-unpack cold-miss).

Added to the nav; cross-linked from the Library & Spring Boot Starter guide (which already carries the dependency snippets + worked usage examples, covering #594's usage part).

Closes the API-index portion of #594. (The remaining #594 sub-item — filling public-class Javadoc gaps to enable doclint — is a larger code pass, trackable separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)