### PR TITLE
fix(cli): non-zero exit code on command failure (#647)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.app;
 
+import java.util.concurrent.Callable;
+
 import org.alexmond.jhelm.app.command.CreateCommand;
 import org.alexmond.jhelm.app.command.DependencyCommand;
 import org.alexmond.jhelm.app.command.GetCommand;
@@ -53,7 +55,7 @@ import picocli.CommandLine;
 				PullCommand.class, PushCommand.class, PackageCommand.class, VerifyCommand.class, LintCommand.class,
 				RepoCommand.class, RegistryCommand.class, PluginCommand.class, SearchCommand.class,
 				VersionCommand.class, EnvCommand.class })
-public class JHelmCommand implements Runnable {
+public class JHelmCommand implements Callable<Integer> {
 
 	private final Environment environment;
 
@@ -83,9 +85,10 @@ public class JHelmCommand implements Runnable {
 	 * usage help when {@code jhelm} is invoked without a subcommand.
 	 */
 	@Override
-	public void run() {
+	public Integer call() {
 		printBanner();
 		CommandLine.usage(this, System.out);
+		return CommandLine.ExitCode.OK;
 	}
 
 	/**

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/CreateCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/CreateCommand.java
@@ -9,6 +9,7 @@ import picocli.CommandLine;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.Callable;
 
 /**
  * Implements {@code jhelm create NAME}, scaffolding a new chart directory with the given
@@ -18,7 +19,7 @@ import java.nio.file.Paths;
 @Component
 @CommandLine.Command(name = "create", mixinStandardHelpOptions = true,
 		description = "Create a new chart with the given name")
-public class CreateCommand implements Runnable {
+public class CreateCommand implements Callable<Integer> {
 
 	private final CreateAction createAction;
 
@@ -41,15 +42,16 @@ public class CreateCommand implements Runnable {
 	 * Scaffolds the new chart and reports the result.
 	 */
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			Path chartPath = Paths.get(name);
 			createAction.create(chartPath);
 			CliOutput.println(CliOutput.success("Creating " + name));
+			return CommandLine.ExitCode.OK;
 		}
 		catch (JhelmException ex) {
 			CliOutput.errPrintln(CliOutput.error("Error creating chart: " + ex.getMessage()));
-			System.exit(1);
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/DependencyCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/DependencyCommand.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 /**
  * Implements the {@code helm dependency} command and its subcommands.
@@ -38,7 +39,7 @@ import java.util.List;
 		subcommands = { DependencyCommand.ListCommand.class, DependencyCommand.UpdateCommand.class,
 				DependencyCommand.BuildCommand.class })
 @Slf4j
-public class DependencyCommand implements Runnable {
+public class DependencyCommand implements Callable<Integer> {
 
 	/** Creates the command. */
 	@SuppressWarnings("PMD.UnnecessaryConstructor")
@@ -49,8 +50,9 @@ public class DependencyCommand implements Runnable {
 	 * Prints the usage help when {@code dependency} is invoked without a subcommand.
 	 */
 	@Override
-	public void run() {
+	public Integer call() {
 		CommandLine.usage(this, System.out);
+		return CommandLine.ExitCode.OK;
 	}
 
 	/**
@@ -62,7 +64,7 @@ public class DependencyCommand implements Runnable {
 	@CommandLine.Command(name = "list", mixinStandardHelpOptions = true,
 			description = "List the dependencies for the given chart")
 	@Slf4j
-	public static class ListCommand implements Runnable {
+	public static class ListCommand implements Callable<Integer> {
 
 		@CommandLine.Parameters(index = "0", description = "chart directory", defaultValue = ".")
 		String chartPath;
@@ -76,19 +78,19 @@ public class DependencyCommand implements Runnable {
 		 * Lists the chart's dependencies and their resolution status.
 		 */
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				File chartDir = new File(chartPath);
 				if (!chartDir.exists() || !chartDir.isDirectory()) {
 					CliOutput.errPrintln(CliOutput.error("Error: Chart directory not found: " + chartPath));
-					return;
+					return CommandLine.ExitCode.SOFTWARE;
 				}
 
 				// Load Chart.yaml
 				ChartMetadata metadata = loadChartMetadata(chartDir);
 				if (metadata.getDependencies() == null || metadata.getDependencies().isEmpty()) {
 					CliOutput.println("No dependencies found in Chart.yaml");
-					return;
+					return CommandLine.ExitCode.OK;
 				}
 
 				// Load Chart.lock if it exists
@@ -128,12 +130,14 @@ public class DependencyCommand implements Runnable {
 					CliOutput.printf("%-20s %-15s %-40s %s%n", name, version, (repository != null) ? repository : "",
 							colorizeDependencyStatus(status));
 				}
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error listing dependencies: " + ex.getMessage()));
 				if (log.isDebugEnabled()) {
 					log.debug("Dependency list error details", ex);
 				}
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -189,7 +193,7 @@ public class DependencyCommand implements Runnable {
 	@CommandLine.Command(name = "update", mixinStandardHelpOptions = true,
 			description = "Update charts/ based on the contents of Chart.yaml")
 	@Slf4j
-	public static class UpdateCommand implements Runnable {
+	public static class UpdateCommand implements Callable<Integer> {
 
 		private final RepoManager repoManager;
 
@@ -216,12 +220,12 @@ public class DependencyCommand implements Runnable {
 		 * Resolves dependencies from Chart.yaml, downloads them, and writes Chart.lock.
 		 */
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				File chartDir = new File(chartPath);
 				if (!chartDir.exists() || !chartDir.isDirectory()) {
 					CliOutput.errPrintln(CliOutput.error("Error: Chart directory not found: " + chartPath));
-					return;
+					return CommandLine.ExitCode.SOFTWARE;
 				}
 
 				// Refresh repositories unless --skip-refresh
@@ -235,7 +239,7 @@ public class DependencyCommand implements Runnable {
 				ChartMetadata metadata = loadChartMetadata(chartDir);
 				if (metadata.getDependencies() == null || metadata.getDependencies().isEmpty()) {
 					CliOutput.println("No dependencies found in Chart.yaml");
-					return;
+					return CommandLine.ExitCode.OK;
 				}
 
 				// Load values.yaml for condition evaluation
@@ -254,12 +258,14 @@ public class DependencyCommand implements Runnable {
 				chartLock.toFile(chartDir);
 				CliOutput.println("Saving " + chartLock.getDependencies().size() + " charts");
 				CliOutput.println(CliOutput.success("Dependency update complete."));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error updating dependencies: " + ex.getMessage()));
 				if (log.isDebugEnabled()) {
 					log.debug("Dependency update error details", ex);
 				}
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -300,7 +306,7 @@ public class DependencyCommand implements Runnable {
 	@CommandLine.Command(name = "build", mixinStandardHelpOptions = true,
 			description = "Rebuild the charts/ directory based on Chart.lock")
 	@Slf4j
-	public static class BuildCommand implements Runnable {
+	public static class BuildCommand implements Callable<Integer> {
 
 		private final RepoManager repoManager;
 
@@ -323,12 +329,12 @@ public class DependencyCommand implements Runnable {
 		 * Rebuilds the charts/ directory from the pinned versions in Chart.lock.
 		 */
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				File chartDir = new File(chartPath);
 				if (!chartDir.exists() || !chartDir.isDirectory()) {
 					CliOutput.errPrintln(CliOutput.error("Error: Chart directory not found: " + chartPath));
-					return;
+					return CommandLine.ExitCode.SOFTWARE;
 				}
 
 				// Load Chart.lock
@@ -336,12 +342,12 @@ public class DependencyCommand implements Runnable {
 				if (chartLock == null) {
 					CliOutput
 						.errPrintln(CliOutput.error("Error: Chart.lock not found. Run 'dependency update' first."));
-					return;
+					return CommandLine.ExitCode.SOFTWARE;
 				}
 
 				if (chartLock.getDependencies() == null || chartLock.getDependencies().isEmpty()) {
 					CliOutput.println("No dependencies found in Chart.lock");
-					return;
+					return CommandLine.ExitCode.OK;
 				}
 
 				// Refresh repositories unless --skip-refresh
@@ -358,12 +364,14 @@ public class DependencyCommand implements Runnable {
 
 				CliOutput.println("Saving " + chartLock.getDependencies().size() + " charts");
 				CliOutput.println(CliOutput.success("Dependency build complete."));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error building dependencies: " + ex.getMessage()));
 				if (log.isDebugEnabled()) {
 					log.debug("Dependency build error details", ex);
 				}
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/EnvCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/EnvCommand.java
@@ -1,6 +1,7 @@
 package org.alexmond.jhelm.app.command;
 
 import java.nio.file.Paths;
+import java.util.concurrent.Callable;
 
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.service.RegistryManager;
@@ -20,7 +21,7 @@ import picocli.CommandLine;
 @Component
 @CommandLine.Command(name = "env", mixinStandardHelpOptions = true,
 		description = "Print the jhelm client environment information")
-public class EnvCommand implements Runnable {
+public class EnvCommand implements Callable<Integer> {
 
 	private final RepoManager repoManager;
 
@@ -55,7 +56,7 @@ public class EnvCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		CliOutput.println("HELM_NAMESPACE=\"" + orDefault("HELM_NAMESPACE", "default") + "\"");
 		CliOutput.println("HELM_REPOSITORY_CONFIG=\"" + this.repoManager.getConfigPath() + "\"");
 		CliOutput.println("HELM_REPOSITORY_CACHE=\"" + this.repoManager.getRepositoryCachePath() + "\"");
@@ -65,6 +66,7 @@ public class EnvCommand implements Runnable {
 		CliOutput.println("JHELM_VERSION=\"" + VersionCommand.versionString() + "\"");
 		CliOutput.println("JAVA_VERSION=\"" + System.getProperty("java.version") + "\"");
 		CliOutput.println("OS=\"" + System.getProperty("os.name") + "/" + System.getProperty("os.arch") + "\"");
+		return CommandLine.ExitCode.OK;
 	}
 
 }

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/GetCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/GetCommand.java
@@ -9,6 +9,7 @@ import picocli.CommandLine;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 /**
  * Implements {@code jhelm get}, downloading extended information about a named release.
@@ -21,7 +22,7 @@ import java.util.Optional;
 		subcommands = { GetCommand.ValuesCommand.class, GetCommand.ManifestCommand.class, GetCommand.NotesCommand.class,
 				GetCommand.HooksCommand.class, GetCommand.MetadataCommand.class, GetCommand.AllCommand.class })
 @Slf4j
-public class GetCommand implements Runnable {
+public class GetCommand implements Callable<Integer> {
 
 	/** Creates the command. */
 	@SuppressWarnings("PMD.UnnecessaryConstructor")
@@ -32,8 +33,9 @@ public class GetCommand implements Runnable {
 	 * Prints the usage help when {@code get} is invoked without a subcommand.
 	 */
 	@Override
-	public void run() {
+	public Integer call() {
 		CommandLine.usage(this, System.out);
+		return CommandLine.ExitCode.OK;
 	}
 
 	private static Optional<Release> resolveRelease(GetAction getAction, String name, String namespace, int revision) {
@@ -51,7 +53,7 @@ public class GetCommand implements Runnable {
 	@CommandLine.Command(name = "values", mixinStandardHelpOptions = true,
 			description = "Download the values file for a named release")
 	@Slf4j
-	public static class ValuesCommand implements Runnable {
+	public static class ValuesCommand implements Callable<Integer> {
 
 		private final GetAction getAction;
 
@@ -84,12 +86,12 @@ public class GetCommand implements Runnable {
 		 * Prints the release values in the requested output format.
 		 */
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				Optional<Release> releaseOpt = resolveRelease(getAction, releaseName, namespace, revision);
 				if (releaseOpt.isEmpty()) {
 					CliOutput.errPrintln(CliOutput.error("Error: release not found: " + releaseName));
-					return;
+					return CommandLine.ExitCode.SOFTWARE;
 				}
 				Release release = releaseOpt.get();
 				if ("json".equalsIgnoreCase(output)) {
@@ -105,9 +107,11 @@ public class GetCommand implements Runnable {
 				else {
 					System.out.println(getAction.getValues(release, allValues));
 				}
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error getting values: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -121,7 +125,7 @@ public class GetCommand implements Runnable {
 	@CommandLine.Command(name = "manifest", mixinStandardHelpOptions = true,
 			description = "Download the manifest for a named release")
 	@Slf4j
-	public static class ManifestCommand implements Runnable {
+	public static class ManifestCommand implements Callable<Integer> {
 
 		private final GetAction getAction;
 
@@ -147,17 +151,19 @@ public class GetCommand implements Runnable {
 		 * Prints the release manifest.
 		 */
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				Optional<Release> releaseOpt = resolveRelease(getAction, releaseName, namespace, revision);
 				if (releaseOpt.isEmpty()) {
 					CliOutput.errPrintln(CliOutput.error("Error: release not found: " + releaseName));
-					return;
+					return CommandLine.ExitCode.SOFTWARE;
 				}
 				System.out.println(getAction.getManifest(releaseOpt.get()));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error getting manifest: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -170,7 +176,7 @@ public class GetCommand implements Runnable {
 	@CommandLine.Command(name = "notes", mixinStandardHelpOptions = true,
 			description = "Download the notes for a named release")
 	@Slf4j
-	public static class NotesCommand implements Runnable {
+	public static class NotesCommand implements Callable<Integer> {
 
 		private final GetAction getAction;
 
@@ -196,12 +202,12 @@ public class GetCommand implements Runnable {
 		 * Prints the release notes, or a placeholder when none exist.
 		 */
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				Optional<Release> releaseOpt = resolveRelease(getAction, releaseName, namespace, revision);
 				if (releaseOpt.isEmpty()) {
 					CliOutput.errPrintln(CliOutput.error("Error: release not found: " + releaseName));
-					return;
+					return CommandLine.ExitCode.SOFTWARE;
 				}
 				String notes = getAction.getNotes(releaseOpt.get());
 				if (notes.isEmpty()) {
@@ -210,9 +216,11 @@ public class GetCommand implements Runnable {
 				else {
 					System.out.println(notes);
 				}
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error getting notes: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -223,7 +231,7 @@ public class GetCommand implements Runnable {
 	@CommandLine.Command(name = "hooks", mixinStandardHelpOptions = true,
 			description = "Download all hooks for a named release")
 	@Slf4j
-	public static class HooksCommand implements Runnable {
+	public static class HooksCommand implements Callable<Integer> {
 
 		private final GetAction getAction;
 
@@ -249,12 +257,12 @@ public class GetCommand implements Runnable {
 		 * Prints the release hooks, or a placeholder when none exist.
 		 */
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				Optional<Release> releaseOpt = resolveRelease(getAction, releaseName, namespace, revision);
 				if (releaseOpt.isEmpty()) {
 					CliOutput.errPrintln(CliOutput.error("Error: release not found: " + releaseName));
-					return;
+					return CommandLine.ExitCode.SOFTWARE;
 				}
 				String hooks = getAction.getHooks(releaseOpt.get());
 				if (hooks.isEmpty()) {
@@ -263,9 +271,11 @@ public class GetCommand implements Runnable {
 				else {
 					System.out.println(hooks);
 				}
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error getting hooks: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -279,7 +289,7 @@ public class GetCommand implements Runnable {
 	@CommandLine.Command(name = "metadata", mixinStandardHelpOptions = true,
 			description = "Download the metadata for a named release")
 	@Slf4j
-	public static class MetadataCommand implements Runnable {
+	public static class MetadataCommand implements Callable<Integer> {
 
 		private final GetAction getAction;
 
@@ -309,12 +319,12 @@ public class GetCommand implements Runnable {
 		 * Prints the release metadata in the requested output format.
 		 */
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				Optional<Release> releaseOpt = resolveRelease(getAction, releaseName, namespace, revision);
 				if (releaseOpt.isEmpty()) {
 					CliOutput.errPrintln(CliOutput.error("Error: release not found: " + releaseName));
-					return;
+					return CommandLine.ExitCode.SOFTWARE;
 				}
 				Map<String, Object> metadata = getAction.getMetadata(releaseOpt.get());
 				if ("json".equalsIgnoreCase(output)) {
@@ -323,9 +333,11 @@ public class GetCommand implements Runnable {
 				else {
 					System.out.println(getAction.toYaml(metadata));
 				}
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error getting metadata: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -339,7 +351,7 @@ public class GetCommand implements Runnable {
 	@CommandLine.Command(name = "all", mixinStandardHelpOptions = true,
 			description = "Download all information for a named release")
 	@Slf4j
-	public static class AllCommand implements Runnable {
+	public static class AllCommand implements Callable<Integer> {
 
 		private final GetAction getAction;
 
@@ -365,17 +377,19 @@ public class GetCommand implements Runnable {
 		 * Prints all available information for the release.
 		 */
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				Optional<Release> releaseOpt = resolveRelease(getAction, releaseName, namespace, revision);
 				if (releaseOpt.isEmpty()) {
 					CliOutput.errPrintln(CliOutput.error("Error: release not found: " + releaseName));
-					return;
+					return CommandLine.ExitCode.SOFTWARE;
 				}
 				System.out.println(getAction.getAll(releaseOpt.get(), false));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error getting release info: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/HistoryCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/HistoryCommand.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
 import java.util.List;
+import java.util.concurrent.Callable;
 
 /**
  * Implements {@code jhelm history RELEASE}, printing the revision history of a release.
@@ -15,7 +16,7 @@ import java.util.List;
 @Component
 @CommandLine.Command(name = "history", mixinStandardHelpOptions = true, description = "Fetch release history")
 @Slf4j
-public class HistoryCommand implements Runnable {
+public class HistoryCommand implements Callable<Integer> {
 
 	private final HistoryAction historyAction;
 
@@ -37,7 +38,7 @@ public class HistoryCommand implements Runnable {
 	 * Prints the release revision history as a table.
 	 */
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			List<Release> history = historyAction.history(name, namespace);
 			CliOutput.printf("%-10s %-30s %-10s %-20s %-30s\n", CliOutput.bold("REVISION"), CliOutput.bold("UPDATED"),
@@ -47,9 +48,11 @@ public class HistoryCommand implements Runnable {
 				CliOutput.printf("%-10d %-30s %-10s %-20s %-30s\n", r.getVersion(), r.getInfo().getLastDeployed(),
 						r.getInfo().getStatus().getValue(), chartInfo, r.getInfo().getDescription());
 			}
+			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error fetching history: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
@@ -28,7 +29,7 @@ import picocli.CommandLine.Option;
 @Component
 @CommandLine.Command(name = "install", mixinStandardHelpOptions = true, description = "Install a chart")
 @Slf4j
-public class InstallCommand implements Runnable {
+public class InstallCommand implements Callable<Integer> {
 
 	private final InstallAction installAction;
 
@@ -114,7 +115,7 @@ public class InstallCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			boolean dryRunEnabled = resolveDryRun();
 			Chart chart = chartResolver.resolve(chartPath, verify, keyring);
@@ -148,6 +149,7 @@ public class InstallCommand implements Runnable {
 					kubeService.waitForReady(namespace, release.getManifest(), timeout);
 				}
 			}
+			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			if (atomic) {
@@ -168,6 +170,7 @@ public class InstallCommand implements Runnable {
 			if (log.isDebugEnabled()) {
 				log.debug("Install error details", ex);
 			}
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/LintCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/LintCommand.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.app.command;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.LintAction;
@@ -18,7 +19,7 @@ import picocli.CommandLine.Option;
 @Component
 @CommandLine.Command(name = "lint", mixinStandardHelpOptions = true,
 		description = "Examine a chart for possible issues")
-public class LintCommand implements Runnable {
+public class LintCommand implements Callable<Integer> {
 
 	private final LintAction lintAction;
 
@@ -52,7 +53,7 @@ public class LintCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
 					setFileValues, setJsonValues);
@@ -69,13 +70,16 @@ public class LintCommand implements Runnable {
 
 			if (result.isOk() && (!strict || result.getWarnings().isEmpty())) {
 				CliOutput.println("1 chart(s) linted, 0 chart(s) failed");
+				return CommandLine.ExitCode.OK;
 			}
 			else {
 				CliOutput.errPrintln(CliOutput.error("1 chart(s) linted, 1 chart(s) failed"));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 /**
  * Implements {@code jhelm list}, printing the releases in a namespace with their
@@ -25,7 +26,7 @@ import java.util.Map;
 @Component
 @CommandLine.Command(name = "list", mixinStandardHelpOptions = true, description = "List releases")
 @Slf4j
-public class ListCommand implements Runnable {
+public class ListCommand implements Callable<Integer> {
 
 	private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
 
@@ -63,7 +64,7 @@ public class ListCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			List<Release> releases = listAction.list(namespace);
 			switch (output.toLowerCase(Locale.ROOT)) {
@@ -71,9 +72,11 @@ public class ListCommand implements Runnable {
 				case "yaml" -> System.out.print(YAML_MAPPER.writeValueAsString(toRows(releases)));
 				default -> printTable(releases);
 			}
+			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error listing releases: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PackageCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PackageCommand.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.Callable;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
@@ -19,7 +20,7 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "package", mixinStandardHelpOptions = true,
 		description = "Package a chart directory into a chart archive")
 @Slf4j
-public class PackageCommand implements Runnable {
+public class PackageCommand implements Callable<Integer> {
 
 	private final PackageAction packageAction;
 
@@ -52,7 +53,7 @@ public class PackageCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			packageAction.setDestination(new File(destination));
 			File archive;
@@ -60,7 +61,7 @@ public class PackageCommand implements Runnable {
 			if (sign) {
 				if (keyId == null) {
 					CliOutput.errPrintln(CliOutput.error("--key is required when --sign is specified"));
-					return;
+					return CommandLine.ExitCode.SOFTWARE;
 				}
 				String resolvedKeyring = (keyring != null) ? keyring : defaultKeyringPath();
 				char[] passphrase = loadPassphrase();
@@ -71,9 +72,11 @@ public class PackageCommand implements Runnable {
 			}
 
 			CliOutput.println(CliOutput.success("Successfully packaged chart: " + archive.getName()));
+			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error packaging chart: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PluginCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PluginCommand.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.app.command;
 
 import java.io.File;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import org.alexmond.jhelm.plugin.model.PluginDescriptor;
 import org.alexmond.jhelm.plugin.service.PluginManager;
@@ -17,7 +18,7 @@ import org.alexmond.jhelm.app.output.CliOutput;
 @Component
 @CommandLine.Command(name = "plugin", mixinStandardHelpOptions = true, description = "Manage plugins",
 		subcommands = { PluginCommand.Install.class, PluginCommand.Uninstall.class, PluginCommand.ListPlugins.class })
-public class PluginCommand implements Runnable {
+public class PluginCommand implements Callable<Integer> {
 
 	/** Creates the command. */
 	@SuppressWarnings("PMD.UnnecessaryConstructor")
@@ -28,8 +29,9 @@ public class PluginCommand implements Runnable {
 	 * Prints the usage help when {@code plugin} is invoked without a subcommand.
 	 */
 	@Override
-	public void run() {
+	public Integer call() {
 		CommandLine.usage(this, System.out);
+		return CommandLine.ExitCode.OK;
 	}
 
 	/**
@@ -38,7 +40,7 @@ public class PluginCommand implements Runnable {
 	@Component
 	@CommandLine.Command(name = "install", mixinStandardHelpOptions = true,
 			description = "Install a plugin from a .jhp archive")
-	public static class Install implements Runnable {
+	public static class Install implements Callable<Integer> {
 
 		@CommandLine.Parameters(index = "0", description = "Path to plugin archive (.jhp)")
 		private File archivePath;
@@ -55,19 +57,21 @@ public class PluginCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			PluginManager pm = pluginManagerProvider.getIfAvailable();
 			if (pm == null) {
 				CliOutput.errPrintln(CliOutput.error("Plugin system is not enabled. Set jhelm.plugins.enabled=true"));
-				return;
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 			try {
 				PluginDescriptor desc = pm.install(archivePath);
 				CliOutput.println(CliOutput.success("Installed plugin: " + desc.getManifest().getName() + " (type: "
 						+ desc.getManifest().getType().getValue() + ")"));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Failed to install plugin: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -76,7 +80,7 @@ public class PluginCommand implements Runnable {
 	/** Implements {@code plugin uninstall}: removes an installed plugin by name. */
 	@Component
 	@CommandLine.Command(name = "uninstall", mixinStandardHelpOptions = true, description = "Uninstall a plugin")
-	public static class Uninstall implements Runnable {
+	public static class Uninstall implements Callable<Integer> {
 
 		@CommandLine.Parameters(index = "0", description = "Plugin name")
 		private String pluginName;
@@ -93,18 +97,20 @@ public class PluginCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			PluginManager pm = pluginManagerProvider.getIfAvailable();
 			if (pm == null) {
 				CliOutput.errPrintln(CliOutput.error("Plugin system is not enabled. Set jhelm.plugins.enabled=true"));
-				return;
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 			try {
 				pm.uninstall(pluginName);
 				CliOutput.println(CliOutput.success("Uninstalled plugin: " + pluginName));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Failed to uninstall plugin: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -113,7 +119,7 @@ public class PluginCommand implements Runnable {
 	/** Implements {@code plugin list}: prints the installed plugins as a table. */
 	@Component
 	@CommandLine.Command(name = "list", mixinStandardHelpOptions = true, description = "List installed plugins")
-	public static class ListPlugins implements Runnable {
+	public static class ListPlugins implements Callable<Integer> {
 
 		private final ObjectProvider<PluginManager> pluginManagerProvider;
 
@@ -127,16 +133,16 @@ public class PluginCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			PluginManager pm = pluginManagerProvider.getIfAvailable();
 			if (pm == null) {
 				CliOutput.errPrintln(CliOutput.error("Plugin system is not enabled. Set jhelm.plugins.enabled=true"));
-				return;
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 			List<PluginDescriptor> plugins = pm.list();
 			if (plugins.isEmpty()) {
 				CliOutput.println("No plugins installed.");
-				return;
+				return CommandLine.ExitCode.OK;
 			}
 			CliOutput.printf("%-20s %-15s %-10s%n", CliOutput.bold("NAME"), CliOutput.bold("TYPE"),
 					CliOutput.bold("VERSION"));
@@ -144,6 +150,7 @@ public class PluginCommand implements Runnable {
 				CliOutput.printf("%-20s %-15s %-10s%n", desc.getManifest().getName(),
 						desc.getManifest().getType().getValue(), desc.getManifest().getVersion());
 			}
+			return CommandLine.ExitCode.OK;
 		}
 
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PullCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PullCommand.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.app.command;
 
+import java.util.concurrent.Callable;
+
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.model.RepositoryConfig;
@@ -16,7 +18,7 @@ import picocli.CommandLine;
 @Component
 @CommandLine.Command(name = "pull", mixinStandardHelpOptions = true, description = "Download a chart from a repository")
 @Slf4j
-public class PullCommand implements Runnable {
+public class PullCommand implements Callable<Integer> {
 
 	private final RepoManager repoManager;
 
@@ -65,7 +67,7 @@ public class PullCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			if (this.repo != null && !this.repo.isBlank()) {
 				repoManager.pullFromRepoUrl(this.repo, this.chart, this.version, this.dest, buildRepoAuth());
@@ -74,9 +76,11 @@ public class PullCommand implements Runnable {
 				repoManager.pull(this.chart, this.version, this.dest);
 			}
 			CliOutput.println(CliOutput.success("Chart pulled to " + this.dest));
+			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error pulling chart: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PushCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PushCommand.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.app.command;
 
+import java.util.concurrent.Callable;
+
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.service.RepoManager;
@@ -14,7 +16,7 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "push", mixinStandardHelpOptions = true,
 		description = "Push a chart to a remote OCI registry")
 @Slf4j
-public class PushCommand implements Runnable {
+public class PushCommand implements Callable<Integer> {
 
 	private final RepoManager repoManager;
 
@@ -33,13 +35,15 @@ public class PushCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			repoManager.pushOci(chart, remote);
 			CliOutput.println(CliOutput.success("Pushed: " + remote));
+			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error pushing chart: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RegistryCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RegistryCommand.java
@@ -9,6 +9,7 @@ import picocli.CommandLine;
 import java.io.Console;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Callable;
 
 /**
  * Implements {@code jhelm registry}, managing authentication to OCI registries via the
@@ -19,7 +20,7 @@ import java.nio.charset.StandardCharsets;
 		description = "Login to or logout from a registry",
 		subcommands = { RegistryCommand.LoginCommand.class, RegistryCommand.LogoutCommand.class })
 @Slf4j
-public class RegistryCommand implements Runnable {
+public class RegistryCommand implements Callable<Integer> {
 
 	/** Creates the command. */
 	@SuppressWarnings("PMD.UnnecessaryConstructor")
@@ -30,15 +31,16 @@ public class RegistryCommand implements Runnable {
 	 * Prints the usage help when {@code registry} is invoked without a subcommand.
 	 */
 	@Override
-	public void run() {
+	public Integer call() {
 		CommandLine.usage(this, System.out);
+		return CommandLine.ExitCode.OK;
 	}
 
 	/** Implements {@code registry login}: authenticates to an OCI registry. */
 	@Component
 	@CommandLine.Command(name = "login", mixinStandardHelpOptions = true, description = "Login to a registry")
 	@Slf4j
-	public static class LoginCommand implements Runnable {
+	public static class LoginCommand implements Callable<Integer> {
 
 		private final RegistryManager registryManager;
 
@@ -63,16 +65,19 @@ public class RegistryCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				registryManager.login(server, username, resolvePassword());
 				CliOutput.println(CliOutput.success("Login Succeeded"));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (IllegalArgumentException ex) {
 				CliOutput.errPrintln(CliOutput.error(ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 			catch (IOException ex) {
 				CliOutput.errPrintln(CliOutput.error("Error logging in: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -116,7 +121,7 @@ public class RegistryCommand implements Runnable {
 	@Component
 	@CommandLine.Command(name = "logout", mixinStandardHelpOptions = true, description = "Logout from a registry")
 	@Slf4j
-	public static class LogoutCommand implements Runnable {
+	public static class LogoutCommand implements Callable<Integer> {
 
 		private final RegistryManager registryManager;
 
@@ -132,13 +137,15 @@ public class RegistryCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				registryManager.logout(server);
 				CliOutput.println(CliOutput.success("Logout Succeeded"));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (IOException ex) {
 				CliOutput.errPrintln(CliOutput.error("Error logging out: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoCommand.java
@@ -9,6 +9,7 @@ import picocli.CommandLine;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 /**
  * Implements {@code jhelm repo}, managing chart repositories via the {@code add},
@@ -19,7 +20,7 @@ import java.util.List;
 		subcommands = { RepoCommand.AddCommand.class, RepoCommand.ListCommand.class, RepoCommand.RemoveCommand.class,
 				RepoCommand.UpdateCommand.class, RepoCommand.SearchCommand.class })
 @Slf4j
-public class RepoCommand implements Runnable {
+public class RepoCommand implements Callable<Integer> {
 
 	/** Creates the command. */
 	@SuppressWarnings("PMD.UnnecessaryConstructor")
@@ -30,15 +31,16 @@ public class RepoCommand implements Runnable {
 	 * Prints the usage help when {@code repo} is invoked without a subcommand.
 	 */
 	@Override
-	public void run() {
+	public Integer call() {
 		CommandLine.usage(this, System.out);
+		return CommandLine.ExitCode.OK;
 	}
 
 	/** Implements {@code repo add}: registers a chart repository by name and URL. */
 	@Component
 	@CommandLine.Command(name = "add", mixinStandardHelpOptions = true, description = "Add a chart repository")
 	@Slf4j
-	public static class AddCommand implements Runnable {
+	public static class AddCommand implements Callable<Integer> {
 
 		private final RepoManager repoManager;
 
@@ -57,13 +59,15 @@ public class RepoCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				repoManager.addRepo(name, url);
 				CliOutput.println(CliOutput.success("\"" + name + "\" has been added to your repositories"));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (IOException ex) {
 				CliOutput.errPrintln(CliOutput.error("Error adding repository: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -73,7 +77,7 @@ public class RepoCommand implements Runnable {
 	@Component
 	@CommandLine.Command(name = "list", mixinStandardHelpOptions = true, description = "List chart repositories")
 	@Slf4j
-	public static class ListCommand implements Runnable {
+	public static class ListCommand implements Callable<Integer> {
 
 		private final RepoManager repoManager;
 
@@ -87,16 +91,18 @@ public class RepoCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				RepositoryConfig config = repoManager.loadConfig();
 				CliOutput.printf("%-20s\t%-50s\n", CliOutput.bold("NAME"), CliOutput.bold("URL"));
 				for (RepositoryConfig.Repository repo : config.getRepositories()) {
 					CliOutput.printf("%-20s\t%-50s\n", repo.getName(), repo.getUrl());
 				}
+				return CommandLine.ExitCode.OK;
 			}
 			catch (IOException ex) {
 				CliOutput.errPrintln(CliOutput.error("Error listing repositories: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -107,7 +113,7 @@ public class RepoCommand implements Runnable {
 	@CommandLine.Command(name = "remove", mixinStandardHelpOptions = true,
 			description = "Remove one or more chart repositories")
 	@Slf4j
-	public static class RemoveCommand implements Runnable {
+	public static class RemoveCommand implements Callable<Integer> {
 
 		private final RepoManager repoManager;
 
@@ -123,13 +129,15 @@ public class RepoCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				repoManager.removeRepo(name);
 				CliOutput.println(CliOutput.success("\"" + name + "\" has been removed from your repositories"));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (IOException ex) {
 				CliOutput.errPrintln(CliOutput.error("Error removing repository: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -144,7 +152,7 @@ public class RepoCommand implements Runnable {
 	@CommandLine.Command(name = "update", aliases = { "up" }, mixinStandardHelpOptions = true,
 			description = "Update the local cache of one or more chart repositories (default: all)")
 	@Slf4j
-	public static class UpdateCommand implements Runnable {
+	public static class UpdateCommand implements Callable<Integer> {
 
 		private final RepoManager repoManager;
 
@@ -160,7 +168,7 @@ public class RepoCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				CliOutput.println("Hang tight while we grab the latest from your chart repositories...");
 				if (names == null || names.isEmpty()) {
@@ -172,9 +180,11 @@ public class RepoCommand implements Runnable {
 					}
 				}
 				CliOutput.println(CliOutput.success("Update Complete. Happy Helming!"));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (IOException ex) {
 				CliOutput.errPrintln(CliOutput.error("Error updating repositories: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -185,7 +195,7 @@ public class RepoCommand implements Runnable {
 	@CommandLine.Command(name = "search", mixinStandardHelpOptions = true,
 			description = "Search the added repositories for a chart")
 	@Slf4j
-	public static class SearchCommand implements Runnable {
+	public static class SearchCommand implements Callable<Integer> {
 
 		private final RepoManager repoManager;
 
@@ -204,11 +214,11 @@ public class RepoCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				if (query == null || !query.contains("/")) {
 					CliOutput.errPrintln(CliOutput.error("Please specify chart as repo/chart (e.g., bitnami/ghost)"));
-					return;
+					return CommandLine.ExitCode.SOFTWARE;
 				}
 				String repo = query.substring(0, query.indexOf('/'));
 				String chart = query.substring(query.indexOf('/') + 1);
@@ -217,7 +227,7 @@ public class RepoCommand implements Runnable {
 				if (versions.isEmpty()) {
 					CliOutput.println(CliOutput.warn("No results found for " + query
 							+ ". Make sure the repo is added (jhelm repo add) and contains the chart."));
-					return;
+					return CommandLine.ExitCode.OK;
 				}
 
 				CliOutput.printf("%-40s %-15s %-15s %-s\n", CliOutput.bold("NAME"), CliOutput.bold("CHART VERSION"),
@@ -233,9 +243,11 @@ public class RepoCommand implements Runnable {
 					CliOutput.printf("%-40s %-15s %-15s %-s\n", v.getName(), nv(v.getChartVersion()),
 							nv(v.getAppVersion()), nv(v.getDescription()));
 				}
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error searching repositories: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.app.command;
 
+import java.util.concurrent.Callable;
+
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.RollbackAction;
@@ -17,7 +19,7 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "rollback", mixinStandardHelpOptions = true,
 		description = "Roll back a release to a previous revision")
 @Slf4j
-public class RollbackCommand implements Runnable {
+public class RollbackCommand implements Callable<Integer> {
 
 	private final RollbackAction rollbackAction;
 
@@ -57,7 +59,7 @@ public class RollbackCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			Release release = rollbackAction.rollback(RollbackOptions.builder()
 				.releaseName(name)
@@ -70,9 +72,11 @@ public class RollbackCommand implements Runnable {
 			if (wait) {
 				kubeService.waitForReady(namespace, release.getManifest(), timeout);
 			}
+			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error during rollback: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchCommand.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.app.command;
 
+import java.util.concurrent.Callable;
+
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
@@ -10,7 +12,7 @@ import picocli.CommandLine;
 @Component
 @CommandLine.Command(name = "search", mixinStandardHelpOptions = true, description = "Search for a keyword in charts",
 		subcommands = { SearchHubCommand.class })
-public class SearchCommand implements Runnable {
+public class SearchCommand implements Callable<Integer> {
 
 	/** Creates the command. */
 	@SuppressWarnings("PMD.UnnecessaryConstructor")
@@ -21,8 +23,9 @@ public class SearchCommand implements Runnable {
 	 * Prints the usage help when {@code search} is invoked without a subcommand.
 	 */
 	@Override
-	public void run() {
+	public Integer call() {
 		CommandLine.usage(this, System.out);
+		return CommandLine.ExitCode.OK;
 	}
 
 }

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchHubCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchHubCommand.java
@@ -1,6 +1,7 @@
 package org.alexmond.jhelm.app.command;
 
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.SearchHubAction;
@@ -13,7 +14,7 @@ import picocli.CommandLine;
  */
 @Component
 @CommandLine.Command(name = "hub", mixinStandardHelpOptions = true, description = "Search for charts in Artifact Hub")
-public class SearchHubCommand implements Runnable {
+public class SearchHubCommand implements Callable<Integer> {
 
 	private final SearchHubAction searchHubAction;
 
@@ -37,17 +38,19 @@ public class SearchHubCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			List<SearchHubAction.HubResult> results = searchHubAction.search(keyword, 25);
 			if (results.isEmpty()) {
 				CliOutput.println("No results found for \"" + keyword + "\"");
-				return;
+				return CommandLine.ExitCode.OK;
 			}
 			printTable(results);
+			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ShowCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ShowCommand.java
@@ -6,6 +6,8 @@ import org.alexmond.jhelm.core.action.ShowAction;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+import java.util.concurrent.Callable;
+
 /**
  * Implements {@code jhelm show}, displaying information about a chart via the
  * {@code chart}, {@code values}, {@code readme}, {@code crds}, and {@code all}
@@ -16,7 +18,7 @@ import picocli.CommandLine;
 		subcommands = { ShowCommand.ChartCommand.class, ShowCommand.ValuesCommand.class,
 				ShowCommand.ReadmeCommand.class, ShowCommand.CrdsCommand.class, ShowCommand.AllCommand.class })
 @Slf4j
-public class ShowCommand implements Runnable {
+public class ShowCommand implements Callable<Integer> {
 
 	/** Creates the command. */
 	@SuppressWarnings("PMD.UnnecessaryConstructor")
@@ -27,15 +29,16 @@ public class ShowCommand implements Runnable {
 	 * Prints the usage help when {@code show} is invoked without a subcommand.
 	 */
 	@Override
-	public void run() {
+	public Integer call() {
 		CommandLine.usage(this, System.out);
+		return CommandLine.ExitCode.OK;
 	}
 
 	/** Implements {@code show chart}: prints the chart's Chart.yaml. */
 	@Component
 	@CommandLine.Command(name = "chart", mixinStandardHelpOptions = true, description = "Show the chart's Chart.yaml")
 	@Slf4j
-	public static class ChartCommand implements Runnable {
+	public static class ChartCommand implements Callable<Integer> {
 
 		private final ShowAction showAction;
 
@@ -51,12 +54,14 @@ public class ShowCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				System.out.println(showAction.showChart(chartPath));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error showing chart: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -66,7 +71,7 @@ public class ShowCommand implements Runnable {
 	@Component
 	@CommandLine.Command(name = "values", mixinStandardHelpOptions = true, description = "Show the chart's values.yaml")
 	@Slf4j
-	public static class ValuesCommand implements Runnable {
+	public static class ValuesCommand implements Callable<Integer> {
 
 		private final ShowAction showAction;
 
@@ -82,12 +87,14 @@ public class ShowCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				System.out.println(showAction.showValues(chartPath));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error showing values: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -97,7 +104,7 @@ public class ShowCommand implements Runnable {
 	@Component
 	@CommandLine.Command(name = "readme", mixinStandardHelpOptions = true, description = "Show the chart's README")
 	@Slf4j
-	public static class ReadmeCommand implements Runnable {
+	public static class ReadmeCommand implements Callable<Integer> {
 
 		private final ShowAction showAction;
 
@@ -113,17 +120,19 @@ public class ShowCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				String readme = showAction.showReadme(chartPath);
 				if (readme.isEmpty()) {
 					System.out.println("No README found in chart");
-					return;
+					return CommandLine.ExitCode.OK;
 				}
 				System.out.println(readme);
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error showing readme: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -134,7 +143,7 @@ public class ShowCommand implements Runnable {
 	@CommandLine.Command(name = "crds", mixinStandardHelpOptions = true,
 			description = "Show the chart's Custom Resource Definitions")
 	@Slf4j
-	public static class CrdsCommand implements Runnable {
+	public static class CrdsCommand implements Callable<Integer> {
 
 		private final ShowAction showAction;
 
@@ -150,17 +159,19 @@ public class ShowCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				String crds = showAction.showCrds(chartPath);
 				if (crds.isEmpty()) {
 					System.out.println("No CRDs found in chart");
-					return;
+					return CommandLine.ExitCode.OK;
 				}
 				System.out.println(crds);
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error showing crds: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 
@@ -174,7 +185,7 @@ public class ShowCommand implements Runnable {
 	@CommandLine.Command(name = "all", mixinStandardHelpOptions = true,
 			description = "Show all information about the chart")
 	@Slf4j
-	public static class AllCommand implements Runnable {
+	public static class AllCommand implements Callable<Integer> {
 
 		private final ShowAction showAction;
 
@@ -190,12 +201,14 @@ public class ShowCommand implements Runnable {
 		}
 
 		@Override
-		public void run() {
+		public Integer call() {
 			try {
 				System.out.println(showAction.showAll(chartPath));
+				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
 				CliOutput.errPrintln(CliOutput.error("Error showing all: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/StatusCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/StatusCommand.java
@@ -11,6 +11,7 @@ import picocli.CommandLine;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 /**
  * Implements {@code jhelm status RELEASE}, displaying the status of a named release and
@@ -20,7 +21,7 @@ import java.util.Optional;
 @CommandLine.Command(name = "status", mixinStandardHelpOptions = true,
 		description = "Display the status of the named release")
 @Slf4j
-public class StatusCommand implements Runnable {
+public class StatusCommand implements Callable<Integer> {
 
 	private final StatusAction statusAction;
 
@@ -54,12 +55,12 @@ public class StatusCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			Optional<Release> releaseOpt = statusAction.status(name, namespace);
 			if (releaseOpt.isEmpty()) {
 				CliOutput.errPrintln(CliOutput.error("Error: release not found: " + name));
-				return;
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 
 			Release r = releaseOpt.get();
@@ -85,9 +86,11 @@ public class StatusCommand implements Runnable {
 			}
 
 			CliOutput.println("\n" + CliOutput.bold("MANIFEST:") + "\n" + r.getManifest());
+			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error fetching status: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.app.command;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
@@ -20,7 +21,7 @@ import picocli.CommandLine.Option;
 @Component
 @CommandLine.Command(name = "template", mixinStandardHelpOptions = true, description = "Locally render templates")
 @Slf4j
-public class TemplateCommand implements Runnable {
+public class TemplateCommand implements Callable<Integer> {
 
 	private final TemplateAction templateAction;
 
@@ -69,7 +70,7 @@ public class TemplateCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
 					setFileValues, setJsonValues);
@@ -78,9 +79,11 @@ public class TemplateCommand implements Runnable {
 				manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
 			}
 			CliOutput.println(manifest);
+			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error rendering template: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TestCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TestCommand.java
@@ -1,6 +1,7 @@
 package org.alexmond.jhelm.app.command;
 
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
@@ -19,7 +20,7 @@ import picocli.CommandLine;
 		description = "Run the test hooks for a named release")
 @Slf4j
 @SuppressWarnings("PMD.TestClassWithoutTestCases")
-public class TestCommand implements Runnable {
+public class TestCommand implements Callable<Integer> {
 
 	private final TestAction testAction;
 
@@ -45,13 +46,13 @@ public class TestCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			List<TestResult> results = testAction.test(name, namespace, timeout);
 
 			if (results.isEmpty()) {
 				CliOutput.println(CliOutput.warn("No test hooks found for release '" + name + "'"));
-				return;
+				return CommandLine.ExitCode.OK;
 			}
 
 			boolean allPassed = true;
@@ -64,13 +65,16 @@ public class TestCommand implements Runnable {
 
 			if (allPassed) {
 				CliOutput.println(CliOutput.success("All tests passed for release '" + name + "'"));
+				return CommandLine.ExitCode.OK;
 			}
 			else {
 				CliOutput.errPrintln(CliOutput.error("Some tests failed for release '" + name + "'"));
+				return CommandLine.ExitCode.SOFTWARE;
 			}
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error running tests: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.app.command;
 
+import java.util.concurrent.Callable;
+
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.UninstallAction;
@@ -14,7 +16,7 @@ import picocli.CommandLine;
 @Component
 @CommandLine.Command(name = "uninstall", mixinStandardHelpOptions = true, description = "Uninstall a release")
 @Slf4j
-public class UninstallCommand implements Runnable {
+public class UninstallCommand implements Callable<Integer> {
 
 	private final UninstallAction uninstallAction;
 
@@ -40,7 +42,7 @@ public class UninstallCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			uninstallAction.uninstall(UninstallOptions.builder()
 				.releaseName(name)
@@ -49,9 +51,11 @@ public class UninstallCommand implements Runnable {
 				.keepHistory(keepHistory)
 				.build());
 			CliOutput.println(CliOutput.success("release \"" + name + "\" uninstalled"));
+			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error uninstalling release: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
@@ -34,7 +35,7 @@ import picocli.CommandLine.Option;
 @Component
 @CommandLine.Command(name = "upgrade", mixinStandardHelpOptions = true, description = "Upgrade a release")
 @Slf4j
-public class UpgradeCommand implements Runnable {
+public class UpgradeCommand implements Callable<Integer> {
 
 	private final KubeService kubeService;
 
@@ -153,7 +154,7 @@ public class UpgradeCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		int previousVersion = -1;
 		boolean wasInstall = false;
 		try {
@@ -181,8 +182,9 @@ public class UpgradeCommand implements Runnable {
 				}
 				else {
 					CliOutput.errPrintln(CliOutput.error("Error: release \"" + name + "\" does not exist"));
+					return CommandLine.ExitCode.SOFTWARE;
 				}
-				return;
+				return CommandLine.ExitCode.OK;
 			}
 
 			previousVersion = currentReleaseOpt.get().getVersion();
@@ -202,28 +204,11 @@ public class UpgradeCommand implements Runnable {
 					kubeService.waitForReady(namespace, upgradedRelease.getManifest(), timeout);
 				}
 			}
+			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			if (atomic) {
-				CliOutput.errPrintln(CliOutput.error("Upgrade failed, performing atomic rollback: " + ex.getMessage()));
-				try {
-					if (wasInstall || previousVersion < 0) {
-						uninstallAction
-							.uninstall(UninstallOptions.builder().releaseName(name).namespace(namespace).build());
-						CliOutput.println("Atomic uninstall of \"" + name + "\" complete.");
-					}
-					else {
-						rollbackAction.rollback(RollbackOptions.builder()
-							.releaseName(name)
-							.namespace(namespace)
-							.revision(previousVersion)
-							.build());
-						CliOutput.println("Atomic rollback of \"" + name + "\" complete.");
-					}
-				}
-				catch (Exception rollbackEx) {
-					CliOutput.errPrintln(CliOutput.error("Atomic rollback failed: " + rollbackEx.getMessage()));
-				}
+				performAtomicRollback(ex, wasInstall, previousVersion);
 			}
 			else {
 				CliOutput.errPrintln(CliOutput.error("Error upgrading release: " + ex.getMessage()));
@@ -231,6 +216,36 @@ public class UpgradeCommand implements Runnable {
 			if (log.isDebugEnabled()) {
 				log.debug("Upgrade error details", ex);
 			}
+			return CommandLine.ExitCode.SOFTWARE;
+		}
+	}
+
+	/**
+	 * Rolls the release back after an {@code --atomic} upgrade failure: uninstalls a
+	 * freshly-installed release, otherwise rolls back to the previous revision. Any
+	 * failure of the rollback itself is reported but does not mask the original error.
+	 * @param ex the upgrade failure that triggered the rollback
+	 * @param wasInstall {@code true} if the release was freshly installed in this run
+	 * @param previousVersion the revision to roll back to, or negative if none exists
+	 */
+	private void performAtomicRollback(Exception ex, boolean wasInstall, int previousVersion) {
+		CliOutput.errPrintln(CliOutput.error("Upgrade failed, performing atomic rollback: " + ex.getMessage()));
+		try {
+			if (wasInstall || previousVersion < 0) {
+				uninstallAction.uninstall(UninstallOptions.builder().releaseName(name).namespace(namespace).build());
+				CliOutput.println("Atomic uninstall of \"" + name + "\" complete.");
+			}
+			else {
+				rollbackAction.rollback(RollbackOptions.builder()
+					.releaseName(name)
+					.namespace(namespace)
+					.revision(previousVersion)
+					.build());
+				CliOutput.println("Atomic rollback of \"" + name + "\" complete.");
+			}
+		}
+		catch (Exception rollbackEx) {
+			CliOutput.errPrintln(CliOutput.error("Atomic rollback failed: " + rollbackEx.getMessage()));
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/VerifyCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/VerifyCommand.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.app.command;
 
+import java.util.concurrent.Callable;
+
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.VerifyAction;
@@ -14,7 +16,7 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "verify", mixinStandardHelpOptions = true,
 		description = "Verify that a chart has a valid provenance file")
 @Slf4j
-public class VerifyCommand implements Runnable {
+public class VerifyCommand implements Callable<Integer> {
 
 	private final VerifyAction verifyAction;
 
@@ -33,14 +35,16 @@ public class VerifyCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		try {
 			String resolvedKeyring = (keyring != null) ? keyring : defaultKeyringPath();
 			verifyAction.verify(chartPath, resolvedKeyring);
 			CliOutput.println(CliOutput.success("Verification succeeded"));
+			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/VersionCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/VersionCommand.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.app.command;
 
+import java.util.concurrent.Callable;
+
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
@@ -12,7 +14,7 @@ import picocli.CommandLine;
 @Component
 @CommandLine.Command(name = "version", mixinStandardHelpOptions = true,
 		description = "Print the jhelm version information")
-public class VersionCommand implements Runnable {
+public class VersionCommand implements Callable<Integer> {
 
 	@CommandLine.Option(names = { "--short" }, description = "print the version number only")
 	private boolean shortOutput;
@@ -33,7 +35,7 @@ public class VersionCommand implements Runnable {
 	}
 
 	@Override
-	public void run() {
+	public Integer call() {
 		if (this.shortOutput) {
 			CliOutput.println(versionString());
 		}
@@ -41,6 +43,7 @@ public class VersionCommand implements Runnable {
 			CliOutput
 				.println("jhelm version " + versionString() + " (Java " + System.getProperty("java.version") + ")");
 		}
+		return CommandLine.ExitCode.OK;
 	}
 
 }

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/GetCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/GetCommandTest.java
@@ -45,7 +45,7 @@ class GetCommandTest {
 	@Test
 	void testGetCommandShowsUsage() {
 		GetCommand getCommand = new GetCommand();
-		getCommand.run();
+		getCommand.call();
 
 		String output = outputStream.toString();
 		assertTrue(output.contains("get") || output.contains("Usage"));

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -9,8 +9,10 @@ import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UninstallOptions;
+import org.alexmond.jhelm.core.exception.WaitTimeoutException;
 
 import java.util.HashMap;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -21,7 +23,9 @@ import picocli.CommandLine;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -72,7 +76,9 @@ class InstallCommandTest {
 		when(installAction.install(any(InstallOptions.class))).thenReturn(release);
 
 		CommandLine cmd = new CommandLine(installCommand);
-		cmd.execute("my-release", chartDir.getAbsolutePath(), "-n", "default");
+		int exitCode = cmd.execute("my-release", chartDir.getAbsolutePath(), "-n", "default");
+
+		assertEquals(CommandLine.ExitCode.OK, exitCode);
 	}
 
 	@Test
@@ -93,7 +99,26 @@ class InstallCommandTest {
 		when(installAction.install(any(InstallOptions.class))).thenThrow(new RuntimeException("Test error"));
 
 		CommandLine cmd = new CommandLine(installCommand);
-		cmd.execute("my-release", chartDir.getAbsolutePath());
+		int exitCode = cmd.execute("my-release", chartDir.getAbsolutePath());
+
+		assertNotEquals(CommandLine.ExitCode.OK, exitCode, "a failed install must exit non-zero");
+	}
+
+	@Test
+	void testInstallWaitTimeoutExitsNonZero() throws Exception {
+		// Regression for #647: a --wait readiness timeout printed an error but exited 0,
+		// so callers could not detect the failed rollout. It must now exit non-zero.
+		File chartDir = createMockChart();
+		Release release = createMockRelease("my-release", 1);
+		when(installAction.install(any(InstallOptions.class))).thenReturn(release);
+		Mockito.doThrow(new WaitTimeoutException("Timeout waiting for resources to be ready", List.of()))
+			.when(kubeService)
+			.waitForReady(anyString(), anyString(), anyInt());
+
+		int exitCode = new CommandLine(installCommand).execute("my-release", chartDir.getAbsolutePath(), "--wait",
+				"--timeout", "5");
+
+		assertNotEquals(CommandLine.ExitCode.OK, exitCode, "a --wait timeout must exit non-zero");
 	}
 
 	@Test

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/LintCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/LintCommandTest.java
@@ -52,7 +52,8 @@ class LintCommandTest {
 			.thenReturn(new LintAction.LintResult("./", List.of("chart name is required"), List.of()));
 		CommandLine cmd = new CommandLine(lintCommand);
 		int exitCode = cmd.execute(".");
-		assertEquals(0, exitCode);
+		// #647: a chart that fails lint must exit non-zero, like `helm lint`.
+		assertEquals(CommandLine.ExitCode.SOFTWARE, exitCode);
 	}
 
 }

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/SearchHubCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/SearchHubCommandTest.java
@@ -110,7 +110,8 @@ class SearchHubCommandTest {
 
 		CommandLine cmd = new CommandLine(searchHubCommand);
 		int exitCode = cmd.execute("nginx");
-		assertEquals(0, exitCode);
+		// #647: a failed hub search must exit non-zero so callers can detect it.
+		assertEquals(CommandLine.ExitCode.SOFTWARE, exitCode);
 	}
 
 }

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ShowCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ShowCommandTest.java
@@ -130,7 +130,7 @@ class ShowCommandTest {
 		ShowCommand.ChartCommand command = new ShowCommand.ChartCommand(showAction);
 		command.chartPath = chartDir.toString();
 
-		command.run();
+		command.call();
 
 		String output = outputStream.toString();
 		assertTrue(output.contains("name: test-chart"), "Output: " + output);
@@ -146,7 +146,7 @@ class ShowCommandTest {
 		ShowCommand.ValuesCommand command = new ShowCommand.ValuesCommand(showAction);
 		command.chartPath = chartDir.toString();
 
-		command.run();
+		command.call();
 
 		String output = outputStream.toString();
 		assertTrue(output.contains("replicaCount: 1"), "Output: " + output);
@@ -160,7 +160,7 @@ class ShowCommandTest {
 		ShowCommand.ReadmeCommand command = new ShowCommand.ReadmeCommand(showAction);
 		command.chartPath = chartDir.toString();
 
-		command.run();
+		command.call();
 
 		String output = outputStream.toString();
 		assertTrue(output.contains("# Test Chart"));
@@ -174,7 +174,7 @@ class ShowCommandTest {
 		ShowCommand.CrdsCommand command = new ShowCommand.CrdsCommand(showAction);
 		command.chartPath = chartDir.toString();
 
-		command.run();
+		command.call();
 
 		String output = outputStream.toString();
 		assertTrue(output.contains("kind: CustomResourceDefinition"));
@@ -190,7 +190,7 @@ class ShowCommandTest {
 		ShowCommand.AllCommand command = new ShowCommand.AllCommand(showAction);
 		command.chartPath = chartDir.toString();
 
-		command.run();
+		command.call();
 
 		String output = outputStream.toString();
 
@@ -232,7 +232,7 @@ class ShowCommandTest {
 		ShowCommand.ReadmeCommand command = new ShowCommand.ReadmeCommand(showAction);
 		command.chartPath = noReadmeDir.toString();
 
-		command.run();
+		command.call();
 
 		String output = outputStream.toString();
 		assertTrue(output.contains("No README found in chart"));
@@ -256,7 +256,7 @@ class ShowCommandTest {
 		ShowCommand.CrdsCommand command = new ShowCommand.CrdsCommand(showAction);
 		command.chartPath = noCrdsDir.toString();
 
-		command.run();
+		command.call();
 
 		String output = outputStream.toString();
 		assertTrue(output.contains("No CRDs found in chart"));
@@ -280,7 +280,7 @@ class ShowCommandTest {
 		ShowCommand.ValuesCommand command = new ShowCommand.ValuesCommand(showAction);
 		command.chartPath = emptyValuesDir.toString();
 
-		command.run();
+		command.call();
 
 		String output = outputStream.toString();
 		assertTrue(output.contains("{}"));
@@ -292,7 +292,7 @@ class ShowCommandTest {
 		command.chartPath = "/nonexistent/path";
 
 		// Should not throw, but should log error
-		command.run();
+		command.call();
 
 		// Verify error was logged (output will be empty since we redirected System.out)
 		// In a real scenario, this would be verified with a logging framework test
@@ -313,7 +313,7 @@ class ShowCommandTest {
 	void testShowCommandRunShowsUsage() {
 		outputStream.reset();
 		ShowCommand showCommand = new ShowCommand();
-		showCommand.run();
+		showCommand.call();
 
 		String output = outputStream.toString();
 		assertTrue(output.contains("show") || output.contains("Usage"));
@@ -328,27 +328,27 @@ class ShowCommandTest {
 			case "chart" -> {
 				var cmd = new ShowCommand.ChartCommand(showAction);
 				cmd.chartPath = invalidDir.toString();
-				cmd.run();
+				cmd.call();
 			}
 			case "values" -> {
 				var cmd = new ShowCommand.ValuesCommand(showAction);
 				cmd.chartPath = invalidDir.toString();
-				cmd.run();
+				cmd.call();
 			}
 			case "all" -> {
 				var cmd = new ShowCommand.AllCommand(showAction);
 				cmd.chartPath = invalidDir.toString();
-				cmd.run();
+				cmd.call();
 			}
 			case "readme" -> {
 				var cmd = new ShowCommand.ReadmeCommand(showAction);
 				cmd.chartPath = invalidDir.toString();
-				cmd.run();
+				cmd.call();
 			}
 			case "crds" -> {
 				var cmd = new ShowCommand.CrdsCommand(showAction);
 				cmd.chartPath = invalidDir.toString();
-				cmd.run();
+				cmd.call();
 			}
 		}
 	}
@@ -363,7 +363,7 @@ class ShowCommandTest {
 		ShowCommand.ChartCommand command = new ShowCommand.ChartCommand(showAction);
 		command.chartPath = chartDir.toString();
 
-		command.run();
+		command.call();
 
 		String output = outputStream.toString();
 		assertTrue(output.contains("test-chart"));

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -12,6 +12,7 @@ import org.alexmond.jhelm.core.action.RollbackOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.action.UpgradeOptions;
+import org.alexmond.jhelm.core.exception.WaitTimeoutException;
 
 import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +25,9 @@ import picocli.CommandLine;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -32,6 +35,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -85,6 +89,23 @@ class UpgradeCommandTest {
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "-n", "default");
+	}
+
+	@Test
+	void testUpgradeWaitTimeoutExitsNonZero() throws Exception {
+		// Regression for #647: an upgrade --wait readiness timeout must exit non-zero.
+		File chartDir = createMockChart();
+		Release existingRelease = createMockRelease("my-release", 1);
+		Release upgradedRelease = createMockRelease("my-release", 2);
+		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(existingRelease));
+		when(upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(upgradedRelease);
+		doThrow(new WaitTimeoutException("Timeout waiting for resources to be ready", List.of())).when(kubeService)
+			.waitForReady(anyString(), anyString(), anyInt());
+
+		int exitCode = new CommandLine(upgradeCommand).execute("my-release", chartDir.getAbsolutePath(), "--wait",
+				"--timeout", "5");
+
+		assertNotEquals(CommandLine.ExitCode.OK, exitCode, "an upgrade --wait timeout must exit non-zero");
 	}
 
 	@Test


### PR DESCRIPTION
## Problem
Every jhelm subcommand implemented `Runnable` and caught its own exceptions — printing a clean error to stderr but returning normally — so picocli's `execute()` always returned exit code **0**. Callers (scripts, CI) could not detect a failed operation.

Most visibly (#647): `install --wait` / `upgrade --wait` printed a readiness-timeout error yet **exited 0**, so a deploy script saw a crashlooping workload as success.

```
jhelm install wtest ./chart -n test --wait --timeout 5
# stderr: Error ... Timeout waiting for resources to be ready: Deployment/...: 0/1 ready
# exit code: 0   ← wrong; helm exits 1
```

## Fix
Converted **all 26 command classes** (top-level + nested subcommands) from `Runnable` to `Callable<Integer>`:
- success → `ExitCode.OK`
- terminal error paths → `ExitCode.SOFTWARE` (1): caught failures, `--wait` timeouts, validation errors, and — matching helm — a failed `lint` and a failed `test`.

The existing `HelmJavaApplication` wiring already routes `execute()`'s result through `ExitCodeGenerator` → `System.exit`, so the code now reaches the shell with no bootstrap change. `CreateCommand`'s ad-hoc `System.exit(1)` is replaced by the same idiom.

Empty-result cases that are **not** failures stay exit 0 to match helm (e.g. `repo search` / `search hub` with no matches, `lint` with warnings only).

## Tests
- New regression tests: `install`/`upgrade --wait` timeout → non-zero exit.
- Updated `testLintCommandWithErrors` and `testSearchHubError`, which asserted the old exit-0 behavior.
- All 205 jhelm-cli tests pass; PMD + checkstyle + spring-javaformat clean.

Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)