### PR TITLE
docs: document the gotmpl4j version stance (#504)

### DIFF
--- a/docs/modules/ROOT/pages/architecture.adoc
+++ b/docs/modules/ROOT/pages/architecture.adoc
@@ -30,6 +30,16 @@ The Go template engine, on Maven Central as `org.alexmond:gotmpl4j-core` and
 * The Sprig function set (strings, collections, math, encoding, crypto, date, semver, …)
 * `missingkey=zero` mode so an absent/nil value renders as the empty string, matching Helm
 
+[NOTE]
+.Version stance
+====
+jhelm pins gotmpl4j to a specific released version (managed as the `gotmpl4j.version` property
+in the root `pom.xml`) — never a `-SNAPSHOT`. gotmpl4j reached its own stable **1.x** line
+ahead of jhelm 1.0, so jhelm 1.x builds against a released gotmpl4j 1.x. Engine upgrades are a
+deliberate dependency bump (run against the full chart-parity suite before release), not a
+floating range, so a given jhelm release always renders with a known-good engine.
+====
+
 === jhelm-gotemplate-helm
 
 The Helm-specific template functions layered on top of gotmpl4j, registered via the engine's


### PR DESCRIPTION
Resolves #504 gate #10 — *"Decide the gotmpl4j-version stance."*

**The premise is now stale.** When #504 was written, jhelm's external Go-template engine was still on a 0.x line. Since then gotmpl4j released its own stable **1.x** (currently **1.2.0** on Central), and jhelm already pins `gotmpl4j.version = 1.2.0` — a released, non-SNAPSHOT 1.x. So a jhelm 1.0 no longer rests on a pre-stable engine.

This PR records the stance in `architecture.adoc`: jhelm pins a **specific released** gotmpl4j version (never SNAPSHOT / floating), engine upgrades are a deliberate parity-tested dependency bump, and jhelm 1.x builds against gotmpl4j 1.x.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)