### PR TITLE
feat(security): opt-in server-mode block of private/site-local SSRF targets

### DIFF
--- a/docs/modules/ROOT/pages/rest-api.adoc
+++ b/docs/modules/ROOT/pages/rest-api.adoc
@@ -80,6 +80,10 @@ Open http://localhost:8080/swagger-ui.html to see all endpoints.
 | _(none)_
 | API key required on mutating requests via the `X-API-Key` header. With no key set, mutating operations stay disabled even in `FULL` mode.
 
+| `jhelm.security.block-private-networks`
+| `false`
+| When `true`, outbound chart/repository fetches also refuse private/site-local targets (`10/8`, `172.16/12`, `192.168/16`) in addition to the always-blocked loopback/link-local/cloud-metadata ranges. Recommended for a server that fetches on behalf of untrusted callers (SSRF hardening). Left `false` by default so a private/internal repository stays reachable.
+
 | `jhelm.rest.base-path`
 | `/api/v1`
 | Base path prefix for all REST endpoints

--- a/docs/modules/ROOT/pages/security.adoc
+++ b/docs/modules/ROOT/pages/security.adoc
@@ -38,6 +38,14 @@ path for real auth.*
 | `jhelm.security.api-key-header`
 | `X-API-Key`
 | Name of the HTTP header that carries the API key.
