### PR TITLE
fix: resolve SonarQube bugs + latent --list-repo-url bug + TLS/temp-file findings

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchHubCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchHubCommand.java
@@ -52,22 +52,14 @@ public class SearchHubCommand implements Runnable {
 	}
 
 	private void printTable(List<SearchHubAction.HubResult> results) {
-		if (listRepoUrl) {
-			CliOutput.println(String.format("%-40s\t%-8s\t%-12s\t%s", "URL", "VERSION", "APP VERSION", "DESCRIPTION"));
-		}
-		else {
-			CliOutput.println(String.format("%-40s\t%-8s\t%-12s\t%s", "URL", "VERSION", "APP VERSION", "DESCRIPTION"));
-		}
+		CliOutput.println(String.format("%-40s\t%-8s\t%-12s\t%s", "URL", "VERSION", "APP VERSION", "DESCRIPTION"));
 		for (SearchHubAction.HubResult r : results) {
 			String description = truncate(r.getDescription(), maxColWidth);
-			if (listRepoUrl) {
-				CliOutput.println(String.format("%-40s\t%-8s\t%-12s\t%s", r.getUrl(), r.getVersion(), r.getAppVersion(),
-						description));
-			}
-			else {
-				CliOutput.println(String.format("%-40s\t%-8s\t%-12s\t%s", r.getUrl(), r.getVersion(), r.getAppVersion(),
-						description));
-			}
+			// --list-repo-url prints the chart's repository URL; the default prints the
+			// Artifact Hub package URL (matching `helm search hub [--list-repo-url]`).
+			String url = listRepoUrl ? r.getRepoUrl() : r.getUrl();
+			CliOutput
+				.println(String.format("%-40s\t%-8s\t%-12s\t%s", url, r.getVersion(), r.getAppVersion(), description));
 		}
 	}
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/SearchHubCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/SearchHubCommandTest.java
@@ -1,5 +1,8 @@
 package org.alexmond.jhelm.app.command;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.alexmond.jhelm.core.action.SearchHubAction;
@@ -11,6 +14,8 @@ import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -43,6 +48,51 @@ class SearchHubCommandTest {
 		CommandLine cmd = new CommandLine(searchHubCommand);
 		int exitCode = cmd.execute("nginx");
 		assertEquals(0, exitCode);
+	}
+
+	@Test
+	void testSearchHubDefaultShowsArtifactHubUrl() throws Exception {
+		when(searchHubAction.search(anyString(), anyInt())).thenReturn(List.of(sampleResult()));
+
+		String out = captureStdout(() -> new CommandLine(searchHubCommand).execute("nginx"));
+
+		assertTrue(out.contains("https://artifacthub.io/packages/helm/bitnami/nginx"), out);
+		assertFalse(out.contains("charts.bitnami.com"), "default output should not show the repo URL: " + out);
+	}
+
+	@Test
+	void testSearchHubListRepoUrlShowsRepositoryUrl() throws Exception {
+		when(searchHubAction.search(anyString(), anyInt())).thenReturn(List.of(sampleResult()));
+
+		String out = captureStdout(() -> new CommandLine(searchHubCommand).execute("nginx", "--list-repo-url"));
+
+		assertTrue(out.contains("https://charts.bitnami.com/bitnami"), out);
+		assertFalse(out.contains("artifacthub.io"),
+				"--list-repo-url output should not show the Artifact Hub URL: " + out);
+	}
+
+	private static SearchHubAction.HubResult sampleResult() {
+		SearchHubAction.HubResult result = new SearchHubAction.HubResult();
+		result.setName("nginx");
+		result.setDescription("A chart for nginx");
+		result.setVersion("15.0.0");
+		result.setAppVersion("1.25.0");
+		result.setRepoName("bitnami");
+		result.setRepoUrl("https://charts.bitnami.com/bitnami");
+		return result;
+	}
+
+	private static String captureStdout(Runnable action) {
+		PrintStream original = System.out;
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(buffer, true, StandardCharsets.UTF_8));
+		try {
+			action.run();
+		}
+		finally {
+			System.setOut(original);
+		}
+		return buffer.toString(StandardCharsets.UTF_8);
 	}
 
 	@Test

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/PackageAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/PackageAction.java
@@ -6,6 +6,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -186,22 +187,6 @@ public class PackageAction {
 			}
 		}
 		return false;
