### PR TITLE
fix(render): exclude test hooks from template/dry-run output (#634)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -113,7 +113,13 @@ public class InstallAction {
 		Capabilities capabilities = (fromCluster != null) ? fromCluster : Capabilities.DEFAULT;
 		String manifest = runPostRenderProcessors(engine.render(chart, values, releaseContext, capabilities));
 
-		release = release.toBuilder().manifest(manifest).build();
+		// A dry-run release is ephemeral and its manifest is only displayed, so strip
+		// test
+		// hooks to match `helm install --dry-run` output. A real install keeps them in
+		// the
+		// stored manifest so `helm test` can run them later (#634).
+		String storedManifest = options.isDryRun() ? HookParser.stripTestHooks(manifest) : manifest;
+		release = release.toBuilder().manifest(storedManifest).build();
 
 		if (kubeService != null && !options.isDryRun()) {
 			applyRelease(options, chart, release, manifest);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
@@ -14,6 +14,7 @@ import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.PostRenderProcessor;
+import org.alexmond.jhelm.core.util.HookParser;
 import org.alexmond.jhelm.core.util.ValuesLoader;
 
 @RequiredArgsConstructor
@@ -63,6 +64,10 @@ public class TemplateAction {
 			.build();
 
 		String manifest = engine.render(chart, values, releaseContext, new Capabilities(kubeVersion, apiVersions));
+		// helm template omits test hooks (they run only under `helm test`); lifecycle
+		// hooks
+		// are kept. See #634.
+		manifest = HookParser.stripTestHooks(manifest);
 
 		for (PostRenderProcessor processor : postRenderProcessors) {
 			try {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -111,7 +111,11 @@ public class UpgradeAction {
 			}
 		}
 
-		newRelease = newRelease.toBuilder().manifest(manifest).build();
+		// A dry-run release is ephemeral and only displayed, so strip test hooks to match
+		// `helm upgrade --dry-run` output; a real upgrade keeps them for `helm test`
+		// (#634).
+		String storedManifest = options.isDryRun() ? HookParser.stripTestHooks(manifest) : manifest;
+		newRelease = newRelease.toBuilder().manifest(storedManifest).build();
 
 		if (kubeService != null && !options.isDryRun()) {
 			applyRelease(options, currentRelease, newRelease, manifest);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/HookParser.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/HookParser.java
@@ -121,6 +121,84 @@ public final class HookParser {
 	}
 
 	/**
+	 * Removes test-hook resources ({@code helm.sh/hook: test}, {@code test-success}, or
+	 * {@code test-failure}) from a rendered manifest, matching {@code helm template} /
+	 * {@code helm install --dry-run}, which omit test hooks (they run only under
+	 * {@code helm test}). Lifecycle hooks ({@code pre-install}, {@code post-install}, …)
+	 * are retained. The kept documents are re-joined with the same {@code \n---\n}
+	 * separator the engine emits, so a manifest with no test hooks is returned
+	 * byte-for-byte unchanged.
+	 * @param manifest the full rendered YAML manifest (may be null or blank)
+	 * @return the manifest with test-hook documents removed
+	 */
+	public static String stripTestHooks(String manifest) {
+		if (manifest == null) {
+			return "";
+		}
+		if (manifest.isBlank()) {
+			return manifest;
+		}
+
+		String[] docs = manifest.strip().split("\n---\n");
+		StringBuilder result = new StringBuilder();
+
+		for (String doc : docs) {
+			String trimmed = doc.strip();
+			if (trimmed.isEmpty() || isTestHook(trimmed)) {
+				continue;
+			}
+			if (result.length() > 0) {
+				result.append("\n---\n");
+			}
+			result.append(trimmed);
+		}
+
+		if (result.length() > 0) {
+			result.append('\n');
+		}
+		return result.toString();
+	}
+
+	/**
+	 * @return {@code true} if the document carries a {@code helm.sh/hook} annotation
+	 * whose value includes {@code test}, {@code test-success}, or {@code test-failure}
+	 */
+	@SuppressWarnings("unchecked")
+	private static boolean isTestHook(String doc) {
+		if (!doc.contains("helm.sh/hook")) {
+			return false;
+		}
+		try {
+			Map<String, Object> parsed = YAML_MAPPER.readValue(doc, Map.class);
+			if (parsed == null) {
+				return false;
+			}
+			Map<String, Object> metadata = (Map<String, Object>) parsed.get("metadata");
+			if (metadata == null) {
+				return false;
+			}
+			Map<String, Object> annotations = (Map<String, Object>) metadata.get("annotations");
+			if (annotations == null) {
+				return false;
+			}
+			Object hook = annotations.get("helm.sh/hook");
+			if (hook == null) {
+				return false;
+			}
+			for (String phase : hook.toString().split(",")) {
+				String value = phase.trim();
+				if ("test".equals(value) || "test-success".equals(value) || "test-failure".equals(value)) {
+					return true;
+				}
+			}
+		}
+		catch (Exception ignored) {
+			// A document that cannot be parsed is conservatively kept (never dropped).
+		}
+		return false;
+	}
+
+	/**
 	 * Strips resources annotated with {@code helm.sh/resource-policy: keep} from the
 	 * manifest. These resources should be preserved during uninstall.
 	 * @param manifest the YAML manifest (may be null or blank)

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/HookParserTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/HookParserTest.java
@@ -243,4 +243,44 @@ class HookParserTest {
 		assertEquals("", HookParser.stripKeptResources(null));
 	}
 
+	@Test
+	void testStripTestHooksRemovesTestButKeepsLifecycleAndRegular() {
+		String regular = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config";
+		String preInstall = "apiVersion: v1\nkind: Secret\nmetadata:\n  name: my-secret\n"
+				+ "  annotations:\n    helm.sh/hook: pre-install";
+		String test = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-test\n"
+				+ "  annotations:\n    helm.sh/hook: test";
+		String manifest = regular + "\n---\n" + preInstall + "\n---\n" + test + "\n";
+
+		String result = HookParser.stripTestHooks(manifest);
+
+		assertTrue(result.contains("my-config"), result);
+		assertTrue(result.contains("pre-install"), "lifecycle hooks must be retained: " + result);
+		assertFalse(result.contains("my-test"), "test hooks must be removed: " + result);
+	}
+
+	@Test
+	void testStripTestHooksAlsoRemovesTestSuccessAndFailure() {
+		String success = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: p1\n"
+				+ "  annotations:\n    helm.sh/hook: test-success";
+		String failure = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: p2\n"
+				+ "  annotations:\n    helm.sh/hook: test-failure";
+		String result = HookParser.stripTestHooks(success + "\n---\n" + failure + "\n");
+		assertEquals("", result);
+	}
+
+	@Test
+	void testStripTestHooksIsByteIdenticalWhenNoTestHooks() {
+		String regular = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: a";
+		String preInstall = "apiVersion: v1\nkind: Job\nmetadata:\n  name: b\n"
+				+ "  annotations:\n    helm.sh/hook: pre-install";
+		String manifest = regular + "\n---\n" + preInstall + "\n";
+		assertEquals(manifest, HookParser.stripTestHooks(manifest));
+	}
+
+	@Test
+	void testStripTestHooksReturnsEmptyForNull() {
+		assertEquals("", HookParser.stripTestHooks(null));
+	}
+
 }

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -109,20 +109,6 @@ jhelmtest:
       - resource: "Job/release-grafana-oncall-engine-migrate-*"
         path: "*"
         reason: "migrate Job name has a per-render now-timestamp suffix"
-      # The grafana subchart's templates/tests/test-*.yaml are annotated
-      # `helm.sh/hook: test`. `helm template` excludes `test`-hook resources (they run
-      # only under `helm test`), but jhelm does not yet filter them from its output, so
-      # it over-emits these three. Lifecycle hooks (pre-install, ...) are emitted by both.
-      # Remove once test-hook filtering lands. Tracked in #634.
-      - resource: "ConfigMap/release-grafana-oncall-test"
-        path: "*"
-        reason: "helm.sh/hook: test resource omitted by `helm template`; jhelm does not yet filter test hooks (#634)"
-      - resource: "ServiceAccount/release-grafana-oncall-test"
-        path: "*"
-        reason: "helm.sh/hook: test resource omitted by `helm template`; jhelm does not yet filter test hooks (#634)"
-      - resource: "Pod/release-grafana-oncall-test"
-        path: "*"
-        reason: "helm.sh/hook: test resource omitted by `helm template`; jhelm does not yet filter test hooks (#634)"
     "[argo/argo]":
       # argo ships its CRDs in the chart's crds/ directory. `helm template` omits crds/
       # resources unless `--include-crds` is passed; the parity harness runs plain


### PR DESCRIPTION
Closes #634.

`helm template` and `helm install/upgrade --dry-run` omit resources annotated `helm.sh/hook: test` (and `test-success` / `test-failure`) — they run only under `helm test`. jhelm rendered them, over-emitting vs helm (surfaced by the parity suite on `grafana/oncall` once over-emission became a hard failure).

- **`HookParser.stripTestHooks`** — drops test-hook documents, keeps lifecycle hooks (`pre-install`, …) and regular resources, re-joined with the engine's exact `\n---\n` separator so a chart with **no** test hooks is byte-for-byte unchanged.
- **`TemplateAction`** applies it to render output (the parity path).
- **`Install`/`UpgradeAction`** strip test hooks from the stored manifest **only for dry-run** (ephemeral/display); a real install keeps them so `helm test` can run them.
- **Removed** the `grafana/oncall` test-hook comparison-ignore (the unrelated migrate-Job timestamp ignore stays).

The 540-chart parity suite is the real validator here — it must stay green (no over-emission on grafana/oncall, no regression on the other 539).

🤖 Generated with [Claude Code](https://claude.com/claude-code)