### PR TITLE
feat(rest,provenance): REST upgrade value-strategy + harden provenance verify

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SignatureService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SignatureService.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Security;
+import java.time.Instant;
 import java.util.Iterator;
 
 import lombok.extern.slf4j.Slf4j;
@@ -128,6 +129,7 @@ public class SignatureService {
 				throw new SignatureVerificationException(
 						"No public key found for key ID " + Long.toHexString(signature.getKeyID()));
 			}
+			checkKeyUsable(verifyKey);
 
 			signature.init(new JcaPGPContentVerifierBuilderProvider().setProvider("BC"), verifyKey);
 			byte[] signedBytes = signedData.getBytes(StandardCharsets.UTF_8);
@@ -153,6 +155,27 @@ public class SignatureService {
 		}
 		catch (IOException | PGPException ex) {
 			throw new SignatureException("Failed to verify chart: " + chartTgz.getName(), ex);
+		}
+	}
+
+	/**
+	 * Rejects a signing key that has been revoked or has passed its expiry time, so a
+	 * retired or compromised provenance key can no longer validate a chart even when the
+	 * signature itself is cryptographically intact.
+	 * @param key the public key that produced the signature
+	 * @throws SignatureVerificationException if the key is revoked or expired
+	 */
+	private void checkKeyUsable(PGPPublicKey key) {
+		String keyId = Long.toHexString(key.getKeyID());
+		if (key.hasRevocation()) {
+			throw new SignatureVerificationException("Signing key " + keyId + " has been revoked");
+		}
+		long validSeconds = key.getValidSeconds();
+		if (validSeconds > 0) {
+			Instant expiry = key.getCreationTime().toInstant().plusSeconds(validSeconds);
+			if (Instant.now().isAfter(expiry)) {
+				throw new SignatureVerificationException("Signing key " + keyId + " expired at " + expiry);
+			}
 		}
 	}
 
