### PR TITLE
docs(model): document the 1.0 mutability contract + KubernetesProvider SPI

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Chart.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Chart.java
@@ -14,6 +14,16 @@ import lombok.NoArgsConstructor;
  * In-memory representation of a loaded Helm chart: its {@link ChartMetadata}, default
  * values, templates, CRDs, subchart dependencies and any non-template files exposed via
  * {@code .Files}. Produced by the chart loader and consumed by the rendering engine.
+ *
+ * <p>
+ * <strong>Mutability contract (1.0):</strong> this is a mutable internal model. The chart
+ * loader and rendering engine mutate it during loading and rendering — the loader
+ * resolves subchart aliases from the on-disk layout, and the engine marks
+ * {@code .Chart.IsRoot} and applies dependency aliases while walking the render tree.
+ * Treat an instance obtained from the API as read-only in your own code: build one with
+ * the generated {@code builder()} and do not call the {@code set*} methods, whose
+ * presence is an implementation detail of loading/rendering rather than part of the
+ * supported surface. (Contrast {@link Release}, which is fully immutable.)
  */
 @Data
 @Builder(toBuilder = true)

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartMetadata.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ChartMetadata.java
@@ -14,6 +14,16 @@ import lombok.NoArgsConstructor;
  * The contents of a chart's {@code Chart.yaml}: name, version, description, API version,
  * type, app version, supported Kubernetes range, dependency declarations and annotations.
  * Unknown keys are ignored on deserialization.
+ *
+ * <p>
+ * <strong>Mutability contract (1.0):</strong> this is a mutable internal model. The
+ * loader and engine mutate it during loading and rendering — the loader backfills
+ * v1-chart {@code requirements.yaml} dependencies, and the engine sets the
+ * {@code .Chart.IsRoot} flag (and, for aliased dependencies, the effective name) as it
+ * walks the render tree. Treat an instance obtained from the API as read-only in your own
+ * code and construct new ones via the generated {@code builder()}; the {@code set*}
+ * methods exist for the loading/rendering pipeline, not as a supported mutation surface.
+ * (Contrast {@link Release}, which is fully immutable.)
  */
 @Data
 @Builder(toBuilder = true)

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Values.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Values.java
@@ -15,6 +15,15 @@ import java.util.Map;
  * value read downstream came back null. Like {@link ChartFiles}, this is a map that also
  * exposes a helper method; the template executor resolves {@code AsMap} by name (falling
  * back from map-key lookup) once the key is absent.
+ *
+ * <p>
+ * <strong>Mutability contract (1.0):</strong> {@code Values} extends {@link HashMap} so
+ * the template executor can resolve {@code .Values.foo} through the {@link Map}
+ * interface, which means it structurally inherits the mutating map methods. In practice
+ * it is built once from the already-merged values and only read during rendering — jhelm
+ * never mutates it after construction, and callers should treat it as read-only. The
+ * {@code HashMap} superclass is an interop detail (so it <em>is-a</em> {@code Map} for
+ * the engine), not an invitation to mutate.
  */
 @SuppressWarnings("PMD.MethodNamingConventions")
 public class Values extends HashMap<String, Object> {

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/KubernetesProvider.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/KubernetesProvider.java
@@ -6,6 +6,14 @@ import java.util.Map;
  * Provider interface for Kubernetes operations. This allows jhelm-gotemplate to remain
  * lightweight and not depend on Kubernetes client libraries. Implementations can be
  * provided by jhelm-kube or other modules.
+ *
+ * <p>
+ * This is a <strong>public extension point (SPI)</strong>: it is a supported, stable part
+ * of the 1.0 API that downstream code may implement to back the {@code lookup} and
+ * {@code kubeVersion} template functions against a custom source (a live cluster, a
+ * fixture, a cache). The default cluster-backed implementation lives in jhelm-kube. Keep
+ * implementations side-effect-free and fast — the methods are called during template
+ * rendering.
  */
 public interface KubernetesProvider {
 


### PR DESCRIPTION
## What

Documents the 1.0 **mutability contract** on the public model and marks `KubernetesProvider` as a stable public SPI. Docs-only — no behavior change.

**Panel finding:** "API-freeze immutability." A read-only audit found:

| Item | Verdict |
|---|---|
| `Chart` / `ChartMetadata` immutable? | **Too invasive for 1.0** — the loader resolves aliases + backfills v1 `requirements.yaml` deps, and the engine sets `.Chart.IsRoot` (and aliased names) on **every render**. Refactoring the render pipeline right before 1.0 is high-risk. → **document the contract** (contrast `Release`, already `@Value`). |
| `Values extends HashMap` | Never mutated post-construction; extending `HashMap` is required so the template executor resolves `.Values.foo` via the `Map` interface. → **document** it's an interop detail, read-only in practice. |
| `KubernetesProvider` public interface | Already a provider SPI. → **document** it as a supported, stable 1.0 extension point. |
| `applyDryRun` decorator-forwarding test | **Already exists** in both `RetryableKubeServiceTest` and `ObservableKubeServiceTest`. → no change. |

## Changes

- `Chart`, `ChartMetadata` — javadoc: mutable internal models the loader/engine mutate during loading/rendering; treat API-obtained instances as read-only, build via `builder()`, `set*` is not a supported mutation surface.
- `Values` — javadoc: extending `HashMap` is an interop detail (is-a `Map` for the engine), not an invitation to mutate; built once, only read.
- `KubernetesProvider` — javadoc: supported, stable public SPI for 1.0.

Making the model classes immutable is recorded as a v2 refactor (constructor-based `Chart`/`ChartMetadata`), out of scope for a safe 1.0 cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
