### PR TITLE
feat(cli): upgrade --force (delete-and-recreate) (#504 gate #3, slice 3/3)

### DIFF
--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -26,7 +26,7 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | `--history-max` (upgrade) | ✅ |
 | `--verify`, `--keyring` | ✅ |
 | `--post-renderer` | ✅ |
-| `--force` | ✗ | Force resource replacement is not implemented.
+| `--force` (upgrade) | ✅ | Delete-and-recreate strategy: existing resources are deleted before the new manifest is applied. May cause downtime or data loss for stateful resources — use with care.
 | `--wait-for-jobs` | ✅ | Accepted for Helm compatibility; implies `--wait`. jhelm's `--wait` already waits for Job completion.
 | `--version`, `--repo`, `--username`/`--password` (install from a repo) | ✗ | Install from an added repo/OCI ref; inline repo+auth flags aren't wired.
 |===

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -100,6 +100,10 @@ public class UpgradeCommand implements Runnable {
 	@Option(names = { "--atomic" }, description = "rollback on failure (implies --wait)")
 	private boolean atomic;
 
+	@Option(names = { "--force" }, description = "force resource updates through a delete-and-recreate strategy "
+			+ "(may cause downtime or data loss for stateful resources)")
+	private boolean force;
+
 	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
 
@@ -249,6 +253,7 @@ public class UpgradeCommand implements Runnable {
 			.dryRun(dryRunEnabled)
 			.noHooks(noHooks)
 			.maxHistory(historyMax)
+			.force(force)
 			.build();
 	}
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -115,6 +115,20 @@ class UpgradeCommandTest {
 	}
 
 	@Test
+	void testUpgradeForceIsWiredIntoOptions() throws Exception {
+		File chartDir = createMockChart();
+		when(kubeService.getRelease(anyString(), anyString()))
+			.thenReturn(Optional.of(createMockRelease("my-release", 1)));
+		when(upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(createMockRelease("my-release", 2));
+		ArgumentCaptor<UpgradeOptions> opts = ArgumentCaptor.forClass(UpgradeOptions.class);
+
+		new CommandLine(upgradeCommand).execute("my-release", chartDir.getAbsolutePath(), "--force");
+
+		verify(upgradeAction).upgrade(opts.capture());
+		assertTrue(opts.getValue().isForce());
+	}
+
+	@Test
 	void testUpgradeInvalidDryRunModeIsHandled() throws Exception {
 		File chartDir = createMockChart();
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -135,6 +135,12 @@ public class UpgradeAction {
 		if (!noHooks) {
 			runHooks(hookExecutor, newRelease.getNamespace(), hooks, "pre-upgrade");
 		}
+		if (options.isForce()) {
+			if (log.isInfoEnabled()) {
+				log.info("--force: deleting existing resources of release {} before recreation", newRelease.getName());
+			}
+			kubeService.delete(newRelease.getNamespace(), regularManifest);
+		}
 		kubeService.apply(newRelease.getNamespace(), regularManifest);
 		try {
 			kubeService.storeRelease(newRelease);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeOptions.java
@@ -60,4 +60,11 @@ public final class UpgradeOptions {
 	@Builder.Default
 	private final int maxHistory = 10;
 
+	/**
+	 * When {@code true}, force resource updates through a delete-and-recreate strategy
+	 * (Helm {@code --force}): existing resources are deleted before the new manifest is
+	 * applied, rather than patched in place. Defaults to {@code false}.
+	 */
+	private final boolean force;
+
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -122,6 +122,76 @@ class UpgradeActionTest {
 	}
 
 	@Test
+	void testUpgradeForceDeletesBeforeApply() throws Exception {
+		Chart oldChart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
+			.values(new HashMap<>())
+			.build();
+		Release currentRelease = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(oldChart)
+			.info(Release.ReleaseInfo.builder().status(ReleaseStatus.DEPLOYED).build())
+			.build();
+
+		Chart newChart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("2.0.0").build())
+			.values(new HashMap<>())
+			.build();
+		String renderedManifest = "---\napiVersion: v1\nkind: Service";
+		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class))).thenReturn(renderedManifest);
+		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(newChart)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.force(true)
+			.build());
+
+		String stripped = HookParser.stripHooks(renderedManifest);
+		// --force deletes the existing resources before recreating them
+		InOrder order = inOrder(kubeService);
+		order.verify(kubeService).delete("default", stripped);
+		order.verify(kubeService).apply("default", stripped);
+	}
+
+	@Test
+	void testUpgradeWithoutForceDoesNotDelete() throws Exception {
+		Chart oldChart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
+			.values(new HashMap<>())
+			.build();
+		Release currentRelease = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(oldChart)
+			.info(Release.ReleaseInfo.builder().status(ReleaseStatus.DEPLOYED).build())
+			.build();
+		Chart newChart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("2.0.0").build())
+			.values(new HashMap<>())
+			.build();
+		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class)))
+			.thenReturn("---\napiVersion: v1\nkind: Service");
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(newChart)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.build());
+
+		// no --force and no orphans (previous release had no manifest) -> no delete
+		verify(kubeService, never()).delete(anyString(), anyString());
+	}
+
+	@Test
 	void testUpgradeWithOverrideValues() throws Exception {
 		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
 		Map<String, Object> chartValues = new HashMap<>();


### PR DESCRIPTION
Slice 3 of #504 gate #3 — the last flag-parity item. Implements Helm's `upgrade --force`.

## What
`upgrade --force` replaces resources through **delete-and-recreate** instead of an in-place patch (Helm uses this when immutable fields change and a patch would be rejected).

- `UpgradeOptions.force`; `UpgradeAction.applyRelease` deletes the (hook-stripped) manifest's resources **before** applying it when force is set — composing the existing `KubeService.delete()`/`apply()`, so **no new kube primitive**.
- CLI `--force` on `upgrade`, wired into `UpgradeOptions`. Help text warns it **may cause downtime or data loss for stateful resources**.

Ordering: pre-upgrade hooks still run first, then delete → apply, then store/prune/orphan-cleanup/post-hooks as before.

## Tests
- `UpgradeActionTest`: `InOrder` asserts **delete precedes apply** under `--force`; a second test asserts **no delete** without force (and no orphans).
- `UpgradeCommandTest`: `--force` is captured into `UpgradeOptions.isForce()`.
- Full core+cli build green incl. doclint.

## Scope note
This completes gate #3's **flag parity**. The one remaining deferred item is *real* server-side `--dry-run=server` (currently client-side with a notice) — it needs `dryRun=All` threaded through both `KubeService` decorators plus live-cluster validation, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)