### PR TITLE
feat(engine): real cluster .Capabilities + template --kube-version/--api-versions

### DIFF
--- a/docs/modules/ROOT/pages/cli-reference.adoc
+++ b/docs/modules/ROOT/pages/cli-reference.adoc
@@ -38,7 +38,8 @@ Render chart templates locally (without deploying).
 
 [source,bash]
 ----
-jhelm template <name> <chartPath> [-n <namespace>] [-f <values>] [--set <key=value>]
+jhelm template <name> <chartPath> [-n <namespace>] [-f <values>] [--set <key=value>] \
+  [--kube-version <version>] [-a <apiVersion>]
 ----
 
 [cols="1,1,3"]
@@ -50,7 +51,15 @@ jhelm template <name> <chartPath> [-n <namespace>] [-f <values>] [--set <key=val
 | `-n, --namespace` | No | Namespace (default: `default`)
 | `-f, --values` | No | Values YAML file(s), repeatable
 | `--set` | No | Set values on the command line (`key=value`, dot notation), repeatable
+| `--kube-version` | No | Kubernetes version used for `.Capabilities.KubeVersion` (e.g. `v1.29.0`). Defaults to the engine's built-in version when omitted.
+| `-a, --api-versions` | No | API group/versions advertised for `.Capabilities.APIVersions.Has` (comma-separated or repeatable). Additive to the built-in default set.
 |===
+
+Since `template` renders offline (no cluster), `--kube-version` / `--api-versions` let you
+pin `.Capabilities` for charts that gate on the Kubernetes version or on an API being
+present — mirroring `helm template --kube-version --api-versions`. During `install` /
+`upgrade` against a live cluster, `.Capabilities.KubeVersion` is instead read from the
+target server automatically.
 
 === install
 

--- a/docs/modules/ROOT/pages/core-engine.adoc
+++ b/docs/modules/ROOT/pages/core-engine.adoc
@@ -24,4 +24,5 @@ The engine handles:
 . *Recursion Protection*: Stack depth tracking prevents infinite template recursion.
 . *Named Templates*: `define` blocks are collected before rendering begins.
 . *Value Merging*: Chart values are merged with user-provided values and release info.
+. *Capabilities*: `.Capabilities.KubeVersion` and `.Capabilities.APIVersions` are supplied via a `Capabilities` override. During `install`/`upgrade` the engine reads the live server version from the `KubeService` so version-gated charts render against the real target; when the cluster is unreachable, or for the offline `template` command, it uses a built-in default (`v1.35.0`) that the `template` command can override with `--kube-version` / `--api-versions`.
 . *Error Handling*: Custom exceptions for parsing, execution, and not-found scenarios.

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
@@ -51,6 +51,15 @@ public class TemplateCommand implements Runnable {
 	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
 
+	@Option(names = { "--kube-version" },
+			description = "Kubernetes version used for .Capabilities.KubeVersion (e.g. v1.29.0)")
+	private String kubeVersion;
+
+	@Option(names = { "-a", "--api-versions" }, split = ",",
+			description = "Kubernetes API versions advertised for .Capabilities.APIVersions.Has "
+					+ "(comma-separated or repeatable; additive to the built-in default set)")
+	private List<String> apiVersions = new ArrayList<>();
+
 	/**
 	 * Creates the command.
 	 * @param templateAction the action that renders chart templates
@@ -64,7 +73,7 @@ public class TemplateCommand implements Runnable {
 		try {
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
 					setFileValues, setJsonValues);
-			String manifest = templateAction.render(chartPath, name, namespace, overrides);
+			String manifest = templateAction.render(chartPath, name, namespace, overrides, kubeVersion, apiVersions);
 			for (String renderer : postRenderers) {
 				manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
 			}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.DeploymentFailedException;
 import org.alexmond.jhelm.core.exception.JhelmException;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
@@ -108,7 +109,9 @@ public class InstallAction {
 			.revision(release.getVersion())
 			.build();
 
-		String manifest = runPostRenderProcessors(engine.render(chart, values, releaseContext));
+		Capabilities fromCluster = (kubeService != null) ? kubeService.getCapabilities() : null;
+		Capabilities capabilities = (fromCluster != null) ? fromCluster : Capabilities.DEFAULT;
+		String manifest = runPostRenderProcessors(engine.render(chart, values, releaseContext, capabilities));
 
 		release = release.toBuilder().manifest(manifest).build();
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.alexmond.jhelm.core.exception.JhelmException;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.alexmond.jhelm.core.service.ChartLoader;
@@ -30,6 +31,24 @@ public class TemplateAction {
 	}
 
 	public String render(String chartPath, String releaseName, String namespace, Map<String, Object> overrides) {
+		return render(chartPath, releaseName, namespace, overrides, null, List.of());
+	}
+
+	/**
+	 * Renders a chart offline with an explicit {@code .Capabilities} override, mirroring
+	 * {@code helm template --kube-version --api-versions}.
+	 * @param chartPath path to the chart directory or archive
+	 * @param releaseName the release name ({@code .Release.Name})
+	 * @param namespace the release namespace
+	 * @param overrides value overrides merged over the chart defaults
+	 * @param kubeVersion the {@code .Capabilities.KubeVersion} override, or {@code null}
+	 * for the engine default
+	 * @param apiVersions extra API group/versions to advertise for
+	 * {@code .Capabilities.APIVersions.Has} (additive to the default set)
+	 * @return the rendered manifest
+	 */
+	public String render(String chartPath, String releaseName, String namespace, Map<String, Object> overrides,
+			String kubeVersion, List<String> apiVersions) {
 		Chart chart = this.chartLoader.load(new File(chartPath));
 
 		Map<String, Object> values = new HashMap<>(chart.getValues());
@@ -43,7 +62,7 @@ public class TemplateAction {
 			.revision(1)
 			.build();
 
-		String manifest = engine.render(chart, values, releaseContext);
+		String manifest = engine.render(chart, values, releaseContext, new Capabilities(kubeVersion, apiVersions));
 
 		for (PostRenderProcessor processor : postRenderProcessors) {
 			try {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.DeploymentFailedException;
 import org.alexmond.jhelm.core.exception.JhelmException;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
@@ -97,7 +98,9 @@ public class UpgradeAction {
 			.revision(newRelease.getVersion())
 			.build();
 
-		String manifest = engine.render(newChart, renderValues, releaseContext);
+		Capabilities fromCluster = (kubeService != null) ? kubeService.getCapabilities() : null;
+		Capabilities capabilities = (fromCluster != null) ? fromCluster : Capabilities.DEFAULT;
+		String manifest = engine.render(newChart, renderValues, releaseContext, capabilities);
 
 		for (PostRenderProcessor processor : postRenderProcessors) {
 			try {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Capabilities.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Capabilities.java
@@ -1,0 +1,36 @@
+package org.alexmond.jhelm.core.model;
+
+import java.util.List;
+
+/**
+ * Overrides for the Helm {@code .Capabilities} built-in used during template rendering.
+ *
+ * <p>
+ * A {@code null} {@link #kubeVersion()} means "use the engine's built-in default
+ * Kubernetes version"; a non-null value (e.g. {@code "v1.29.0"}) sets
+ * {@code .Capabilities.KubeVersion} so charts that gate on the cluster version render as
+ * if against that server. {@link #extraApiVersions()} are advertised <em>in addition
+ * to</em> the engine's built-in default API-version set, so
+ * {@code .Capabilities.APIVersions.Has "custom.io/v1"} can be made to succeed for
+ * group/versions the defaults don't include.
+ *
+ * <p>
+ * Populated two ways: from a live cluster by {@code KubeService.getCapabilities()} during
+ * install/upgrade, or from the {@code --kube-version} / {@code --api-versions} flags of
+ * the offline {@code template} command. {@link #DEFAULT} leaves everything at the engine
+ * defaults.
+ *
+ * @param kubeVersion the Kubernetes version string, or {@code null} for the engine
+ * default
+ * @param extraApiVersions additional API group/versions to advertise (never {@code null})
+ */
+public record Capabilities(String kubeVersion, List<String> extraApiVersions) {
+
+	/** Use the engine's built-in defaults for both the kube version and API versions. */
+	public static final Capabilities DEFAULT = new Capabilities(null, List.of());
+
+	public Capabilities {
+		extraApiVersions = (extraApiVersions != null) ? List.copyOf(extraApiVersions) : List.of();
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartFiles;
 import org.alexmond.jhelm.core.model.Dependency;
@@ -63,6 +64,12 @@ public class Engine {
 			"resource.k8s.io/v1", "resource.k8s.io/v1alpha3", "resource.k8s.io/v1beta1", "resource.k8s.io/v1beta2",
 			"scheduling.k8s.io/v1", "scheduling.k8s.io/v1alpha1", "scheduling.k8s.io/v1beta1", "storage.k8s.io/v1",
 			"storage.k8s.io/v1alpha1", "storage.k8s.io/v1beta1", "storagemigration.k8s.io/v1alpha1", "v1");
+
+	// Default .Capabilities.KubeVersion when no live cluster / override is supplied. Kept
+	// in sync with the helm --kube-version the parity harness (KpsComparisonTest) pins,
+	// so
+	// offline `template` output matches upstream helm.
+	private static final String DEFAULT_KUBE_VERSION = "v1.35.0";
 
 	private final Map<String, String> namedTemplates = new HashMap<>();
 
@@ -183,14 +190,29 @@ public class Engine {
 	 */
 	@SneakyThrows
 	public String render(Chart chart, Map<String, Object> values, ReleaseContext release) {
+		return render(chart, values, release, Capabilities.DEFAULT);
+	}
+
+	/**
+	 * Renders a chart with an explicit {@code .Capabilities} override.
+	 * @param chart the chart to render
+	 * @param values the merged values for this render
+	 * @param release the release context ({@code .Release})
+	 * @param capabilities the {@code .Capabilities} override (kube version + extra API
+	 * versions); use {@link Capabilities#DEFAULT} for the engine built-ins
+	 * @return the rendered manifest
+	 */
+	@SneakyThrows
+	public String render(Chart chart, Map<String, Object> values, ReleaseContext release, Capabilities capabilities) {
 		Map<String, Object> releaseInfo = release.toMap();
+		Capabilities caps = (capabilities != null) ? capabilities : Capabilities.DEFAULT;
 		long startNanos = System.nanoTime();
 		try {
 			AtomicReference<String> result = new AtomicReference<>();
 			AtomicReference<RuntimeException> error = new AtomicReference<>();
 			Thread renderThread = new Thread(null, () -> {
 				try {
-					result.set(doRender(chart, values, releaseInfo));
+					result.set(doRender(chart, values, releaseInfo, caps));
 				}
 				catch (RuntimeException ex) {
 					error.set(ex);
@@ -210,7 +232,8 @@ public class Engine {
 		}
 	}
 
-	private String doRender(Chart chart, Map<String, Object> values, Map<String, Object> releaseInfo) {
+	private String doRender(Chart chart, Map<String, Object> values, Map<String, Object> releaseInfo,
+			Capabilities capabilities) {
 		namedTemplates.clear();
 		templateVersions.clear();
 		parsedTextHash.clear();
@@ -231,7 +254,7 @@ public class Engine {
 			// Using a shared set for the whole rendering process to avoid redundant work
 			// and loops
 			Set<String> renderedCharts = new HashSet<>();
-			String rendered = renderWithSubcharts(chart, values, releaseInfo, renderedCharts, 0);
+			String rendered = renderWithSubcharts(chart, values, releaseInfo, renderedCharts, 0, capabilities);
 			return cleanManifest(rendered);
 		}
 		catch (StackOverflowError ex) {
@@ -244,6 +267,71 @@ public class Engine {
 			throw new TemplateRenderException("recursive template inclusion or too deep nesting while rendering chart '"
 					+ chartName + "'; check for circular {{ template }} calls", ex, chartName, null);
 		}
+	}
+
+	/**
+	 * Builds the {@code .Capabilities} object for the render context. Uses the supplied
+	 * kube-version override when present (else {@link #DEFAULT_KUBE_VERSION}) and
+	 * advertises the built-in {@link #DEFAULT_API_VERSIONS} plus any extra API versions
+	 * from the override.
+	 * @param capabilities the override (never {@code null}; use
+	 * {@link Capabilities#DEFAULT})
+	 * @return the {@code .Capabilities} map exposed to templates
+	 */
+	private Map<String, Object> buildCapabilities(Capabilities capabilities) {
+		String kubeVersion = (capabilities.kubeVersion() != null && !capabilities.kubeVersion().isBlank())
+				? normalizeKubeVersion(capabilities.kubeVersion()) : DEFAULT_KUBE_VERSION;
+		String[] majorMinor = parseMajorMinor(kubeVersion);
+		List<String> apiVersions = new ArrayList<>(DEFAULT_API_VERSIONS);
+		// extraApiVersions is guaranteed non-null with non-null elements by Capabilities
+		for (String extra : capabilities.extraApiVersions()) {
+			if (!extra.isBlank() && !apiVersions.contains(extra)) {
+				apiVersions.add(extra);
+			}
+		}
+		return Map.of("KubeVersion",
+				Map.of("Version", kubeVersion, "Major", majorMinor[0], "Minor", majorMinor[1], "GitVersion",
+						kubeVersion),
+				"HelmVersion", Map.of("Version", "v3.16.0", "GitCommit", "", "GitTreeState", "", "GoVersion", ""),
+				"APIVersions", new VersionSet(apiVersions));
+	}
+
+	/**
+	 * Normalises a user/cluster kube-version string to the Helm {@code vX.Y.Z} form,
+	 * adding a leading {@code v} when absent.
+	 * @param version the raw version (e.g. {@code 1.29}, {@code v1.29.0})
+	 * @return the normalised version string
+	 */
+	private static String normalizeKubeVersion(String version) {
+		String trimmed = version.trim();
+		return trimmed.startsWith("v") ? trimmed : "v" + trimmed;
+	}
+
+	/**
+	 * Extracts the {@code Major}/{@code Minor} fields from a kube-version string, keeping
+	 * only the leading digits of each segment (a cluster may report a minor like
+	 * {@code "35+"}).
+	 * @param version a normalised kube-version (e.g. {@code v1.35.0})
+	 * @return a two-element array {@code [major, minor]}
+	 */
+	private static String[] parseMajorMinor(String version) {
+		String stripped = version.startsWith("v") ? version.substring(1) : version;
+		String[] parts = stripped.split("\\.");
+		String major = (parts.length > 0) ? leadingDigits(parts[0]) : "0";
+		String minor = (parts.length > 1) ? leadingDigits(parts[1]) : "0";
+		return new String[] { major.isEmpty() ? "0" : major, minor.isEmpty() ? "0" : minor };
+	}
+
+	private static String leadingDigits(String value) {
+		StringBuilder digits = new StringBuilder();
+		for (int i = 0; i < value.length(); i++) {
+			char ch = value.charAt(i);
+			if (ch < '0' || ch > '9') {
+				break;
+			}
+			digits.append(ch);
+		}
+		return digits.toString();
 	}
 
 	/**
@@ -572,7 +660,7 @@ public class Engine {
 	}
 
 	private String renderWithSubcharts(Chart chart, Map<String, Object> values, Map<String, Object> releaseInfo,
-			Set<String> renderedCharts, int depth) {
+			Set<String> renderedCharts, int depth, Capabilities capabilities) {
 		String chartKey = chart.getMetadata().getName() + ":" + chart.getMetadata().getVersion();
 		if (renderedCharts.contains(chartKey)) {
 			if (log.isDebugEnabled()) {
@@ -645,10 +733,7 @@ public class Engine {
 		context.put("Release", releaseInfo);
 
 		// Add standard Helm objects
-		context.put("Capabilities", Map.of("KubeVersion",
-				Map.of("Version", "v1.35.0", "Major", "1", "Minor", "35", "GitVersion", "v1.35.0"), "HelmVersion",
-				Map.of("Version", "v3.16.0", "GitCommit", "", "GitTreeState", "", "GoVersion", ""), "APIVersions",
-				new VersionSet(DEFAULT_API_VERSIONS)));
+		context.put("Capabilities", buildCapabilities(capabilities));
 		String chartBasePath = chart.getMetadata().getName() + "/templates";
 		context.put("Template", Map.of("Name", "", "BasePath", chartBasePath));
 		context.put("Files", new ChartFiles(chart.getFiles()));
@@ -739,7 +824,8 @@ public class Engine {
 			if (log.isDebugEnabled()) {
 				log.debug("Rendering subchart: {}", subchartName);
 			}
-			sb.append(renderWithSubcharts(subchart, subchartOverrides, releaseInfo, renderedCharts, depth + 1));
+			sb.append(renderWithSubcharts(subchart, subchartOverrides, releaseInfo, renderedCharts, depth + 1,
+					capabilities));
 		}
 
 		// This chart's own templates render last (see the ordering note above).

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.exception.ReleaseStorageException;
 import org.alexmond.jhelm.core.exception.WaitTimeoutException;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 
@@ -139,5 +140,17 @@ public interface KubeService {
 	 * API cannot be reached
 	 */
 	void waitForReady(String namespace, String manifest, int timeoutSeconds);
+
+	/**
+	 * Returns the {@code .Capabilities} to expose to templates for this cluster — chiefly
+	 * the live server {@code KubeVersion}, so charts that gate on the Kubernetes version
+	 * render against the real target instead of an engine default. The default
+	 * implementation returns {@link Capabilities#DEFAULT} (engine built-ins), so an
+	 * implementation that cannot reach a cluster, or a test double, still works.
+	 * @return the capability override, never {@code null}
+	 */
+	default Capabilities getCapabilities() {
+		return Capabilities.DEFAULT;
+	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.alexmond.jhelm.core.exception.DeploymentFailedException;
 import org.alexmond.jhelm.core.metrics.JhelmMetrics;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.HelmHook;
@@ -56,7 +57,8 @@ class InstallActionTest {
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
 
 		String manifest = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(manifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(manifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
@@ -84,7 +86,8 @@ class InstallActionTest {
 		installAction.setMetrics(new JhelmMetrics(registry));
 		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("---\n");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("---\n");
 
 		installAction.install(InstallOptions.builder()
 			.chart(chart)
@@ -103,7 +106,8 @@ class InstallActionTest {
 	void testInstallPersistsUserValuesAsConfig() throws Exception {
 		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("---\n");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("---\n");
 		Map<String, Object> overrides = Map.of("replicaCount", 3, "image", Map.of("tag", "v2"));
 
 		Release release = installAction.install(InstallOptions.builder()
@@ -125,7 +129,8 @@ class InstallActionTest {
 		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
 
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("---\nkind: ConfigMap\n");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("---\nkind: ConfigMap\n");
 
 		Release release = installAction.install(InstallOptions.builder()
 			.chart(chart)
@@ -141,12 +146,36 @@ class InstallActionTest {
 	}
 
 	@Test
+	void testInstallDryRunWithoutKubeService() throws Exception {
+		// no KubeService (offline dry-run): capabilities fall back to the engine default
+		InstallAction offline = new InstallAction(engine, null);
+		Chart chart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
+			.values(new HashMap<>())
+			.build();
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("---\nkind: ConfigMap\n");
+
+		Release release = offline.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.revision(1)
+			.dryRun(true)
+			.build());
+
+		assertNotNull(release);
+		assertEquals(ReleaseStatus.PENDING_INSTALL, release.getInfo().getStatus());
+	}
+
+	@Test
 	void testInstallServerDryRunValidatesWithoutPersisting() throws Exception {
 		Chart chart = Chart.builder()
 			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
 			.values(new HashMap<>())
 			.build();
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("---\nkind: ConfigMap\n");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("---\nkind: ConfigMap\n");
 
 		Release release = installAction.install(InstallOptions.builder()
 			.chart(chart)
@@ -187,7 +216,8 @@ class InstallActionTest {
 		String regularYaml = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
 		String fullManifest = "---\n" + hookYaml + regularYaml;
 
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(fullManifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(fullManifest);
 		doNothing().when(kubeService).delete(anyString(), anyString());
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
@@ -231,7 +261,8 @@ class InstallActionTest {
 		String regularYaml = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
 		String fullManifest = "---\n" + hookYaml + regularYaml;
 
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(fullManifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(fullManifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
@@ -259,7 +290,8 @@ class InstallActionTest {
 		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
 
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("---\nkind: ConfigMap\n");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("---\nkind: ConfigMap\n");
 
 		Release release = noKubeInstall.install(InstallOptions.builder()
 			.chart(chart)
@@ -278,7 +310,8 @@ class InstallActionTest {
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
 
 		String manifest = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(manifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(manifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doThrow(new RuntimeException("storage failed")).when(kubeService).storeRelease(any(Release.class));
 		doNothing().when(kubeService).delete(anyString(), anyString());
@@ -306,7 +339,8 @@ class InstallActionTest {
 			.crds(List.of(Chart.Crd.builder().name("foos.yaml").data(crdYaml).build()))
 			.build();
 
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("---\nkind: ConfigMap\n");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("---\nkind: ConfigMap\n");
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
@@ -329,7 +363,8 @@ class InstallActionTest {
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
 
 		String manifest = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(manifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(manifest);
 		doNothing().when(kubeService).ensureNamespace(anyString());
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
@@ -354,7 +389,8 @@ class InstallActionTest {
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
 
 		String manifest = "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n";
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(manifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(manifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/TemplateActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/TemplateActionTest.java
@@ -5,16 +5,21 @@ import org.alexmond.jhelm.core.service.ChartLoader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.when;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.alexmond.jhelm.core.service.Engine;
@@ -49,12 +54,34 @@ class TemplateActionTest {
 		Files.writeString(chartDir.resolve("Chart.yaml"), chartYaml);
 
 		String manifest = "---\nkind: Service\nmetadata:\n  name: myservice";
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(manifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(manifest);
 
 		String result = templateAction.render(chartDir.toString(), "myrelease", "default");
 
 		assertNotNull(result);
 		assertTrue(result.contains("Service"));
+	}
+
+	@Test
+	void testRenderPassesCapabilitiesOverride() throws Exception {
+		Path chartDir = tempDir.resolve("capchart");
+		Files.createDirectories(chartDir);
+		Files.writeString(chartDir.resolve("Chart.yaml"), """
+				apiVersion: v2
+				name: capchart
+				version: 1.0.0
+				""");
+
+		ArgumentCaptor<Capabilities> capsCaptor = ArgumentCaptor.forClass(Capabilities.class);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), capsCaptor.capture()))
+			.thenReturn("---\n");
+
+		templateAction.render(chartDir.toString(), "r", "default", new HashMap<>(), "v1.29.0", List.of("custom.io/v1"));
+
+		Capabilities passed = capsCaptor.getValue();
+		assertEquals("v1.29.0", passed.kubeVersion());
+		assertTrue(passed.extraApiVersions().contains("custom.io/v1"));
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.inOrder;
 import org.alexmond.jhelm.core.exception.DeploymentFailedException;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.HelmHook;
@@ -85,7 +86,8 @@ class UpgradeActionTest {
 		Chart newChart = Chart.builder().metadata(newMetadata).values(newValues).build();
 
 		String renderedManifest = "---\napiVersion: v1\nkind: Service";
-		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class))).thenReturn(renderedManifest);
+		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(renderedManifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
@@ -111,7 +113,7 @@ class UpgradeActionTest {
 		verify(kubeService).pruneReleaseHistory("myapp", "default", 10);
 
 		ArgumentCaptor<ReleaseContext> releaseDataCaptor = ArgumentCaptor.forClass(ReleaseContext.class);
-		verify(engine).render(eq(newChart), anyMap(), releaseDataCaptor.capture());
+		verify(engine).render(eq(newChart), anyMap(), releaseDataCaptor.capture(), any(Capabilities.class));
 
 		Map<String, Object> releaseData = releaseDataCaptor.getValue().toMap();
 		assertEquals("myapp", releaseData.get("Name"));
@@ -140,7 +142,8 @@ class UpgradeActionTest {
 			.values(new HashMap<>())
 			.build();
 		String renderedManifest = "---\napiVersion: v1\nkind: Service";
-		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class))).thenReturn(renderedManifest);
+		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(renderedManifest);
 		doNothing().when(kubeService).delete(anyString(), anyString());
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
@@ -177,7 +180,8 @@ class UpgradeActionTest {
 			.values(new HashMap<>())
 			.build();
 		String renderedManifest = "---\napiVersion: v1\nkind: Service";
-		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class))).thenReturn(renderedManifest);
+		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(renderedManifest);
 
 		upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(currentRelease)
@@ -211,7 +215,7 @@ class UpgradeActionTest {
 			.metadata(ChartMetadata.builder().name("mychart").version("2.0.0").build())
 			.values(new HashMap<>())
 			.build();
-		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class)))
+		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
 			.thenReturn("---\napiVersion: v1\nkind: Service");
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
@@ -251,7 +255,8 @@ class UpgradeActionTest {
 		Map<String, Object> overrideValues = new HashMap<>();
 		overrideValues.put("replicaCount", 5);
 
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("manifest");
 
 		upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(currentRelease)
@@ -262,7 +267,7 @@ class UpgradeActionTest {
 
 		@SuppressWarnings("unchecked")
 		ArgumentCaptor<Map<String, Object>> valuesCaptor = ArgumentCaptor.forClass(Map.class);
-		verify(engine).render(eq(chart), valuesCaptor.capture(), any(ReleaseContext.class));
+		verify(engine).render(eq(chart), valuesCaptor.capture(), any(ReleaseContext.class), any(Capabilities.class));
 
 		Map<String, Object> mergedValues = valuesCaptor.getValue();
 		assertEquals(5, mergedValues.get("replicaCount"));
@@ -288,7 +293,8 @@ class UpgradeActionTest {
 			.info(info)
 			.build();
 
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("dry-run-manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("dry-run-manifest");
 
 		Release upgradedRelease = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(currentRelease)
@@ -325,7 +331,8 @@ class UpgradeActionTest {
 			.info(info)
 			.build();
 
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("manifest");
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
@@ -378,7 +385,8 @@ class UpgradeActionTest {
 		String regularYaml = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: myapp-svc\n";
 		String fullManifest = "---\n" + hookYaml + regularYaml;
 
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(fullManifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(fullManifest);
 		doNothing().when(kubeService).delete(anyString(), anyString());
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
@@ -434,7 +442,8 @@ class UpgradeActionTest {
 		String regularYaml = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: myapp-svc\n";
 		String fullManifest = "---\n" + hookYaml + regularYaml;
 
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(fullManifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(fullManifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
@@ -491,7 +500,8 @@ class UpgradeActionTest {
 			.build();
 
 		String newManifest = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: myapp-svc\n";
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(newManifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(newManifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).delete(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
@@ -546,7 +556,8 @@ class UpgradeActionTest {
 				metadata:
 				  name: myapp-config
 				""";
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(newManifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(newManifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
@@ -578,7 +589,8 @@ class UpgradeActionTest {
 			.info(info)
 			.build();
 
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("manifest");
 
 		Release upgradedRelease = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(currentRelease)
@@ -612,7 +624,8 @@ class UpgradeActionTest {
 			.build();
 
 		String newManifest = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: new-svc\n";
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn(newManifest);
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(newManifest);
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doThrow(new RuntimeException("storage failed")).when(kubeService).storeRelease(any(Release.class));
 
@@ -689,7 +702,7 @@ class UpgradeActionTest {
 	@SuppressWarnings("unchecked")
 	private Map<String, Object> renderValuesFor(Release upgraded) {
 		ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
-		verify(engine).render(any(Chart.class), captor.capture(), any(ReleaseContext.class));
+		verify(engine).render(any(Chart.class), captor.capture(), any(ReleaseContext.class), any(Capabilities.class));
 		return captor.getValue();
 	}
 
@@ -697,7 +710,8 @@ class UpgradeActionTest {
 	void testDefaultNoOverridesReusesPriorConfig() {
 		Release current = currentReleaseWithPrior();
 		Chart newChart = newChartWithChangedDefault();
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("manifest");
 
 		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(current)
@@ -720,7 +734,8 @@ class UpgradeActionTest {
 		Chart newChart = newChartWithChangedDefault();
 		Map<String, Object> overrides = new HashMap<>();
 		overrides.put("extra", "x");
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("manifest");
 
 		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(current)
@@ -746,7 +761,8 @@ class UpgradeActionTest {
 		Chart newChart = newChartWithChangedDefault();
 		Map<String, Object> overrides = new HashMap<>();
 		overrides.put("extra", "x");
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("manifest");
 
 		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(current)
@@ -770,7 +786,8 @@ class UpgradeActionTest {
 		Chart newChart = newChartWithChangedDefault();
 		Map<String, Object> overrides = new HashMap<>();
 		overrides.put("extra", "x");
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("manifest");
 
 		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(current)
@@ -797,7 +814,8 @@ class UpgradeActionTest {
 		Chart newChart = newChartWithChangedDefault();
 		Map<String, Object> overrides = new HashMap<>();
 		overrides.put("extra", "x");
-		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class))).thenReturn("manifest");
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("manifest");
 
 		Release upgraded = upgradeAction.upgrade(UpgradeOptions.builder()
 			.currentRelease(current)

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -5,13 +5,17 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Map;
 
 import org.alexmond.jhelm.core.exception.TemplateRenderException;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Dependency;
+import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ReleaseContext;
+import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -503,6 +507,155 @@ class EngineTest {
 				List.of(tmpl("test.yaml", "kube: {{ .Capabilities.KubeVersion.Version }}")), Map.of());
 		String result = engine.render(chart, Map.of(), releaseInfo());
 		assertTrue(result.contains("kube: v1.35.0"));
+	}
+
+	@Test
+	void testCapabilitiesKubeVersionOverride() {
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("test.yaml",
+						"ver: {{ .Capabilities.KubeVersion.Version }} major: {{ .Capabilities.KubeVersion.Major }}"
+								+ " minor: {{ .Capabilities.KubeVersion.Minor }}")),
+				Map.of());
+		String result = engine.render(chart, Map.of(), releaseInfo(), new Capabilities("v1.29.4", List.of()));
+		assertTrue(result.contains("ver: v1.29.4"), result);
+		assertTrue(result.contains("major: 1"), result);
+		assertTrue(result.contains("minor: 29"), result);
+	}
+
+	@Test
+	void testCapabilitiesKubeVersionOverrideAddsLeadingV() {
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("test.yaml", "ver: {{ .Capabilities.KubeVersion.Version }}")), Map.of());
+		// a bare "1.30" is normalised to the helm vX.Y form
+		String result = engine.render(chart, Map.of(), releaseInfo(), new Capabilities("1.30", List.of()));
+		assertTrue(result.contains("ver: v1.30"), result);
+	}
+
+	@Test
+	void testCapabilitiesExtraApiVersionsAreAdditive() {
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("test.yaml", "custom: {{ .Capabilities.APIVersions.Has \"custom.example.com/v1\" }}"
+						+ " builtin: {{ .Capabilities.APIVersions.Has \"policy/v1\" }}")),
+				Map.of());
+		String result = engine.render(chart, Map.of(), releaseInfo(),
+				new Capabilities(null, List.of("custom.example.com/v1")));
+		// the extra version is advertised AND the built-in default set is still present
+		assertTrue(result.contains("custom: true"), result);
+		assertTrue(result.contains("builtin: true"), result);
+	}
+
+	@Test
+	void testCapabilitiesNonNumericVersionYieldsZeroMajorMinor() {
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("test.yaml",
+						"major: {{ .Capabilities.KubeVersion.Major }} minor: {{ .Capabilities.KubeVersion.Minor }}")),
+				Map.of());
+		// a version with no numeric segments falls back to 0/0 rather than throwing
+		String result = engine.render(chart, Map.of(), releaseInfo(), new Capabilities("vX", List.of()));
+		assertTrue(result.contains("major: 0"), result);
+		assertTrue(result.contains("minor: 0"), result);
+	}
+
+	@Test
+	void testCapabilitiesBlankKubeVersionUsesDefault() {
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("test.yaml", "kube: {{ .Capabilities.KubeVersion.Version }}")), Map.of());
+		// a blank kube-version override is ignored in favour of the engine default
+		String result = engine.render(chart, Map.of(), releaseInfo(), new Capabilities("   ", List.of()));
+		assertTrue(result.contains("kube: v1.35.0"), result);
+	}
+
+	@Test
+	void testCapabilitiesExtraApiVersionsSkipsBlankAndDuplicate() {
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("test.yaml", "custom: {{ .Capabilities.APIVersions.Has \"custom.io/v1\" }}"
+						+ " builtin: {{ .Capabilities.APIVersions.Has \"policy/v1\" }}")),
+				Map.of());
+		// a blank entry is skipped and a duplicate of a built-in is not re-added
+		String result = engine.render(chart, Map.of(), releaseInfo(),
+				new Capabilities(null, List.of("custom.io/v1", "  ", "policy/v1")));
+		assertTrue(result.contains("custom: true"), result);
+		assertTrue(result.contains("builtin: true"), result);
+	}
+
+	@Test
+	void testCapabilitiesRecordNullExtraApiVersionsBecomesEmpty() {
+		Capabilities caps = new Capabilities("v1.0.0", null);
+		assertTrue(caps.extraApiVersions().isEmpty());
+	}
+
+	@Test
+	void testKubeServiceDefaultCapabilitiesIsDefault() {
+		// the KubeService interface default method returns the engine defaults
+		KubeService bare = new KubeService() {
+			@Override
+			public void storeRelease(Release release) {
+			}
+
+			@Override
+			public Optional<Release> getRelease(String name, String namespace) {
+				return Optional.empty();
+			}
+
+			@Override
+			public List<Release> listReleases(String namespace) {
+				return List.of();
+			}
+
+			@Override
+			public List<Release> getReleaseHistory(String name, String namespace) {
+				return List.of();
+			}
+
+			@Override
+			public void deleteReleaseHistory(String name, String namespace) {
+			}
+
+			@Override
+			public void pruneReleaseHistory(String name, String namespace, int maxHistory) {
+			}
+
+			@Override
+			public void ensureNamespace(String namespace) {
+			}
+
+			@Override
+			public void apply(String namespace, String yamlContent) {
+			}
+
+			@Override
+			public void delete(String namespace, String yamlContent) {
+			}
+
+			@Override
+			public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) {
+				return List.of();
+			}
+
+			@Override
+			public void waitForReady(String namespace, String manifest, int timeoutSeconds) {
+			}
+		};
+		assertEquals(Capabilities.DEFAULT, bare.getCapabilities());
+	}
+
+	@Test
+	void testCapabilitiesKubeVersionMinorWithSuffix() {
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("test.yaml", "minor: {{ .Capabilities.KubeVersion.Minor }}")), Map.of());
+		// some managed clusters report a minor like "29+"; only the leading digits are
+		// kept
+		String result = engine.render(chart, Map.of(), releaseInfo(), new Capabilities("v1.29+", List.of()));
+		assertTrue(result.contains("minor: 29"), result);
+	}
+
+	@Test
+	void testCapabilitiesDefaultWhenOverrideNull() {
+		Chart chart = simpleChart("mychart", "1.0.0",
+				List.of(tmpl("test.yaml", "kube: {{ .Capabilities.KubeVersion.Version }}")), Map.of());
+		// a null Capabilities argument falls back to the engine default
+		String result = engine.render(chart, Map.of(), releaseInfo(), null);
+		assertTrue(result.contains("kube: v1.35.0"), result);
 	}
 
 	// --- Cross-template context mutations ---

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/KubernetesFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/KubernetesFunctions.java
@@ -91,11 +91,14 @@ public final class KubernetesFunctions {
 	private static Function kubeVersion(KubernetesProvider provider) {
 		return (args) -> {
 			if (provider == null || !provider.isAvailable()) {
-				// Stub implementation - returns default version
+				// Stub implementation — returns the engine's default
+				// .Capabilities.KubeVersion
+				// so the kubeVersion function agrees with .Capabilities when no cluster
+				// is up.
 				Map<String, Object> version = new HashMap<>();
 				version.put("Major", "1");
-				version.put("Minor", "28");
-				version.put("GitVersion", "v1.28.0");
+				version.put("Minor", "35");
+				version.put("GitVersion", "v1.35.0");
 				return version;
 			}
 

--- a/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/KubernetesFunctionsTest.java
+++ b/jhelm-gotemplate-helm/src/test/java/org/alexmond/jhelm/gotemplate/helm/functions/KubernetesFunctionsTest.java
@@ -36,8 +36,8 @@ class KubernetesFunctionsTest {
 		@SuppressWarnings("unchecked")
 		Map<String, Object> version = (Map<String, Object>) result;
 		assertEquals("1", version.get("Major"));
-		assertEquals("28", version.get("Minor"));
-		assertEquals("v1.28.0", version.get("GitVersion"));
+		assertEquals("35", version.get("Minor"));
+		assertEquals("v1.35.0", version.get("GitVersion"));
 	}
 
 	@Test

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
@@ -7,6 +7,7 @@ import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.apis.VersionApi;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1DaemonSet;
 import io.kubernetes.client.openapi.models.V1Deployment;
@@ -19,6 +20,7 @@ import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretList;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
+import io.kubernetes.client.openapi.models.VersionInfo;
 import io.kubernetes.client.util.Yaml;
 import io.kubernetes.client.util.generic.KubernetesApiResponse;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi;
@@ -29,6 +31,7 @@ import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.exception.ReleaseStorageException;
 import org.alexmond.jhelm.core.exception.WaitTimeoutException;
 import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.HelmReleaseCodec;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
@@ -75,6 +78,28 @@ public class HelmKubeService implements KubeService {
 	 */
 	public HelmKubeService(KubeClient kubeClient) {
 		this.apiClient = kubeClient.apiClient();
+	}
+
+	/**
+	 * Reads the live server version so {@code .Capabilities.KubeVersion} reflects the
+	 * real target cluster during install/upgrade. Falls back to
+	 * {@link Capabilities#DEFAULT} (engine default version) when the server cannot be
+	 * reached, so a dry-run/offline path still renders. API versions are left at the
+	 * engine default set.
+	 */
+	@Override
+	public Capabilities getCapabilities() {
+		try {
+			VersionInfo info = new VersionApi(apiClient).getCode().execute();
+			String gitVersion = (info != null) ? info.getGitVersion() : null;
+			if (gitVersion != null && !gitVersion.isBlank()) {
+				return new Capabilities(gitVersion, List.of());
+			}
+		}
+		catch (ApiException | RuntimeException ex) {
+			log.debug("Could not read server version for .Capabilities; using engine default", ex);
+		}
+		return Capabilities.DEFAULT;
 	}
 
 	/**

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/KubernetesClientProvider.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/KubernetesClientProvider.java
@@ -301,13 +301,16 @@ public class KubernetesClientProvider implements KubernetesProvider {
 	}
 
 	/**
-	 * Return stub version when Kubernetes API is not available
+	 * Return stub version when Kubernetes API is not available. Kept aligned with the
+	 * engine's default {@code .Capabilities.KubeVersion} ({@code v1.35.0}) so the
+	 * {@code kubeVersion} template function and {@code .Capabilities.KubeVersion} agree
+	 * when no live cluster is reachable.
 	 */
 	private Map<String, Object> getStubVersion() {
 		Map<String, Object> version = new HashMap<>();
 		version.put("Major", "1");
-		version.put("Minor", "28");
-		version.put("GitVersion", "v1.28.0");
+		version.put("Minor", "35");
+		version.put("GitVersion", "v1.35.0");
 		version.put("GitCommit", "unknown");
 		version.put("Platform", "linux/amd64");
 		return version;

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeService.java
@@ -7,6 +7,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.metrics.JhelmMetrics;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.alexmond.jhelm.core.service.KubeService;
@@ -114,6 +115,12 @@ public class ObservableKubeService implements KubeService {
 	@Override
 	public void waitForReady(String namespace, String manifest, int timeoutSeconds) {
 		delegate.waitForReady(namespace, manifest, timeoutSeconds);
+	}
+
+	@Override
+	public Capabilities getCapabilities() {
+		// lightweight read-only introspection; forward without a metric
+		return delegate.getCapabilities();
 	}
 
 	private <T> T time(Timer timer, Supplier<T> supplier) {

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import io.kubernetes.client.openapi.ApiException;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.alexmond.jhelm.core.service.KubeService;
@@ -122,6 +123,12 @@ public class RetryableKubeService implements KubeService {
 	public void waitForReady(String namespace, String manifest, int timeoutSeconds) {
 		// waitForReady already polls internally; do not retry the entire operation
 		delegate.waitForReady(namespace, manifest, timeoutSeconds);
+	}
+
+	@Override
+	public Capabilities getCapabilities() {
+		// read-only introspection that already falls back to defaults on failure; forward
+		return delegate.getCapabilities();
 	}
 
 	private <T> T executeWithRetry(String operation, Retryable<T> callback) {

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
@@ -4,6 +4,8 @@ import tools.jackson.databind.json.JsonMapper;
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.VersionApi;
+import io.kubernetes.client.openapi.models.VersionInfo;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
@@ -28,6 +30,7 @@ import io.kubernetes.client.util.generic.options.PatchOptions;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.exception.ReleaseStorageException;
 import org.alexmond.jhelm.core.exception.WaitTimeoutException;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.model.ResourceStatus;
@@ -214,6 +217,46 @@ class HelmKubeServiceTest {
 		});
 
 		assertThrows(ReleaseStorageException.class, () -> kubeService.storeRelease(release));
+	}
+
+	// --- getCapabilities ---
+
+	@Test
+	void testGetCapabilitiesReadsLiveServerVersion() {
+		VersionInfo info = new VersionInfo();
+		info.setGitVersion("v1.31.2");
+		try (MockedConstruction<VersionApi> versionApi = mockConstruction(VersionApi.class, (mock, ctx) -> {
+			VersionApi.APIgetCodeRequest req = mock(VersionApi.APIgetCodeRequest.class);
+			when(req.execute()).thenReturn(info);
+			when(mock.getCode()).thenReturn(req);
+		})) {
+			Capabilities caps = kubeService.getCapabilities();
+			assertEquals("v1.31.2", caps.kubeVersion());
+		}
+	}
+
+	@Test
+	void testGetCapabilitiesFallsBackToDefaultOnApiError() {
+		try (MockedConstruction<VersionApi> versionApi = mockConstruction(VersionApi.class, (mock, ctx) -> {
+			VersionApi.APIgetCodeRequest req = mock(VersionApi.APIgetCodeRequest.class);
+			when(req.execute()).thenThrow(new ApiException(500, "server error"));
+			when(mock.getCode()).thenReturn(req);
+		})) {
+			assertEquals(Capabilities.DEFAULT, kubeService.getCapabilities());
+		}
+	}
+
+	@Test
+	void testGetCapabilitiesFallsBackToDefaultOnBlankVersion() {
+		VersionInfo info = new VersionInfo();
+		info.setGitVersion("");
+		try (MockedConstruction<VersionApi> versionApi = mockConstruction(VersionApi.class, (mock, ctx) -> {
+			VersionApi.APIgetCodeRequest req = mock(VersionApi.APIgetCodeRequest.class);
+			when(req.execute()).thenReturn(info);
+			when(mock.getCode()).thenReturn(req);
+		})) {
+			assertEquals(Capabilities.DEFAULT, kubeService.getCapabilities());
+		}
 	}
 
 	// --- getRelease ---

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/KubernetesClientProviderTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/KubernetesClientProviderTest.java
@@ -110,8 +110,8 @@ class KubernetesClientProviderTest {
 		Map<String, Object> version = provider.getVersion();
 
 		assertEquals("1", version.get("Major"));
-		assertEquals("28", version.get("Minor"));
-		assertEquals("v1.28.0", version.get("GitVersion"));
+		assertEquals("35", version.get("Minor"));
+		assertEquals("v1.35.0", version.get("GitVersion"));
 		assertEquals("unknown", version.get("GitCommit"));
 		assertEquals("linux/amd64", version.get("Platform"));
 	}
@@ -147,7 +147,7 @@ class KubernetesClientProviderTest {
 		when(versionApi.getCode()).thenReturn(versionReq);
 
 		Map<String, Object> version = provider.getVersion();
-		assertEquals("v1.28.0", version.get("GitVersion"));
+		assertEquals("v1.35.0", version.get("GitVersion"));
 	}
 
 	// --- lookup when unavailable ---

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeServiceTest.java
@@ -7,6 +7,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.alexmond.jhelm.core.metrics.JhelmMetrics;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.alexmond.jhelm.core.service.KubeService;
@@ -58,6 +59,14 @@ class ObservableKubeServiceTest {
 		Timer timer = registry.find("jhelm.kube.operation").tag("operation", "apply").timer();
 		assertNotNull(timer);
 		assertEquals(1, timer.count());
+	}
+
+	@Test
+	void testGetCapabilitiesForwardsDelegateResult() {
+		Capabilities caps = new Capabilities("v1.31.2", List.of());
+		when(delegate.getCapabilities()).thenReturn(caps);
+		assertEquals(caps, service.getCapabilities());
+		verify(delegate).getCapabilities();
 	}
 
 	@Test

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeServiceTest.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import io.kubernetes.client.openapi.ApiException;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.KubeService;
 import java.time.Duration;
@@ -82,6 +83,15 @@ class RetryableKubeServiceTest {
 	void testApplyDelegatesToWrapped() throws Exception {
 		retryableService.apply("default", "yaml-content");
 		verify(delegate).apply("default", "yaml-content");
+	}
+
+	@Test
+	void testGetCapabilitiesForwardsDelegateResult() {
+		Capabilities caps = new Capabilities("v1.31.2", List.of());
+		when(delegate.getCapabilities()).thenReturn(caps);
+
+		assertEquals(caps, retryableService.getCapabilities());
+		verify(delegate).getCapabilities();
 	}
 
 	@Test


### PR DESCRIPTION
## What

Makes Helm's `.Capabilities` reflect reality instead of a hardcoded stub, and adds the offline overrides Helm has.

**Panel finding:** `.Capabilities` was hardcoded in the engine, so a chart gating on `.Capabilities.KubeVersion` (very common) or `.Capabilities.APIVersions.Has` rendered as if against a fixed fake cluster. Two code paths also disagreed on the default version — engine `v1.35.0` vs the provider/`kubeVersion`-function stub `v1.28.0`.

## How

- **Engine** — `.Capabilities` is now built from a `Capabilities` override (kube version + extra API versions). A **non-breaking** `render(chart, values, release, capabilities)` overload threads it; the existing 3-arg `render` delegates with `Capabilities.DEFAULT`. Version string is normalised (`1.30` → `v1.30`) and `Major`/`Minor` parsed from it.
- **install / upgrade** — read the live server version via `KubeService.getCapabilities()` (interface default → `DEFAULT`; `HelmKubeService` queries `VersionApi`, falling back to the engine default when the server is unreachable) so version-gated charts render against the **real target**. The `Retryable`/`Observable` decorators forward the call.
- **template** — new `--kube-version` and `-a, --api-versions` flags (mirroring `helm template`) pin `.Capabilities` for the offline path, wired through `TemplateAction`.
- **Consistency fix** — the provider stub and the `kubeVersion` function stub now report `v1.35.0`, matching the engine default the parity harness pins.

## Tests

- Engine override: kube-version reflected, `Major`/`Minor` parsed, leading-`v` normalisation, extra API versions additive to the default set, `null` → default.
- `TemplateAction` forwards `--kube-version`/`--api-versions` into a `Capabilities`.
- `Retryable`/`Observable` decorators forward `getCapabilities()`.
- Updated the two stub-version assertions to `v1.35.0`.

Default rendering output is unchanged (default kube version stays `v1.35.0`, default API-version set unchanged), so parity is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