-	}
-
-	private static class UncheckedIOException extends RuntimeException {
-
-		private final IOException cause;
-
-		UncheckedIOException(IOException cause) {
-			super(cause);
-			this.cause = cause;
-		}
-
-		@Override
-		public IOException getCause() {
-			return this.cause;
-		}
-
 	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
@@ -208,6 +208,13 @@ final class RepoHttpClientFactory {
 		return kf.generatePrivate(spec);
 	}
 
+	/**
+	 * Trust-all manager used only when the caller explicitly opts in with
+	 * {@code --insecure-skip-tls-verify} (mirroring Helm's flag of the same name).
+	 * Disabling certificate validation is the documented, user-requested behaviour for
+	 * that flag, not a default; secure verification is used otherwise.
+	 */
+	@SuppressWarnings("java:S4830") // intentional: opt-in --insecure-skip-tls-verify path
 	private static final class InsecureTrustManager implements X509TrustManager {
 
 		@Override

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -748,7 +748,10 @@ public class RepoManager {
 		RepositoryConfig.Repository repo = (auth != null) ? auth : RepositoryConfig.Repository.builder().build();
 		repo.setUrl(repoUrl);
 		String indexUrl = repoUrl.endsWith("/") ? repoUrl + "index.yaml" : repoUrl + "/index.yaml";
-		File indexTmp = File.createTempFile("jhelm-index-", ".yaml");
+		// NIO createTempFile creates the file atomically with owner-only permissions on
+		// POSIX, unlike File.createTempFile which uses the umask default in the shared
+		// temp directory.
+		File indexTmp = Files.createTempFile("jhelm-index-", ".yaml").toFile();
 		try {
 			HttpGet httpGet = new HttpGet(indexUrl);
 			httpGet.setHeader("User-Agent", "jhelm");

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -48,7 +48,11 @@ public final class ConversionFunctions {
 	private ConversionFunctions() {
 	}
 
-	private static final ThreadLocal<YAMLMapper> YAML_MAPPER = ThreadLocal.withInitial(() -> YAMLMapper.builder()
+	// Jackson mappers are immutable and thread-safe once built, so a single shared
+	// instance
+	// is safe for concurrent renders and avoids a per-thread mapper (plus the ThreadLocal
+	// leak in pooled / virtual threads). Every use below is a stateless read/write call.
+	private static final YAMLMapper YAML_MAPPER = YAMLMapper.builder()
 		.disable(YAMLWriteFeature.WRITE_DOC_START_MARKER)
 		// Go's yaml.Marshal never wraps long lines; Jackson defaults to 80-char width
 		// which inserts \ line continuations that break tpl(toYaml ...) patterns (#203)
@@ -63,20 +67,20 @@ public final class ConversionFunctions {
 		.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
 		// Render whole-number floats as ints (1.0 -> 1) like Helm's JSON-based marshal.
 		.addModule(goNumberModule())
-		.build());
+		.build();
 
 	/**
 	 * YAML mapper for {@code toYamlPretty}. Identical to {@link #YAML_MAPPER} but indents
 	 * block sequence items under their key ({@code   - x} instead of {@code - x}),
 	 * matching Helm's {@code toYamlPretty} (a yaml.v3 encoder with indent 2).
 	 */
-	private static final ThreadLocal<YAMLMapper> PRETTY_YAML_MAPPER = ThreadLocal.withInitial(() -> YAMLMapper.builder()
+	private static final YAMLMapper PRETTY_YAML_MAPPER = YAMLMapper.builder()
 		.disable(YAMLWriteFeature.WRITE_DOC_START_MARKER)
 		.disable(YAMLWriteFeature.SPLIT_LINES)
 		.enable(YAMLWriteFeature.MINIMIZE_QUOTES)
 		.enable(YAMLWriteFeature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)
 		.enable(YAMLWriteFeature.INDENT_ARRAYS_WITH_INDICATOR)
-		.build());
+		.build();
 
 	/**
 	 * YAML 1.1 octal pattern: bare-zero prefix followed by octal digits (e.g. 0660,
@@ -129,8 +133,12 @@ public final class ConversionFunctions {
 	 * over-quoted by Jackson and need plain-style normalisation to match Go's
 	 * {@code yaml.Marshal} (#312).
 	 */
+	// The quoted-content group uses the unrolled form [^"\]*(?:\.[^"\]*)* rather than
+	// (?:[^"\]|\.)* : both match the same language (chars and backslash-escapes) but the
+	// unrolled loop cannot backtrack/recurse on a long scalar, so it can't
+	// stack-overflow.
 	private static final Pattern QUOTED_VALUE = Pattern
-		.compile("^(\\s*(?:\\S+:|-)\\s+)\"((?:[^\"\\\\]|\\\\.)*)\"\\s*$");
+		.compile("^(\\s*(?:\\S+:|-)\\s+)\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"\\s*$");
 
 	/** YAML boolean and null literals that must remain quoted. */
 	private static final Set<String> YAML_KEYWORDS = Set.of("true", "false", "yes", "no", "on", "off", "null", "~");
@@ -139,19 +147,18 @@ public final class ConversionFunctions {
 	private static final Pattern NUMERIC = Pattern
 		.compile("^[+-]?(\\d[\\d_]*(\\.[\\d_]*)?([eE][+-]?\\d+)?|\\.inf|\\.nan|0x[\\da-fA-F]+|0o[0-7]+)$");
 
-	private static final ThreadLocal<JsonMapper> JSON_MAPPER = ThreadLocal.withInitial(() -> JsonMapper.builder()
+	private static final JsonMapper JSON_MAPPER = JsonMapper.builder()
 		.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
 		.addModule(goNumberModule())
-		.build());
+		.build();
 
-	private static final ThreadLocal<JsonMapper> RAW_JSON_MAPPER = ThreadLocal.withInitial(() -> JsonMapper.builder()
+	private static final JsonMapper RAW_JSON_MAPPER = JsonMapper.builder()
 		.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
 		.disable(JsonWriteFeature.ESCAPE_NON_ASCII)
 		.addModule(goNumberModule())
-		.build());
+		.build();
 
-	private static final ThreadLocal<TomlMapper> TOML_MAPPER = ThreadLocal
-		.withInitial(() -> TomlMapper.builder().build());
+	private static final TomlMapper TOML_MAPPER = TomlMapper.builder().build();
 
 	/**
 	 * Go's json.Marshal normalizes whole-number float64 values to integer representation
@@ -224,7 +231,7 @@ public final class ConversionFunctions {
 				return "null";
 			}
 			try {
-				String yaml = YAML_MAPPER.get().writeValueAsString(args[0]);
+				String yaml = YAML_MAPPER.writeValueAsString(args[0]);
 				// Remove document start marker if present
 				if (yaml.startsWith("---\n")) {
 					yaml = yaml.substring(4);
@@ -257,7 +264,7 @@ public final class ConversionFunctions {
 				return "null";
 			}
 			try {
-				String yaml = PRETTY_YAML_MAPPER.get().writeValueAsString(args[0]);
+				String yaml = PRETTY_YAML_MAPPER.writeValueAsString(args[0]);
 				if (yaml.startsWith("---\n")) {
 					yaml = yaml.substring(4);
 				}
@@ -291,7 +298,7 @@ public final class ConversionFunctions {
 				return "null";
 			}
 			try {
-				String yaml = YAML_MAPPER.get().writeValueAsString(args[0]);
+				String yaml = YAML_MAPPER.writeValueAsString(args[0]);
 				// Remove document start marker if present
 				if (yaml.startsWith("---\n")) {
 					yaml = yaml.substring(4);
@@ -525,7 +532,7 @@ public final class ConversionFunctions {
 				return "null";
 			}
 			try {
-				return JSON_MAPPER.get().writeValueAsString(args[0]);
+				return JSON_MAPPER.writeValueAsString(args[0]);
 			}
 			catch (Exception ex) {
 				log.debug("toJson failed: {}", ex.getMessage());
@@ -544,7 +551,7 @@ public final class ConversionFunctions {
 				throw new FunctionExecutionException("mustToJson: no value provided");
 			}
 			try {
-				return JSON_MAPPER.get().writeValueAsString(args[0]);
+				return JSON_MAPPER.writeValueAsString(args[0]);
 			}
 			catch (Exception ex) {
 				throw new FunctionExecutionException("mustToJson: failed to convert to JSON: " + ex.getMessage(), ex);
@@ -562,7 +569,7 @@ public final class ConversionFunctions {
 				return "null";
 			}
 			try {
-				return JSON_MAPPER.get().writerWithDefaultPrettyPrinter().writeValueAsString(args[0]);
+				return JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(args[0]);
 			}
 			catch (Exception ex) {
 				log.debug("toPrettyJson failed: {}", ex.getMessage());
@@ -581,7 +588,7 @@ public final class ConversionFunctions {
 				throw new FunctionExecutionException("mustToPrettyJson: no value provided");
 			}
 			try {
-				return JSON_MAPPER.get().writerWithDefaultPrettyPrinter().writeValueAsString(args[0]);
+				return JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(args[0]);
 			}
 			catch (Exception ex) {
 				throw new FunctionExecutionException("mustToPrettyJson: failed to convert to JSON: " + ex.getMessage(),
@@ -600,7 +607,7 @@ public final class ConversionFunctions {
 				return "null";
 			}
 			try {
-				return RAW_JSON_MAPPER.get().writeValueAsString(args[0]);
+				return RAW_JSON_MAPPER.writeValueAsString(args[0]);
 			}
 			catch (Exception ex) {
 				log.debug("toRawJson failed: {}", ex.getMessage());
@@ -619,7 +626,7 @@ public final class ConversionFunctions {
 				throw new FunctionExecutionException("mustToRawJson: no value provided");
 			}
 			try {
-				return RAW_JSON_MAPPER.get().writeValueAsString(args[0]);
+				return RAW_JSON_MAPPER.writeValueAsString(args[0]);
 			}
 			catch (Exception ex) {
 				throw new FunctionExecutionException("mustToRawJson: failed to convert to JSON: " + ex.getMessage(),
@@ -641,7 +648,7 @@ public final class ConversionFunctions {
 				if (json.isBlank() || "null".equals(json)) {
 					return Map.of();
 				}
-				Object result = JSON_MAPPER.get().readValue(json, Object.class);
+				Object result = JSON_MAPPER.readValue(json, Object.class);
 				if (result instanceof Map<?, ?> map) {
 					return map;
 				}
@@ -676,7 +683,7 @@ public final class ConversionFunctions {
 				// via an Error entry; only mustFromJson is shape-agnostic.) "null"
 				// decodes
 				// to null, matching Helm.
-				return JSON_MAPPER.get().readValue(json, Object.class);
+				return JSON_MAPPER.readValue(json, Object.class);
 			}
 			catch (FunctionExecutionException ex) {
 				throw ex;
@@ -700,7 +707,7 @@ public final class ConversionFunctions {
 				if (json.isBlank() || "null".equals(json)) {
 					return Collections.emptyList();
 				}
-				Object result = JSON_MAPPER.get().readValue(json, Object.class);
+				Object result = JSON_MAPPER.readValue(json, Object.class);
 				if (result instanceof List<?> list) {
 					return list;
 				}
@@ -731,7 +738,7 @@ public final class ConversionFunctions {
 				if ("null".equals(json)) {
 					throw new FunctionExecutionException("mustFromJsonArray: cannot parse null");
 				}
-				return JSON_MAPPER.get().readValue(json, List.class);
+				return JSON_MAPPER.readValue(json, List.class);
 			}
 			catch (Exception ex) {
 				throw new FunctionExecutionException(
@@ -783,7 +790,7 @@ public final class ConversionFunctions {
 				if (toml.isBlank()) {
 					return Map.of();
 				}
-				return TOML_MAPPER.get().readValue(toml, Map.class);
+				return TOML_MAPPER.readValue(toml, Map.class);
 			}
 			catch (Exception ex) {
 				log.debug("fromToml failed: {}", ex.getMessage());
@@ -802,7 +809,7 @@ public final class ConversionFunctions {
 				if (toml.isBlank()) {
 					throw new FunctionExecutionException("mustFromToml: empty TOML string");
 				}
-				return TOML_MAPPER.get().readValue(toml, Map.class);
+				return TOML_MAPPER.readValue(toml, Map.class);
 			}
 			catch (Exception ex) {
 				throw new FunctionExecutionException("mustFromToml: failed to parse TOML: " + ex.getMessage(), ex);

--- a/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/service/PluginLoader.java
+++ b/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/service/PluginLoader.java
@@ -6,6 +6,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Objects;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.plugin.exception.PluginLoadException;
@@ -95,6 +97,28 @@ public class PluginLoader {
 	 * @param wasmBytes the raw bytes of the plugin's WASM binary
 	 */
 	public record LoadResult(PluginManifest manifest, byte[] wasmBytes) {
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (!(o instanceof LoadResult other)) {
+				return false;
+			}
+			return Objects.equals(this.manifest, other.manifest) && Arrays.equals(this.wasmBytes, other.wasmBytes);
+		}
+
+		@Override
+		public int hashCode() {
+			return 31 * Objects.hashCode(this.manifest) + Arrays.hashCode(this.wasmBytes);
+		}
+
+		@Override
+		public String toString() {
+			return "LoadResult[manifest=" + this.manifest + ", wasmBytes="
+					+ ((this.wasmBytes != null) ? this.wasmBytes.length + " bytes" : "null") + "]";
+		}
 	}
 
 }


### PR DESCRIPTION
## What

Resolves the findings from an internal SonarQube scan — 10 bugs + the actionable security findings. Each was verified before changing.

### `ConversionFunctions` (5 bugs + 1 regex)
- **ThreadLocal → shared `static final` mappers.** Verified: Jackson 3 (`tools.jackson`) mappers are immutable/thread-safe once built, and every use here is a stateless `writeValueAsString`/`readValue`. So a shared instance is correct **and faster** — no per-thread mapper build, one instance instead of one per virtual/pool thread, and no `ThreadLocal` leak. No behaviour change (`ConversionFunctionsTest` + the 133 helm-function tests stay green).
- **`QUOTED_VALUE` regex** unrolled from `(?:[^"\]|\.)*` to `[^"\]*(?:\.[^"\]*)*` — same language, linear, can't stack-overflow on a long scalar.

### `SearchHubCommand` — real latent bug (2 findings)
Both branches of `if (listRepoUrl)` were **identical**, so `--list-repo-url` did nothing. Fixed: default prints the Artifact Hub package URL, `--list-repo-url` prints the repository URL (matching `helm search hub`). **Added regression tests** asserting the two outputs differ.

### Other bugs
- **`PackageAction`**: dropped the hand-rolled `UncheckedIOException` (its `getCause()` override tripped *both* Sonar's synchronized-mismatch rule and PMD's method-level-lock rule) for `java.io.UncheckedIOException`, whose `getCause()` already returns `IOException`.
- **`PluginLoader.LoadResult`**: content-based `equals`/`hashCode`/`toString` for the `byte[]` record component.

### Security findings
- **`RepoManager`**: index temp file now created via NIO `Files.createTempFile` (owner-only perms) instead of `File.createTempFile`.
- **`RepoHttpClientFactory`**: documented + `@SuppressWarnings("java:S4830")` on `InsecureTrustManager` — it's the opt-in `--insecure-skip-tls-verify` path (mirrors helm), not a default. (`ChartResolver` already uses the secure NIO `createTempDirectory`, so it's left as-is.)

All affected module tests pass; checkstyle 0, PMD clean. A follow-up Sonar re-scan will confirm the drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
