### PR TITLE
docs: 1.0.0 release prep — version:true, roadmap, changelog, parity notes (#637)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,10 +20,30 @@ The pre-1.0 *API freeze* release.
 * *Engine* -- now on `gotmpl4j 1.1.0`; recursive/too-deep renders fail with a
   `TemplateRenderException` instead of an inline `ERROR:` string.
 
-== Unreleased (targeting 1.0.0)
+== 1.0.0
 
-Toward the *1.0.0 release* (see the Roadmap in the docs): a broad byte-parity gate
-against `helm template` plus an extraction-ready template engine.
+The first stable release. 1.0 draws a supported public API surface, hardens security and
+provenance, verifies Helm interoperability against the real `helm` binary, and backs the
+byte-parity claim with a 540-chart gate against `helm template`. The full, categorized notes
+are in the docs changelog; the highlights:
+
+* *Security* — opt-in server-mode SSRF block of private/link-local/site-local targets
+  (`jhelm.security.block-private-networks`, default off); host-gated repository credentials,
+  a chart un-tar decompression-bomb cap, OCI URL validation, and owner-only permissions on the
+  written registry-credentials file.
+* *Provenance* — `verify` rejects revoked/expired signing keys and reverses OpenPGP
+  dash-escaping so a `helm`/GnuPG-produced `.prov` verifies correctly.
+* *Real cluster* — `.Capabilities.KubeVersion` / `.APIVersions` populated from the connected
+  cluster for install/upgrade; `template --kube-version` / `-a`/`--api-versions` pin them
+  offline.
+* *Helm interoperability* — release records are byte-schema-compatible with Helm 3's
+  `sh.helm.release.v1` Secret format (two-way `helm` ↔ `jhelm` verified in CI against a real
+  cluster); jhelm honors `HELM_*` env vars and Helm's `repositories.yaml` /
+  `registry/config.json`.
+* *Exception infrastructure* — the dedicated `JhelmException` hierarchy is applied
+  consistently (no generic `Exception`/`RuntimeException` throws); the REST layer maps each
+  subtype to a correct HTTP status.
+* *Dependency hygiene* — clean SonarQube quality gate (0 bugs, 0 vulnerabilities, A ratings).
 
 === Engine — Helm byte-parity
 

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,10 +1,9 @@
 name: jhelm
 title: jhelm Documentation
-version: master
+version: true
 start_page: ROOT:index.adoc
 asciidoc:
   attributes:
-    jhelm-version: 1.0.0
     api-core: 'https://javadoc.io/page/org.alexmond/jhelm-core'
     api-gotemplate-helm: 'https://javadoc.io/page/org.alexmond/jhelm-gotemplate-helm'
     api-kube: 'https://javadoc.io/page/org.alexmond/jhelm-kube'

--- a/docs/modules/ROOT/pages/api.adoc
+++ b/docs/modules/ROOT/pages/api.adoc
@@ -2,7 +2,7 @@
 
 jhelm's library artifacts publish versioned Javadoc to https://javadoc.io[javadoc.io], which
 serves it automatically from Maven Central — no build or hosting required. The links below track
-the {jhelm-version} release.
+the {page-component-version} release.
 
 * For how to add these as dependencies and worked usage examples, see
   xref:spring-boot-starter.adoc[Library & Spring Boot Starter].
@@ -16,22 +16,22 @@ the {jhelm-version} release.
 | Artifact | Javadoc
 
 | `jhelm-core` — chart model, rendering engine, action layer, repositories
-| {api-core}/{jhelm-version}/index.html[browse^]
+| {api-core}/{page-component-version}/index.html[browse^]
 
 | `jhelm-gotemplate-helm` — Helm template functions
-| {api-gotemplate-helm}/{jhelm-version}/index.html[browse^]
+| {api-gotemplate-helm}/{page-component-version}/index.html[browse^]
 
 | `jhelm-kube` — Kubernetes install / upgrade / rollback / uninstall
-| {api-kube}/{jhelm-version}/index.html[browse^]
+| {api-kube}/{page-component-version}/index.html[browse^]
 
 | `jhelm-rest` — REST API and controllers
-| {api-rest}/{jhelm-version}/index.html[browse^]
+| {api-rest}/{page-component-version}/index.html[browse^]
 
 | `jhelm-mcp` — MCP server tools
-| {api-mcp}/{jhelm-version}/index.html[browse^]
+| {api-mcp}/{page-component-version}/index.html[browse^]
 
 | `jhelm-plugin` — WASM plugin runtime
-| {api-plugin}/{jhelm-version}/index.html[browse^]
+| {api-plugin}/{page-component-version}/index.html[browse^]
 |===
 
 [NOTE]
@@ -46,22 +46,22 @@ are not published to Maven Central.
 
 *Core engine and model* (`jhelm-core`)
 
-* {api-core}/{jhelm-version}/org/alexmond/jhelm/core/service/Engine.html[Engine^] — renders a chart to Kubernetes manifests
-* {api-core}/{jhelm-version}/org/alexmond/jhelm/core/model/Chart.html[Chart^] — the in-memory chart model
-* {api-core}/{jhelm-version}/org/alexmond/jhelm/core/service/ChartLoader.html[ChartLoader^] — loads a chart from a directory or archive
-* {api-core}/{jhelm-version}/org/alexmond/jhelm/core/service/RepoManager.html[RepoManager^] — chart repositories and pulls
-* {api-core}/{jhelm-version}/org/alexmond/jhelm/core/service/KubeService.html[KubeService^] — the cluster-operations SPI
+* {api-core}/{page-component-version}/org/alexmond/jhelm/core/service/Engine.html[Engine^] — renders a chart to Kubernetes manifests
+* {api-core}/{page-component-version}/org/alexmond/jhelm/core/model/Chart.html[Chart^] — the in-memory chart model
+* {api-core}/{page-component-version}/org/alexmond/jhelm/core/service/ChartLoader.html[ChartLoader^] — loads a chart from a directory or archive
+* {api-core}/{page-component-version}/org/alexmond/jhelm/core/service/RepoManager.html[RepoManager^] — chart repositories and pulls
+* {api-core}/{page-component-version}/org/alexmond/jhelm/core/service/KubeService.html[KubeService^] — the cluster-operations SPI
 
 *Action layer* (`jhelm-core`, package `org.alexmond.jhelm.core.action`)
 
-* {api-core}/{jhelm-version}/org/alexmond/jhelm/core/action/InstallAction.html[InstallAction^], with the sibling `UpgradeAction`, `UninstallAction`, `RollbackAction`, `ListAction`, `StatusAction`, `HistoryAction`, `GetAction`, and `TemplateAction` in the same package.
+* {api-core}/{page-component-version}/org/alexmond/jhelm/core/action/InstallAction.html[InstallAction^], with the sibling `UpgradeAction`, `UninstallAction`, `RollbackAction`, `ListAction`, `StatusAction`, `HistoryAction`, `GetAction`, and `TemplateAction` in the same package.
 
 *Helm template functions* (`jhelm-gotemplate-helm`)
 
-* {api-gotemplate-helm}/{jhelm-version}/org/alexmond/jhelm/gotemplate/helm/HelmFunctions.html[HelmFunctions^] — the Helm function provider. The Go template engine itself is the external https://github.com/alexmond/gotmpl4j[gotmpl4j] library, which publishes its own Javadoc.
+* {api-gotemplate-helm}/{page-component-version}/org/alexmond/jhelm/gotemplate/helm/HelmFunctions.html[HelmFunctions^] — the Helm function provider. The Go template engine itself is the external https://github.com/alexmond/gotmpl4j[gotmpl4j] library, which publishes its own Javadoc.
 
 *Spring Boot auto-configuration entry points*
 
-* {api-kube}/{jhelm-version}/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.html[JhelmKubeAutoConfiguration^]
-* {api-rest}/{jhelm-version}/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.html[JhelmRestAutoConfiguration^]
-* {api-mcp}/{jhelm-version}/org/alexmond/jhelm/mcp/JhelmMcpAutoConfiguration.html[JhelmMcpAutoConfiguration^]
+* {api-kube}/{page-component-version}/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.html[JhelmKubeAutoConfiguration^]
+* {api-rest}/{page-component-version}/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.html[JhelmRestAutoConfiguration^]
+* {api-mcp}/{page-component-version}/org/alexmond/jhelm/mcp/JhelmMcpAutoConfiguration.html[JhelmMcpAutoConfiguration^]

--- a/docs/modules/ROOT/pages/cli-reference.adoc
+++ b/docs/modules/ROOT/pages/cli-reference.adoc
@@ -10,7 +10,7 @@ helm-flag → jhelm-flag mapping and a "porting a helm script" checklist.
 
 [source,bash]
 ----
-java -jar jhelm-cli/target/jhelm-{jhelm-version}.jar [command] [options]
+java -jar jhelm-cli/target/jhelm-{page-component-version}.jar [command] [options]
 ----
 
 == Chart Lifecycle Commands

--- a/docs/modules/ROOT/pages/function-coverage.adoc
+++ b/docs/modules/ROOT/pages/function-coverage.adoc
@@ -114,6 +114,14 @@ Open / under investigation:
   annotation string (which would trigger a spurious pod rollout), not the resource content,
   so the parity suite excludes such `checksum/*` annotations via documented comparison-ignore
   rules rather than treating them as rendering bugs (see issues #237, #491).
+* Subchart-gated test resources. A subchart whose test templates are guarded by a value it
+  defaults on (e.g. the `grafana` subchart's `templates/tests/*` behind
+  `{{- if .Values.testFramework.enabled }}`) can render under jhelm while `helm template`
+  omits them, because jhelm's subchart value coalescing resolves the parent-scoped default
+  differently. The one known instance is `grafana/oncall` (three `+*-test+` resources);
+  it is covered by a documented per-chart comparison-ignore rather than a rendering
+  correctness fix (tracked in #634). This is a *non-semantic* difference — the affected
+  resources are `helm test` fixtures, not part of the deployed workload.
 
 == References
 

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -21,7 +21,7 @@ After building, run the CLI via the application JAR:
 
 [source,bash]
 ----
-java -jar jhelm-cli/target/jhelm-{jhelm-version}.jar --help
+java -jar jhelm-cli/target/jhelm-{page-component-version}.jar --help
 ----
 
 === Examples
@@ -64,7 +64,7 @@ Add `jhelm-core` to your Maven project for offline operations (template renderin
 <dependency>
     <groupId>org.alexmond</groupId>
     <artifactId>jhelm-core</artifactId>
-    <version>{jhelm-version}</version>
+    <version>{page-component-version}</version>
 </dependency>
 ----
 
@@ -75,7 +75,7 @@ Add `jhelm-kube` when you also need Kubernetes operations (install, upgrade, rol
 <dependency>
     <groupId>org.alexmond</groupId>
     <artifactId>jhelm-kube</artifactId>
-    <version>{jhelm-version}</version>
+    <version>{page-component-version}</version>
 </dependency>
 ----
 
@@ -117,7 +117,7 @@ Add `jhelm-rest-starter` to a Spring Boot web application to expose Helm operati
 <dependency>
     <groupId>org.alexmond</groupId>
     <artifactId>jhelm-rest-starter</artifactId>
-    <version>{jhelm-version}</version>
+    <version>{page-component-version}</version>
 </dependency>
 ----
 
@@ -176,7 +176,7 @@ https://modelcontextprotocol.io[Model Context Protocol] tools for AI agents:
 <dependency>
     <groupId>org.alexmond</groupId>
     <artifactId>jhelm-mcp-starter</artifactId>
-    <version>{jhelm-version}</version>
+    <version>{page-component-version}</version>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -19,6 +19,12 @@ Java client. Parity is enforced in CI on every change, so behaviour tracks upstr
 closely rather than approximating it. Rendering is driven by the standalone
 https://github.com/alexmond/gotmpl4j[gotmpl4j] Go-template engine.
 
+Recognizable charts in the suite that render byte-for-byte include
+`ingress-nginx/ingress-nginx`, `jetstack/cert-manager`,
+`prometheus-community/kube-prometheus-stack`, `prometheus-community/prometheus`,
+`grafana/grafana`, `grafana/loki`, `argo/argo-cd`, `cilium/cilium`, `traefik/traefik`, and
+the Bitnami `redis`, `postgresql`, and `mysql` charts — alongside 500+ more.
+
 == MCP-native
 
 The same operations are exposed as https://modelcontextprotocol.io[Model Context Protocol]

--- a/docs/modules/ROOT/pages/mcp.adoc
+++ b/docs/modules/ROOT/pages/mcp.adoc
@@ -18,7 +18,7 @@ server. Add the starter to a Spring Boot application:
 <dependency>
     <groupId>org.alexmond</groupId>
     <artifactId>jhelm-mcp-starter</artifactId>
-    <version>{jhelm-version}</version>
+    <version>{page-component-version}</version>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/rest-api.adoc
+++ b/docs/modules/ROOT/pages/rest-api.adoc
@@ -17,7 +17,7 @@ Add `jhelm-rest-starter` to your Spring Boot web application:
 <dependency>
     <groupId>org.alexmond</groupId>
     <artifactId>jhelm-rest-starter</artifactId>
-    <version>{jhelm-version}</version>
+    <version>{page-component-version}</version>
 </dependency>
 ----
 
@@ -614,7 +614,7 @@ Add `jhelm-mcp-starter` to a Spring Boot application for the auto-configured ser
 <dependency>
     <groupId>org.alexmond</groupId>
     <artifactId>jhelm-mcp-starter</artifactId>
-    <version>{jhelm-version}</version>
+    <version>{page-component-version}</version>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/roadmap.adoc
+++ b/docs/modules/ROOT/pages/roadmap.adoc
@@ -2,72 +2,58 @@
 
 This document outlines the planned improvements, feature priorities, and strategic vision for jhelm.
 
-== 0.1.0 Prerelease Target
+== 1.0.0 — first stable release
 
-The first published prerelease (`0.1.0`, on Maven Central, marked _pre-release_) is defined
-by two things being true at once: a *broad real-world conformance bar* and a *stable,
-extraction-ready engine*. The release is cut via `maven_release.yml`
-(`releaseVersion=0.1.0`, `nextVersion=0.2.0-SNAPSHOT`).
+jhelm `1.0.0` is the first stable release on Maven Central, defined by two things being true
+at once: a *broad real-world conformance bar* and a *stable, extraction-ready engine and API*.
 
-=== Exit criteria (Definition of Done)
+=== What 1.0 delivers
 
-[cols="1,3,1"]
+[cols="1,3"]
 |===
-| Area | Criterion | Status
+| Area | Delivered in 1.0
 
-| Conformance gate
-| *≥ 300 charts* render byte-identical to `helm template` in CI (the `KpsComparisonTest`
-  suite, `charts.csv`), order-independent and with only the documented comparison-ignores
-  (random/timestamp names, generated secrets/certs).
-| ✅ 540 / 540
+| Conformance
+| *540 / 540* real-world charts render byte-identical to `helm template` in CI (the parity
+  suite, `charts.csv`), order-independent, with only a small set of documented
+  comparison-ignores (random/timestamp names, generated secrets/certs, and the known
+  non-semantic differences in xref:interoperability.adoc[Interoperability]).
 
-| Engine maturity
+| Engine
 | The Go template + Sprig engine ships as the standalone
   https://github.com/alexmond/gotmpl4j[gotmpl4j] library on Maven Central; jhelm consumes it
-  as a dependency (`gotmpl4j 1.2.0`). The 540-chart suite is its de-facto conformance test.
-| ✅ Extracted — gotmpl4j on Maven Central; 540-chart suite green
+  as a dependency and keeps only the Helm-specific function layer (`jhelm-gotemplate-helm`).
 
-| Supported surface
-| All modules ship as supported: `gotemplate`/`sprig`/`helm` (engine), `core` (chart
-  lifecycle: install/upgrade/rollback/uninstall/list/status/history), `kube` (apply/wait),
-  `rest`, `plugin`, `cli`, plus the Spring Boot starter.
-| —
+| Chart lifecycle
+| install / upgrade / rollback / uninstall / list / status / history / get / template /
+  package / lint / dependency, plus hooks, JSON-Schema validation, and Helm-faithful SemVer
+  version selection.
 
-| Repo + deps
-| HTTP and OCI repositories with digest verification; Helm-faithful SemVer version
-  selection; recursive dependency value coalescing; hooks; JSON-Schema validation.
-| Mostly done
+| Repositories
+| HTTP and OCI repositories with digest verification and recursive dependency value
+  coalescing.
 
-| Quality gates
-| `spring-javaformat`, Checkstyle, PMD, and JaCoCo coverage all green on a full
-  `./mvnw clean verify`.
-| Green
+| Real cluster
+| `.Capabilities` populated from the live cluster; `template --kube-version` /
+  `--api-versions` overrides for offline rendering.
 
-| Docs
-| Antora docs current; `CHANGELOG.adoc` `0.1.0` section; README "`Status`" reflects the
-  prerelease.
-| In progress
+| Provenance & security
+| Chart signing / verification (PGP), opt-in SSRF protection for server mode, and host-gated
+  repository credentials.
+
+| Distribution
+| Published modules: `gotemplate-helm`, `core`, `kube`, `rest` (+ starter), `mcp` (+ starter),
+  `plugin`. The `jhelm` CLI and sample apps build from source and are not published to
+  Central. All quality gates (`spring-javaformat`, Checkstyle, PMD, JaCoCo) are green on a
+  full `./mvnw clean verify`.
+
+| API stability
+| The public surface was frozen in `0.4.0` (below) and is documented in
+  xref:api-surface.adoc[API Surface & Stability]; `1.0` commits to it under semantic
+  versioning.
 |===
 
-=== `gotmpl4j` (engine extraction — done)
-
-The Go template engine has been extracted into the standalone
-https://github.com/alexmond/gotmpl4j[gotmpl4j] library, published to Maven Central
-(`org.alexmond:gotmpl4j-core`, `gotmpl4j-sprig`, plus a Spring Boot starter; `gotmpl4j 1.2.0`).
-jhelm consumes
-it as an ordinary dependency, keeping only the Helm-specific function layer
-(`jhelm-gotemplate-helm`) in this repository. The extraction holds the properties that made it
-mechanical rather than a redesign:
-
-* *Correctness* — no known rendering gaps; the 540-chart parity suite is the conformance
-  bar.
-* *Clean boundary* — the engine has zero dependencies on Sprig, Helm, or `core`; Sprig
-  (priority 100) and Helm (priority 200) functions load only via `ServiceLoader`.
-* *Stable API* — `GoTemplate`, `Function`, `FunctionProvider` are settled.
-* *Coverage* — comprehensive unit tests for lexer/parser/executor and every function
-  category, independent of the chart suite.
-
-=== API freeze (shipped in 0.4.0 — toward 1.0)
+=== API freeze (shipped in 0.4.0)
 
 The pre-1.0 *API freeze* milestone landed in `0.4.0`, settling the public surface ahead of a
 stable `1.0`. The supported surface — and the `+.internal+` convention that separates it from
@@ -82,15 +68,12 @@ implementation detail — is documented in xref:api-surface.adoc[API Surface & S
 * *Immutable result models* — `Release`/`ReleaseInfo`/`MapConfig` are immutable; release
   `status` is a typed `ReleaseStatus` enum and the lifecycle phase a `LifecyclePhase` enum.
 
-=== Explicit non-goals for 0.1.0
+=== Post-1.0 direction
 
-* Full *gitlab* parity — blocked on a complete Helm `CoalesceValues`/`ProcessDependencies`
-  reimplementation (deep, high-risk); tracked separately.
-* The `gotmpl4j` *extraction itself* — `0.1.0` makes the engine _ready_; the split lands
-  post-`0.1.0`.
-* Charts that are inherently uncomparable to a separate `helm template` run (wall-clock
-  timestamps or random suffixes in resource _names_).
-* Server-Side Apply, WASM plugins, post-renderers, and chart signing (later phases below).
+The phases and design below are forward-looking. The near-term priorities after 1.0 are
+Server-Side Apply in `HelmKubeService`, structured logging, and closing the remaining OCI and
+gitlab value-coalescing gaps; the longer-term vision is the Spring Boot management platform
+described at the end of this page.
 
 == Recommended Implementation Roadmap
 

--- a/docs/modules/ROOT/pages/spring-boot-starter.adoc
+++ b/docs/modules/ROOT/pages/spring-boot-starter.adoc
@@ -31,7 +31,7 @@ For template rendering and chart management only:
 <dependency>
     <groupId>org.alexmond</groupId>
     <artifactId>jhelm-core</artifactId>
-    <version>{jhelm-version}</version>
+    <version>{page-component-version}</version>
 </dependency>
 ----
 
@@ -42,12 +42,12 @@ For full Kubernetes lifecycle management, add both:
 <dependency>
     <groupId>org.alexmond</groupId>
     <artifactId>jhelm-core</artifactId>
-    <version>{jhelm-version}</version>
+    <version>{page-component-version}</version>
 </dependency>
 <dependency>
     <groupId>org.alexmond</groupId>
     <artifactId>jhelm-kube</artifactId>
-    <version>{jhelm-version}</version>
+    <version>{page-component-version}</version>
 </dependency>
 ----
 

--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -109,20 +109,21 @@ jhelmtest:
       - resource: "Job/release-grafana-oncall-engine-migrate-*"
         path: "*"
         reason: "migrate Job name has a per-render now-timestamp suffix"
-      # The grafana subchart's templates/tests/test-*.yaml are annotated
-      # `helm.sh/hook: test`. `helm template` excludes `test`-hook resources (they run
-      # only under `helm test`), but jhelm does not yet filter them from its output, so
-      # it over-emits these three. Lifecycle hooks (pre-install, ...) are emitted by both.
-      # Remove once test-hook filtering lands. Tracked in #634.
+      # The grafana subchart's templates/tests/test-*.yaml are gated by
+      # `{{- if .Values.testFramework.enabled }}`. helm resolves that parent-scoped subchart
+      # value to false here and omits the three resources; jhelm's subchart value coalescing
+      # resolves it truthy and emits them. This is a subchart value-resolution difference
+      # (NOT test-hook filtering — `helm template` keeps test hooks). The resources are
+      # `helm test` fixtures, so the divergence is non-semantic. Tracked in #634.
       - resource: "ConfigMap/release-grafana-oncall-test"
         path: "*"
-        reason: "helm.sh/hook: test resource omitted by `helm template`; jhelm does not yet filter test hooks (#634)"
+        reason: "subchart testFramework.enabled resolves differently; non-semantic test fixture (#634)"
       - resource: "ServiceAccount/release-grafana-oncall-test"
         path: "*"
-        reason: "helm.sh/hook: test resource omitted by `helm template`; jhelm does not yet filter test hooks (#634)"
+        reason: "subchart testFramework.enabled resolves differently; non-semantic test fixture (#634)"
       - resource: "Pod/release-grafana-oncall-test"
         path: "*"
-        reason: "helm.sh/hook: test resource omitted by `helm template`; jhelm does not yet filter test hooks (#634)"
+        reason: "subchart testFramework.enabled resolves differently; non-semantic test fixture (#634)"
     "[argo/argo]":
       # argo ships its CRDs in the chart's crds/ directory. `helm template` omits crds/
       # resources unless `--include-crds` is passed; the parity harness runs plain


### PR DESCRIPTION
Addresses the documentation blockers in #637 (these freeze into the 1.0.0 tag).

- **Docs 404 (item 1)** — `antora.yml` `version: master` → `true`, and the hand-maintained `jhelm-version` attribute migrated to the built-in `{page-component-version}` across all six pages. The version + API links now track the tag with no per-release bump, and the README's `/jhelm/current/` links resolve (fixing the 404s). *(A post-release hub navbar/homepage link update `/jhelm/` → `/jhelm/current/` remains, via the docs-hub skill.)*
- **Roadmap (item 2)** — replaced the stale "0.1.0 Prerelease Target" lead with a "1.0.0 — first stable release" section (what 1.0 delivers + post-1.0 direction).
- **CHANGELOG (item 3)** — turned the stale "Unreleased (targeting 1.0.0)" heading into a real `1.0.0` section with the security / provenance / real-cluster / interop / exception-infra highlights.
- **Notable charts (item 5)** — `index.adoc` now names recognizable byte-parity charts (ingress-nginx, cert-manager, kube-prometheus-stack, grafana, loki, argo-cd, cilium, traefik, Bitnami redis/postgresql/mysql).
- **#634** — documented the grafana/oncall subchart test-fixture divergence as a known, **non-semantic** difference in `function-coverage.adoc`, and corrected the parity-ignore comment: the real cause is subchart `testFramework.enabled` value resolution, **not** test-hook filtering (verified: `helm template` keeps test hooks).

**Item 6** (starter API docs) is already a documented conscious skip in `api.adoc`. **Item 7** (version jump 0.6.1 → 1.0.0) confirmed intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)