### PR TITLE
feat(cli): enrich `jhelm env` with effective Helm config locations (#504)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/EnvCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/EnvCommand.java
@@ -1,22 +1,44 @@
 package org.alexmond.jhelm.app.command;
 
+import java.nio.file.Paths;
+
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.service.RegistryManager;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
 /**
  * Implements {@code jhelm env}, printing the environment jhelm runs in — the active
- * namespace, the jhelm/Java/OS versions, and which recognized environment variables are
- * set. Mirrors {@code helm env} as a quick way to inspect the client environment.
+ * namespace, the effective Helm config/registry/cache and kubeconfig locations (resolved
+ * the same way jhelm resolves them: explicit property, then
+ * {@code HELM_*}/{@code KUBECONFIG} env, then the per-OS Helm default), and the
+ * jhelm/Java/OS versions. Mirrors {@code helm env} as a quick way to inspect the client
+ * environment.
  */
 @Component
 @CommandLine.Command(name = "env", mixinStandardHelpOptions = true,
 		description = "Print the jhelm client environment information")
 public class EnvCommand implements Runnable {
 
-	/** Creates the command. */
-	@SuppressWarnings("PMD.UnnecessaryConstructor")
-	public EnvCommand() {
+	private final RepoManager repoManager;
+
+	private final RegistryManager registryManager;
+
+	private final JhelmKubernetesProperties kubeProperties;
+
+	/**
+	 * Creates the command.
+	 * @param repoManager supplies the effective repository config and cache paths
+	 * @param registryManager supplies the effective registry config path
+	 * @param kubeProperties supplies the configured kubeconfig path override, if any
+	 */
+	public EnvCommand(RepoManager repoManager, RegistryManager registryManager,
+			JhelmKubernetesProperties kubeProperties) {
+		this.repoManager = repoManager;
+		this.registryManager = registryManager;
+		this.kubeProperties = kubeProperties;
 	}
 
 	private static String orDefault(String envVar, String fallback) {
@@ -24,9 +46,21 @@ public class EnvCommand implements Runnable {
 		return ((value != null) && !value.isBlank()) ? value : fallback;
 	}
 
+	private String resolveKubeconfig() {
+		String configured = this.kubeProperties.getKubeconfigPath();
+		if ((configured != null) && !configured.isBlank()) {
+			return configured;
+		}
+		return orDefault("KUBECONFIG", Paths.get(System.getProperty("user.home"), ".kube/config").toString());
+	}
+
 	@Override
 	public void run() {
 		CliOutput.println("HELM_NAMESPACE=\"" + orDefault("HELM_NAMESPACE", "default") + "\"");
+		CliOutput.println("HELM_REPOSITORY_CONFIG=\"" + this.repoManager.getConfigPath() + "\"");
+		CliOutput.println("HELM_REPOSITORY_CACHE=\"" + this.repoManager.getRepositoryCachePath() + "\"");
+		CliOutput.println("HELM_REGISTRY_CONFIG=\"" + this.registryManager.getConfigPath() + "\"");
+		CliOutput.println("KUBECONFIG=\"" + resolveKubeconfig() + "\"");
 		CliOutput.println("HELM_PASSPHRASE_SET=\"" + (System.getenv("HELM_PASSPHRASE") != null) + "\"");
 		CliOutput.println("JHELM_VERSION=\"" + VersionCommand.versionString() + "\"");
 		CliOutput.println("JAVA_VERSION=\"" + System.getProperty("java.version") + "\"");

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/EnvCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/EnvCommandTest.java
@@ -4,6 +4,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
+import org.alexmond.jhelm.core.service.RegistryManager;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
@@ -13,19 +16,30 @@ class EnvCommandTest {
 
 	@Test
 	void testEnvPrintsKeyValues() {
+		RepoManager repoManager = new RepoManager("/tmp/jhelm-env/repositories.yaml");
+		RegistryManager registryManager = new RegistryManager("/tmp/jhelm-env/registry/config.json");
+		JhelmKubernetesProperties kubeProperties = new JhelmKubernetesProperties();
+		kubeProperties.setKubeconfigPath("/tmp/jhelm-env/kubeconfig");
+
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		PrintStream original = System.out;
 		System.setOut(new PrintStream(bos, true, StandardCharsets.UTF_8));
 		try {
-			new CommandLine(new EnvCommand()).execute();
+			new CommandLine(new EnvCommand(repoManager, registryManager, kubeProperties)).execute();
 		}
 		finally {
 			System.setOut(original);
 		}
 		String out = bos.toString(StandardCharsets.UTF_8);
-		assertTrue(out.contains("HELM_NAMESPACE="));
-		assertTrue(out.contains("JHELM_VERSION="));
-		assertTrue(out.contains("JAVA_VERSION="));
+		// the base info Helm users expect
+		assertTrue(out.contains("HELM_NAMESPACE="), out);
+		assertTrue(out.contains("JHELM_VERSION="), out);
+		assertTrue(out.contains("JAVA_VERSION="), out);
+		// the effective Helm config locations jhelm resolves and honors
+		assertTrue(out.contains("HELM_REPOSITORY_CONFIG=\"/tmp/jhelm-env/repositories.yaml\""), out);
+		assertTrue(out.contains("HELM_REGISTRY_CONFIG=\"/tmp/jhelm-env/registry/config.json\""), out);
+		assertTrue(out.contains("HELM_REPOSITORY_CACHE="), out);
+		assertTrue(out.contains("KUBECONFIG=\"/tmp/jhelm-env/kubeconfig\""), out);
 	}
 
 }

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/EnvCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/EnvCommandTest.java
@@ -42,4 +42,27 @@ class EnvCommandTest {
 		assertTrue(out.contains("KUBECONFIG=\"/tmp/jhelm-env/kubeconfig\""), out);
 	}
 
+	@Test
+	void testEnvKubeconfigFallsBackWhenNoOverride() {
+		// no jhelm.kubernetes.kubeconfig-path set -> falls back to $KUBECONFIG or
+		// ~/.kube/config
+		RepoManager repoManager = new RepoManager("/tmp/jhelm-env/repositories.yaml");
+		RegistryManager registryManager = new RegistryManager("/tmp/jhelm-env/registry/config.json");
+		JhelmKubernetesProperties kubeProperties = new JhelmKubernetesProperties();
+
+		ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		PrintStream original = System.out;
+		System.setOut(new PrintStream(bos, true, StandardCharsets.UTF_8));
+		try {
+			new CommandLine(new EnvCommand(repoManager, registryManager, kubeProperties)).execute();
+		}
+		finally {
+			System.setOut(original);
+		}
+		String out = bos.toString(StandardCharsets.UTF_8);
+		String expected = (System.getenv("KUBECONFIG") != null) ? System.getenv("KUBECONFIG")
+				: System.getProperty("user.home") + "/.kube/config";
+		assertTrue(out.contains("KUBECONFIG=\"" + expected + "\""), out);
+	}
+
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RegistryManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RegistryManager.java
@@ -70,6 +70,15 @@ public class RegistryManager {
 				System.getProperty("os.name"));
 	}
 
+	/**
+	 * Returns the effective registry {@code config.json} path this manager reads and
+	 * writes.
+	 * @return the registry config path
+	 */
+	public String getConfigPath() {
+		return this.configPath;
+	}
+
 	public void login(String registry, String username, String password) throws IOException {
 		Config config = loadConfig();
 		String auth = Base64.getEncoder().encodeToString((username + ":" + password).getBytes());

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -224,6 +224,25 @@ public class RepoManager {
 			.orElse(null);
 	}
 
+	/**
+	 * Returns the effective {@code repositories.yaml} path this manager reads and writes.
+	 * @return the repository config path
+	 */
+	public String getConfigPath() {
+		return this.configPath;
+	}
+
+	/**
+	 * Returns the effective repository index cache directory
+	 * ({@code $HELM_REPOSITORY_CACHE} or the per-OS default), without creating it.
+	 * @return the repository cache directory path
+	 */
+	public String getRepositoryCachePath() {
+		return resolveCacheDir(System.getenv("HELM_REPOSITORY_CACHE"), System.getProperty("user.home"),
+				System.getProperty("os.name"))
+			.getPath();
+	}
+
 	private File getCacheDir() {
 		File base = resolveCacheDir(System.getenv("HELM_REPOSITORY_CACHE"), System.getProperty("user.home"),
 				System.getProperty("os.name"));


### PR DESCRIPTION
Closes the `helm env` half of the #504 "add `helm version` / `helm env`" gate (`helm version` already exists; the audit confirmed `env` existed but printed only 3 fields).

## What changed
`jhelm env` now reports the same config surface `helm env` does — and, importantly, the **effective resolved paths** jhelm actually uses after the #606/#613 `HELM_*` work, so operators can confirm where jhelm reads things:

```
HELM_NAMESPACE="default"
HELM_REPOSITORY_CONFIG="/home/me/.config/helm/repositories.yaml"
HELM_REPOSITORY_CACHE="/home/me/.cache/jhelm/repository"
HELM_REGISTRY_CONFIG="/home/me/.config/helm/registry/config.json"
KUBECONFIG="/home/me/.kube/config"
HELM_PASSPHRASE_SET="false"
JHELM_VERSION="..."  JAVA_VERSION="..."  OS="..."
```

These reflect the real resolution order (explicit `jhelm.*` property > `HELM_*`/`$KUBECONFIG` env > per-OS default) — sourced from the live `RepoManager`/`RegistryManager` beans, not just raw env reads.

## Details
- Adds `getConfigPath()` / `getRepositoryCachePath()` to `RepoManager` and `getConfigPath()` to `RegistryManager` (the cache accessor resolves **without** creating the dir).
- `EnvCommand` injects the managers + `JhelmKubernetesProperties`; test asserts the effective locations. Full cli build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)