### PR TITLE
fix(post-render): handle InterruptedException at its source

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -1,6 +1,5 @@
 package org.alexmond.jhelm.app.command;
 
-import org.alexmond.jhelm.core.exception.JhelmException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -178,13 +177,7 @@ public class InstallCommand implements Runnable {
 		}
 		String manifest = release.getManifest();
 		for (String renderer : postRenderers) {
-			try {
-				manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
-			}
-			catch (InterruptedException ex) {
-				Thread.currentThread().interrupt();
-				throw new JhelmException("Interrupted while running post-renderer: " + renderer, ex);
-			}
+			manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
 		}
 		return release.toBuilder().manifest(manifest).build();
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -1,6 +1,5 @@
 package org.alexmond.jhelm.app.command;
 
-import org.alexmond.jhelm.core.exception.JhelmException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -269,13 +268,7 @@ public class UpgradeCommand implements Runnable {
 		}
 		String manifest = release.getManifest();
 		for (String renderer : postRenderers) {
-			try {
-				manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
-			}
-			catch (InterruptedException ex) {
-				Thread.currentThread().interrupt();
-				throw new JhelmException("Interrupted while running post-renderer: " + renderer, ex);
-			}
+			manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
 		}
 		return release.toBuilder().manifest(manifest).build();
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ExternalCommandPostRenderer.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ExternalCommandPostRenderer.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.core.service;
 
+import org.alexmond.jhelm.core.exception.JhelmException;
 import java.io.UncheckedIOException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -48,7 +49,7 @@ public class ExternalCommandPostRenderer implements PostRenderProcessor {
 	}
 
 	@Override
-	public String process(String renderedManifest) throws IOException, InterruptedException {
+	public String process(String renderedManifest) throws IOException {
 		ProcessBuilder pb = new ProcessBuilder(command);
 		pb.redirectErrorStream(false);
 
@@ -106,6 +107,10 @@ public class ExternalCommandPostRenderer implements PostRenderProcessor {
 				log.debug("Post-renderer completed successfully");
 			}
 			return stdout;
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			throw new JhelmException("Interrupted while running post-renderer: " + String.join(" ", command), ex);
 		}
 		finally {
 			process.destroyForcibly();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/PostRenderProcessor.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/PostRenderProcessor.java
@@ -14,8 +14,7 @@ public interface PostRenderProcessor {
 	 * @param renderedManifest the rendered YAML manifest
 	 * @return the transformed manifest
 	 * @throws IOException if reading from or writing to the post-render process fails
-	 * @throws InterruptedException if the post-render process is interrupted
 	 */
-	String process(String renderedManifest) throws IOException, InterruptedException;
+	String process(String renderedManifest) throws IOException;
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ExternalCommandPostRendererTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ExternalCommandPostRendererTest.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.core.service;
 
+import org.alexmond.jhelm.core.exception.JhelmException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -84,6 +85,20 @@ class ExternalCommandPostRendererTest {
 		String input = "apiVersion: apps/v1\nkind: Deployment\nspec:\n  replicas: 1\n";
 		String result = renderer.process(input);
 		assertTrue(result.contains("replicas: 3"));
+	}
+
+	@Test
+	void processReInterruptsWhenThreadInterrupted() {
+		// A long-running command keeps the process alive so waitFor() is still blocking
+		// when
+		// it observes the pre-set interrupt and throws InterruptedException.
+		ExternalCommandPostRenderer renderer = new ExternalCommandPostRenderer(List.of("sleep", "10"));
+		Thread.currentThread().interrupt();
+		JhelmException ex = assertThrows(JhelmException.class, () -> renderer.process("data: x\n"));
+		// The interrupt flag must be restored (cleared here so it does not leak to other
+		// tests).
+		assertTrue(Thread.interrupted(), "interrupt flag should be restored");
+		assertTrue(ex.getMessage().contains("Interrupted"), ex.getMessage());
 	}
 
 }


### PR DESCRIPTION
Making `InterruptedException` explicit on `process()` (#641) surfaced **four latent S2142 bugs** (reliability dropped to C): `InstallAction`, `TemplateAction`, `UpgradeAction`, `TemplateCommand` all catch it in a broad `catch` without restoring the interrupt flag.

Fixed once, at the source: `ExternalCommandPostRenderer.process()` now catches its own `InterruptedException` from `waitFor()`, **re-interrupts the thread**, and rethrows as `JhelmException` — so it (and the `PostRenderProcessor` SPI) throw only `IOException`. Every caller stops seeing `InterruptedException`:

- clears all 4 S2142 bugs (reliability back to A),
- removes the duplicated re-interrupt blocks added to the two CLI helpers in #642 (fixes the new-code **duplication** + **coverage** the gate flagged),
- adds a test pinning the re-interrupt behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)