### PR TITLE
docs: bump jhelm-version to 1.0.0 for the 1.0 release (#504 gate #8)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 = jhelm
-:jhelm-version: 0.6.0
+:jhelm-version: 1.0.0
 :url-docs: https://www.alexmond.org/jhelm/current/index.html
 :url-docs-mcp: https://www.alexmond.org/jhelm/current/mcp.html
 :url-docs-rest: https://www.alexmond.org/jhelm/current/rest-api.html

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -4,7 +4,7 @@ version: master
 start_page: ROOT:index.adoc
 asciidoc:
   attributes:
-    jhelm-version: 0.6.0
+    jhelm-version: 1.0.0
     api-core: 'https://javadoc.io/page/org.alexmond/jhelm-core'
     api-gotemplate-helm: 'https://javadoc.io/page/org.alexmond/jhelm-gotemplate-helm'
     api-kube: 'https://javadoc.io/page/org.alexmond/jhelm-kube'


### PR DESCRIPTION
Pre-release docs sweep (gate #8 of #504). Confirmed target: **1.0.0**.

All version-bound text — Maven dependency snippets, `jhelm-cli` jar names, and javadoc.io API links — flows from a single `jhelm-version` attribute, so the sweep is two one-liners:

- `docs/antora.yml`: `jhelm-version` `0.6.0` → `1.0.0` (drives the Antora docs)
- `README.adoc`: `:jhelm-version:` `0.6.0` → `1.0.0` (GitHub-rendered, local AsciiDoc attribute)

**API-link set verified:** `core, gotemplate-helm, kube, rest, mcp, plugin` still matches the published modules; `rest-starter`/`mcp-starter` are code-less (no `-javadoc.jar`) and correctly excluded. No modules added/removed since #617.

**Safe timing:** docs are tag-pinned on the hub, so the live site keeps serving 0.6.0 until the 1.0.0 tag is cut (gate #11) and the hub re-pins — at which point the 1.0.0 javadoc.io deep links resolve (they need the 1.0.0 `-javadoc.jar` on Central). No premature 1.0.0 on the live site.

No code changes; historical version references (changelog 0.4.0, "API freeze shipped in 0.4.0") intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)