### PR TITLE
feat(cli): --dry-run=client|server|none + --wait-for-jobs (#504 gate #3, slice 2/3)

### DIFF
--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -15,8 +15,8 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | `-n`, `--namespace` | ✅ | Defaults to `default` (Helm uses the kube-context namespace).
 | `-f`, `--values` | ✅ |
 | `--set`, `--set-string`, `--set-file`, `--set-json` | ✅ |
-| `--dry-run` | ✎ | Boolean; Helm's `--dry-run=client\|server` value form is not parsed.
-| `--wait` | ✅ |
+| `--dry-run[=client\|server\|none]` | ✅ | Bare `--dry-run` = `client`. `client`/`none` fully supported; `server` currently performs a client-side dry run with a notice (server-side simulation not yet wired).
+| `--wait` | ✅ | Waits for all resources, **including Jobs** (Helm needs `--wait-for-jobs` for that).
 | `--timeout` | ✎ | Takes **seconds** (e.g. `--timeout 300`); Helm takes a duration (`5m0s`).
 | `--atomic` | ✅ |
 | `--no-hooks` | ✅ |
@@ -27,7 +27,7 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | `--verify`, `--keyring` | ✅ |
 | `--post-renderer` | ✅ |
 | `--force` | ✗ | Force resource replacement is not implemented.
-| `--wait-for-jobs` | ✗ | `--wait` does not yet extend to Jobs.
+| `--wait-for-jobs` | ✅ | Accepted for Helm compatibility; implies `--wait`. jhelm's `--wait` already waits for Job completion.
 | `--version`, `--repo`, `--username`/`--password` (install from a repo) | ✗ | Install from an added repo/OCI ref; inline repo+auth flags aren't wired.
 |===
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -52,8 +52,9 @@ public class InstallCommand implements Runnable {
 	@CommandLine.Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
 	private String namespace;
 
-	@CommandLine.Option(names = { "--dry-run" }, description = "simulate an install")
-	private boolean dryRun;
+	@CommandLine.Option(names = { "--dry-run" }, arity = "0..1", fallbackValue = "client", paramLabel = "MODE",
+			description = "simulate an install without installing: client (default), server, or none")
+	private String dryRun;
 
 	@Option(names = { "-f", "--values" }, description = "specify values YAML files")
 	private List<String> valuesFiles = new ArrayList<>();
@@ -72,6 +73,11 @@ public class InstallCommand implements Runnable {
 
 	@Option(names = { "--wait" }, description = "wait until all resources are ready")
 	private boolean wait;
+
+	@Option(names = { "--wait-for-jobs" },
+			description = "wait for Jobs to complete before marking deployed (implies --wait; "
+					+ "jhelm's --wait already waits for Jobs)")
+	private boolean waitForJobs;
 
 	@Option(names = { "--timeout" }, defaultValue = "300", description = "timeout in seconds for --wait (default 300)")
 	private int timeout;
@@ -107,6 +113,7 @@ public class InstallCommand implements Runnable {
 	@Override
 	public void run() {
 		try {
+			boolean dryRunEnabled = resolveDryRun();
 			Chart chart = chartResolver.resolve(chartPath, verify, keyring);
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
 					setFileValues, setJsonValues);
@@ -117,13 +124,13 @@ public class InstallCommand implements Runnable {
 				.namespace(namespace)
 				.values(overrides)
 				.revision(1)
-				.dryRun(dryRun)
+				.dryRun(dryRunEnabled)
 				.noHooks(noHooks)
 				.createNamespace(createNamespace)
 				.build());
 			release = applyCliPostRenderers(release);
 
-			if (dryRun) {
+			if (dryRunEnabled) {
 				CliOutput.println(CliOutput.bold("NAME:") + " " + release.getName());
 				CliOutput.println(CliOutput.bold("LAST DEPLOYED:") + " " + release.getInfo().getLastDeployed());
 				CliOutput.println(CliOutput.bold("NAMESPACE:") + " " + release.getNamespace());
@@ -133,7 +140,7 @@ public class InstallCommand implements Runnable {
 			}
 			else {
 				CliOutput.println(CliOutput.success("Release \"" + name + "\" has been installed."));
-				if (wait || atomic) {
+				if (wait || atomic || waitForJobs) {
 					kubeService.waitForReady(namespace, release.getManifest(), timeout);
 				}
 			}
@@ -169,6 +176,30 @@ public class InstallCommand implements Runnable {
 			manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
 		}
 		return release.toBuilder().manifest(manifest).build();
+	}
+
+	/**
+	 * Resolves the {@code --dry-run} mode to whether a dry run should be performed.
+	 * {@code client} (the default when the flag is given bare) and {@code server} both
+	 * enable a dry run; {@code none} (or the flag omitted) disables it. Server-side
+	 * simulation is not yet supported, so {@code server} performs a client-side dry run
+	 * with a notice.
+	 * @return {@code true} if the install should be a dry run
+	 */
+	private boolean resolveDryRun() {
+		if (dryRun == null || dryRun.isBlank() || "none".equalsIgnoreCase(dryRun)) {
+			return false;
+		}
+		if ("server".equalsIgnoreCase(dryRun)) {
+			CliOutput
+				.errPrintln(CliOutput.warn("--dry-run=server is not yet supported; performing a client-side dry-run."));
+			return true;
+		}
+		if (!"client".equalsIgnoreCase(dryRun)) {
+			throw new IllegalArgumentException(
+					"invalid --dry-run mode '" + dryRun + "' (expected client, server, or none)");
+		}
+		return true;
 	}
 
 }

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -65,8 +65,11 @@ public class UpgradeCommand implements Runnable {
 	@CommandLine.Option(names = { "--install" }, description = "install if not exists")
 	private boolean install;
 
-	@CommandLine.Option(names = { "--dry-run" }, description = "simulate an upgrade")
-	private boolean dryRun;
+	@CommandLine.Option(names = { "--dry-run" }, arity = "0..1", fallbackValue = "client", paramLabel = "MODE",
+			description = "simulate an upgrade without applying: client (default), server, or none")
+	private String dryRun;
+
+	private boolean dryRunEnabled;
 
 	@Option(names = { "-f", "--values" }, description = "specify values YAML files")
 	private List<String> valuesFiles = new ArrayList<>();
@@ -85,6 +88,11 @@ public class UpgradeCommand implements Runnable {
 
 	@Option(names = { "--wait" }, description = "wait until all resources are ready")
 	private boolean wait;
+
+	@Option(names = { "--wait-for-jobs" },
+			description = "wait for Jobs to complete before marking deployed (implies --wait; "
+					+ "jhelm's --wait already waits for Jobs)")
+	private boolean waitForJobs;
 
 	@Option(names = { "--timeout" }, defaultValue = "300", description = "timeout in seconds for --wait (default 300)")
 	private int timeout;
@@ -142,6 +150,7 @@ public class UpgradeCommand implements Runnable {
 		int previousVersion = -1;
 		boolean wasInstall = false;
 		try {
+			this.dryRunEnabled = resolveDryRun();
 			Optional<Release> currentReleaseOpt = kubeService.getRelease(name, namespace);
 			Chart chart = chartResolver.resolve(chartPath, verify, keyring);
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
@@ -152,13 +161,13 @@ public class UpgradeCommand implements Runnable {
 					wasInstall = true;
 					Release release = installAction.install(buildInstallOptions(chart, overrides));
 					release = applyCliPostRenderers(release);
-					if (dryRun) {
+					if (dryRunEnabled) {
 						printRelease(release);
 					}
 					else {
 						CliOutput
 							.println(CliOutput.success("Release \"" + name + "\" does not exist. Installing it now."));
-						if (wait || atomic) {
+						if (wait || atomic || waitForJobs) {
 							kubeService.waitForReady(namespace, release.getManifest(), timeout);
 						}
 					}
@@ -177,12 +186,12 @@ public class UpgradeCommand implements Runnable {
 				.upgrade(buildUpgradeOptions(currentReleaseOpt.get(), chart, overrides, strategy));
 			upgradedRelease = applyCliPostRenderers(upgradedRelease);
 
-			if (dryRun) {
+			if (dryRunEnabled) {
 				printRelease(upgradedRelease);
 			}
 			else {
 				CliOutput.println(CliOutput.success("Release \"" + name + "\" has been upgraded. Happy Helming!"));
-				if (wait || atomic) {
+				if (wait || atomic || waitForJobs) {
 					kubeService.waitForReady(namespace, upgradedRelease.getManifest(), timeout);
 				}
 			}
@@ -225,7 +234,7 @@ public class UpgradeCommand implements Runnable {
 			.namespace(namespace)
 			.values(overrides)
 			.revision(1)
-			.dryRun(dryRun)
+			.dryRun(dryRunEnabled)
 			.noHooks(noHooks)
 			.build();
 	}
@@ -237,7 +246,7 @@ public class UpgradeCommand implements Runnable {
 			.newChart(chart)
 			.values(overrides)
 			.valueStrategy(strategy)
-			.dryRun(dryRun)
+			.dryRun(dryRunEnabled)
 			.noHooks(noHooks)
 			.maxHistory(historyMax)
 			.build();
@@ -261,6 +270,30 @@ public class UpgradeCommand implements Runnable {
 		CliOutput.println(CliOutput.bold("STATUS:") + " " + release.getInfo().getStatus().getValue());
 		CliOutput.println(CliOutput.bold("REVISION:") + " " + release.getVersion());
 		CliOutput.println("\n" + CliOutput.bold("MANIFEST:") + "\n" + release.getManifest());
+	}
+
+	/**
+	 * Resolves the {@code --dry-run} mode to whether a dry run should be performed.
+	 * {@code client} (the default when the flag is given bare) and {@code server} both
+	 * enable a dry run; {@code none} (or the flag omitted) disables it. Server-side
+	 * simulation is not yet supported, so {@code server} performs a client-side dry run
+	 * with a notice.
+	 * @return {@code true} if the upgrade should be a dry run
+	 */
+	private boolean resolveDryRun() {
+		if (dryRun == null || dryRun.isBlank() || "none".equalsIgnoreCase(dryRun)) {
+			return false;
+		}
+		if ("server".equalsIgnoreCase(dryRun)) {
+			CliOutput
+				.errPrintln(CliOutput.warn("--dry-run=server is not yet supported; performing a client-side dry-run."));
+			return true;
+		}
+		if (!"client".equalsIgnoreCase(dryRun)) {
+			throw new IllegalArgumentException(
+					"invalid --dry-run mode '" + dryRun + "' (expected client, server, or none)");
+		}
+		return true;
 	}
 
 }

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -21,13 +21,17 @@ import picocli.CommandLine;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 class InstallCommandTest {
@@ -117,6 +121,64 @@ class InstallCommandTest {
 
 		// waitForReady should NOT be called when --dry-run is active
 		verify(kubeService, Mockito.never()).waitForReady(anyString(), anyString(), anyInt());
+	}
+
+	@Test
+	void testInstallDryRunClientModeEnablesDryRun() throws Exception {
+		File chartDir = createMockChart();
+		when(installAction.install(any(InstallOptions.class))).thenReturn(createMockRelease("my-release", 1));
+		ArgumentCaptor<InstallOptions> opts = ArgumentCaptor.forClass(InstallOptions.class);
+
+		new CommandLine(installCommand).execute("my-release", chartDir.getAbsolutePath(), "--dry-run=client");
+
+		verify(installAction).install(opts.capture());
+		assertTrue(opts.getValue().isDryRun());
+		verify(kubeService, never()).waitForReady(anyString(), anyString(), anyInt());
+	}
+
+	@Test
+	void testInstallDryRunNoneModeInstallsForReal() throws Exception {
+		File chartDir = createMockChart();
+		when(installAction.install(any(InstallOptions.class))).thenReturn(createMockRelease("my-release", 1));
+		ArgumentCaptor<InstallOptions> opts = ArgumentCaptor.forClass(InstallOptions.class);
+
+		new CommandLine(installCommand).execute("my-release", chartDir.getAbsolutePath(), "--dry-run=none", "--wait");
+
+		verify(installAction).install(opts.capture());
+		assertFalse(opts.getValue().isDryRun());
+		verify(kubeService).waitForReady(eq("default"), anyString(), anyInt());
+	}
+
+	@Test
+	void testInstallDryRunServerModeIsDryRun() throws Exception {
+		File chartDir = createMockChart();
+		when(installAction.install(any(InstallOptions.class))).thenReturn(createMockRelease("my-release", 1));
+		ArgumentCaptor<InstallOptions> opts = ArgumentCaptor.forClass(InstallOptions.class);
+
+		new CommandLine(installCommand).execute("my-release", chartDir.getAbsolutePath(), "--dry-run=server");
+
+		verify(installAction).install(opts.capture());
+		assertTrue(opts.getValue().isDryRun());
+	}
+
+	@Test
+	void testInstallWaitForJobsTriggersWait() throws Exception {
+		File chartDir = createMockChart();
+		when(installAction.install(any(InstallOptions.class))).thenReturn(createMockRelease("my-release", 1));
+
+		new CommandLine(installCommand).execute("my-release", chartDir.getAbsolutePath(), "--wait-for-jobs");
+
+		verify(kubeService).waitForReady(eq("default"), anyString(), anyInt());
+	}
+
+	@Test
+	void testInstallInvalidDryRunModeIsHandled() throws Exception {
+		File chartDir = createMockChart();
+
+		new CommandLine(installCommand).execute("my-release", chartDir.getAbsolutePath(), "--dry-run=bogus");
+
+		// invalid mode is reported, not crashed; installAction is never invoked
+		verify(installAction, never()).install(any(InstallOptions.class));
 	}
 
 	@Test

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -25,13 +25,17 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.mockito.ArgumentCaptor;
 
 class UpgradeCommandTest {
 
@@ -81,6 +85,33 @@ class UpgradeCommandTest {
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "-n", "default");
+	}
+
+	@Test
+	void testUpgradeWaitForJobsTriggersWait() throws Exception {
+		File chartDir = createMockChart();
+		when(kubeService.getRelease(anyString(), anyString()))
+			.thenReturn(Optional.of(createMockRelease("my-release", 1)));
+		when(upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(createMockRelease("my-release", 2));
+
+		new CommandLine(upgradeCommand).execute("my-release", chartDir.getAbsolutePath(), "--wait-for-jobs");
+
+		verify(kubeService).waitForReady(eq("default"), anyString(), anyInt());
+	}
+
+	@Test
+	void testUpgradeDryRunServerModeIsDryRun() throws Exception {
+		File chartDir = createMockChart();
+		when(kubeService.getRelease(anyString(), anyString()))
+			.thenReturn(Optional.of(createMockRelease("my-release", 1)));
+		when(upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(createMockRelease("my-release", 2));
+		ArgumentCaptor<UpgradeOptions> opts = ArgumentCaptor.forClass(UpgradeOptions.class);
+
+		new CommandLine(upgradeCommand).execute("my-release", chartDir.getAbsolutePath(), "--dry-run=server");
+
+		verify(upgradeAction).upgrade(opts.capture());
+		assertTrue(opts.getValue().isDryRun());
+		verify(kubeService, never()).waitForReady(anyString(), anyString(), anyInt());
 	}
 
 	@Test

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -115,6 +115,31 @@ class UpgradeCommandTest {
 	}
 
 	@Test
+	void testUpgradeInvalidDryRunModeIsHandled() throws Exception {
+		File chartDir = createMockChart();
+
+		new CommandLine(upgradeCommand).execute("my-release", chartDir.getAbsolutePath(), "--dry-run=bogus");
+
+		// invalid mode is reported before any work; upgrade is never attempted
+		verify(upgradeAction, never()).upgrade(any(UpgradeOptions.class));
+	}
+
+	@Test
+	void testUpgradeDryRunNoneUpgradesForReal() throws Exception {
+		File chartDir = createMockChart();
+		when(kubeService.getRelease(anyString(), anyString()))
+			.thenReturn(Optional.of(createMockRelease("my-release", 1)));
+		when(upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(createMockRelease("my-release", 2));
+		ArgumentCaptor<UpgradeOptions> opts = ArgumentCaptor.forClass(UpgradeOptions.class);
+
+		new CommandLine(upgradeCommand).execute("my-release", chartDir.getAbsolutePath(), "--dry-run=none", "--wait");
+
+		verify(upgradeAction).upgrade(opts.capture());
+		assertTrue(!opts.getValue().isDryRun());
+		verify(kubeService).waitForReady(eq("default"), anyString(), anyInt());
+	}
+
+	@Test
 	void testUpgradeCommandWithInstallFlag() throws Exception {
 		File chartDir = createMockChart();
 		Release newRelease = createMockRelease("my-release", 1);


### PR DESCRIPTION
Slice 2 of #504 gate #3. Two flags that improve Helm-script compatibility, both fully tested.

## `--dry-run[=client|server|none]`
`install`/`upgrade` only accepted a **boolean** `--dry-run`, so Helm's value form (`--dry-run=client`, common in CI) **broke argument parsing**. Now the mode is parsed:
- bare `--dry-run` = `client`
- `client` / `none` — fully supported (client = render only; none = real install)
- `server` — currently performs a **client-side** dry run with a clear stderr notice.

**Why server isn't real yet:** a faithful `--dry-run=server` means threading `dryRun=All` through the `KubeService` server-side-apply path **and both decorators** (`RetryableKubeService`, `ObservableKubeService`). If a decorator failed to forward it, the "dry run" would **apply for real** — a dangerous trap that needs a live cluster to validate. Deferred rather than shipped half-correct. Tracked for a follow-up.

## `--wait-for-jobs`
Accepted for Helm compatibility; implies `--wait`. Not a no-op: jhelm's `--wait` **already** waits for Job completion (`getResourceStatuses` → `checkJob` waits `succeeded >= completions`), so this is faithful. (Helm needs the separate flag; jhelm's `--wait` is stricter.)

## Tests
Mode → `isDryRun()` mapping (client/server enable, none disables), invalid mode reported not crashed, `--wait-for-jobs` triggers the readiness wait — on **both** install and upgrade. Existing bare `--dry-run` tests unchanged (fallback = client). Full cli build green (incl. doclint). cli-parity docs updated.

Slice 3 (next): `--force` (delete-and-recreate on upgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)