### PR TITLE
feat(cli): pull --repo URL with inline auth/TLS flags (#504 gate #3, slice 1/3)

### DIFF
--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -85,7 +85,9 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | `repo update [name...]` | ✅ | Refreshes all repos, or the named ones.
 | `repo add` auth (`--username`, `--password`, `--ca-file`) | ✗ |
 | `registry login` (`-u`, `-p`, `--password-stdin`) / `logout` | ✅ |
-| `pull` (`--version`, `-d/--dest`) | ✅ | `--untar`, `--verify`, `--repo`, auth flags: ✗
+| `pull` (`--version`, `-d/--dest`) | ✅ |
+| `pull --repo URL` + auth/TLS (`--username`, `--password`, `--cert-file`, `--key-file`, `--ca-file`, `--insecure-skip-tls-verify`, `--pass-credentials`) | ✅ | Pull a chart directly from a repository URL with inline credentials, without a prior `repo add`.
+| `pull` (`--untar`, `--verify`) | ✗ | Charts are unpacked into `--dest`; provenance verification not yet wired.
 |===
 
 == Porting a Helm script to jhelm

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PullCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PullCommand.java
@@ -2,13 +2,16 @@ package org.alexmond.jhelm.app.command;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.model.RepositoryConfig;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
 /**
  * Implements {@code jhelm pull CHART}, downloading a chart from a repository or OCI
- * registry to a local directory.
+ * registry to a local directory. Supports Helm's {@code --repo} form for pulling directly
+ * from a repository URL with inline credentials and TLS settings, without adding the repo
+ * first.
  */
 @Component
 @CommandLine.Command(name = "pull", mixinStandardHelpOptions = true, description = "Download a chart from a repository")
@@ -26,6 +29,33 @@ public class PullCommand implements Runnable {
 	@CommandLine.Option(names = { "--dest", "-d" }, defaultValue = ".", description = "destination directory")
 	private String dest;
 
+	@CommandLine.Option(names = { "--repo" },
+			description = "chart repository URL to pull the named chart from directly (no prior repo add)")
+	private String repo;
+
+	@CommandLine.Option(names = { "--username" }, description = "chart repository username (with --repo)")
+	private String username;
+
+	@CommandLine.Option(names = { "--password" }, description = "chart repository password (with --repo)")
+	private String password;
+
+	@CommandLine.Option(names = { "--cert-file" }, description = "identity certificate (PEM) for client TLS auth")
+	private String certFile;
+
+	@CommandLine.Option(names = { "--key-file" }, description = "identity key (PEM) for client TLS auth")
+	private String keyFile;
+
+	@CommandLine.Option(names = { "--ca-file" }, description = "verify server certificate against this CA bundle (PEM)")
+	private String caFile;
+
+	@CommandLine.Option(names = { "--insecure-skip-tls-verify" },
+			description = "skip TLS verification of the repository")
+	private boolean insecureSkipTlsVerify;
+
+	@CommandLine.Option(names = { "--pass-credentials" },
+			description = "send credentials to all domains, not just the repository host")
+	private boolean passCredentials;
+
 	/**
 	 * Creates the command.
 	 * @param repoManager the repository manager that downloads the chart
@@ -37,12 +67,30 @@ public class PullCommand implements Runnable {
 	@Override
 	public void run() {
 		try {
-			repoManager.pull(chart, version, dest);
-			CliOutput.println(CliOutput.success("Chart pulled to " + dest));
+			if (this.repo != null && !this.repo.isBlank()) {
+				repoManager.pullFromRepoUrl(this.repo, this.chart, this.version, this.dest, buildRepoAuth());
+			}
+			else {
+				repoManager.pull(this.chart, this.version, this.dest);
+			}
+			CliOutput.println(CliOutput.success("Chart pulled to " + this.dest));
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error pulling chart: " + ex.getMessage()));
 		}
+	}
+
+	private RepositoryConfig.Repository buildRepoAuth() {
+		return RepositoryConfig.Repository.builder()
+			.url(this.repo)
+			.username(this.username)
+			.password(this.password)
+			.certFile(this.certFile)
+			.keyFile(this.keyFile)
+			.caFile(this.caFile)
+			.insecureSkipTlsVerify(this.insecureSkipTlsVerify)
+			.passCredentialsAll(this.passCredentials)
+			.build();
 	}
 
 }

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/PullCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/PullCommandTest.java
@@ -1,13 +1,18 @@
 package org.alexmond.jhelm.app.command;
 
+import org.alexmond.jhelm.core.model.RepositoryConfig;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
 import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -65,6 +70,25 @@ class PullCommandTest {
 		CommandLine cmd = new CommandLine(pullCommand);
 		cmd.execute("oci://ghcr.io/helm/charts/nginx:1.0.0");
 		// Should log error without throwing
+	}
+
+	@Test
+	void testPullWithRepoUrlAndAuth() throws IOException {
+		doNothing().when(repoManager)
+			.pullFromRepoUrl(anyString(), anyString(), anyString(), anyString(),
+					any(RepositoryConfig.Repository.class));
+
+		CommandLine cmd = new CommandLine(pullCommand);
+		cmd.execute("mychart", "--repo", "https://charts.example.com", "--version", "1.0.0", "--username", "u",
+				"--password", "p", "--insecure-skip-tls-verify");
+
+		ArgumentCaptor<RepositoryConfig.Repository> auth = ArgumentCaptor.forClass(RepositoryConfig.Repository.class);
+		verify(repoManager).pullFromRepoUrl(eq("https://charts.example.com"), eq("mychart"), eq("1.0.0"), eq("."),
+				auth.capture());
+		RepositoryConfig.Repository built = auth.getValue();
+		assertEquals("u", built.getUsername());
+		assertEquals("p", built.getPassword());
+		assertTrue(built.isInsecureSkipTlsVerify());
 	}
 
 	@Test

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -699,6 +699,53 @@ public class RepoManager {
 		}
 	}
 
+	/**
+	 * Pulls a chart directly from a repository URL (Helm's {@code --repo}), fetching that
+	 * repo's {@code index.yaml} with the supplied credentials and TLS settings instead of
+	 * resolving a named repository from {@code repositories.yaml}. Backs
+	 * {@code jhelm pull --repo URL CHART --version V}.
+	 * @param repoUrl the repository base URL (its {@code index.yaml} is fetched)
+	 * @param chartName the chart name to resolve in the index
+	 * @param version the chart version (required)
+	 * @param destDir the destination directory
+	 * @param auth a repository descriptor carrying auth and TLS settings; its URL is set
+	 * to {@code repoUrl} (may be {@code null} for an anonymous pull)
+	 * @throws IOException if the index or chart cannot be downloaded
+	 */
+	public void pullFromRepoUrl(String repoUrl, String chartName, String version, String destDir,
+			RepositoryConfig.Repository auth) throws IOException {
+		if (version == null || version.isBlank()) {
+			throw new IOException("version is required when pulling with --repo");
+		}
+		RepositoryConfig.Repository repo = (auth != null) ? auth : RepositoryConfig.Repository.builder().build();
+		repo.setUrl(repoUrl);
+		String indexUrl = repoUrl.endsWith("/") ? repoUrl + "index.yaml" : repoUrl + "/index.yaml";
+		File indexTmp = File.createTempFile("jhelm-index-", ".yaml");
+		try {
+			HttpGet httpGet = new HttpGet(indexUrl);
+			httpGet.setHeader("User-Agent", "jhelm");
+			httpClientFactory.executeGet(httpGet, repo, (response) -> {
+				if (response.getCode() != 200) {
+					throw new IOException("Failed to download index from " + indexUrl + ": " + response.getCode() + " "
+							+ response.getReasonPhrase());
+				}
+				HttpEntity entity = response.getEntity();
+				if (entity != null) {
+					try (InputStream in = entity.getContent(); OutputStream out = new FileOutputStream(indexTmp)) {
+						in.transferTo(out);
+					}
+				}
+				return null;
+			});
+			String[] indexEntry = lookupChartInIndex(indexTmp, chartName, version);
+			String chartUrl = resolveChartUrl((indexEntry != null) ? indexEntry[0] : null, repoUrl, chartName, version);
+			pullFromUrl(chartUrl, destDir, chartName + "-" + version + ".tgz", repo);
+		}
+		finally {
+			Files.deleteIfExists(indexTmp.toPath());
+		}
+	}
+
 	String[] lookupChartInIndex(File indexFile, String chartName, String version) throws IOException {
 		if (!indexFile.exists()) {
 			return null;

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
@@ -368,6 +368,34 @@ class RepoManagerTest {
 	}
 
 	@Test
+	void testPullFromRepoUrl() throws Exception {
+		RepoManager rm = new RepoManager();
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		rm.setHttpClientForTest(mockClient);
+		byte[] tgz = createMinimalTgz();
+		String index = """
+				entries:
+				  mychart:
+				    - version: "1.0.0"
+				      urls:
+				        - "https://charts.example.com/mychart-1.0.0.tgz"
+				""";
+		when(mockClient.execute(isA(HttpGet.class), any(HttpClientResponseHandler.class)))
+			.thenAnswer(httpAnswer(200, index.getBytes(StandardCharsets.UTF_8)))
+			.thenAnswer(httpAnswer(200, tgz));
+		RepositoryConfig.Repository auth = RepositoryConfig.Repository.builder().username("u").password("p").build();
+		rm.pullFromRepoUrl("https://charts.example.com", "mychart", "1.0.0", tempDir.toString(), auth);
+		assertTrue(tempDir.resolve("mychart-1.0.0.tgz").toFile().exists());
+	}
+
+	@Test
+	void testPullFromRepoUrlRequiresVersion() {
+		RepoManager rm = new RepoManager();
+		assertThrows(java.io.IOException.class,
+				() -> rm.pullFromRepoUrl("https://charts.example.com", "mychart", null, tempDir.toString(), null));
+	}
+
+	@Test
 	void testPullOci() throws Exception {
 		RepoManager rm = new RepoManager();
 		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
@@ -396,6 +396,38 @@ class RepoManagerTest {
 	}
 
 	@Test
+	void testPullFromRepoUrlAnonymous() throws Exception {
+		RepoManager rm = new RepoManager();
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		rm.setHttpClientForTest(mockClient);
+		byte[] tgz = createMinimalTgz();
+		String index = """
+				entries:
+				  mychart:
+				    - version: "1.0.0"
+				      urls:
+				        - "https://charts.example.com/mychart-1.0.0.tgz"
+				""";
+		when(mockClient.execute(isA(HttpGet.class), any(HttpClientResponseHandler.class)))
+			.thenAnswer(httpAnswer(200, index.getBytes(StandardCharsets.UTF_8)))
+			.thenAnswer(httpAnswer(200, tgz));
+		// null auth -> anonymous pull (exercises the null-auth branch)
+		rm.pullFromRepoUrl("https://charts.example.com/", "mychart", "1.0.0", tempDir.toString(), null);
+		assertTrue(tempDir.resolve("mychart-1.0.0.tgz").toFile().exists());
+	}
+
+	@Test
+	void testPullFromRepoUrlIndexDownloadFails() throws Exception {
+		RepoManager rm = new RepoManager();
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		rm.setHttpClientForTest(mockClient);
+		when(mockClient.execute(isA(HttpGet.class), any(HttpClientResponseHandler.class)))
+			.thenAnswer(httpAnswer(404, new byte[0]));
+		assertThrows(java.io.IOException.class,
+				() -> rm.pullFromRepoUrl("https://charts.example.com", "mychart", "1.0.0", tempDir.toString(), null));
+	}
+
+	@Test
 	void testPullOci() throws Exception {
 		RepoManager rm = new RepoManager();
 		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);


### PR DESCRIPTION
First of three slices for #504 gate #3 (remaining install/upgrade/pull flags). An audit showed `--atomic`/`--wait` already work at the CLI, so this gate is really about the genuinely-missing flags. This slice closes the **pull auth/TLS gap**.

## What's added
`jhelm pull` gains Helm's **`--repo URL`** form — pull a chart directly from a repository URL with inline credentials, no prior `repo add`:

`--repo`, `--username`, `--password`, `--cert-file`, `--key-file`, `--ca-file`, `--insecure-skip-tls-verify`, `--pass-credentials`.

## How
- `RepoManager.pullFromRepoUrl(repoUrl, chart, version, dest, auth)` — fetches the ad-hoc repo's `index.yaml` with the supplied auth/TLS, resolves the chart through the **existing** `lookupChartInIndex`/`resolveChartUrl`, and downloads via `pullFromUrl`. This reuses the `RepoHttpClientFactory` auth/TLS path that already consumes a `Repository` (the capability existed; it just wasn't reachable from the CLI).
- `PullCommand` wires the flags into a transient `Repository`. Without `--repo`, the named-repo/OCI path is byte-for-byte unchanged.

## Tests
RepoManager pulls from an ad-hoc repo URL (mocked index + tgz) and rejects a missing version; PullCommand builds the correct `Repository` from the flags and calls `pullFromRepoUrl`. cli-parity docs updated.

Slices 2–3 (next): `--dry-run=client|server|none` + `--wait-for-jobs`, then `--force`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)