### PR TITLE
feat(rest): ship springdoc + a well-documented OpenAPI document (#504)

### DIFF
--- a/docs/modules/ROOT/pages/rest-api.adoc
+++ b/docs/modules/ROOT/pages/rest-api.adoc
@@ -21,16 +21,38 @@ Add `jhelm-rest-starter` to your Spring Boot web application:
 </dependency>
 ----
 
-For Swagger UI, add springdoc-openapi:
+Swagger UI and the OpenAPI document are **included** — `jhelm-rest` ships
+`springdoc-openapi-starter-webmvc-ui`, so once the module is on the classpath you get, with no
+extra dependency:
 
-[source,xml]
+* the interactive UI at `/swagger-ui.html`, and
+* the machine-readable spec at `/v3/api-docs` (JSON) and `/v3/api-docs.yaml`.
+
+The document's title, description, version, license (Apache-2.0) and contact come from a
+default `OpenAPI` bean the auto-configuration registers. It is annotated with
+`@ConditionalOnMissingBean`, so to customize the metadata (or add servers, security schemes,
+tags) just define your own:
+
+[source,java]
 ----
-<dependency>
-    <groupId>org.springdoc</groupId>
-    <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-    <version>3.0.2</version>
-</dependency>
+@Bean
+OpenAPI openAPI() {
+    return new OpenAPI().info(new Info()
+        .title("My Platform — Helm API")
+        .version("2.0")
+        .license(new License().name("Apache-2.0")));
+}
 ----
+
+Every operation in the document is annotated with a summary, its parameters, and the shared
+error responses the API can return — `400` (invalid request), `404` (unknown chart / release /
+repository), `500` (server error), plus `401`/`403` on mutating endpoints when the API-key
+policy applies. Errors use RFC&nbsp;7807 `application/problem+json`, described by the
+`ProblemDetail` schema in the document's components.
+
+TIP: springdoc's own behaviour (paths, grouping, whether the UI is enabled in production) is
+tuned with the standard `springdoc.*` properties — see the
+https://springdoc.org[springdoc-openapi docs].
 
 === Sample Application
 

--- a/jhelm-rest/pom.xml
+++ b/jhelm-rest/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>swagger-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -20,13 +20,20 @@ import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.DependencyResolver;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
+import org.alexmond.jhelm.rest.config.OpenApiErrorResponsesCustomizer;
 import org.alexmond.jhelm.rest.controller.ChartController;
 import org.alexmond.jhelm.rest.controller.DependencyController;
 import org.alexmond.jhelm.rest.controller.HubController;
 import org.alexmond.jhelm.rest.controller.ReleaseController;
 import org.alexmond.jhelm.rest.controller.RepoController;
 import org.alexmond.jhelm.rest.security.AccessModeInterceptor;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
 import jakarta.servlet.MultipartConfigElement;
+
+import java.util.Optional;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -64,6 +71,38 @@ public class JhelmRestAutoConfiguration {
 	@ConditionalOnMissingBean
 	public JhelmRestExceptionHandler jhelmRestExceptionHandler() {
 		return new JhelmRestExceptionHandler();
+	}
+
+	/**
+	 * Supplies the OpenAPI document metadata (title, description, version, license, and
+	 * contact) that springdoc serves at {@code /v3/api-docs} and renders in Swagger UI.
+	 * The version is read from the {@code jhelm-rest} jar manifest so it tracks releases
+	 * without a hard-coded string. Defined with {@link ConditionalOnMissingBean} so an
+	 * application can replace it wholesale.
+	 * @return the OpenAPI metadata bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public OpenAPI jhelmOpenAPI() {
+		String version = Optional.ofNullable(getClass().getPackage().getImplementationVersion()).orElse("dev");
+		return new OpenAPI().info(new Info().title("jhelm REST API")
+			.description("REST API for Helm chart and release operations, backed by jhelm.")
+			.version(version)
+			.license(new License().name("Apache-2.0").url("https://www.apache.org/licenses/LICENSE-2.0.txt"))
+			.contact(new Contact().name("jhelm").url("https://github.com/alexmond/jhelm")));
+	}
+
+	/**
+	 * Registers the customizer that documents the shared RFC 7807 error responses (and
+	 * the {@code ProblemDetail} schema) on every generated operation, so the served
+	 * OpenAPI document reflects the real error contract. springdoc applies every
+	 * {@code OpenApiCustomizer} bean it finds in the context.
+	 * @return the error-responses customizer bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public OpenApiErrorResponsesCustomizer jhelmOpenApiErrorResponsesCustomizer() {
+		return new OpenApiErrorResponsesCustomizer();
 	}
 
 	/**

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/config/OpenApiErrorResponsesCustomizer.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/config/OpenApiErrorResponsesCustomizer.java
@@ -1,0 +1,98 @@
+package org.alexmond.jhelm.rest.config;
+
+import java.util.Map;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+
+/**
+ * Documents the shared RFC&nbsp;7807 error responses on every generated operation so the
+ * OpenAPI document reflects what
+ * {@link org.alexmond.jhelm.rest.JhelmRestExceptionHandler} and the API-key security
+ * interceptor actually return — without annotating each endpoint by hand. Read (GET)
+ * operations get {@code 400}/{@code 404}/{@code 500}; mutating operations additionally
+ * get {@code 401}/{@code 403} for the security policy. Any response a controller already
+ * declares (via {@code @ApiResponse}) is preserved — never overwritten.
+ */
+public class OpenApiErrorResponsesCustomizer implements OpenApiCustomizer {
+
+	private static final String PROBLEM_SCHEMA = "ProblemDetail";
+
+	private static final String PROBLEM_JSON = "application/problem+json";
+
+	private static final String SCHEMA_REF = "#/components/schemas/" + PROBLEM_SCHEMA;
+
+	@Override
+	public void customise(OpenAPI openApi) {
+		registerProblemSchema(openApi);
+		if (openApi.getPaths() != null) {
+			openApi.getPaths().values().forEach(this::applyToPath);
+		}
+	}
+
+	private void applyToPath(PathItem pathItem) {
+		for (Map.Entry<PathItem.HttpMethod, Operation> entry : pathItem.readOperationsMap().entrySet()) {
+			boolean mutating = entry.getKey() != PathItem.HttpMethod.GET;
+			addResponses(entry.getValue(), mutating);
+		}
+	}
+
+	private void addResponses(Operation operation, boolean mutating) {
+		if (operation.getResponses() == null) {
+			operation.setResponses(new ApiResponses());
+		}
+		ApiResponses responses = operation.getResponses();
+		putIfAbsent(responses, "400", "Invalid request (malformed body or failed validation).");
+		if (mutating) {
+			putIfAbsent(responses, "401", "Missing or invalid API key.");
+			putIfAbsent(responses, "403", "Operation not permitted by the server's security mode.");
+		}
+		putIfAbsent(responses, "404", "The referenced chart, release, or repository does not exist.");
+		putIfAbsent(responses, "500", "Unexpected server error.");
+	}
+
+	private void putIfAbsent(ApiResponses responses, String code, String description) {
+		if (responses.containsKey(code)) {
+			return;
+		}
+		Schema<?> ref = new Schema<>().$ref(SCHEMA_REF);
+		ApiResponse response = new ApiResponse().description(description)
+			.content(new Content().addMediaType(PROBLEM_JSON, new MediaType().schema(ref)));
+		responses.addApiResponse(code, response);
+	}
+
+	private void registerProblemSchema(OpenAPI openApi) {
+		Components components = openApi.getComponents();
+		if (components == null) {
+			components = new Components();
+			openApi.setComponents(components);
+		}
+		if ((components.getSchemas() != null) && components.getSchemas().containsKey(PROBLEM_SCHEMA)) {
+			return;
+		}
+		ObjectSchema problem = new ObjectSchema();
+		problem.description("RFC 7807 problem detail, returned as application/problem+json.");
+		problem.addProperty("type",
+				new StringSchema().format("uri").description("A URI identifying the problem type."));
+		problem.addProperty("title", new StringSchema().description("A short, human-readable summary of the problem."));
+		problem.addProperty("status", new IntegerSchema().description("The HTTP status code."));
+		problem.addProperty("detail", new StringSchema().description("A human-readable explanation of the problem."));
+		problem.addProperty("instance",
+				new StringSchema().format("uri").description("A URI identifying the specific occurrence."));
+		problem.addProperty("timestamp",
+				new StringSchema().format("date-time").description("When the error occurred (ISO-8601)."));
+		components.addSchemas(PROBLEM_SCHEMA, problem);
+	}
+
+}

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/JhelmRestAutoConfigurationTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/JhelmRestAutoConfigurationTest.java
@@ -2,9 +2,13 @@ package org.alexmond.jhelm.rest;
 
 import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -36,6 +40,35 @@ class JhelmRestAutoConfigurationTest {
 	@Test
 	void autoConfigurationRegistersExceptionHandler() {
 		this.contextRunner.run((context) -> assertNotNull(context.getBean(JhelmRestExceptionHandler.class)));
+	}
+
+	@Test
+	void autoConfigurationRegistersOpenApiMetadata() {
+		this.contextRunner.run((context) -> {
+			OpenAPI openApi = context.getBean(OpenAPI.class);
+			assertNotNull(openApi.getInfo());
+			assertEquals("jhelm REST API", openApi.getInfo().getTitle());
+			assertEquals("Apache-2.0", openApi.getInfo().getLicense().getName());
+			assertNotNull(openApi.getInfo().getVersion());
+		});
+	}
+
+	@Test
+	void openApiMetadataIsOverridable() {
+		this.contextRunner.withUserConfiguration(CustomOpenApiConfig.class).run((context) -> {
+			OpenAPI openApi = context.getBean(OpenAPI.class);
+			assertEquals("Custom API", openApi.getInfo().getTitle());
+		});
+	}
+
+	@Configuration
+	static class CustomOpenApiConfig {
+
+		@Bean
+		OpenAPI openAPI() {
+			return new OpenAPI().info(new Info().title("Custom API"));
+		}
+
 	}
 
 }

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/config/OpenApiErrorResponsesCustomizerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/config/OpenApiErrorResponsesCustomizerTest.java
@@ -1,0 +1,66 @@
+package org.alexmond.jhelm.rest.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenApiErrorResponsesCustomizerTest {
+
+	private OpenAPI apiWithGetAndPost() {
+		Operation get = new Operation()
+			.responses(new ApiResponses().addApiResponse("200", new ApiResponse().description("OK")));
+		Operation post = new Operation().responses(new ApiResponses());
+		return new OpenAPI().paths(new Paths().addPathItem("/releases", new PathItem().get(get))
+			.addPathItem("/releases/install", new PathItem().post(post)));
+	}
+
+	@Test
+	void getOperationGetsReadErrorResponsesButNotAuth() {
+		OpenAPI api = apiWithGetAndPost();
+		new OpenApiErrorResponsesCustomizer().customise(api);
+
+		ApiResponses get = api.getPaths().get("/releases").getGet().getResponses();
+		assertTrue(get.containsKey("200"), "existing response preserved");
+		assertTrue(get.containsKey("400"));
+		assertTrue(get.containsKey("404"));
+		assertTrue(get.containsKey("500"));
+		assertFalse(get.containsKey("401"), "read operations are not auth-gated");
+		assertFalse(get.containsKey("403"));
+	}
+
+	@Test
+	void mutatingOperationAlsoGetsAuthResponses() {
+		OpenAPI api = apiWithGetAndPost();
+		new OpenApiErrorResponsesCustomizer().customise(api);
+
+		ApiResponses post = api.getPaths().get("/releases/install").getPost().getResponses();
+		assertTrue(post.containsKey("400"));
+		assertTrue(post.containsKey("401"));
+		assertTrue(post.containsKey("403"));
+		assertTrue(post.containsKey("404"));
+		assertTrue(post.containsKey("500"));
+	}
+
+	@Test
+	void registersProblemDetailSchemaAndReferencesItAsProblemJson() {
+		OpenAPI api = apiWithGetAndPost();
+		new OpenApiErrorResponsesCustomizer().customise(api);
+
+		assertNotNull(api.getComponents());
+		assertTrue(api.getComponents().getSchemas().containsKey("ProblemDetail"));
+
+		ApiResponse notFound = api.getPaths().get("/releases").getGet().getResponses().get("404");
+		assertNotNull(notFound.getContent().get("application/problem+json"));
+		assertTrue(
+				notFound.getContent().get("application/problem+json").getSchema().get$ref().endsWith("/ProblemDetail"));
+	}
+
+}


### PR DESCRIPTION
Closes the #504 gate: *"Ship springdoc in the REST starter (or document the add-on) + an OpenAPI info/license bean."* Done the way `jsupervisor` does it — and taken past the bare gate to a genuinely **well-documented** spec.

## What changed
- **Ship springdoc** — `jhelm-rest` now brings `springdoc-openapi-starter-webmvc-ui` (version already managed at 3.0.3). Swagger UI (`/swagger-ui.html`) and the spec (`/v3/api-docs`, `/v3/api-docs.yaml`) work out of the box for both the library and the starter; no manual add-on step.
- **OpenAPI info/license/contact bean** — title, description, Apache-2.0 license, contact; version read from the jar manifest so it tracks releases. `@ConditionalOnMissingBean`, so apps can replace it.
- **Well-documented, not just present** — the controllers already had `@Operation`/`@Parameter`/`@Tag`, but response codes were almost entirely undocumented. Rather than hand-annotate ~34 endpoints, an `OpenApiCustomizer` documents the shared **RFC 7807** error responses on every operation (`400`/`404`/`500`, plus `401`/`403` on mutating endpoints) and registers the `ProblemDetail` schema — matching what the exception handler + security interceptor actually return. Any `@ApiResponse` a controller already declares is preserved.

## Accuracy / tests
- Error set is verb-aware: GET gets read errors only; mutating verbs also get the API-key `401`/`403`.
- 8 tests: autoconfig registers **and** allows overriding the OpenAPI bean; customizer adds the right responses per verb, preserves declared ones, and wires the `ProblemDetail` `$ref` as `application/problem+json`. Full `jhelm-rest` + starter + sample builds green (springdoc autoconfig loads cleanly in the real app context).

`rest-api.adoc` updated: Swagger UI is built in (was "add this dependency"), and the documented error contract is described.

Note: the fuller jsupervisor "generate + share" pipeline (commit the spec to docs attachments, `html2`-render it, generate a typed client, publish via Antora) is captured as a reusable example in alexmond/spring-boot-playground#7 rather than pulled into jhelm here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)