### PR TITLE
build: enable Javadoc doclint enforcement (#504)

### DIFF
--- a/jhelm-cli/pom.xml
+++ b/jhelm-cli/pom.xml
@@ -11,6 +11,11 @@
     <name>jhelm-cli</name>
     <description>Spring Boot application for Helm Java</description>
 
+    <properties>
+        <!-- Not published; skip Javadoc (and its doclint enforcement) for the app module. -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.alexmond</groupId>

--- a/jhelm-mcp-sample/pom.xml
+++ b/jhelm-mcp-sample/pom.xml
@@ -11,6 +11,11 @@
 	<name>jhelm-mcp-sample</name>
 	<description>Sample Spring Boot application exposing jhelm operations as MCP tools</description>
 
+	<properties>
+		<!-- Not published; skip Javadoc (and its doclint enforcement) for the sample. -->
+		<maven.javadoc.skip>true</maven.javadoc.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.alexmond</groupId>

--- a/jhelm-rest-sample/pom.xml
+++ b/jhelm-rest-sample/pom.xml
@@ -11,6 +11,11 @@
 	<name>jhelm-rest-sample</name>
 	<description>Sample Spring Boot application with jhelm REST API and Swagger UI</description>
 
+	<properties>
+		<!-- Not published; skip Javadoc (and its doclint enforcement) for the sample. -->
+		<maven.javadoc.skip>true</maven.javadoc.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.alexmond</groupId>

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -106,9 +106,9 @@ public class JhelmRestAutoConfiguration {
 	}
 
 	/**
-	 * Caps multipart uploads (chart archives) at
-	 * {@link JhelmRestProperties#getMaxUploadSize()}, registered before Spring Boot's own
-	 * so the module default applies unless the application defines its own
+	 * Caps multipart uploads (chart archives) at the configured {@code maxUploadSize}
+	 * (see {@link JhelmRestProperties}), registered before Spring Boot's own so the
+	 * module default applies unless the application defines its own
 	 * {@link MultipartConfigElement}.
 	 * @param properties REST module configuration providing the upload cap
 	 * @return the multipart configuration bean

--- a/jhelm-sample/pom.xml
+++ b/jhelm-sample/pom.xml
@@ -11,6 +11,11 @@
 	<name>jhelm-sample</name>
 	<description>Sample Spring Boot application to verify jhelm auto-configuration wiring</description>
 
+	<properties>
+		<!-- Not published; skip Javadoc (and its doclint enforcement) for the sample. -->
+		<maven.javadoc.skip>true</maven.javadoc.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.alexmond</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
-                        <failOnError>false</failOnError>
+                        <!-- Enforce clean published Javadoc: broken @links, malformed
+                             HTML, and doc syntax errors fail the build. Lombok-generated
+                             accessors are invisible to doclint, so link the declaring type
+                             rather than a generated getter. -->
+                        <doclint>reference,html,syntax</doclint>
+                        <failOnError>true</failOnError>
                     </configuration>
                     <executions>
                         <execution>
@@ -473,6 +478,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <!-- Run Javadoc (with doclint enforcement, see pluginManagement) on every
+                 build so broken references / HTML / syntax fail PR CI, not just release.
+                 Skipped for the non-published cli + sample modules. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Closes the #504 gate: *"Enable doclint enforcement (`reference,html,syntax` groups fail the build) now that Javadoc is clean."*

## What changed
- **Enforcement** — `maven-javadoc-plugin` config: `<doclint>reference,html,syntax</doclint>` + `<failOnError>true</failOnError>`. Verified all three categories surface as **errors** and fail the build (injected a bad `{@link}` → "reference not found"; an unclosed `<b>` → "element not closed"). `failOnWarnings` proved unnecessary — the target categories are errors, so the config stays scoped to exactly the three groups the gate names.
- **Runs in PR CI** — activated the plugin in the **main build**, not just the release profile, so the javadoc jar goal runs during `mvn install`. Javadoc regressions now fail PR CI, not only release.
- **Scoped to published artifacts** — `maven.javadoc.skip=true` on the non-published `jhelm-cli` + the three sample modules.

## Was the Javadoc actually clean?
Measured first: a doclint run across **all** modules found exactly **one** violation — a `{@link JhelmRestProperties#getMaxUploadSize()}` pointing at a **Lombok-generated getter** (invisible to doclint, which runs before Lombok). Re-pointed it at the declaring type. Everything else was already clean, so enforcement went green on a full `mvn clean install`.

Adds Javadoc generation to every build (~the 6 code-bearing published modules); consistent with the project's other build-failing gates (PMD, checkstyle, spring-javaformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)