### PR TITLE
ci(release): use MAVEN_GPG_PASSPHRASE instead of deprecated -Dgpg.passphrase

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -32,7 +32,6 @@ jobs:
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
 
       - name: Configure Git
         run: |
@@ -51,11 +50,13 @@ jobs:
           git tag -a ${{ github.event.inputs.releaseVersion }} -m "Release ${{ github.event.inputs.releaseVersion }}"
 
       - name: Deploy to Maven Central
-        run: ./mvnw --batch-mode clean deploy -Prelease -Dgpg.passphrase="${GPG_PASSPHRASE}" --no-transfer-progress
+        run: ./mvnw --batch-mode clean deploy -Prelease --no-transfer-progress
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          # maven-gpg-plugin 3.x reads the passphrase from this env var (batch mode with
+          # --pinentry-mode loopback), avoiding the deprecated -Dgpg.passphrase property.
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Set Next Development Version
         run: |


### PR DESCRIPTION
The release deploy passed `-Dgpg.passphrase="${GPG_PASSPHRASE}"`, which maven-gpg-plugin 3.x deprecates:

> Parameter 'passphrase' (user property 'gpg.passphrase') is deprecated … rely on gpg-agent or env variables instead … provide passphrase in `MAVEN_GPG_PASSPHRASE` environment variable for batch mode.

Switched to exactly that: the deploy step now exports `MAVEN_GPG_PASSPHRASE` (read natively by the plugin in batch mode, with `--pinentry-mode loopback` already set in the pom) and drops both the `-Dgpg.passphrase` flag and setup-java's `gpg-passphrase` wiring — so no deprecated passphrase property is used. Signing/publishing behaviour is unchanged; only the mechanism the passphrase is supplied through.

Applies to the next release (1.0.0 already published successfully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)