### PR TITLE
feat(metrics): action-layer + chart-pull metrics in JhelmMetrics (#504)

### DIFF
--- a/docs/modules/ROOT/pages/spring-boot-starter.adoc
+++ b/docs/modules/ROOT/pages/spring-boot-starter.adoc
@@ -384,6 +384,43 @@ CompletableFuture<List<Release>> releases =
     kubeService.listReleasesAsync("production");
 ----
 
+== Metrics
+
+When a Micrometer `MeterRegistry` is on the context (e.g. via
+`spring-boot-starter-actuator`), jhelm auto-configures a `JhelmMetrics` bean and publishes the
+following meters. With no registry present there is no bean and no overhead.
+
+[cols="2,1,3"]
+|===
+| Meter | Type | Tags
+
+| `jhelm.engine.render`
+| timer
+| — (chart template render duration)
+
+| `jhelm.cache.requests`
+| counter
+| `result` = `hit` \| `miss`
+
+| `jhelm.cache.size`
+| gauge
+| — (current template-cache entries)
+
+| `jhelm.action` / `jhelm.actions`
+| timer / counter
+| `action` = `install` \| `upgrade` \| `uninstall` \| `rollback`; counter adds `outcome` = `success` \| `error`
+
+| `jhelm.chart.pull` / `jhelm.chart.pulls`
+| timer / counter
+| `source` = `http` \| `oci`; counter adds `outcome` = `success` \| `error`
+
+| `jhelm.kube.operation` / `jhelm.kube.operations`
+| timer / counter
+| `operation` (e.g. `apply`, `delete`, `store`); counter adds `outcome` = `success` \| `error`
+|===
+
+Exposing them (Prometheus, etc.) is standard Spring Boot Actuator configuration.
+
 == Custom Bean Overrides
 
 All auto-configured beans are registered with `@ConditionalOnMissingBean`. You can replace any bean by defining your own:

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -93,15 +93,19 @@ public class JhelmCoreAutoConfiguration {
 	/**
 	 * Provides the chart repository manager, configured from the jhelm properties.
 	 * @param props the jhelm core configuration properties
+	 * @param registryManager the OCI registry auth provider
+	 * @param metrics optional metrics for instrumenting chart pulls
 	 * @return the repository manager bean
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	public RepoManager repoManager(JhelmCoreProperties props, RegistryManager registryManager) {
-		if (props.getConfigPath() != null) {
-			return new RepoManager(props.getConfigPath(), registryManager, props.isInsecureSkipTlsVerify());
-		}
-		return new RepoManager(registryManager, props.isInsecureSkipTlsVerify());
+	public RepoManager repoManager(JhelmCoreProperties props, RegistryManager registryManager,
+			ObjectProvider<JhelmMetrics> metrics) {
+		RepoManager repoManager = (props.getConfigPath() != null)
+				? new RepoManager(props.getConfigPath(), registryManager, props.isInsecureSkipTlsVerify())
+				: new RepoManager(registryManager, props.isInsecureSkipTlsVerify());
+		repoManager.setMetrics(metrics.getIfAvailable());
+		return repoManager;
 	}
 
 	/**
@@ -235,7 +239,7 @@ public class JhelmCoreAutoConfiguration {
 	@ConditionalOnBean(KubeService.class)
 	public InstallAction installAction(Engine engine, KubeService kubeService,
 			ObjectProvider<List<PostRenderProcessor>> postRenderProcessors,
-			ObjectProvider<List<LifecycleListener>> lifecycleListeners) {
+			ObjectProvider<List<LifecycleListener>> lifecycleListeners, ObjectProvider<JhelmMetrics> metrics) {
 		InstallAction action = new InstallAction(engine, kubeService);
 		List<PostRenderProcessor> processors = postRenderProcessors.getIfAvailable();
 		if (processors != null) {
@@ -245,6 +249,7 @@ public class JhelmCoreAutoConfiguration {
 		if (listeners != null) {
 			action.setLifecycleListeners(listeners);
 		}
+		action.setMetrics(metrics.getIfAvailable());
 		return action;
 	}
 
@@ -262,7 +267,7 @@ public class JhelmCoreAutoConfiguration {
 	@ConditionalOnBean(KubeService.class)
 	public UpgradeAction upgradeAction(Engine engine, KubeService kubeService,
 			ObjectProvider<List<PostRenderProcessor>> postRenderProcessors,
-			ObjectProvider<List<LifecycleListener>> lifecycleListeners) {
+			ObjectProvider<List<LifecycleListener>> lifecycleListeners, ObjectProvider<JhelmMetrics> metrics) {
 		UpgradeAction action = new UpgradeAction(engine, kubeService);
 		List<PostRenderProcessor> processors = postRenderProcessors.getIfAvailable();
 		if (processors != null) {
@@ -272,6 +277,7 @@ public class JhelmCoreAutoConfiguration {
 		if (listeners != null) {
 			action.setLifecycleListeners(listeners);
 		}
+		action.setMetrics(metrics.getIfAvailable());
 		return action;
 	}
 
@@ -279,13 +285,16 @@ public class JhelmCoreAutoConfiguration {
 	 * Provides the {@code helm uninstall} action; only created when a {@link KubeService}
 	 * is present.
 	 * @param kubeService the cluster client
+	 * @param metrics optional metrics for instrumenting the action
 	 * @return the uninstall action bean
 	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(KubeService.class)
-	public UninstallAction uninstallAction(KubeService kubeService) {
-		return new UninstallAction(kubeService);
+	public UninstallAction uninstallAction(KubeService kubeService, ObjectProvider<JhelmMetrics> metrics) {
+		UninstallAction action = new UninstallAction(kubeService);
+		action.setMetrics(metrics.getIfAvailable());
+		return action;
 	}
 
 	/**
@@ -331,13 +340,16 @@ public class JhelmCoreAutoConfiguration {
 	 * Provides the {@code helm rollback} action; only created when a {@link KubeService}
 	 * is present.
 	 * @param kubeService the cluster client
+	 * @param metrics optional metrics for instrumenting the action
 	 * @return the rollback action bean
 	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(KubeService.class)
-	public RollbackAction rollbackAction(KubeService kubeService) {
-		return new RollbackAction(kubeService);
+	public RollbackAction rollbackAction(KubeService kubeService, ObjectProvider<JhelmMetrics> metrics) {
+		RollbackAction action = new RollbackAction(kubeService);
+		action.setMetrics(metrics.getIfAvailable());
+		return action;
 	}
 
 	/**

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +46,9 @@ public class InstallAction {
 	@Setter
 	private List<LifecycleListener> lifecycleListeners = List.of();
 
+	@Setter
+	private JhelmMetrics metrics;
+
 	/**
 	 * Installs a chart as a new release. Chart default values are merged with the
 	 * supplied overrides, the templates are rendered, and—unless this is a dry run—the
@@ -59,6 +63,11 @@ public class InstallAction {
 	 * @throws JhelmException if rendering or a cluster operation fails
 	 */
 	public Release install(InstallOptions options) {
+		return (this.metrics == null) ? doInstall(options)
+				: this.metrics.timeAction("install", () -> doInstall(options));
+	}
+
+	private Release doInstall(InstallOptions options) {
 		ReleaseNames.validateReleaseName(options.getReleaseName());
 		ReleaseNames.validateNamespace(options.getNamespace());
 		Chart chart = options.getChart();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
@@ -5,8 +5,10 @@ import java.util.List;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.JhelmException;
+import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
@@ -21,6 +23,9 @@ public class RollbackAction {
 
 	private final KubeService kubeService;
 
+	@Setter
+	private JhelmMetrics metrics;
+
 	/**
 	 * Rolls a release back to a previous revision, optionally skipping its pre-rollback
 	 * and post-rollback hooks and pruning old revision history. After the new revision is
@@ -31,6 +36,11 @@ public class RollbackAction {
 	 * @return the newly created {@link Release} representing the rolled-back revision
 	 */
 	public Release rollback(RollbackOptions options) {
+		return (this.metrics == null) ? doRollback(options)
+				: this.metrics.timeAction("rollback", () -> doRollback(options));
+	}
+
+	private Release doRollback(RollbackOptions options) {
 		String name = options.getReleaseName();
 		String namespace = options.getNamespace();
 		int revision = options.getRevision();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
@@ -5,8 +5,10 @@ import java.util.List;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.JhelmException;
+import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
@@ -21,11 +23,26 @@ public class UninstallAction {
 
 	private final KubeService kubeService;
 
+	@Setter
+	private JhelmMetrics metrics;
+
 	/**
 	 * Uninstalls a release, optionally skipping its pre-delete and post-delete hooks.
 	 * @param options the uninstall options (release name, namespace and no-hooks flag)
 	 */
 	public void uninstall(UninstallOptions options) {
+		if (this.metrics == null) {
+			doUninstall(options);
+		}
+		else {
+			this.metrics.timeAction("uninstall", () -> {
+				doUninstall(options);
+				return null;
+			});
+		}
+	}
+
+	private void doUninstall(UninstallOptions options) {
 		String releaseName = options.getReleaseName();
 		String namespace = options.getNamespace();
 		boolean noHooks = options.isNoHooks();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +40,9 @@ public class UpgradeAction {
 	@Setter
 	private List<LifecycleListener> lifecycleListeners = List.of();
 
+	@Setter
+	private JhelmMetrics metrics;
+
 	/**
 	 * Upgrades a release, resolving values according to the configured
 	 * {@link UpgradeValueStrategy}, optionally skipping hooks and pruning old revision
@@ -49,6 +53,11 @@ public class UpgradeAction {
 	 * @return the upgraded release
 	 */
 	public Release upgrade(UpgradeOptions options) {
+		return (this.metrics == null) ? doUpgrade(options)
+				: this.metrics.timeAction("upgrade", () -> doUpgrade(options));
+	}
+
+	private Release doUpgrade(UpgradeOptions options) {
 		Chart newChart = options.getNewChart();
 		if ("library".equals(newChart.getMetadata().getType())) {
 			throw new IllegalArgumentException(

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/metrics/JhelmMetrics.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/metrics/JhelmMetrics.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.core.metrics;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -113,11 +114,122 @@ public class JhelmMetrics {
 	}
 
 	/**
+	 * Times an action-layer operation (install, upgrade, uninstall, rollback), recording
+	 * its duration on {@code jhelm.action} and incrementing {@code jhelm.actions} with
+	 * the outcome. The operation's own exceptions propagate unchanged (counted as
+	 * {@code error}).
+	 * @param <T> the result type
+	 * @param action the action name (e.g. "install", "upgrade")
+	 * @param op the action to run
+	 * @return the action result
+	 */
+	public <T> T timeAction(String action, Supplier<T> op) {
+		boolean success = false;
+		try {
+			T result = actionTimer(action).record(op);
+			success = true;
+			return result;
+		}
+		finally {
+			actionCounter(action, success ? "success" : "error").increment();
+		}
+	}
+
+	/**
+	 * Create a timer for the given action-layer operation.
+	 * @param action the action name
+	 * @return the timer
+	 */
+	public Timer actionTimer(String action) {
+		return Timer.builder(PREFIX + ".action")
+			.description("Helm action-layer operation duration")
+			.tag("action", action)
+			.register(registry);
+	}
+
+	/**
+	 * Create a counter for the given action-layer outcome.
+	 * @param action the action name
+	 * @param outcome "success" or "error"
+	 * @return the counter
+	 */
+	public Counter actionCounter(String action, String outcome) {
+		return Counter.builder(PREFIX + ".actions")
+			.description("Helm action-layer operation count")
+			.tag("action", action)
+			.tag("outcome", outcome)
+			.register(registry);
+	}
+
+	/**
+	 * Times a chart pull, recording its duration on {@code jhelm.chart.pull} and
+	 * incrementing {@code jhelm.chart.pulls} with the outcome. Checked
+	 * {@link IOException} (and any runtime exception) from the pull propagates unchanged
+	 * (counted as {@code error}).
+	 * @param source the pull source ("http" or "oci")
+	 * @param op the pull to run
+	 * @throws IOException if the pull fails
+	 */
+	public void timeChartPull(String source, IoRunnable op) throws IOException {
+		Timer.Sample sample = Timer.start(registry);
+		boolean success = false;
+		try {
+			op.run();
+			success = true;
+		}
+		finally {
+			sample.stop(chartPullTimer(source));
+			chartPullCounter(source, success ? "success" : "error").increment();
+		}
+	}
+
+	/**
+	 * Create a timer for chart pulls from the given source.
+	 * @param source the pull source ("http" or "oci")
+	 * @return the timer
+	 */
+	public Timer chartPullTimer(String source) {
+		return Timer.builder(PREFIX + ".chart.pull")
+			.description("Chart pull duration")
+			.tag("source", source)
+			.register(registry);
+	}
+
+	/**
+	 * Create a counter for chart pull outcomes from the given source.
+	 * @param source the pull source ("http" or "oci")
+	 * @param outcome "success" or "error"
+	 * @return the counter
+	 */
+	public Counter chartPullCounter(String source, String outcome) {
+		return Counter.builder(PREFIX + ".chart.pulls")
+			.description("Chart pull count")
+			.tag("source", source)
+			.tag("outcome", outcome)
+			.register(registry);
+	}
+
+	/**
 	 * Returns the underlying {@link MeterRegistry}.
 	 * @return the registry backing this metrics service
 	 */
 	public MeterRegistry getRegistry() {
 		return registry;
+	}
+
+	/**
+	 * A chart-pull operation that may throw {@link IOException}. Enables
+	 * {@link #timeChartPull(String, IoRunnable)} to wrap the checked download calls.
+	 */
+	@FunctionalInterface
+	public interface IoRunnable {
+
+		/**
+		 * Runs the pull.
+		 * @throws IOException if the pull fails
+		 */
+		void run() throws IOException;
+
 	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -40,6 +40,7 @@ import java.util.Map;
 
 import tools.jackson.databind.JsonNode;
 
+import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.core.model.RepositoryConfig;
 
 @Slf4j
@@ -58,6 +59,10 @@ public class RepoManager {
 	private final boolean insecureSkipTlsVerify;
 
 	private final RegistryManager registryManager;
+
+	// Optional metrics; set by the auto-configuration when a JhelmMetrics bean exists.
+	// Null in library/direct-construction use (no instrumentation, no overhead).
+	private JhelmMetrics metrics;
 
 	// Parsed repo indexes (the full entries map of an index.yaml) keyed by repo name.
 	// A repo's index can be tens of MB (e.g. bitnami), so this is bounded by an LRU:
@@ -114,6 +119,24 @@ public class RepoManager {
 		this.registryManager = registryManager;
 		this.insecureSkipTlsVerify = insecureSkipTlsVerify;
 		initHttpClient();
+	}
+
+	/**
+	 * Sets the optional metrics service used to instrument chart pulls. Wired by the
+	 * auto-configuration; leave unset (null) to disable instrumentation.
+	 * @param metrics the metrics service, or {@code null}
+	 */
+	public void setMetrics(JhelmMetrics metrics) {
+		this.metrics = metrics;
+	}
+
+	private void recordChartPull(String source, JhelmMetrics.IoRunnable op) throws IOException {
+		if (metrics == null) {
+			op.run();
+		}
+		else {
+			metrics.timeChartPull(source, op);
+		}
 	}
 
 	void setHttpClientForTest(CloseableHttpClient client) {
@@ -724,6 +747,11 @@ public class RepoManager {
 			pullOci(chartUrl, destDir, fileName);
 			return;
 		}
+		recordChartPull("http", () -> doHttpPull(chartUrl, destDir, fileName, repo));
+	}
+
+	private void doHttpPull(String chartUrl, String destDir, String fileName, RepositoryConfig.Repository repo)
+			throws IOException {
 		if (log.isInfoEnabled()) {
 			log.info("Pulling chart from {} to {}", chartUrl, destDir);
 		}
@@ -755,6 +783,10 @@ public class RepoManager {
 	}
 
 	public void pullOci(String ociUrl, String destDir, String fileName) throws IOException {
+		recordChartPull("oci", () -> doPullOci(ociUrl, destDir, fileName));
+	}
+
+	private void doPullOci(String ociUrl, String destDir, String fileName) throws IOException {
 		if (log.isInfoEnabled()) {
 			log.info("Pulling OCI chart from {} to {}", ociUrl, destDir);
 		}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
@@ -21,7 +21,9 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.alexmond.jhelm.core.exception.DeploymentFailedException;
+import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.HelmHook;
@@ -74,6 +76,27 @@ class InstallActionTest {
 
 		verify(kubeService).apply("default", HookParser.stripHooks(manifest));
 		verify(kubeService).storeRelease(any(Release.class));
+	}
+
+	@Test
+	void testInstallRecordsActionMetrics() throws Exception {
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+		installAction.setMetrics(new JhelmMetrics(registry));
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("---\n");
+
+		installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.revision(1)
+			.dryRun(true)
+			.build());
+
+		assertEquals(1, registry.find("jhelm.action").tag("action", "install").timer().count());
+		assertEquals(1.0,
+				registry.find("jhelm.actions").tag("action", "install").tag("outcome", "success").counter().count());
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/metrics/JhelmMetricsTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/metrics/JhelmMetricsTest.java
@@ -12,7 +12,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
@@ -87,6 +89,45 @@ class JhelmMetricsTest {
 		assertNotNull(counter);
 		counter.increment();
 		assertEquals(1.0, counter.count());
+	}
+
+	@Test
+	void testTimeActionSuccessRecordsTimerAndCounter() {
+		String result = metrics.timeAction("install", () -> "ok");
+		assertEquals("ok", result);
+		assertEquals(1, registry.find("jhelm.action").tag("action", "install").timer().count());
+		assertEquals(1.0,
+				registry.find("jhelm.actions").tag("action", "install").tag("outcome", "success").counter().count());
+	}
+
+	@Test
+	void testTimeActionErrorCountsErrorOutcomeAndRethrows() {
+		assertThrows(IllegalStateException.class, () -> metrics.timeAction("upgrade", () -> {
+			throw new IllegalStateException("boom");
+		}));
+		assertEquals(1, registry.find("jhelm.action").tag("action", "upgrade").timer().count());
+		assertEquals(1.0,
+				registry.find("jhelm.actions").tag("action", "upgrade").tag("outcome", "error").counter().count());
+	}
+
+	@Test
+	void testTimeChartPullSuccessRecordsHttpSource() throws IOException {
+		metrics.timeChartPull("http", () -> {
+			// a successful pull does nothing observable here
+		});
+		assertEquals(1, registry.find("jhelm.chart.pull").tag("source", "http").timer().count());
+		assertEquals(1.0,
+				registry.find("jhelm.chart.pulls").tag("source", "http").tag("outcome", "success").counter().count());
+	}
+
+	@Test
+	void testTimeChartPullErrorCountsErrorAndRethrows() {
+		assertThrows(IOException.class, () -> metrics.timeChartPull("oci", () -> {
+			throw new IOException("nope");
+		}));
+		assertEquals(1, registry.find("jhelm.chart.pull").tag("source", "oci").timer().count());
+		assertEquals(1.0,
+				registry.find("jhelm.chart.pulls").tag("source", "oci").tag("outcome", "error").counter().count());
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
@@ -45,7 +45,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.ArgumentCaptor;
 
+import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.core.model.RepositoryConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 import java.net.URL;
 import java.util.Base64;
@@ -347,6 +349,22 @@ class RepoManagerTest {
 			.thenAnswer(httpAnswer(200, tgz));
 		rm.pullFromUrl("https://charts.example.com/mychart-1.0.0.tgz", tempDir.toString(), "mychart-1.0.0.tgz");
 		assertTrue(tempDir.resolve("mychart-1.0.0.tgz").toFile().exists());
+	}
+
+	@Test
+	void testPullFromUrlRecordsHttpMetrics() throws Exception {
+		RepoManager rm = new RepoManager();
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+		rm.setMetrics(new JhelmMetrics(registry));
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		rm.setHttpClientForTest(mockClient);
+		byte[] tgz = createMinimalTgz();
+		when(mockClient.execute(isA(HttpGet.class), any(HttpClientResponseHandler.class)))
+			.thenAnswer(httpAnswer(200, tgz));
+		rm.pullFromUrl("https://charts.example.com/mychart-1.0.0.tgz", tempDir.toString(), "mychart-1.0.0.tgz");
+		assertEquals(1, registry.find("jhelm.chart.pull").tag("source", "http").timer().count());
+		assertEquals(1.0,
+				registry.find("jhelm.chart.pulls").tag("source", "http").tag("outcome", "success").counter().count());
 	}
 
 	@Test


### PR DESCRIPTION
Closes the #504 gate: *"Action-layer + chart-pull metrics in `JhelmMetrics`."* `JhelmMetrics` already covered render/cache/kube; this adds the two missing families, following the existing optional-metrics pattern (nullable, wired by the auto-configuration — `null` in library/direct use means no instrumentation and no overhead).

## New meters
| Meter | Type | Tags |
|---|---|---|
| `jhelm.action` / `jhelm.actions` | timer / counter | `action` = install\|upgrade\|uninstall\|rollback; counter adds `outcome` = success\|error |
| `jhelm.chart.pull` / `jhelm.chart.pulls` | timer / counter | `source` = http\|oci; counter adds `outcome` = success\|error |

## How it's wired (no churn)
- **Actions** — a `@Setter private JhelmMetrics metrics` on Install/Upgrade/Uninstall/Rollback, set from the autoconfig (same pattern the actions already use for post-render processors / lifecycle listeners). Entry methods delegate through `timeAction(...)`, which times, counts the outcome, and rethrows unchanged. Existing action tests (metrics unset) exercise the null path untouched.
- **Chart pull** — instrumented at the **two non-overlapping leaf downloaders** in `RepoManager` (the HTTP branch of `pullFromUrl`, and `pullOci`), so every pull — direct, repo, or OCI — is counted **exactly once** (verified against the call graph; the oci-delegation branch of `pullFromUrl` isn't double-counted). `RepoManager` gets an optional metrics setter, wired from the autoconfig.

## Tests
`JhelmMetrics` success **and** error paths for both `timeAction` and `timeChartPull` (outcome tagging + rethrow); `InstallAction` records install metrics on a dry-run; `RepoManager` records `http` pull metrics through a mocked client. Full `jhelm-core`/`kube`/`cli` build green. Meters documented in the library guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)