### PR TITLE
fix(cli): restore interrupt flag when a post-renderer is interrupted

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.app.command;
 
+import org.alexmond.jhelm.core.exception.JhelmException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -171,13 +172,19 @@ public class InstallCommand implements Runnable {
 		}
 	}
 
-	private Release applyCliPostRenderers(Release release) throws IOException, InterruptedException {
+	private Release applyCliPostRenderers(Release release) throws IOException {
 		if (postRenderers.isEmpty()) {
 			return release;
 		}
 		String manifest = release.getManifest();
 		for (String renderer : postRenderers) {
-			manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
+			try {
+				manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				throw new JhelmException("Interrupted while running post-renderer: " + renderer, ex);
+			}
 		}
 		return release.toBuilder().manifest(manifest).build();
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.app.command;
 
+import org.alexmond.jhelm.core.exception.JhelmException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -262,13 +263,19 @@ public class UpgradeCommand implements Runnable {
 			.build();
 	}
 
-	private Release applyCliPostRenderers(Release release) throws IOException, InterruptedException {
+	private Release applyCliPostRenderers(Release release) throws IOException {
 		if (postRenderers.isEmpty()) {
 			return release;
 		}
 		String manifest = release.getManifest();
 		for (String renderer : postRenderers) {
-			manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
+			try {
+				manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				throw new JhelmException("Interrupted while running post-renderer: " + renderer, ex);
+			}
 		}
 		return release.toBuilder().manifest(manifest).build();
 	}


### PR DESCRIPTION
Narrowing `applyCliPostRenderers` to declare `InterruptedException` (#641) surfaced **S2142**: the install/upgrade commands' broad `catch (Exception)` swallowed it without restoring the thread's interrupt status.

Fix at the source — re-interrupt the thread (`Thread.currentThread().interrupt()`) and rethrow as `JhelmException` inside the helper — so it throws only `IOException` and the interrupt is never lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)