### PR TITLE
fix(sonar): clear the new-code quality gate (regex, temp-dir, record equals)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ChartResolver.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ChartResolver.java
@@ -56,6 +56,10 @@ public class ChartResolver {
 	 * @throws IllegalArgumentException if the path is missing, or {@code verify} is set
 	 * for a directory
 	 */
+	// S5443: the work directory is created via NIO createTempDirectory with owner-only
+	// permissions and holds only the extracted chart (no secrets), so the shared temp
+	// directory is used safely here.
+	@SuppressWarnings("java:S5443")
 	public Chart resolve(String chartPath, boolean verify, String keyring) throws IOException {
 		File source = new File(chartPath);
 		if (!source.exists()) {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/SearchHubCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/SearchHubCommandTest.java
@@ -51,7 +51,7 @@ class SearchHubCommandTest {
 	}
 
 	@Test
-	void testSearchHubDefaultShowsArtifactHubUrl() throws Exception {
+	void testSearchHubDefaultShowsArtifactHubUrl() {
 		when(searchHubAction.search(anyString(), anyInt())).thenReturn(List.of(sampleResult()));
 
 		String out = captureStdout(() -> new CommandLine(searchHubCommand).execute("nginx"));
@@ -61,7 +61,7 @@ class SearchHubCommandTest {
 	}
 
 	@Test
-	void testSearchHubListRepoUrlShowsRepositoryUrl() throws Exception {
+	void testSearchHubListRepoUrlShowsRepositoryUrl() {
 		when(searchHubAction.search(anyString(), anyInt())).thenReturn(List.of(sampleResult()));
 
 		String out = captureStdout(() -> new CommandLine(searchHubCommand).execute("nginx", "--list-repo-url"));

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -740,6 +740,12 @@ public class RepoManager {
 	 * to {@code repoUrl} (may be {@code null} for an anonymous pull)
 	 * @throws IOException if the index or chart cannot be downloaded
 	 */
+	// S5443: the temp file is created via NIO with owner-only permissions and holds only
+	// a
+	// downloaded public repository index.yaml (no secrets), so the shared temp directory
+	// is
+	// used safely here.
+	@SuppressWarnings("java:S5443")
 	public void pullFromRepoUrl(String repoUrl, String chartName, String version, String destDir,
 			RepositoryConfig.Repository auth) throws IOException {
 		if (version == null || version.isBlank()) {

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/ConversionFunctions.java
@@ -133,12 +133,12 @@ public final class ConversionFunctions {
 	 * over-quoted by Jackson and need plain-style normalisation to match Go's
 	 * {@code yaml.Marshal} (#312).
 	 */
-	// The quoted-content group uses the unrolled form [^"\]*(?:\.[^"\]*)* rather than
-	// (?:[^"\]|\.)* : both match the same language (chars and backslash-escapes) but the
-	// unrolled loop cannot backtrack/recurse on a long scalar, so it can't
-	// stack-overflow.
+	// The quoted-content group uses possessive quantifiers ([^"\]*+ and (?:...)*+)
+	// instead
+	// of (?:[^"\]|\.)* : it matches the same language (chars and backslash-escapes) but
+	// never backtracks, so it cannot exhaust the regex engine's stack on a long scalar.
 	private static final Pattern QUOTED_VALUE = Pattern
-		.compile("^(\\s*(?:\\S+:|-)\\s+)\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"\\s*$");
+		.compile("^(\\s*(?:\\S+:|-)\\s+)\"([^\"\\\\]*+(?:\\\\.[^\"\\\\]*+)*+)\"\\s*$");
 
 	/** YAML boolean and null literals that must remain quoted. */
 	private static final Set<String> YAML_KEYWORDS = Set.of("true", "false", "yes", "no", "on", "off", "null", "~");

--- a/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/service/PluginLoader.java
+++ b/jhelm-plugin/src/main/java/org/alexmond/jhelm/plugin/service/PluginLoader.java
@@ -98,7 +98,11 @@ public class PluginLoader {
 	 */
 	public record LoadResult(PluginManifest manifest, byte[] wasmBytes) {
 
+		// S6878 (prefer a record deconstruction pattern) is suppressed: the Checkstyle
+		// grammar in this build cannot parse record patterns, so the type-pattern form is
+		// used instead.
 		@Override
+		@SuppressWarnings("java:S6878")
 		public boolean equals(Object o) {
 			if (this == o) {
 				return true;

--- a/jhelm-plugin/src/test/java/org/alexmond/jhelm/plugin/service/PluginLoaderTest.java
+++ b/jhelm-plugin/src/test/java/org/alexmond/jhelm/plugin/service/PluginLoaderTest.java
@@ -15,8 +15,10 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PluginLoaderTest {
 
@@ -79,6 +81,20 @@ class PluginLoaderTest {
 	void loadNonexistentArchiveThrowsLoadException() {
 		File nonexistent = new File(tempDir, "nonexistent.jhp");
 		assertThrows(PluginLoadException.class, () -> loader.load(nonexistent));
+	}
+
+	@Test
+	void loadResultEqualsHashCodeAndToStringUseContent() {
+		PluginLoader.LoadResult a = new PluginLoader.LoadResult(null, new byte[] { 1, 2, 3 });
+		PluginLoader.LoadResult b = new PluginLoader.LoadResult(null, new byte[] { 1, 2, 3 });
+		PluginLoader.LoadResult different = new PluginLoader.LoadResult(null, new byte[] { 9 });
+
+		// Array components must compare by content, not identity.
+		assertEquals(a, b);
+		assertEquals(a.hashCode(), b.hashCode());
+		assertNotEquals(a, different);
+		// toString reports the byte count, not a raw array dump.
+		assertTrue(a.toString().contains("3 bytes"), a.toString());
 	}
 
 	private File createArchive(String name, String manifest, String wasmName, byte[] wasmBytes) throws Exception {


### PR DESCRIPTION
Follow-up to #638. Greens SonarQube's clean-as-you-code gate on the diff (`new_violations` 5→0, and covers the new `LoadResult` methods for `new_coverage`).

- **`ConversionFunctions`** — `QUOTED_VALUE` quantifiers made **possessive** (`[^"\]*+` / `(?:...)*+`) so the matcher never backtracks and can't overflow the regex stack (**S5998**). Same matched language; the 79 `ConversionFunctionsTest` cases stay green.
- **`RepoManager` / `ChartResolver`** — `@SuppressWarnings("java:S5443")` with justification on the two temp-dir sites: both create via **NIO with owner-only perms** and hold only non-sensitive data (a public `index.yaml` / an extracted chart).
- **`PluginLoader.LoadResult.equals`** — kept the `instanceof` type-pattern (the Checkstyle grammar here **can't parse record deconstruction patterns**) and suppressed **S6878** with that reason; added a `LoadResult` test covering `equals`/`hashCode`/`toString`.
- **`SearchHubCommandTest`** — dropped the unneeded `throws Exception` on the two new tests (**S1130**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)