@@ -271,7 +294,22 @@ public class SignatureService {
 		if (sigStart < 0) {
 			throw new SignatureVerificationException("Invalid clear-signed message: no signature block");
 		}
-		return clearSigned.substring(blankLine + 2, sigStart);
+		return unescapeDashes(clearSigned.substring(blankLine + 2, sigStart));
+	}
+
+	/**
+	 * Reverses OpenPGP clear-sign dash-escaping (RFC 4880 §7.1): a producer prefixes any
+	 * text line beginning with {@code '-'} with {@code "- "} so it cannot be confused
+	 * with an armor delimiter. The signature is computed over the original (un-escaped)
+	 * text, so the escape must be removed before verifying — otherwise a provenance file
+	 * produced by {@code helm}/GnuPG whose signed body contains such a line (e.g. a
+	 * {@code "- name:"} YAML sequence entry, or a literal {@code "-----BEGIN"}) fails to
+	 * verify.
+	 * @param signedText the raw clear-signed body between the headers and the signature
+	 * @return the body with any leading {@code "- "} dash-escape removed from each line
+	 */
+	private static String unescapeDashes(String signedText) {
+		return signedText.replaceAll("(?m)^- ", "");
 	}
 
 	/**

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/SignatureServiceTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/SignatureServiceTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Security;
+import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 
@@ -21,15 +22,22 @@ import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openpgp.PGPKeyPair;
 import org.bouncycastle.openpgp.PGPKeyRingGenerator;
+import org.bouncycastle.openpgp.PGPPrivateKey;
+import org.bouncycastle.openpgp.PGPPublicKey;
+import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
 import org.bouncycastle.openpgp.PGPSecretKey;
 import org.bouncycastle.openpgp.PGPSecretKeyRing;
 import org.bouncycastle.openpgp.PGPSecretKeyRingCollection;
 import org.bouncycastle.openpgp.PGPSignature;
+import org.bouncycastle.openpgp.PGPSignatureGenerator;
+import org.bouncycastle.openpgp.PGPSignatureSubpacketGenerator;
+import org.bouncycastle.openpgp.PGPSignatureSubpacketVector;
 import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator;
 import org.bouncycastle.openpgp.operator.jcajce.JcaPGPContentSignerBuilder;
 import org.bouncycastle.openpgp.operator.jcajce.JcaPGPDigestCalculatorProviderBuilder;
 import org.bouncycastle.openpgp.operator.jcajce.JcaPGPKeyPair;
+import org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyDecryptorBuilder;
 import org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyEncryptorBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +46,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -265,6 +274,54 @@ class SignatureServiceTest {
 				() -> signatureService.verify(chartFile, "no signature content", verificationKeyring));
 	}
 
+	@Test
+	void testExtractSignedDataUnescapesDashEscapedLines() {
+		// A clear-signed body dash-escaped per RFC 4880 §7.1: text lines that begin with
+		// '-' are prefixed with "- " for transport. extractSignedData must reverse this
+		// so
+		// the signed bytes match what was actually signed.
+		String clearSigned = "-----BEGIN PGP SIGNED MESSAGE-----\n" + "Hash: SHA256\n\n"
+				+ "- -----BEGIN CERTIFICATE-----\n" + "- - name: an item\n" + "plain: value\n"
+				+ "-----BEGIN PGP SIGNATURE-----\n";
+
+		String signed = signatureService.extractSignedData(clearSigned);
+
+		assertTrue(signed.contains("-----BEGIN CERTIFICATE-----"), "dash-escaped armor line should be unescaped");
+		assertFalse(signed.contains("- -----BEGIN CERTIFICATE-----"), "dash escape should be removed");
+		assertTrue(signed.contains("- name: an item"), "escaped YAML sequence line should be unescaped once");
+		assertTrue(signed.contains("plain: value"), "non-escaped lines should be untouched");
+	}
+
+	@Test
+	void testVerifyRejectsExpiredKey() throws Exception {
+		// Key created 10 days ago with a 1-day validity period => expired 9 days ago.
+		PGPSignatureSubpacketGenerator sp = new PGPSignatureSubpacketGenerator();
+		sp.setKeyExpirationTime(false, Duration.ofDays(1).toSeconds());
+		Date created = new Date(System.currentTimeMillis() - Duration.ofDays(10).toMillis());
+		KeyBundle bundle = buildKeyBundle(created, sp.generate(), false);
+
+		File chartFile = createTempChartFile("expired-1.0.0.tgz", "data");
+		ChartMetadata metadata = ChartMetadata.builder().name("expired").version("1.0.0").apiVersion("v2").build();
+		String prov = signatureService.sign(chartFile, metadata, bundle.signingKey(), PASSPHRASE);
+
+		SignatureVerificationException ex = assertThrows(SignatureVerificationException.class,
+				() -> signatureService.verify(chartFile, prov, bundle.keyring()));
+		assertTrue(ex.getMessage().contains("expired"), "message should mention expiry: " + ex.getMessage());
+	}
+
+	@Test
+	void testVerifyRejectsRevokedKey() throws Exception {
+		KeyBundle bundle = buildKeyBundle(new Date(), null, true);
+
+		File chartFile = createTempChartFile("revoked-1.0.0.tgz", "data");
+		ChartMetadata metadata = ChartMetadata.builder().name("revoked").version("1.0.0").apiVersion("v2").build();
+		String prov = signatureService.sign(chartFile, metadata, bundle.signingKey(), PASSPHRASE);
+
+		SignatureVerificationException ex = assertThrows(SignatureVerificationException.class,
+				() -> signatureService.verify(chartFile, prov, bundle.keyring()));
+		assertTrue(ex.getMessage().contains("revoked"), "message should mention revocation: " + ex.getMessage());
+	}
+
 	@SuppressWarnings("deprecation") // JcaPGPKeyPair 3-arg constructor; 4-arg version has
 										// a BouncyCastle bug
 	private static PGPKeyRingGenerator createKeyRingGenerator(String userId) throws Exception {
@@ -285,12 +342,57 @@ class SignatureServiceTest {
 					.build(PASSPHRASE));
 	}
 
+	/**
+	 * Builds a matching signing key + verification keyring, optionally with a
+	 * key-expiration subpacket and/or a self-revocation, so key-usability rejection can
+	 * be exercised.
+	 */
+	@SuppressWarnings("deprecation") // JcaPGPKeyPair 3-arg constructor; 4-arg version has
+										// a
+										// BouncyCastle bug
+	private static KeyBundle buildKeyBundle(Date creation, PGPSignatureSubpacketVector hashedPackets, boolean revoke)
+			throws Exception {
+		KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "BC");
+		kpg.initialize(2048);
+		PGPKeyPair pgpKeyPair = new JcaPGPKeyPair(PublicKeyAlgorithmTags.RSA_GENERAL, kpg.generateKeyPair(), creation);
+		PGPKeyRingGenerator gen = new PGPKeyRingGenerator(PGPSignature.POSITIVE_CERTIFICATION, pgpKeyPair, USER_ID,
+				new JcaPGPDigestCalculatorProviderBuilder().setProvider("BC").build().get(HashAlgorithmTags.SHA1),
+				hashedPackets, null,
+				new JcaPGPContentSignerBuilder(pgpKeyPair.getPublicKey().getAlgorithm(), HashAlgorithmTags.SHA256)
+					.setProvider("BC"),
+				new JcePBESecretKeyEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_256,
+						new JcaPGPDigestCalculatorProviderBuilder().setProvider("BC")
+							.build()
+							.get(HashAlgorithmTags.SHA256))
+					.setProvider("BC")
+					.build(PASSPHRASE));
+
+		PGPSecretKey sk = gen.generateSecretKeyRing().getSecretKey();
+		PGPPublicKeyRing ring = gen.generatePublicKeyRing();
+		if (revoke) {
+			PGPPublicKey master = ring.getPublicKey();
+			PGPPrivateKey priv = sk
+				.extractPrivateKey(new JcePBESecretKeyDecryptorBuilder().setProvider("BC").build(PASSPHRASE));
+			PGPSignatureGenerator sigGen = new PGPSignatureGenerator(
+					new JcaPGPContentSignerBuilder(master.getAlgorithm(), HashAlgorithmTags.SHA256).setProvider("BC"),
+					master);
+			sigGen.init(PGPSignature.KEY_REVOCATION, priv);
+			PGPPublicKey revoked = PGPPublicKey.addCertification(master, sigGen.generateCertification(master));
+			ring = PGPPublicKeyRing.insertPublicKey(ring, revoked);
+		}
+		PGPPublicKeyRingCollection keyring = new PGPPublicKeyRingCollection(List.of(ring));
+		return new KeyBundle(new SigningKey(sk), new VerificationKeyring(keyring));
+	}
+
 	private File createTempChartFile(String name, String content) throws IOException {
 		File file = tempDir.resolve(name).toFile();
 		try (OutputStream os = new FileOutputStream(file)) {
 			os.write(content.getBytes());
 		}
 		return file;
+	}
+
+	private record KeyBundle(SigningKey signingKey, VerificationKeyring keyring) {
 	}
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
@@ -237,14 +237,11 @@ public class ReleaseController {
 			Chart chart = ChartSourceResolver.fromChartRef(request.getChartRef(), request.getVersion(),
 					this.repoManager, this.chartLoader, tempDir);
 			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
-			// TODO: expose UpgradeValueStrategy (reset/reuse/reset-then-reuse) on the
-			// REST
-			// request as a follow-up.
 			Release upgraded = this.upgradeAction.upgrade(UpgradeOptions.builder()
 				.currentRelease(current)
 				.newChart(chart)
 				.values(values)
-				.valueStrategy(UpgradeValueStrategy.DEFAULT)
+				.valueStrategy(resolveStrategy(request.getValueStrategy()))
 				.dryRun(request.isDryRun())
 				.build());
 			return ReleaseDto.from(upgraded);
@@ -274,18 +271,25 @@ public class ReleaseController {
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-upgrade-upload-")) {
 			Chart loaded = ChartSourceResolver.fromUpload(chart, this.repoManager, this.chartLoader, tempDir);
 			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
-			// TODO: expose UpgradeValueStrategy (reset/reuse/reset-then-reuse) on the
-			// REST
-			// request as a follow-up.
 			Release upgraded = this.upgradeAction.upgrade(UpgradeOptions.builder()
 				.currentRelease(current)
 				.newChart(loaded)
 				.values(values)
-				.valueStrategy(UpgradeValueStrategy.DEFAULT)
+				.valueStrategy(resolveStrategy(request.getValueStrategy()))
 				.dryRun(request.isDryRun())
 				.build());
 			return ReleaseDto.from(upgraded);
 		}
+	}
+
+	/**
+	 * Resolves the request's value strategy, defaulting to
+	 * {@link UpgradeValueStrategy#DEFAULT} when the client omits it.
+	 * @param strategy the strategy from the request, or {@code null}
+	 * @return the strategy to apply, never {@code null}
+	 */
+	private static UpgradeValueStrategy resolveStrategy(UpgradeValueStrategy strategy) {
+		return (strategy != null) ? strategy : UpgradeValueStrategy.DEFAULT;
 	}
 
 	/**

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeRequest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
 
 /**
  * Request body for upgrading an existing release from a repository chart reference.
@@ -24,6 +25,13 @@ public class UpgradeRequest {
 
 	@Schema(description = "Override values for the chart")
 	private Map<String, Object> values;
+
+	@Schema(description = "How prior release values are combined with the supplied overrides: "
+			+ "DEFAULT (reuse prior values only when no overrides are given), RESET (discard prior "
+			+ "values), REUSE (merge overrides onto prior values), or RESET_THEN_REUSE (merge onto "
+			+ "prior values but render against the new chart defaults). Mirrors helm upgrade's "
+			+ "--reset-values / --reuse-values / --reset-then-reuse-values.", defaultValue = "DEFAULT")
+	private UpgradeValueStrategy valueStrategy;
 
 	@Schema(description = "Simulate an upgrade without applying", defaultValue = "false")
 	private boolean dryRun;

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeUploadRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/UpgradeUploadRequest.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
 
 /**
  * Metadata accompanying an uploaded {@code .tgz} chart archive when upgrading a release.
@@ -14,6 +15,11 @@ public class UpgradeUploadRequest {
 
 	@Schema(description = "Override values for the chart")
 	private Map<String, Object> values;
+
+	@Schema(description = "How prior release values are combined with the supplied overrides: "
+			+ "DEFAULT, RESET, REUSE, or RESET_THEN_REUSE. Mirrors helm upgrade's --reset-values / "
+			+ "--reuse-values / --reset-then-reuse-values.", defaultValue = "DEFAULT")
+	private UpgradeValueStrategy valueStrategy;
 
 	@Schema(description = "Simulate an upgrade without applying", defaultValue = "false")
 	private boolean dryRun;

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
@@ -20,6 +20,7 @@ import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.action.UpgradeOptions;
+import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
@@ -214,6 +215,50 @@ class ReleaseControllerTest {
 						"""))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.version").value(2));
+	}
+
+	@Test
+	void upgradeReleaseHonorsRequestedValueStrategy() throws Exception {
+		Release current = sampleRelease();
+		when(this.getAction.getRelease("my-release", "default")).thenReturn(Optional.of(current));
+		stubPull();
+		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("2.0.0").build()).build();
+		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
+		when(this.upgradeAction.upgrade(any(UpgradeOptions.class)))
+			.thenReturn(sampleRelease().toBuilder().version(2).build());
+
+		this.mockMvc
+			.perform(put("/api/v1/releases/my-release").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartRef": "bitnami/nginx", "version": "2.0.0", "valueStrategy": "REUSE"}
+						"""))
+			.andExpect(status().isOk());
+
+		verify(this.upgradeAction)
+			.upgrade(argThat((UpgradeOptions options) -> options.getValueStrategy() == UpgradeValueStrategy.REUSE));
+	}
+
+	@Test
+	void upgradeReleaseDefaultsValueStrategyWhenOmitted() throws Exception {
+		Release current = sampleRelease();
+		when(this.getAction.getRelease("my-release", "default")).thenReturn(Optional.of(current));
+		stubPull();
+		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("2.0.0").build()).build();
+		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
+		when(this.upgradeAction.upgrade(any(UpgradeOptions.class)))
+			.thenReturn(sampleRelease().toBuilder().version(2).build());
+
+		this.mockMvc
+			.perform(put("/api/v1/releases/my-release").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartRef": "bitnami/nginx", "version": "2.0.0"}
+						"""))
+			.andExpect(status().isOk());
+
+		verify(this.upgradeAction)
+			.upgrade(argThat((UpgradeOptions options) -> options.getValueStrategy() == UpgradeValueStrategy.DEFAULT));
 	}
 
 	@Test


### PR DESCRIPTION
## What

The final pre-1.0 nice-to-haves from the release-prep panel: expose the upgrade value-strategy over REST, and harden PGP provenance verification.

## REST — `UpgradeValueStrategy` on the upgrade endpoints

`ReleaseController` hardcoded `UpgradeValueStrategy.DEFAULT` (two standing TODOs), so reuse/reset value handling was unreachable over HTTP even though the CLI and action layer supported it.

- `UpgradeRequest` and `UpgradeUploadRequest` gain a `valueStrategy` field: `DEFAULT | RESET | REUSE | RESET_THEN_REUSE`, documented via `@Schema`, mirroring the CLI's `--reset-values` / `--reuse-values` / `--reset-then-reuse-values`.
- The controller threads it into `UpgradeOptions`, null-coalescing an omitted value to `DEFAULT` (backward-compatible).

## Provenance — `SignatureService.verify` hardening

- **Key expiry + revocation.** `verify` now rejects a **revoked** key (`PGPPublicKey.hasRevocation`) and an **expired** key (`creationTime + getValidSeconds`), so a retired or compromised provenance key can no longer validate a chart even when the signature itself is cryptographically intact.
- **Clear-sign dash-unescaping (RFC 4880 §7.1).** The signed body is now un-escaped before verification, so a `helm`/GnuPG-produced `.prov` whose signed text contains a line beginning with `-` (a `"- name:"` YAML sequence entry, or a literal `"-----BEGIN"`) verifies correctly. jhelm's own minimal provenance has no such lines, so the sign→verify round-trip is unchanged.

## Tests

- REST: `valueStrategy` passthrough (`REUSE`) and default-when-omitted, asserted via `argThat` on `UpgradeOptions`.
- Provenance: expired-key rejection (key built with a `KeyExpirationTime` subpacket + past creation), revoked-key rejection (self-revocation certification), and dash-unescaping. `SignatureServiceTest` 14 → 17, `ReleaseControllerTest` 20 → 22, all green.

All BouncyCastle PGP types remain confined to `jhelm-core` (CLI/REST see only `SigningKey` / `VerificationKeyring`). Follow-up filed for jhelm-core's `helm.sh/hook: test` emission is #634 (separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
