### PR TITLE
fix(kube): apply cluster-scoped resources at cluster scope (#650)

### DIFF
--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
@@ -370,10 +370,11 @@ public class HelmKubeService implements KubeService {
 		String kind = obj.getKind();
 		String name = obj.getMetadata().getName();
 		String plural = inferPlural(kind);
+		boolean namespaced = inferNamespaced(kind);
 
 		if (log.isInfoEnabled()) {
-			log.info("{} {} ({}/{}) {} in namespace {}", serverDryRun ? "Validating (server dry-run)" : "Applying",
-					kind, group, version, name, namespace);
+			log.info("{} {} ({}/{}) {}{}", serverDryRun ? "Validating (server dry-run)" : "Applying", kind, group,
+					version, name, namespaced ? " in namespace " + namespace : " (cluster-scoped)");
 		}
 
 		V1Patch patch = new V1Patch(Yaml.dump(obj));
@@ -386,9 +387,11 @@ public class HelmKubeService implements KubeService {
 		// DynamicKubernetesApi resolves the request path from the group, so core-group
 		// resources (empty group, e.g. Service/ConfigMap/Secret) hit /api/<version>
 		// while named groups hit /apis/<group>/<version>. CustomObjectsApi always emits
-		// /apis/<group>/... and 404s on the core group.
+		// /apis/<group>/... and 404s on the core group. Cluster-scoped kinds
+		// (ClusterRole/CRD/...) must skip the namespace segment or the API server rejects
+		// them, so the scope comes from the kind rather than the release namespace.
 		DynamicKubernetesApi api = new DynamicKubernetesApi(group, version, plural, apiClient);
-		KubernetesApiResponse<DynamicKubernetesObject> response = (namespace != null && !namespace.isEmpty())
+		KubernetesApiResponse<DynamicKubernetesObject> response = namespaced
 				? api.patch(namespace, name, V1Patch.PATCH_FORMAT_APPLY_YAML, patch, options)
 				: api.patch(name, V1Patch.PATCH_FORMAT_APPLY_YAML, patch, options);
 		response.throwsApiException();
@@ -421,18 +424,21 @@ public class HelmKubeService implements KubeService {
 		String kind = obj.getKind();
 		String name = obj.getMetadata().getName();
 		String plural = inferPlural(kind);
+		boolean namespaced = inferNamespaced(kind);
 
 		if (log.isInfoEnabled()) {
-			log.info("Deleting {} {} in namespace {}", kind, name, namespace);
+			log.info("Deleting {} {}{}", kind, name, namespaced ? " in namespace " + namespace : " (cluster-scoped)");
 		}
 
 		// As with apply, DynamicKubernetesApi targets /api/<version> for the core group;
 		// CustomObjectsApi 404s there, which previously made core-resource deletes
 		// silently
-		// no-op (the 404 was swallowed below as "already gone").
+		// no-op (the 404 was swallowed below as "already gone"). Cluster-scoped kinds
+		// skip
+		// the namespace segment based on the kind, not the release namespace.
 		DynamicKubernetesApi api = new DynamicKubernetesApi(group, version, plural, apiClient);
-		KubernetesApiResponse<DynamicKubernetesObject> response = (namespace != null && !namespace.isEmpty())
-				? api.delete(namespace, name) : api.delete(name);
+		KubernetesApiResponse<DynamicKubernetesObject> response = namespaced ? api.delete(namespace, name)
+				: api.delete(name);
 		if (!response.isSuccess() && response.getHttpStatusCode() != 404) {
 			response.throwsApiException();
 		}
@@ -708,6 +714,13 @@ public class HelmKubeService implements KubeService {
 			pluralizer = new ResourcePluralizer(apiClient);
 		}
 		return pluralizer.toPlural(kind);
+	}
+
+	private boolean inferNamespaced(String kind) {
+		if (pluralizer == null) {
+			pluralizer = new ResourcePluralizer(apiClient);
+		}
+		return pluralizer.isNamespaced(kind);
 	}
 
 	/**

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/ResourcePluralizer.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/ResourcePluralizer.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.kube.service.internal;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
@@ -95,11 +96,45 @@ class ResourcePluralizer {
 		// apiregistration.k8s.io/v1
 		Map.entry("APIService", "apiservices")
 	);
+
+	/**
+	 * Built-in Kubernetes kinds that live at the cluster scope (no namespace). Charts commonly
+	 * ship the RBAC and CRD subset of these; applying any of them through the namespaced API
+	 * path is rejected by the API server. Kinds not listed here (and not otherwise discovered)
+	 * are assumed namespaced — the safe default, and correct for the vast majority of CRDs.
+	 */
+	private static final Set<String> CLUSTER_SCOPED_KINDS = Set.of(
+		// core/v1
+		"ComponentStatus", "Namespace", "Node", "PersistentVolume",
+		// rbac.authorization.k8s.io/v1
+		"ClusterRole", "ClusterRoleBinding",
+		// storage.k8s.io/v1
+		"CSIDriver", "CSINode", "StorageClass", "VolumeAttachment",
+		// admissionregistration.k8s.io/v1
+		"MutatingWebhookConfiguration", "ValidatingWebhookConfiguration",
+		"ValidatingAdmissionPolicy", "ValidatingAdmissionPolicyBinding",
+		// apiextensions.k8s.io/v1
+		"CustomResourceDefinition",
+		// certificates.k8s.io/v1
+		"CertificateSigningRequest",
+		// scheduling.k8s.io/v1
+		"PriorityClass",
+		// node.k8s.io/v1
+		"RuntimeClass",
+		// networking.k8s.io/v1
+		"IngressClass",
+		// flowcontrol.apiserver.k8s.io/v1
+		"FlowSchema", "PriorityLevelConfiguration",
+		// apiregistration.k8s.io/v1
+		"APIService"
+	);
 	// @formatter:on
 
 	private final ApiClient apiClient;
 
 	private Map<String, String> discoveredPlurals;
+
+	private Map<String, Boolean> discoveredNamespaced;
 
 	ResourcePluralizer(ApiClient apiClient) {
 		this.apiClient = apiClient;
@@ -130,8 +165,36 @@ class ResourcePluralizer {
 		return heuristicPlural(kind);
 	}
 
+	/**
+	 * Reports whether a Kubernetes resource kind is namespaced (versus cluster-scoped).
+	 * Well-known cluster-scoped and namespaced built-ins are answered from static tables;
+	 * anything else is resolved from API-server discovery, defaulting to namespaced when
+	 * discovery is unavailable or the kind is unknown.
+	 * @param kind the resource kind (e.g., "ClusterRole", "ConfigMap")
+	 * @return {@code true} if the kind is namespaced, {@code false} if cluster-scoped
+	 */
+	boolean isNamespaced(String kind) {
+		// 1. Known cluster-scoped built-in
+		if (CLUSTER_SCOPED_KINDS.contains(kind)) {
+			return false;
+		}
+		// 2. Any other well-known built-in is namespaced (cluster-scoped ones are caught
+		// above)
+		if (WELL_KNOWN_PLURALS.containsKey(kind)) {
+			return true;
+		}
+		// 3. Discovery cache (lazy-loaded) — authoritative for CRDs
+		if (discoveredNamespaced == null) {
+			discoverResources();
+		}
+		Boolean namespaced = discoveredNamespaced.get(kind);
+		// 4. Default to namespaced for unknown kinds (the common case for CRDs)
+		return namespaced == null || namespaced;
+	}
+
 	private void discoverResources() {
 		discoveredPlurals = new HashMap<>();
+		discoveredNamespaced = new HashMap<>();
 		try {
 			addResourcesFrom(new CoreV1Api(apiClient).getAPIResources().execute());
 			addResourcesFrom(new AppsV1Api(apiClient).getAPIResources().execute());
@@ -160,6 +223,9 @@ class ResourcePluralizer {
 			// Skip subresources (e.g., "pods/status", "deployments/scale")
 			if (resource.getName() != null && !resource.getName().contains("/") && resource.getKind() != null) {
 				discoveredPlurals.putIfAbsent(resource.getKind(), resource.getName());
+				if (resource.getNamespaced() != null) {
+					discoveredNamespaced.putIfAbsent(resource.getKind(), resource.getNamespaced());
+				}
 			}
 		}
 	}

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
@@ -531,6 +531,54 @@ class HelmKubeServiceTest {
 	}
 
 	@Test
+	void testApplyClusterScopedResourceUsesClusterPath() throws Exception {
+		// Regression for #650: a ClusterRole must be applied via the cluster-scoped path
+		// (no namespace segment), not scoped into the release namespace.
+		String yaml = """
+				apiVersion: rbac.authorization.k8s.io/v1
+				kind: ClusterRole
+				metadata:
+				  name: demo-discovery
+				rules:
+				  - apiGroups: [""]
+				    resources: ["services"]
+				    verbs: ["get", "list"]
+				""";
+
+		setupSsaMock();
+		kubeService.apply("demo", yaml);
+
+		assertEquals("rbac.authorization.k8s.io", lastDynamicApiCtorArgs.get(0));
+		assertEquals("v1", lastDynamicApiCtorArgs.get(1));
+		assertEquals("clusterroles", lastDynamicApiCtorArgs.get(2));
+
+		// cluster-scoped overload (name, format, patch, options) — no namespace
+		verify(mockDynamicApi).patch(eq("demo-discovery"), eq(V1Patch.PATCH_FORMAT_APPLY_YAML), any(V1Patch.class),
+				any(PatchOptions.class));
+		// the namespaced overload must NOT be used
+		verify(mockDynamicApi, never()).patch(anyString(), anyString(), anyString(), any(V1Patch.class),
+				any(PatchOptions.class));
+	}
+
+	@Test
+	void testDeleteClusterScopedResourceUsesClusterPath() throws Exception {
+		// #650: deleting a ClusterRoleBinding must also skip the namespace segment.
+		String yaml = """
+				apiVersion: rbac.authorization.k8s.io/v1
+				kind: ClusterRoleBinding
+				metadata:
+				  name: demo-discovery
+				roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: demo-discovery }
+				""";
+
+		setupSsaMock();
+		kubeService.delete("demo", yaml);
+
+		verify(mockDynamicApi).delete(eq("demo-discovery"));
+		verify(mockDynamicApi, never()).delete(anyString(), anyString());
+	}
+
+	@Test
 	void testApplyCoreV1ResourceUsesSSA() throws Exception {
 		String yaml = """
 				apiVersion: v1

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/ResourcePluralizerTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/ResourcePluralizerTest.java
@@ -3,10 +3,36 @@ package org.alexmond.jhelm.kube.service.internal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ResourcePluralizerTest {
+
+	@ParameterizedTest
+	@ValueSource(strings = { "ClusterRole", "ClusterRoleBinding", "Namespace", "Node", "PersistentVolume",
+			"StorageClass", "CustomResourceDefinition", "PriorityClass", "IngressClass", "APIService",
+			"MutatingWebhookConfiguration", "ValidatingWebhookConfiguration", "CSIDriver", "VolumeAttachment" })
+	void testClusterScopedKindsAreNotNamespaced(String kind) {
+		// #650: cluster-scoped kinds must resolve as not-namespaced from static tables
+		// (no cluster).
+		assertFalse(new ResourcePluralizer(null).isNamespaced(kind), kind + " should be cluster-scoped");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "ConfigMap", "Secret", "Service", "ServiceAccount", "Deployment", "StatefulSet", "Pod",
+			"Role", "RoleBinding", "Ingress", "Job", "CronJob", "PersistentVolumeClaim", "NetworkPolicy" })
+	void testNamespacedKindsAreNamespaced(String kind) {
+		assertTrue(new ResourcePluralizer(null).isNamespaced(kind), kind + " should be namespaced");
+	}
+
+	@Test
+	void testUnknownKindDefaultsToNamespaced() {
+		// An unknown CRD with no reachable cluster (null client) defaults to namespaced.
+		assertTrue(new ResourcePluralizer(null).isNamespaced("WidgetThing"));
+	}
 
 	@ParameterizedTest
 	@CsvSource({ "Pod,pods", "Service,services", "ConfigMap,configmaps", "Secret,secrets", "Namespace,namespaces",


### PR DESCRIPTION
## Problem
`apply`/`delete` chose the namespaced vs cluster API path purely on whether the release namespace string was empty — which it never is — so **cluster-scoped kinds** (`ClusterRole`, `ClusterRoleBinding`, `CustomResourceDefinition`, `StorageClass`, `PriorityClass`, webhook configs, …) were POSTed to the **namespaced** endpoint and rejected by the API server, failing the whole install/upgrade. Any chart shipping cluster-wide RBAC couldn't be installed (#650).

The tell was the log line `Applying ClusterRole (...) in namespace <ns>`.

## Fix
Scope now comes from the **kind**, not the release namespace:
- `ResourcePluralizer.isNamespaced(kind)` — a static table of well-known cluster-scoped built-ins, backed by API discovery (`V1APIResource.namespaced`) for CRDs, defaulting to namespaced when unknown. This reuses the discovery the pluralizer already performs.
- `HelmKubeService.applyResource`/`deleteResource` route cluster-scoped kinds to the no-namespace path, and log `(cluster-scoped)` instead of a misleading `in namespace <ns>`.

## Verification
- **New tests reproduce the bug and prove the fix:** `HelmKubeServiceTest` asserts a `ClusterRole` apply and `ClusterRoleBinding` delete use the cluster path and **never** the namespaced overload; `ResourcePluralizerTest` covers cluster-scoped vs namespaced vs unknown kinds.
- Logs now read `Applying ClusterRole (rbac.authorization.k8s.io/v1) demo-discovery (cluster-scoped)`.
- Full **jhelm-kube suite green** (243 reactor tests, PMD + checkstyle clean).

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)