### PR TITLE
fix(security): host-gate creds + untar cap + OCI URL guard + creds-file perms

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/OciRegistryClient.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/OciRegistryClient.java
@@ -59,6 +59,18 @@ class OciRegistryClient {
 	}
 
 	/**
+	 * Applies the SSRF guard to a registry URL built from a caller-supplied
+	 * {@code oci://host/path} reference, rejecting disallowed schemes and
+	 * internal/non-routable hosts before the request is sent. Complements the
+	 * connection-time {@link SsrfGuardingDnsResolver}; throws {@link SecurityException}
+	 * (unchecked) when the URL is unsafe.
+	 * @param url the registry URL about to be requested
+	 */
+	private static void validateOciUrl(String url) {
+		UrlSecurity.validateFetchUrl(URI.create(url));
+	}
+
+	/**
 	 * Fetches a bearer token from the registry's token endpoint.
 	 * @param registry the registry hostname
 	 * @param path the repository path
@@ -75,6 +87,7 @@ class OciRegistryClient {
 		}
 
 		String url = tokenUrlPrefix + "?service=" + tokenService + "&scope=repository:" + path + ":" + scope;
+		validateOciUrl(url);
 		HttpGet httpGet = new HttpGet(url);
 		if (auth != null) {
 			httpGet.setHeader("Authorization", "Basic " + auth);
@@ -118,6 +131,7 @@ class OciRegistryClient {
 	 * @return the manifest as a JSON tree
 	 */
 	JsonNode getManifest(String manifestUrl, String token, String accept) throws IOException {
+		validateOciUrl(manifestUrl);
 		HttpGet httpGet = new HttpGet(manifestUrl);
 		if (token != null) {
 			httpGet.setHeader("Authorization", "Bearer " + token);
@@ -245,6 +259,7 @@ class OciRegistryClient {
 	 */
 	boolean blobExists(String registry, String path, String token, String digest) {
 		String url = "https://" + registry + "/v2/" + path + "/blobs/" + digest;
+		validateOciUrl(url);
 		HttpHead head = new HttpHead(url);
 		if (token != null) {
 			head.setHeader("Authorization", "Bearer " + token);
@@ -265,6 +280,7 @@ class OciRegistryClient {
 	 */
 	void uploadBlob(String registry, String path, String token, String digest, byte[] content) throws IOException {
 		String initiateUrl = "https://" + registry + "/v2/" + path + "/blobs/uploads/";
+		validateOciUrl(initiateUrl);
 		HttpPost post = new HttpPost(initiateUrl);
 		if (token != null) {
 			post.setHeader("Authorization", "Bearer " + token);
@@ -284,6 +300,9 @@ class OciRegistryClient {
 		});
 
 		String putUrl = uploadUrl.contains("?") ? uploadUrl + "&digest=" + digest : uploadUrl + "?digest=" + digest;
+		// The upload URL comes from the registry's Location header and may point at a
+		// different host — re-validate before sending credentials/content there.
+		validateOciUrl(putUrl);
 		HttpPut put = new HttpPut(putUrl);
 		if (token != null) {
 			put.setHeader("Authorization", "Bearer " + token);
@@ -304,6 +323,7 @@ class OciRegistryClient {
 	 */
 	void pushManifest(String registry, String path, String tag, String token, byte[] manifest) throws IOException {
 		String url = "https://" + registry + "/v2/" + path + "/manifests/" + tag;
+		validateOciUrl(url);
 		HttpPut put = new HttpPut(url);
 		if (token != null) {
 			put.setHeader("Authorization", "Bearer " + token);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RegistryManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RegistryManager.java
@@ -110,14 +110,42 @@ public class RegistryManager {
 	private void saveConfig(Config config) throws IOException {
 		File file = new File(configPath);
 		File dir = file.getParentFile();
-		dir.mkdirs();
 		// The registry config holds base64 credentials — keep it owner-only (0600), and
 		// the containing directory 0700, mirroring how helm/docker protect their auth
 		// files. Best-effort: POSIX only, and a failure to tighten must not lose the
 		// save.
-		restrictPermissions(dir.toPath(), "rwx------");
+		if (dir != null) {
+			dir.mkdirs();
+			restrictPermissions(dir.toPath(), "rwx------");
+		}
+		// Create the file with owner-only perms BEFORE writing the credentials, so there
+		// is no window where it exists on disk with default (looser) permissions.
+		ensureOwnerOnlyFile(file.toPath());
 		jsonMapper.writeValue(file, config);
-		restrictPermissions(file.toPath(), "rw-------");
+	}
+
+	/**
+	 * Ensures the credentials file exists with owner-only ({@code 0600}) permissions
+	 * before it is written. A new file is created atomically with the restrictive mode
+	 * (closing the create-then-chmod TOCTOU window); an existing file is re-tightened.
+	 * Best-effort on non-POSIX filesystems.
+	 * @param path the credentials file path
+	 * @throws IOException if the file cannot be created
+	 */
+	private static void ensureOwnerOnlyFile(Path path) throws IOException {
+		boolean posix = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+		if (Files.notExists(path)) {
+			if (posix) {
+				Files.createFile(path,
+						PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+			}
+			else {
+				Files.createFile(path);
+			}
+		}
+		else {
+			restrictPermissions(path, "rw-------");
+		}
 	}
 
 	private static void restrictPermissions(Path path, String posix) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.core.service;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -53,10 +54,46 @@ final class RepoHttpClientFactory {
 			return;
 		}
 		if (repo.getUsername() != null && !repo.getUsername().isEmpty()) {
+			if (!maySendCredentials(request, repo)) {
+				return;
+			}
 			String password = (repo.getPassword() != null) ? repo.getPassword() : "";
 			String credentials = repo.getUsername() + ":" + password;
 			String encoded = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
 			request.setHeader("Authorization", "Basic " + encoded);
+		}
+	}
+
+	/**
+	 * Whether Basic-Auth credentials may be attached to this request. By default
+	 * credentials are only sent to the repository's own host: a chart URL resolved from a
+	 * third-party {@code index.yaml} can point at an arbitrary host, and sending the repo
+	 * credentials there would leak them (this mirrors Helm, where
+	 * {@code --pass-credentials} is off by default). When the repository's
+	 * {@code passCredentialsAll} flag (see {@link RepositoryConfig.Repository}) is set
+	 * the credentials go to any host. Fails closed (no credentials) if the hosts cannot
+	 * be compared.
+	 * @param request the request about to be sent
+	 * @param repo the repository whose credentials would be attached
+	 * @return {@code true} if credentials may be sent
+	 */
+	private boolean maySendCredentials(HttpGet request, RepositoryConfig.Repository repo) {
+		if (repo.isPassCredentialsAll()) {
+			return true;
+		}
+		String repoUrl = repo.getUrl();
+		if (repoUrl == null || repoUrl.isBlank()) {
+			// No repository host to compare against — fail closed rather than risk a
+			// leak.
+			return false;
+		}
+		try {
+			String repoHost = URI.create(repoUrl).getHost();
+			String requestHost = request.getUri().getHost();
+			return repoHost != null && repoHost.equalsIgnoreCase(requestHost);
+		}
+		catch (Exception ex) {
+			return false;
 		}
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -977,6 +977,17 @@ public class RepoManager {
 		}
 	}
 
+	/**
+	 * Maximum total uncompressed bytes a chart archive may expand to (decompression-bomb
+	 * guard).
+	 */
+	private static final long MAX_UNTAR_TOTAL_BYTES = 1L << 30; // 1 GiB
+
+	/**
+	 * Maximum number of entries a chart archive may contain (decompression-bomb guard).
+	 */
+	private static final int MAX_UNTAR_ENTRIES = 50_000;
+
 	public void untar(File tgzFile, File destDir) throws IOException {
 		if (log.isInfoEnabled()) {
 			log.info("Untarring {} to {}", tgzFile.getAbsolutePath(), destDir.getAbsolutePath());
@@ -993,7 +1004,13 @@ public class RepoManager {
 				TarArchiveInputStream ti = new TarArchiveInputStream(gzi)) {
 
 			TarArchiveEntry entry;
+			long totalBytes = 0;
+			int entryCount = 0;
 			while ((entry = ti.getNextEntry()) != null) {
+				if (++entryCount > MAX_UNTAR_ENTRIES) {
+					throw new IOException("chart archive has too many entries (> " + MAX_UNTAR_ENTRIES
+							+ "): possible decompression bomb");
+				}
 				if (!ti.canReadEntryData(entry)) {
 					continue;
 				}
@@ -1013,12 +1030,37 @@ public class RepoManager {
 					if (!parent.isDirectory() && !parent.mkdirs()) {
 						throw new IOException("failed to create directory " + parent);
 					}
-					try (OutputStream o = Files.newOutputStream(f.toPath())) {
-						ti.transferTo(o);
-					}
+					totalBytes = copyEntryBounded(ti, f, totalBytes);
 				}
 			}
 		}
+	}
+
+	/**
+	 * Copies a single tar entry to {@code dest}, enforcing a cumulative uncompressed-size
+	 * cap ({@link #MAX_UNTAR_TOTAL_BYTES}) so a maliciously small archive cannot expand
+	 * to exhaust disk (decompression bomb).
+	 * @param ti the tar stream positioned at the entry's data
+	 * @param dest the destination file
+	 * @param totalBytesSoFar bytes already written across previous entries
+	 * @return the updated running total of bytes written
+	 * @throws IOException if writing fails or the cumulative size cap is exceeded
+	 */
+	private long copyEntryBounded(TarArchiveInputStream ti, File dest, long totalBytesSoFar) throws IOException {
+		long total = totalBytesSoFar;
+		byte[] buffer = new byte[8192];
+		try (OutputStream o = Files.newOutputStream(dest.toPath())) {
+			int read;
+			while ((read = ti.read(buffer)) != -1) {
+				total += read;
+				if (total > MAX_UNTAR_TOTAL_BYTES) {
+					throw new IOException("chart archive expands beyond the maximum allowed size ("
+							+ MAX_UNTAR_TOTAL_BYTES + " bytes): possible decompression bomb");
+				}
+				o.write(buffer, 0, read);
+			}
+		}
+		return total;
 	}
 
 	@lombok.Data

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/OciRegistryClientTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/OciRegistryClientTest.java
@@ -33,6 +33,26 @@ class OciRegistryClientTest {
 	private final OciRegistryClient client = new OciRegistryClient(mock(CloseableHttpClient.class));
 
 	@Test
+	void testFetchTokenRejectsInternalMetadataHost() {
+		// SSRF guard must fire before any request when the registry host is the
+		// cloud-metadata (link-local) address
+		assertThrows(SecurityException.class,
+				() -> client.fetchToken("169.254.169.254", "library/nginx", null, "pull"));
+	}
+
+	@Test
+	void testGetManifestRejectsInternalMetadataHost() {
+		assertThrows(SecurityException.class,
+				() -> client.getManifest("https://169.254.169.254/v2/library/nginx/manifests/latest", "tok", null));
+	}
+
+	@Test
+	void testBlobExistsRejectsInternalMetadataHost() {
+		assertThrows(SecurityException.class,
+				() -> client.blobExists("169.254.169.254", "library/nginx", "tok", "sha256:abc"));
+	}
+
+	@Test
 	void testParseOciUrlWithTag() throws IOException {
 		String[] parts = client.parseOciUrl("oci://my.registry.io/charts/mychart:1.2.3");
 		assertEquals("my.registry.io", parts[0]);

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RegistryManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RegistryManagerTest.java
@@ -5,12 +5,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Base64;
+import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class RegistryManagerTest {
 
@@ -37,6 +43,19 @@ class RegistryManagerTest {
 		RegistryManager.Config config = registryManager.loadConfig();
 		assertNotNull(config);
 		assertNotNull(config.getAuths());
+	}
+
+	@Test
+	void testLoginWritesOwnerOnlyCredentialsFile() throws IOException {
+		Path configFile = tempDir.resolve("registry-config.json");
+		assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"),
+				"POSIX permissions not supported on this filesystem");
+
+		registryManager.login("ghcr.io", "user", "pass");
+
+		Set<PosixFilePermission> perms = Files.getPosixFilePermissions(configFile);
+		// credentials file must be owner-only (0600) — no group/other access
+		assertEquals(PosixFilePermissions.fromString("rw-------"), perms);
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoHttpClientFactoryTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoHttpClientFactoryTest.java
@@ -46,6 +46,54 @@ class RepoHttpClientFactoryTest {
 	}
 
 	@Test
+	void testConfigureAuthSkipsCredentialsOnDifferentHost() {
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		RepoHttpClientFactory factory = new RepoHttpClientFactory(mockClient, false);
+		RepositoryConfig.Repository repo = RepositoryConfig.Repository.builder()
+			.name("test")
+			.url("https://charts.example.com")
+			.username("myuser")
+			.password("mypass")
+			.build();
+		// chart URL resolved from a third-party index points at a different host —
+		// credentials must not be leaked there
+		HttpGet request = new HttpGet("https://evil.example.net/charts/pkg.tgz");
+		factory.configureAuth(request, repo);
+		assertNull(request.getFirstHeader("Authorization"));
+	}
+
+	@Test
+	void testConfigureAuthSendsCrossHostWhenPassCredentialsAll() {
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		RepoHttpClientFactory factory = new RepoHttpClientFactory(mockClient, false);
+		RepositoryConfig.Repository repo = RepositoryConfig.Repository.builder()
+			.name("test")
+			.url("https://charts.example.com")
+			.username("myuser")
+			.password("mypass")
+			.passCredentialsAll(true)
+			.build();
+		HttpGet request = new HttpGet("https://cdn.example.net/charts/pkg.tgz");
+		factory.configureAuth(request, repo);
+		assertNotNull(request.getFirstHeader("Authorization"));
+	}
+
+	@Test
+	void testConfigureAuthFailsClosedWhenRepoUrlMissing() {
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		RepoHttpClientFactory factory = new RepoHttpClientFactory(mockClient, false);
+		RepositoryConfig.Repository repo = RepositoryConfig.Repository.builder()
+			.name("test")
+			.username("myuser")
+			.password("mypass")
+			.build();
+		HttpGet request = new HttpGet("https://example.com/index.yaml");
+		factory.configureAuth(request, repo);
+		// no repo host to compare against -> do not send credentials
+		assertNull(request.getFirstHeader("Authorization"));
+	}
+
+	@Test
 	void testConfigureAuthSkipsNullRepo() {
 		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
 		RepoHttpClientFactory factory = new RepoHttpClientFactory(mockClient, false);


### PR DESCRIPTION
PR 2 of the pre-release fix series (security lens). Contained hardening — the server-mode private-range block ships as a focused follow-up (PR2b).

## M2 — credential leak (verified)
`RepoHttpClientFactory.configureAuth` attached `Authorization: Basic` to **every** request regardless of host, and `passCredentialsAll` was **stored but never read**. A chart URL is resolved from a third-party `index.yaml` and can point at an arbitrary host, so repo credentials **leaked cross-domain by default**. Now credentials are sent **only when the request host matches the repository host**, unless `passCredentialsAll` is set; **fails closed** when hosts can't be compared. (Matches Helm's default-off `--pass-credentials`.)

## Also
- **Decompression-bomb guard:** `untar` caps total uncompressed bytes (1 GiB) + entry count (50k) via a bounded per-entry copy — a small malicious `.tgz` can't exhaust disk (matters for the REST server).
- **OCI SSRF defense-in-depth:** `validateFetchUrl` now applied to the OCI token / manifest / blob-exists / upload / push URLs (previously only `downloadBlob`), so an internal/non-routable registry host is rejected up front.
- **Creds-file TOCTOU:** the base64 credentials file is created with owner-only `0600` **before** writing, closing the create-then-chmod window.

## Tests
Cross-host credential suppression (+ `passCredentialsAll` override, + fail-closed on missing repo URL); OCI token/manifest/blob-exists reject the cloud-metadata host; creds file written `0600` (POSIX-guarded). Full core build green incl. doclint.

## Panel positives confirmed (unchanged)
SSRF DNS guard consistent + drops bearer on cross-host redirect; Zip-Slip handled; template engine has no file/net/exec funcs; no credential logging; provenance fails-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)