### PR TITLE
perf(cli): lazy bean initialization to halve startup time

### DIFF
--- a/jhelm-cli/src/main/resources/application.properties
+++ b/jhelm-cli/src/main/resources/application.properties
@@ -2,3 +2,12 @@
 # with no subcommand, so that command output on stdout (e.g. `jhelm template`
 # piped to a file) stays clean. Disable Spring's automatic stdout banner here.
 spring.main.banner-mode=off
+
+# Lazy bean initialization: a CLI invocation only exercises the beans for the one
+# command being run, so eagerly instantiating the whole context (chart engine,
+# repo/registry managers, kube client, ...) on every startup is wasted work. Lazy
+# init defers each bean to first use, roughly halving Spring context startup (a
+# trivial command such as `jhelm version` goes from ~4.2s to ~2.1s of context
+# init). Errors from a misconfigured bean now surface when the command that needs
+# it runs, rather than at startup — which is the desired behavior for a CLI.
+spring.main.lazy-initialization=true


### PR DESCRIPTION
## What
Enable `spring.main.lazy-initialization=true` for the `jhelm` CLI.

A CLI invocation only touches the beans for the one command being run, so eagerly building the entire Spring context (chart engine, repo/registry managers, kube client, …) on every startup is wasted work. Lazy init defers each bean to first use.

## Measured (`jhelm version`, median of 5 runs, same JVM/machine)
| | wall-clock | Spring context init |
|---|---|---|
| before | ~5.45s | ~4.2s |
| after | **~3.51s** | ~2.1s |
| | **~36% faster** | ~halved |

## Safety
- Offline commands verified working under lazy init: `version`, `env`, `template` (full Engine/ChartLoader graph), `lint`, `--help`.
- Full **205-test jhelm-cli suite green**, including `HelmJavaApplicationTests` (which loads the Spring context).
- Trade-off: a misconfigured bean now errors when its command runs rather than at startup — the right behavior for a CLI (and the failing command still exits non-zero per #647).

One-line config change; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)