### PR TITLE
fix(exceptions): un-deprecate 422 status + finish the S112 tail

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.app.command;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -170,7 +171,7 @@ public class InstallCommand implements Runnable {
 		}
 	}
 
-	private Release applyCliPostRenderers(Release release) throws Exception {
+	private Release applyCliPostRenderers(Release release) throws IOException, InterruptedException {
 		if (postRenderers.isEmpty()) {
 			return release;
 		}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.app.command;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -261,7 +262,7 @@ public class UpgradeCommand implements Runnable {
 			.build();
 	}
 
-	private Release applyCliPostRenderers(Release release) throws Exception {
+	private Release applyCliPostRenderers(Release release) throws IOException, InterruptedException {
 		if (postRenderers.isEmpty()) {
 			return release;
 		}

--- a/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctions.java
+++ b/jhelm-gotemplate-helm/src/main/java/org/alexmond/jhelm/gotemplate/helm/functions/TemplateFunctions.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.gotemplate.helm.functions;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
@@ -123,7 +124,7 @@ public final class TemplateFunctions {
 	 * @param data the rendering context
 	 * @return the rendered output
 	 */
-	private static String renderInline(GoTemplate factory, String text, Object data) throws Exception {
+	private static String renderInline(GoTemplate factory, String text, Object data) throws IOException {
 		StringWriter writer = new StringWriter();
 		// Fast path: a tpl string that declares no `define` contributes only its own
 		// body, so

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
@@ -682,7 +682,7 @@ public class HelmKubeService implements KubeService {
 		}
 	}
 
-	private byte[] encodeRelease(Release release) throws Exception {
+	private byte[] encodeRelease(Release release) throws IOException {
 		byte[] json = releaseCodec.toJson(release);
 		byte[] gzipped = gzip(json);
 		String b64 = Base64.getEncoder().encodeToString(gzipped);

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandler.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandler.java
@@ -105,7 +105,7 @@ public class JhelmRestExceptionHandler {
 	@ExceptionHandler({ SchemaValidationException.class, TemplateRenderException.class })
 	public ProblemDetail handleUnprocessable(JhelmException ex) {
 		log.debug("Unprocessable entity: {}", ex.getMessage());
-		return problem(HttpStatus.UNPROCESSABLE_ENTITY, ex.getMessage());
+		return problem(HttpStatus.UNPROCESSABLE_CONTENT, ex.getMessage());
 	}
 
 	/**

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandlerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandlerTest.java
@@ -118,8 +118,8 @@ class JhelmRestExceptionHandlerTest {
 		ProblemDetail template = this.handler
 			.handleUnprocessable(new TemplateRenderException("render failed", "mychart", "deployment.yaml"));
 
-		assertEquals(HttpStatus.UNPROCESSABLE_ENTITY.value(), schema.getStatus());
-		assertEquals(HttpStatus.UNPROCESSABLE_ENTITY.value(), template.getStatus());
+		assertEquals(HttpStatus.UNPROCESSABLE_CONTENT.value(), schema.getStatus());
+		assertEquals(HttpStatus.UNPROCESSABLE_CONTENT.value(), template.getStatus());
 	}
 
 	@Test


### PR DESCRIPTION
Follow-up to #640: greens SonarQube's new-code gate and clears the last generic-exception findings.

- **S1874** — `JhelmRestExceptionHandler` (+ test) use `HttpStatus.UNPROCESSABLE_CONTENT` instead of the deprecated `UNPROCESSABLE_ENTITY` (these 3 new-code uses flipped the gate to ERROR). Same 422.
- **S112 tail** — narrowed four more pre-existing `throws Exception` helpers to their real checked types: `InstallCommand`/`UpgradeCommand.applyCliPostRenderers` → `IOException, InterruptedException`; `HelmKubeService.encodeRelease` → `IOException`; `TemplateFunctions.renderInline` → `IOException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)