### PR TITLE
feat: real server-side --dry-run=server (#504 gate #3 follow-up)

### DIFF
--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -15,7 +15,7 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | `-n`, `--namespace` | ✅ | Defaults to `default` (Helm uses the kube-context namespace).
 | `-f`, `--values` | ✅ |
 | `--set`, `--set-string`, `--set-file`, `--set-json` | ✅ |
-| `--dry-run[=client\|server\|none]` | ✅ | Bare `--dry-run` = `client`. `client`/`none` fully supported; `server` currently performs a client-side dry run with a notice (server-side simulation not yet wired).
+| `--dry-run[=client\|server\|none]` | ✅ | Bare `--dry-run` = `client`. `client` renders locally; `server` also validates the manifest against the API server via a server-side dry-run apply (admission/defaulting/quota, persists nothing); `none` disables the dry run.
 | `--wait` | ✅ | Waits for all resources, **including Jobs** (Helm needs `--wait-for-jobs` for that).
 | `--timeout` | ✎ | Takes **seconds** (e.g. `--timeout 300`); Helm takes a duration (`5m0s`).
 | `--atomic` | ✅ |

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -56,6 +56,8 @@ public class InstallCommand implements Runnable {
 			description = "simulate an install without installing: client (default), server, or none")
 	private String dryRun;
 
+	private boolean serverDryRun;
+
 	@Option(names = { "-f", "--values" }, description = "specify values YAML files")
 	private List<String> valuesFiles = new ArrayList<>();
 
@@ -125,6 +127,7 @@ public class InstallCommand implements Runnable {
 				.values(overrides)
 				.revision(1)
 				.dryRun(dryRunEnabled)
+				.serverDryRun(serverDryRun)
 				.noHooks(noHooks)
 				.createNamespace(createNamespace)
 				.build());
@@ -179,20 +182,19 @@ public class InstallCommand implements Runnable {
 	}
 
 	/**
-	 * Resolves the {@code --dry-run} mode to whether a dry run should be performed.
-	 * {@code client} (the default when the flag is given bare) and {@code server} both
-	 * enable a dry run; {@code none} (or the flag omitted) disables it. Server-side
-	 * simulation is not yet supported, so {@code server} performs a client-side dry run
-	 * with a notice.
+	 * Resolves the {@code --dry-run} mode. {@code client} (the default when the flag is
+	 * given bare) renders locally; {@code server} additionally validates the manifest
+	 * against the API server via a server-side dry-run apply (setting
+	 * {@link #serverDryRun}); {@code none} (or the flag omitted) disables the dry run.
 	 * @return {@code true} if the install should be a dry run
 	 */
 	private boolean resolveDryRun() {
+		this.serverDryRun = false;
 		if (dryRun == null || dryRun.isBlank() || "none".equalsIgnoreCase(dryRun)) {
 			return false;
 		}
 		if ("server".equalsIgnoreCase(dryRun)) {
-			CliOutput
-				.errPrintln(CliOutput.warn("--dry-run=server is not yet supported; performing a client-side dry-run."));
+			this.serverDryRun = true;
 			return true;
 		}
 		if (!"client".equalsIgnoreCase(dryRun)) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -71,6 +71,8 @@ public class UpgradeCommand implements Runnable {
 
 	private boolean dryRunEnabled;
 
+	private boolean serverDryRun;
+
 	@Option(names = { "-f", "--values" }, description = "specify values YAML files")
 	private List<String> valuesFiles = new ArrayList<>();
 
@@ -239,6 +241,7 @@ public class UpgradeCommand implements Runnable {
 			.values(overrides)
 			.revision(1)
 			.dryRun(dryRunEnabled)
+			.serverDryRun(serverDryRun)
 			.noHooks(noHooks)
 			.build();
 	}
@@ -251,6 +254,7 @@ public class UpgradeCommand implements Runnable {
 			.values(overrides)
 			.valueStrategy(strategy)
 			.dryRun(dryRunEnabled)
+			.serverDryRun(serverDryRun)
 			.noHooks(noHooks)
 			.maxHistory(historyMax)
 			.force(force)
@@ -278,20 +282,19 @@ public class UpgradeCommand implements Runnable {
 	}
 
 	/**
-	 * Resolves the {@code --dry-run} mode to whether a dry run should be performed.
-	 * {@code client} (the default when the flag is given bare) and {@code server} both
-	 * enable a dry run; {@code none} (or the flag omitted) disables it. Server-side
-	 * simulation is not yet supported, so {@code server} performs a client-side dry run
-	 * with a notice.
+	 * Resolves the {@code --dry-run} mode. {@code client} (the default when the flag is
+	 * given bare) renders locally; {@code server} additionally validates the manifest
+	 * against the API server via a server-side dry-run apply (setting
+	 * {@link #serverDryRun}); {@code none} (or the flag omitted) disables the dry run.
 	 * @return {@code true} if the upgrade should be a dry run
 	 */
 	private boolean resolveDryRun() {
+		this.serverDryRun = false;
 		if (dryRun == null || dryRun.isBlank() || "none".equalsIgnoreCase(dryRun)) {
 			return false;
 		}
 		if ("server".equalsIgnoreCase(dryRun)) {
-			CliOutput
-				.errPrintln(CliOutput.warn("--dry-run=server is not yet supported; performing a client-side dry-run."));
+			this.serverDryRun = true;
 			return true;
 		}
 		if (!"client".equalsIgnoreCase(dryRun)) {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -159,6 +159,7 @@ class InstallCommandTest {
 
 		verify(installAction).install(opts.capture());
 		assertTrue(opts.getValue().isDryRun());
+		assertTrue(opts.getValue().isServerDryRun());
 	}
 
 	@Test

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -111,6 +111,7 @@ class UpgradeCommandTest {
 
 		verify(upgradeAction).upgrade(opts.capture());
 		assertTrue(opts.getValue().isDryRun());
+		assertTrue(opts.getValue().isServerDryRun());
 		verify(kubeService, never()).waitForReady(anyString(), anyString(), anyInt());
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -113,35 +113,53 @@ public class InstallAction {
 		release = release.toBuilder().manifest(manifest).build();
 
 		if (kubeService != null && !options.isDryRun()) {
-			String namespace = options.getNamespace();
-			boolean noHooks = options.isNoHooks();
-			if (options.isCreateNamespace()) {
-				kubeService.ensureNamespace(namespace);
-			}
-			applyCrds(chart, namespace);
-			fireLifecycleEvent(LifecyclePhase.PRE_INSTALL, options.getReleaseName(), namespace);
-			String regularManifest = HookParser.stripHooks(manifest);
-			List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(manifest);
-			HookExecutor hookExecutor = noHooks ? null : new HookExecutor(kubeService);
-			if (!noHooks) {
-				runHooks(hookExecutor, namespace, hooks, "pre-install");
-			}
-			kubeService.apply(namespace, regularManifest);
-			try {
-				kubeService.storeRelease(release);
-			}
-			catch (Exception ex) {
-				rollbackAppliedResources(namespace, regularManifest);
-				throw new DeploymentFailedException("Failed to store release after apply; resources rolled back", ex,
-						regularManifest);
-			}
-			if (!noHooks) {
-				runHooks(hookExecutor, namespace, hooks, "post-install");
-			}
-			fireLifecycleEvent(LifecyclePhase.POST_INSTALL, options.getReleaseName(), namespace);
+			applyRelease(options, chart, release, manifest);
+		}
+		else if (kubeService != null && options.isServerDryRun()) {
+			// server-side dry-run: validate against the API server without persisting the
+			// release or running hooks
+			kubeService.applyDryRun(options.getNamespace(), HookParser.stripHooks(manifest));
 		}
 
 		return release;
+	}
+
+	/**
+	 * Applies a non-dry-run install to the cluster: ensures the namespace, applies CRDs,
+	 * runs pre-install hooks, applies the hook-stripped manifest, stores the release
+	 * (rolling back applied resources on failure) and runs post-install hooks.
+	 * @param options the install options
+	 * @param chart the chart being installed (for CRDs)
+	 * @param release the release being applied
+	 * @param manifest the full rendered manifest (hooks not yet stripped)
+	 */
+	private void applyRelease(InstallOptions options, Chart chart, Release release, String manifest) {
+		String namespace = options.getNamespace();
+		boolean noHooks = options.isNoHooks();
+		if (options.isCreateNamespace()) {
+			kubeService.ensureNamespace(namespace);
+		}
+		applyCrds(chart, namespace);
+		fireLifecycleEvent(LifecyclePhase.PRE_INSTALL, options.getReleaseName(), namespace);
+		String regularManifest = HookParser.stripHooks(manifest);
+		List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(manifest);
+		HookExecutor hookExecutor = noHooks ? null : new HookExecutor(kubeService);
+		if (!noHooks) {
+			runHooks(hookExecutor, namespace, hooks, "pre-install");
+		}
+		kubeService.apply(namespace, regularManifest);
+		try {
+			kubeService.storeRelease(release);
+		}
+		catch (Exception ex) {
+			rollbackAppliedResources(namespace, regularManifest);
+			throw new DeploymentFailedException("Failed to store release after apply; resources rolled back", ex,
+					regularManifest);
+		}
+		if (!noHooks) {
+			runHooks(hookExecutor, namespace, hooks, "post-install");
+		}
+		fireLifecycleEvent(LifecyclePhase.POST_INSTALL, options.getReleaseName(), namespace);
 	}
 
 	private String runPostRenderProcessors(String manifest) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallOptions.java
@@ -43,6 +43,13 @@ public final class InstallOptions {
 	private final boolean dryRun;
 
 	/**
+	 * When {@code true}, validate the rendered manifest against the API server via a
+	 * server-side dry-run apply (Helm {@code --dry-run=server}) without persisting
+	 * anything. Implies {@link #dryRun}. Defaults to {@code false}.
+	 */
+	private final boolean serverDryRun;
+
+	/**
 	 * When {@code true}, skip running pre-install and post-install hooks. Defaults to
 	 * {@code false}.
 	 */

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -113,6 +113,11 @@ public class UpgradeAction {
 		if (kubeService != null && !options.isDryRun()) {
 			applyRelease(options, currentRelease, newRelease, manifest);
 		}
+		else if (kubeService != null && options.isServerDryRun()) {
+			// server-side dry-run: validate against the API server without persisting the
+			// release or running hooks
+			kubeService.applyDryRun(newRelease.getNamespace(), HookParser.stripHooks(manifest));
+		}
 
 		return newRelease;
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeOptions.java
@@ -48,6 +48,13 @@ public final class UpgradeOptions {
 	private final boolean dryRun;
 
 	/**
+	 * When {@code true}, validate the rendered manifest against the API server via a
+	 * server-side dry-run apply (Helm {@code --dry-run=server}) without persisting
+	 * anything. Implies {@link #dryRun}. Defaults to {@code false}.
+	 */
+	private final boolean serverDryRun;
+
+	/**
 	 * When {@code true}, skip running pre-upgrade and post-upgrade hooks. Defaults to
 	 * {@code false}.
 	 */

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
@@ -90,6 +90,26 @@ public interface KubeService {
 	void apply(String namespace, String yamlContent);
 
 	/**
+	 * Validates a rendered manifest against the cluster via a server-side dry-run apply
+	 * (Helm {@code --dry-run=server}). The API server admits and validates the resources
+	 * (defaulting, admission webhooks, quota) but persists nothing.
+	 * <p>
+	 * The default throws {@link UnsupportedOperationException} so that an implementation
+	 * which does not support server-side dry-run fails loudly rather than silently
+	 * applying the manifest for real. Decorators must forward this call to their
+	 * delegate.
+	 * @param namespace the target namespace
+	 * @param yamlContent rendered YAML manifest (may contain multiple documents)
+	 * @throws KubernetesOperationException if a resource fails server-side validation
+	 * @throws UnsupportedOperationException if the implementation has no server-side
+	 * dry-run support
+	 */
+	default void applyDryRun(String namespace, String yamlContent) {
+		throw new UnsupportedOperationException(
+				"server-side dry-run is not supported by this KubeService implementation");
+	}
+
+	/**
 	 * Deletes the resources described in a rendered manifest.
 	 * @param namespace the target namespace
 	 * @param yamlContent rendered YAML manifest (may contain multiple documents)

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
@@ -141,6 +141,31 @@ class InstallActionTest {
 	}
 
 	@Test
+	void testInstallServerDryRunValidatesWithoutPersisting() throws Exception {
+		Chart chart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
+			.values(new HashMap<>())
+			.build();
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("---\nkind: ConfigMap\n");
+
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.revision(1)
+			.dryRun(true)
+			.serverDryRun(true)
+			.build());
+
+		assertEquals(ReleaseStatus.PENDING_INSTALL, release.getInfo().getStatus());
+		// server-side dry-run validates against the API server but never applies or
+		// stores
+		verify(kubeService).applyDryRun("default", HookParser.stripHooks("---\nkind: ConfigMap\n"));
+		verify(kubeService, never()).apply(anyString(), anyString());
+		verify(kubeService, never()).storeRelease(any(Release.class));
+	}
+
+	@Test
 	void testInstallRunsHooksAndStripsManifest() throws Exception {
 		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -160,6 +160,41 @@ class UpgradeActionTest {
 	}
 
 	@Test
+	void testUpgradeServerDryRunValidatesWithoutPersisting() throws Exception {
+		Chart oldChart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
+			.values(new HashMap<>())
+			.build();
+		Release currentRelease = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(oldChart)
+			.info(Release.ReleaseInfo.builder().status(ReleaseStatus.DEPLOYED).build())
+			.build();
+		Chart newChart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("2.0.0").build())
+			.values(new HashMap<>())
+			.build();
+		String renderedManifest = "---\napiVersion: v1\nkind: Service";
+		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class))).thenReturn(renderedManifest);
+
+		upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(newChart)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.dryRun(true)
+			.serverDryRun(true)
+			.build());
+
+		// server-side dry-run validates against the API server but never applies or
+		// stores
+		verify(kubeService).applyDryRun("default", HookParser.stripHooks(renderedManifest));
+		verify(kubeService, never()).apply(anyString(), anyString());
+		verify(kubeService, never()).storeRelease(any(Release.class));
+	}
+
+	@Test
 	void testUpgradeWithoutForceDoesNotDelete() throws Exception {
 		Chart oldChart = Chart.builder()
 			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
@@ -312,11 +312,20 @@ public class HelmKubeService implements KubeService {
 	 */
 	@Override
 	public void apply(String namespace, String yamlContent) {
+		applyManifest(namespace, yamlContent, false);
+	}
+
+	@Override
+	public void applyDryRun(String namespace, String yamlContent) {
+		applyManifest(namespace, yamlContent, true);
+	}
+
+	private void applyManifest(String namespace, String yamlContent, boolean serverDryRun) {
 		try {
 			Iterable<Object> objects = Yaml.loadAll(yamlContent);
 			for (Object obj : objects) {
 				if (obj instanceof KubernetesObject k8sObj) {
-					applyResource(namespace, k8sObj);
+					applyResource(namespace, k8sObj, serverDryRun);
 				}
 			}
 		}
@@ -328,7 +337,7 @@ public class HelmKubeService implements KubeService {
 		}
 	}
 
-	private void applyResource(String namespace, KubernetesObject obj) throws ApiException {
+	private void applyResource(String namespace, KubernetesObject obj, boolean serverDryRun) throws ApiException {
 		String apiVersion = obj.getApiVersion();
 		String group = apiVersion.contains("/") ? apiVersion.split("/")[0] : "";
 		String version = apiVersion.contains("/") ? apiVersion.split("/")[1] : apiVersion;
@@ -337,13 +346,17 @@ public class HelmKubeService implements KubeService {
 		String plural = inferPlural(kind);
 
 		if (log.isInfoEnabled()) {
-			log.info("Applying {} ({}/{}) {} in namespace {}", kind, group, version, name, namespace);
+			log.info("{} {} ({}/{}) {} in namespace {}", serverDryRun ? "Validating (server dry-run)" : "Applying",
+					kind, group, version, name, namespace);
 		}
 
 		V1Patch patch = new V1Patch(Yaml.dump(obj));
 		PatchOptions options = new PatchOptions();
 		options.setFieldManager("helm");
 		options.setForce(true);
+		if (serverDryRun) {
+			options.setDryRun("All");
+		}
 		// DynamicKubernetesApi resolves the request path from the group, so core-group
 		// resources (empty group, e.g. Service/ConfigMap/Secret) hit /api/<version>
 		// while named groups hit /apis/<group>/<version>. CustomObjectsApi always emits

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeService.java
@@ -97,6 +97,11 @@ public class ObservableKubeService implements KubeService {
 	}
 
 	@Override
+	public void applyDryRun(String namespace, String yamlContent) {
+		timeVoid(applyTimer, () -> delegate.applyDryRun(namespace, yamlContent));
+	}
+
+	@Override
 	public void delete(String namespace, String yamlContent) {
 		timeVoid(deleteTimer, () -> delegate.delete(namespace, yamlContent));
 	}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeService.java
@@ -98,6 +98,14 @@ public class RetryableKubeService implements KubeService {
 	}
 
 	@Override
+	public void applyDryRun(String namespace, String yamlContent) {
+		executeWithRetry("applyDryRun", () -> {
+			delegate.applyDryRun(namespace, yamlContent);
+			return null;
+		});
+	}
+
+	@Override
 	public void delete(String namespace, String yamlContent) {
 		executeWithRetry("delete", () -> {
 			delegate.delete(namespace, yamlContent);

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeServiceTest.java
@@ -61,6 +61,15 @@ class ObservableKubeServiceTest {
 	}
 
 	@Test
+	void testApplyDryRunForwardsToDelegate() throws Exception {
+		service.applyDryRun("default", "apiVersion: v1");
+		verify(delegate).applyDryRun("default", "apiVersion: v1");
+		Timer timer = registry.find("jhelm.kube.operation").tag("operation", "apply").timer();
+		assertNotNull(timer);
+		assertEquals(1, timer.count());
+	}
+
+	@Test
 	void testDeleteRecordsTimer() throws Exception {
 		service.delete("default", "yaml");
 		verify(delegate).delete("default", "yaml");

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeServiceTest.java
@@ -85,6 +85,12 @@ class RetryableKubeServiceTest {
 	}
 
 	@Test
+	void testApplyDryRunDelegatesToWrapped() throws Exception {
+		retryableService.applyDryRun("default", "yaml-content");
+		verify(delegate).applyDryRun("default", "yaml-content");
+	}
+
+	@Test
 	void testDeleteDelegatesToWrapped() throws Exception {
 		retryableService.delete("default", "yaml-content");
 		verify(delegate).delete("default", "yaml-content");


### PR DESCRIPTION
Implements the one deferred item from gate #3: a genuine **server-side** `--dry-run=server`. Previously the mode was accepted but fell back to a client-side dry run with a notice.

Now `--dry-run=server` performs a real server-side dry-run apply — the API server admits and validates the manifest (defaulting, admission webhooks, quota) and **persists nothing**.

## Fail-safe by construction
The danger with server dry-run is a dropped flag mid-chain silently applying **for real**. The design makes that impossible:

- `KubeService.applyDryRun(ns, yaml)` is a **default that throws** `UnsupportedOperationException` — an impl that doesn't support it fails loudly, never applies.
- `HelmKubeService` overrides it, reusing the server-side-apply path with `PatchOptions.dryRun="All"` (fieldManager/force unchanged).
- **Both decorators** (`ObservableKubeService`, `RetryableKubeService`) forward to their delegate — the flag can't be lost in the chain.
- `AsyncHelmKubeService` inherits the override.

## Threading
`InstallOptions`/`UpgradeOptions` gain `serverDryRun` (implies `dryRun`). The actions, when `serverDryRun` and not a plain dry run, call `applyDryRun` on the hook-stripped manifest — **no store, no hooks**. CLI `resolveDryRun` sets it for `mode=server` and drops the old notice. `InstallAction.applyRelease` was extracted to keep `doInstall` under the method-length limit.

## Tests
- **Action-level** (both install + upgrade): server dry-run calls `applyDryRun`, never `apply`/`storeRelease`.
- **Decorator forwarding** (both decorators): `applyDryRun` reaches the delegate.
- **Command-level** (both commands): `--dry-run=server` sets `serverDryRun` in the captured options.

Note: the *real* API-server round-trip only exercises against a live cluster; unit tests verify the wiring/routing and no-persist contract. Full core+kube+cli build green incl. doclint.

Closes the gate #3 deferred item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)