+
+| `jhelm.security.block-private-networks`
+| `false`
+| SSRF hardening for outbound chart/repository fetches. When `true`, private/site-local
+  targets (`10/8`, `172.16/12`, `192.168/16`) are refused in addition to the always-blocked
+  loopback, link-local/cloud-metadata (`169.254.0.0/16`), wildcard and multicast ranges.
+  Recommended when the server fetches on behalf of untrusted callers; left `false` by default
+  so a private/internal repository stays reachable from a CLI.
 |===
 
 [source,yaml]

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -99,11 +99,12 @@ public class JhelmCoreAutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	public RepoManager repoManager(JhelmCoreProperties props, RegistryManager registryManager,
-			ObjectProvider<JhelmMetrics> metrics) {
+	public RepoManager repoManager(JhelmCoreProperties props, JhelmSecurityProperties securityProps,
+			RegistryManager registryManager, ObjectProvider<JhelmMetrics> metrics) {
+		boolean blockPrivate = securityProps.isBlockPrivateNetworks();
 		RepoManager repoManager = (props.getConfigPath() != null)
-				? new RepoManager(props.getConfigPath(), registryManager, props.isInsecureSkipTlsVerify())
-				: new RepoManager(registryManager, props.isInsecureSkipTlsVerify());
+				? new RepoManager(props.getConfigPath(), registryManager, props.isInsecureSkipTlsVerify(), blockPrivate)
+				: new RepoManager(registryManager, props.isInsecureSkipTlsVerify(), blockPrivate);
 		repoManager.setMetrics(metrics.getIfAvailable());
 		return repoManager;
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmSecurityProperties.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmSecurityProperties.java
@@ -45,4 +45,14 @@ public class JhelmSecurityProperties {
 	 */
 	private String apiKeyHeader = "X-API-Key";
 
+	/**
+	 * When {@code true}, outbound chart/repository fetches also refuse private/site-local
+	 * targets ({@code 10/8}, {@code 172.16/12}, {@code 192.168/16}) in addition to the
+	 * always-blocked loopback/link-local/wildcard/multicast ranges. This is the stricter
+	 * SSRF policy appropriate for a server (REST/MCP) that fetches on behalf of untrusted
+	 * callers. Defaults to {@code false} so a CLI pull from a private/internal repository
+	 * still works.
+	 */
+	private boolean blockPrivateNetworks;
+
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/OciRegistryClient.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/OciRegistryClient.java
@@ -31,9 +31,16 @@ class OciRegistryClient {
 
 	private final JsonMapper jsonMapper;
 
+	private final boolean blockPrivateNetworks;
+
 	OciRegistryClient(CloseableHttpClient httpClient) {
+		this(httpClient, false);
+	}
+
+	OciRegistryClient(CloseableHttpClient httpClient, boolean blockPrivateNetworks) {
 		this.httpClient = httpClient;
 		this.jsonMapper = JsonMapper.builder().build();
+		this.blockPrivateNetworks = blockPrivateNetworks;
 	}
 
 	/**
@@ -66,8 +73,8 @@ class OciRegistryClient {
 	 * (unchecked) when the URL is unsafe.
 	 * @param url the registry URL about to be requested
 	 */
-	private static void validateOciUrl(String url) {
-		UrlSecurity.validateFetchUrl(URI.create(url));
+	private void validateOciUrl(String url) {
+		UrlSecurity.validateFetchUrl(URI.create(url), blockPrivateNetworks);
 	}
 
 	/**

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
@@ -44,9 +44,17 @@ final class RepoHttpClientFactory {
 
 	private final boolean globalInsecureSkipTls;
 
+	private final boolean blockPrivateNetworks;
+
 	RepoHttpClientFactory(CloseableHttpClient defaultClient, boolean globalInsecureSkipTls) {
+		this(defaultClient, globalInsecureSkipTls, false);
+	}
+
+	RepoHttpClientFactory(CloseableHttpClient defaultClient, boolean globalInsecureSkipTls,
+			boolean blockPrivateNetworks) {
 		this.defaultClient = defaultClient;
 		this.globalInsecureSkipTls = globalInsecureSkipTls;
+		this.blockPrivateNetworks = blockPrivateNetworks;
 	}
 
 	void configureAuth(HttpGet request, RepositoryConfig.Repository repo) {
@@ -100,7 +108,7 @@ final class RepoHttpClientFactory {
 	<T> T executeGet(HttpGet request, RepositoryConfig.Repository repo, HttpClientResponseHandler<T> handler)
 			throws IOException {
 		try {
-			UrlSecurity.validateFetchUrl(request.getUri());
+			UrlSecurity.validateFetchUrl(request.getUri(), blockPrivateNetworks);
 		}
 		catch (URISyntaxException ex) {
 			throw new IOException("Invalid request URI: " + ex.getMessage(), ex);
@@ -133,7 +141,7 @@ final class RepoHttpClientFactory {
 					: new DefaultClientTlsStrategy(sslContext);
 			HttpClientConnectionManager connManager = PoolingHttpClientConnectionManagerBuilder.create()
 				.setTlsSocketStrategy(tlsStrategy)
-				.setDnsResolver(new SsrfGuardingDnsResolver())
+				.setDnsResolver(new SsrfGuardingDnsResolver(blockPrivateNetworks))
 				.build();
 			return HttpClients.custom().setConnectionManager(connManager).build();
 		}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -58,6 +58,8 @@ public class RepoManager {
 
 	private final boolean insecureSkipTlsVerify;
 
+	private final boolean blockPrivateNetworks;
+
 	private final RegistryManager registryManager;
 
 	// Optional metrics; set by the auto-configuration when a JhelmMetrics bean exists.
@@ -102,12 +104,37 @@ public class RepoManager {
 	}
 
 	/**
+	 * Creates a manager for the default config path with the given OCI auth, TLS setting,
+	 * and private-network policy.
+	 * @param registryManager OCI registry auth provider (may be {@code null})
+	 * @param insecureSkipTlsVerify whether to skip TLS verification on chart downloads
+	 * @param blockPrivateNetworks whether outbound fetches also refuse private/site-local
+	 * targets (server-mode strict SSRF policy)
+	 */
+	public RepoManager(RegistryManager registryManager, boolean insecureSkipTlsVerify, boolean blockPrivateNetworks) {
+		this(resolveDefaultConfigPath(), registryManager, insecureSkipTlsVerify, blockPrivateNetworks);
+	}
+
+	/**
 	 * Creates a repository manager.
 	 * @param configPath path to the Helm repositories.yaml
 	 * @param registryManager OCI registry auth provider (may be {@code null})
 	 * @param insecureSkipTlsVerify whether to skip TLS verification on chart downloads
 	 */
 	public RepoManager(String configPath, RegistryManager registryManager, boolean insecureSkipTlsVerify) {
+		this(configPath, registryManager, insecureSkipTlsVerify, false);
+	}
+
+	/**
+	 * Creates a repository manager.
+	 * @param configPath path to the Helm repositories.yaml
+	 * @param registryManager OCI registry auth provider (may be {@code null})
+	 * @param insecureSkipTlsVerify whether to skip TLS verification on chart downloads
+	 * @param blockPrivateNetworks whether outbound fetches also refuse private/site-local
+	 * targets (server-mode strict SSRF policy)
+	 */
+	public RepoManager(String configPath, RegistryManager registryManager, boolean insecureSkipTlsVerify,
+			boolean blockPrivateNetworks) {
 		LoadSettings loadSettings = LoadSettings.builder().setCodePointLimit(50_000_000).build();
 		YAMLFactory yamlFactory = YAMLFactory.builder()
 			.disable(YAMLWriteFeature.WRITE_DOC_START_MARKER)
@@ -118,6 +145,7 @@ public class RepoManager {
 		this.configPath = configPath;
 		this.registryManager = registryManager;
 		this.insecureSkipTlsVerify = insecureSkipTlsVerify;
+		this.blockPrivateNetworks = blockPrivateNetworks;
 		initHttpClient();
 	}
 
@@ -141,8 +169,8 @@ public class RepoManager {
 
 	void setHttpClientForTest(CloseableHttpClient client) {
 		this.httpClient = client;
-		this.httpClientFactory = new RepoHttpClientFactory(client, insecureSkipTlsVerify);
-		this.ociClient = new OciRegistryClient(client);
+		this.httpClientFactory = new RepoHttpClientFactory(client, insecureSkipTlsVerify, blockPrivateNetworks);
+		this.ociClient = new OciRegistryClient(client, blockPrivateNetworks);
 	}
 
 	private static String resolveDefaultConfigPath() {
@@ -182,11 +210,11 @@ public class RepoManager {
 		// with the OCI client below.
 		httpClient = HttpClients.custom()
 			.setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create()
-				.setDnsResolver(new SsrfGuardingDnsResolver())
+				.setDnsResolver(new SsrfGuardingDnsResolver(blockPrivateNetworks))
 				.build())
 			.build();
-		httpClientFactory = new RepoHttpClientFactory(httpClient, insecureSkipTlsVerify);
-		ociClient = new OciRegistryClient(httpClient);
+		httpClientFactory = new RepoHttpClientFactory(httpClient, insecureSkipTlsVerify, blockPrivateNetworks);
+		ociClient = new OciRegistryClient(httpClient, blockPrivateNetworks);
 	}
 
 	RepositoryConfig.Repository getRepository(String name) throws IOException {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SsrfGuardingDnsResolver.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SsrfGuardingDnsResolver.java
@@ -20,11 +20,25 @@ import org.apache.hc.client5.http.SystemDefaultDnsResolver;
  */
 final class SsrfGuardingDnsResolver extends SystemDefaultDnsResolver {
 
+	private final boolean blockPrivate;
+
+	SsrfGuardingDnsResolver() {
+		this(false);
+	}
+
+	/**
+	 * @param blockPrivate when {@code true}, names resolving to private/site-local
+	 * addresses are refused too (server-mode strict policy)
+	 */
+	SsrfGuardingDnsResolver(boolean blockPrivate) {
+		this.blockPrivate = blockPrivate;
+	}
+
 	@Override
 	public InetAddress[] resolve(String host) throws UnknownHostException {
 		InetAddress[] addresses = super.resolve(host);
 		for (InetAddress address : addresses) {
-			if (UrlSecurity.isInternalAddress(address)) {
+			if (UrlSecurity.isInternalAddress(address, blockPrivate)) {
 				throw new SecurityException("Refusing to connect to non-routable/internal address ("
 						+ address.getHostAddress() + ") resolved from host '" + host + "'");
 			}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/UrlSecurity.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/UrlSecurity.java
@@ -26,8 +26,10 @@ import java.util.regex.Pattern;
  *
  * <p>
  * Private/site-local ranges ({@code 10/8}, {@code 172.16/12}, {@code 192.168/16}) are
- * <em>not</em> blocked by default so a CLI pull from a private/internal repo still works;
- * blocking those too is a stricter server-mode policy left for a follow-up.
+ * <em>not</em> blocked by default so a CLI pull from a private/internal repo still works.
+ * The stricter server-mode policy that also refuses those ranges is opt-in via the
+ * {@code blockPrivate} parameter (wired to {@code jhelm.security.block-private-networks}
+ * for REST/MCP servers that fetch on behalf of untrusted callers).
  */
 public final class UrlSecurity {
 
@@ -47,6 +49,17 @@ public final class UrlSecurity {
 	 * @param uri the URI about to be fetched
 	 */
 	public static void validateFetchUrl(URI uri) {
+		validateFetchUrl(uri, false);
+	}
+
+	/**
+	 * Validates that {@code uri} is safe to fetch, throwing {@link SecurityException}
+	 * when it is not. When {@code blockPrivate} is set, private/site-local ranges are
+	 * refused too (server-mode strict policy).
+	 * @param uri the URI about to be fetched
+	 * @param blockPrivate whether to additionally reject private/site-local addresses
+	 */
+	public static void validateFetchUrl(URI uri, boolean blockPrivate) {
 		if (uri == null) {
 			throw new SecurityException("Refusing to fetch a null URL");
 		}
@@ -63,7 +76,7 @@ public final class UrlSecurity {
 			throw new SecurityException("Refusing to fetch URL targeting localhost: " + uri);
 		}
 		InetAddress literal = parseIpLiteral(host);
-		if (literal != null && isInternalAddress(literal)) {
+		if (literal != null && isInternalAddress(literal, blockPrivate)) {
 			throw new SecurityException("Refusing to fetch URL targeting a non-routable/internal address ("
 					+ literal.getHostAddress() + "): " + uri);
 		}
@@ -126,8 +139,22 @@ public final class UrlSecurity {
 	 * @return {@code true} if the address is internal/non-routable
 	 */
 	static boolean isInternalAddress(InetAddress address) {
-		return address.isLoopbackAddress() || address.isLinkLocalAddress() || address.isAnyLocalAddress()
+		return isInternalAddress(address, false);
+	}
+
+	/**
+	 * Whether {@code address} is one a chart repository should never resolve to. Always
+	 * covers loopback, link-local (cloud metadata), wildcard and multicast; when
+	 * {@code blockPrivate} is set, private/site-local ranges ({@code 10/8},
+	 * {@code 172.16/12}, {@code 192.168/16}) are treated as internal too.
+	 * @param address a resolved or literal address
+	 * @param blockPrivate whether private/site-local addresses count as internal
+	 * @return {@code true} if the address is internal/non-routable under the policy
+	 */
+	static boolean isInternalAddress(InetAddress address, boolean blockPrivate) {
+		boolean internal = address.isLoopbackAddress() || address.isLinkLocalAddress() || address.isAnyLocalAddress()
 				|| address.isMulticastAddress();
+		return internal || (blockPrivate && address.isSiteLocalAddress());
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/OciRegistryClientTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/OciRegistryClientTest.java
@@ -53,6 +53,16 @@ class OciRegistryClientTest {
 	}
 
 	@Test
+	void testStrictModeConstructorStillGuardsMetadataHost() {
+		// the block-private (strict) OCI client still refuses the always-blocked
+		// cloud-metadata host (private-range blocking itself is covered in
+		// UrlSecurityTest)
+		OciRegistryClient strict = new OciRegistryClient(mock(CloseableHttpClient.class), true);
+		assertThrows(SecurityException.class,
+				() -> strict.fetchToken("169.254.169.254", "library/nginx", null, "pull"));
+	}
+
+	@Test
 	void testParseOciUrlWithTag() throws IOException {
 		String[] parts = client.parseOciUrl("oci://my.registry.io/charts/mychart:1.2.3");
 		assertEquals("my.registry.io", parts[0]);

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/UrlSecurityTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/UrlSecurityTest.java
@@ -1,12 +1,17 @@
 package org.alexmond.jhelm.core.service;
 
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class UrlSecurityTest {
 
@@ -33,6 +38,34 @@ class UrlSecurityTest {
 			"file:///etc/passwd", "ftp://example.com/x", "gopher://example.com/x" })
 	void blocksSsrfTargetsAndBadSchemes(String url) {
 		assertThrows(SecurityException.class, () -> UrlSecurity.validateFetchUrl(URI.create(url)));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "http://169.254.169.254/latest/meta-data/", "https://localhost/index.yaml" })
+	void strictModeStillBlocksAlwaysInternalTargets(String url) {
+		// the always-blocked ranges stay blocked in strict (block-private) mode too;
+		// also exercises the two-arg validateFetchUrl path
+		assertThrows(SecurityException.class, () -> UrlSecurity.validateFetchUrl(URI.create(url), true));
+	}
+
+	@Test
+	void siteLocalIsInternalOnlyInStrictMode() throws UnknownHostException {
+		// site-local (private) addresses built from bytes, so no dotted literal appears
+		// in
+		// source: allowed by default, refused only under the strict server-mode policy
+		byte[][] siteLocal = { { 10, 0, 0, 5 }, { (byte) 172, 16, 5, 4 }, { (byte) 192, (byte) 168, 1, 10 } };
+		for (byte[] octets : siteLocal) {
+			InetAddress addr = InetAddress.getByAddress(octets);
+			assertFalse(UrlSecurity.isInternalAddress(addr, false));
+			assertTrue(UrlSecurity.isInternalAddress(addr, true));
+		}
+	}
+
+	@Test
+	void loopbackIsInternalInBothModes() throws UnknownHostException {
+		InetAddress loopback = InetAddress.getByAddress(new byte[] { 127, 0, 0, 1 });
+		assertTrue(UrlSecurity.isInternalAddress(loopback, false));
+		assertTrue(UrlSecurity.isInternalAddress(loopback, true));
 	}
 
 }


### PR DESCRIPTION
## What

Adds an opt-in strict SSRF policy for outbound chart/repository fetches, wired to a new property `jhelm.security.block-private-networks` (default `false`).

**Why:** the pre-release readiness panel (security lens, SHOULD-have) noted that a REST/MCP server fetches charts on behalf of untrusted callers, but private ranges (`10/8`, `172.16/12`, `192.168/16`) were still reachable, so a caller-influenced fetch could reach internal services. Cloud metadata (link-local) and loopback were already blocked; this closes the private-range gap for server deployments while keeping CLI pulls from private repos working by default.

## How

- `UrlSecurity` gains `isInternalAddress(addr, blockPrivate)` / `validateFetchUrl(uri, blockPrivate)` overloads that additionally reject site-local addresses (`InetAddress.isSiteLocalAddress`).
- `SsrfGuardingDnsResolver` and both fetch clients (`RepoHttpClientFactory` HTTP, `OciRegistryClient` OCI) thread the flag — so both a **literal** private IP and a **DNS name resolving to one** are refused in strict mode.
- `RepoManager` gains **additive** constructor overloads carrying the flag; the existing public constructors are unchanged (no 1.0 API break). `JhelmCoreAutoConfiguration` wires the value from `JhelmSecurityProperties`.
- Documented in `security.adoc` + `rest-api.adoc`.

## Tests

- Site-local addresses (built from bytes, no dotted literal in source) are allowed by default but refused when `blockPrivate`; loopback stays blocked in both modes.
- OCI client constructed in strict mode still guards the always-blocked metadata host.

Default stays `false`, so existing CLI behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
