### PR TITLE
fix(release): exclude CLI from Central + docs-version fixes (1.0.0 prep)

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -71,5 +71,8 @@ jobs:
           tag_name: ${{ github.event.inputs.releaseVersion }}
           name: Release ${{ github.event.inputs.releaseVersion }}
           generate_release_notes: true
+          # The CLI is not published to Central (it is a fat jar, not a library);
+          # attach it here so users have a downloadable runnable jar per release.
+          files: jhelm-cli/target/jhelm-${{ github.event.inputs.releaseVersion }}.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,10 +20,10 @@ The pre-1.0 *API freeze* release.
 * *Engine* -- now on `gotmpl4j 1.1.0`; recursive/too-deep renders fail with a
   `TemplateRenderException` instead of an inline `ERROR:` string.
 
-== Unreleased (targeting 0.1.0)
+== Unreleased (targeting 1.0.0)
 
-Toward the *0.1.0 prerelease target* (see the Roadmap in the docs): a *≥ 300-chart*
-byte-parity gate against `helm template` plus an extraction-ready template engine.
+Toward the *1.0.0 release* (see the Roadmap in the docs): a broad byte-parity gate
+against `helm template` plus an extraction-ready template engine.
 
 === Engine — Helm byte-parity
 

--- a/README.adoc
+++ b/README.adoc
@@ -86,7 +86,7 @@ as a dependency.
 | Java | 21
 | Spring Boot | 4.0.7
 | Kubernetes Client | 26.0.0
-| Template engine | gotmpl4j 1.1.0
+| Template engine | gotmpl4j 1.2.0
 | CLI framework | Picocli 4.7.7
 |===
 

--- a/pom.xml
+++ b/pom.xml
@@ -306,11 +306,15 @@
                         <publishingServerId>central</publishingServerId>
                         <autoPublish>true</autoPublish>
                         <waitUntil>published</waitUntil>
-                        <!-- The sample/demo modules are apps, not libraries — keep them out
-                             of the Central bundle. central-publishing ignores
+                        <!-- The sample/demo modules and the CLI are apps, not libraries —
+                             keep them out of the Central bundle. central-publishing ignores
                              maven.deploy.skip, so excludeArtifacts on the aggregator config
-                             is the safe lever (drops just these artifactIds). (#560) -->
+                             is the safe lever (drops just these artifactIds). The CLI
+                             (artifactId 'jhelm') is a Spring Boot fat jar with javadoc
+                             skipped, so Central would reject it for a missing -javadoc.jar
+                             and abort the whole publish. (#560) -->
                         <excludeArtifacts>
+                            <excludeArtifact>jhelm</excludeArtifact>
                             <excludeArtifact>jhelm-sample</excludeArtifact>
                             <excludeArtifact>jhelm-rest-sample</excludeArtifact>
                             <excludeArtifact>jhelm-mcp-sample</excludeArtifact>


### PR DESCRIPTION
PR 1 of the pre-release fix series (panel findings). Packaging + docs-version.

## M1 — release blocker (verified)
The CLI module (artifactId `jhelm`) was **not** in central-publishing `<excludeArtifacts>` — only the 3 samples were. It is a Spring Boot **fat jar** with `maven.javadoc.skip=true`, so Central rejects it for a **missing `-javadoc.jar`** and the whole 1.0.0 publish aborts. Added `jhelm` to the exclude list. **Without this the release literally fails.**

## Also
- **CLI as a release asset:** attach `jhelm-cli/target/jhelm-<ver>.jar` to the GitHub Release (it's intentionally off Central) so users get a downloadable runnable jar.
- **README** tech-stack said `gotmpl4j 1.1.0`; pom pins **1.2.0** — corrected.
- **CHANGELOG** `Unreleased (targeting 0.1.0)` → `targeting 1.0.0` (stale heading).

## Dropped (false finding)
The panel flagged docs referencing `ReleaseInfo`/`MapConfig` as "types that don't exist" — **verified they do** (nested `@Value` classes in `Release.java:60,85`, both immutable), so the docs are correct. No scrub.

Docs/pom/CI only — no code change. Root pom validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)