### PR TITLE
fix(cli): enforce READ_ONLY access mode for mutating commands (#653)

### DIFF
--- a/docs/modules/ROOT/pages/security.adoc
+++ b/docs/modules/ROOT/pages/security.adoc
@@ -1,8 +1,11 @@
 = Security Model
 
 jhelm exposes Helm operations over two network surfaces -- the xref:rest-api.adoc[REST API]
-and the xref:mcp.adoc[MCP server] -- and both share a single, unified security model under
-`jhelm.security.*`.
+and the xref:mcp.adoc[MCP server] -- which share a single, unified security model under
+`jhelm.security.*`. The CLI honors the same access mode: in the default `READ_ONLY` posture
+its cluster-mutating commands (`install`, `upgrade`, `uninstall`, `rollback`, `test`) are
+refused, so it behaves consistently with the adapters (set `mode=FULL` + an `api-key` to
+enable them).
 
 The design in one line: *MCP runs local-first, the REST API is deny-by-default behind an API
 key, read-only is the default everywhere, and Spring Security is the bring-your-own upgrade

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -12,6 +12,7 @@ import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UninstallOptions;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
@@ -38,6 +39,8 @@ public class InstallCommand implements Callable<Integer> {
 	private final KubeService kubeService;
 
 	private final ChartResolver chartResolver;
+
+	private final JhelmSecurityPolicy securityPolicy;
 
 	@CommandLine.Parameters(index = "0", description = "release name")
 	private String name;
@@ -105,17 +108,23 @@ public class InstallCommand implements Callable<Integer> {
 	 * @param kubeService the Kubernetes service used to wait for resource readiness
 	 * @param chartResolver resolves the chart source (directory or {@code .tgz}), with
 	 * optional provenance verification
+	 * @param securityPolicy the unified access-mode policy; install is refused unless
+	 * mutating operations are enabled
 	 */
 	public InstallCommand(InstallAction installAction, UninstallAction uninstallAction, KubeService kubeService,
-			ChartResolver chartResolver) {
+			ChartResolver chartResolver, JhelmSecurityPolicy securityPolicy) {
 		this.installAction = installAction;
 		this.uninstallAction = uninstallAction;
 		this.kubeService = kubeService;
 		this.chartResolver = chartResolver;
+		this.securityPolicy = securityPolicy;
 	}
 
 	@Override
 	public Integer call() {
+		if (MutatingGuard.blocked(securityPolicy)) {
+			return CommandLine.ExitCode.SOFTWARE;
+		}
 		try {
 			boolean dryRunEnabled = resolveDryRun();
 			Chart chart = chartResolver.resolve(chartPath, verify, keyring);

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/MutatingGuard.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/MutatingGuard.java
@@ -1,0 +1,41 @@
+package org.alexmond.jhelm.app.command;
+
+import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+
+/**
+ * Shared deny-by-default gate for cluster-mutating CLI commands.
+ * <p>
+ * Mirrors the {@code jhelm-rest} / {@code jhelm-mcp} adapters: the cluster-mutating
+ * operations (install, upgrade, uninstall, rollback, test) run only when the unified
+ * {@link JhelmSecurityPolicy} has mutating operations enabled — that is,
+ * {@code jhelm.security.mode=FULL} <em>and</em> an API key are configured. In the default
+ * {@code READ_ONLY} posture the command refuses, so the CLI's behavior matches the
+ * access-mode banner it logs at startup rather than silently mutating the cluster.
+ */
+final class MutatingGuard {
+
+	static final String DISABLED_MESSAGE = "mutating operations are disabled — set jhelm.security.mode=FULL "
+			+ "and jhelm.security.api-key to enable";
+
+	private MutatingGuard() {
+	}
+
+	/**
+	 * Reports whether a cluster-mutating command must be refused under the current
+	 * policy, printing the deny message to stderr when it must. The caller returns a
+	 * non-zero exit code (typically {@code CommandLine.ExitCode.SOFTWARE}) when this
+	 * returns {@code true}.
+	 * @param policy the unified security policy
+	 * @return {@code true} if the operation is blocked (deny-by-default), {@code false}
+	 * if it may proceed
+	 */
+	static boolean blocked(JhelmSecurityPolicy policy) {
+		if (policy.mutatingEnabled()) {
+			return false;
+		}
+		CliOutput.errPrintln(CliOutput.error(DISABLED_MESSAGE));
+		return true;
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.RollbackAction;
 import org.alexmond.jhelm.core.action.RollbackOptions;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.springframework.stereotype.Component;
@@ -24,6 +25,8 @@ public class RollbackCommand implements Callable<Integer> {
 	private final RollbackAction rollbackAction;
 
 	private final KubeService kubeService;
+
+	private final JhelmSecurityPolicy securityPolicy;
 
 	@CommandLine.Parameters(index = "0", description = "release name")
 	private String name;
@@ -52,14 +55,20 @@ public class RollbackCommand implements Callable<Integer> {
 	 * Creates the command.
 	 * @param rollbackAction the action that performs the rollback
 	 * @param kubeService the Kubernetes service used to wait for resource readiness
+	 * @param securityPolicy the unified access-mode policy; the operation is refused
+	 * unless mutating operations are enabled
 	 */
-	public RollbackCommand(RollbackAction rollbackAction, KubeService kubeService) {
+	public RollbackCommand(RollbackAction rollbackAction, KubeService kubeService, JhelmSecurityPolicy securityPolicy) {
 		this.rollbackAction = rollbackAction;
 		this.kubeService = kubeService;
+		this.securityPolicy = securityPolicy;
 	}
 
 	@Override
 	public Integer call() {
+		if (MutatingGuard.blocked(securityPolicy)) {
+			return CommandLine.ExitCode.SOFTWARE;
+		}
 		try {
 			Release release = rollbackAction.rollback(RollbackOptions.builder()
 				.releaseName(name)

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TestCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TestCommand.java
@@ -8,6 +8,7 @@ import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.TestAction.TestResult;
 import org.alexmond.jhelm.core.action.TestAction.TestStatus;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
@@ -23,6 +24,8 @@ import picocli.CommandLine;
 public class TestCommand implements Callable<Integer> {
 
 	private final TestAction testAction;
+
+	private final JhelmSecurityPolicy securityPolicy;
 
 	@CommandLine.Parameters(index = "0", description = "release name")
 	private String name;
@@ -40,13 +43,19 @@ public class TestCommand implements Callable<Integer> {
 	/**
 	 * Creates the command.
 	 * @param testAction the action that runs the release test hooks
+	 * @param securityPolicy the unified access-mode policy; the operation is refused
+	 * unless mutating operations are enabled
 	 */
-	public TestCommand(TestAction testAction) {
+	public TestCommand(TestAction testAction, JhelmSecurityPolicy securityPolicy) {
 		this.testAction = testAction;
+		this.securityPolicy = securityPolicy;
 	}
 
 	@Override
 	public Integer call() {
+		if (MutatingGuard.blocked(securityPolicy)) {
+			return CommandLine.ExitCode.SOFTWARE;
+		}
 		try {
 			List<TestResult> results = testAction.test(name, namespace, timeout);
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UninstallOptions;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
@@ -19,6 +20,8 @@ import picocli.CommandLine;
 public class UninstallCommand implements Callable<Integer> {
 
 	private final UninstallAction uninstallAction;
+
+	private final JhelmSecurityPolicy securityPolicy;
 
 	@CommandLine.Parameters(index = "0", description = "release name")
 	private String name;
@@ -36,13 +39,19 @@ public class UninstallCommand implements Callable<Integer> {
 	/**
 	 * Creates the command.
 	 * @param uninstallAction the action that uninstalls the release
+	 * @param securityPolicy the unified access-mode policy; the operation is refused
+	 * unless mutating operations are enabled
 	 */
-	public UninstallCommand(UninstallAction uninstallAction) {
+	public UninstallCommand(UninstallAction uninstallAction, JhelmSecurityPolicy securityPolicy) {
 		this.uninstallAction = uninstallAction;
+		this.securityPolicy = securityPolicy;
 	}
 
 	@Override
 	public Integer call() {
+		if (MutatingGuard.blocked(securityPolicy)) {
+			return CommandLine.ExitCode.SOFTWARE;
+		}
 		try {
 			uninstallAction.uninstall(UninstallOptions.builder()
 				.releaseName(name)

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -18,6 +18,7 @@ import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.action.UpgradeOptions;
 import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
@@ -48,6 +49,8 @@ public class UpgradeCommand implements Callable<Integer> {
 	private final RollbackAction rollbackAction;
 
 	private final ChartResolver chartResolver;
+
+	private final JhelmSecurityPolicy securityPolicy;
 
 	@CommandLine.Parameters(index = "0", description = "release name")
 	private String name;
@@ -142,19 +145,26 @@ public class UpgradeCommand implements Callable<Integer> {
 	 * atomic failure
 	 * @param chartResolver resolves the chart source (directory or {@code .tgz}), with
 	 * optional provenance verification
+	 * @param securityPolicy the unified access-mode policy; the operation is refused
+	 * unless mutating operations are enabled
 	 */
 	public UpgradeCommand(KubeService kubeService, InstallAction installAction, UninstallAction uninstallAction,
-			UpgradeAction upgradeAction, RollbackAction rollbackAction, ChartResolver chartResolver) {
+			UpgradeAction upgradeAction, RollbackAction rollbackAction, ChartResolver chartResolver,
+			JhelmSecurityPolicy securityPolicy) {
 		this.kubeService = kubeService;
 		this.installAction = installAction;
 		this.uninstallAction = uninstallAction;
 		this.upgradeAction = upgradeAction;
 		this.rollbackAction = rollbackAction;
 		this.chartResolver = chartResolver;
+		this.securityPolicy = securityPolicy;
 	}
 
 	@Override
 	public Integer call() {
+		if (MutatingGuard.blocked(securityPolicy)) {
+			return CommandLine.ExitCode.SOFTWARE;
+		}
 		int previousVersion = -1;
 		boolean wasInstall = false;
 		try {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -9,6 +9,9 @@ import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UninstallOptions;
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
 import org.alexmond.jhelm.core.exception.WaitTimeoutException;
 
 import java.util.HashMap;
@@ -65,7 +68,19 @@ class InstallCommandTest {
 			.values(new HashMap<>())
 			.build();
 		when(chartResolver.resolve(anyString(), anyBoolean(), any())).thenReturn(defaultChart);
-		installCommand = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver);
+		installCommand = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver,
+				enabledPolicy());
+	}
+
+	private static JhelmSecurityPolicy enabledPolicy() {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(JhelmAccessMode.FULL);
+		props.setApiKey("test-key");
+		return new JhelmSecurityPolicy(props);
+	}
+
+	private static JhelmSecurityPolicy readOnlyPolicy() {
+		return new JhelmSecurityPolicy(new JhelmSecurityProperties());
 	}
 
 	@Test
@@ -102,6 +117,20 @@ class InstallCommandTest {
 		int exitCode = cmd.execute("my-release", chartDir.getAbsolutePath());
 
 		assertNotEquals(CommandLine.ExitCode.OK, exitCode, "a failed install must exit non-zero");
+	}
+
+	@Test
+	void testInstallBlockedInReadOnlyMode() throws Exception {
+		// #653: READ_ONLY (the default) must refuse a cluster-mutating install and not
+		// run it.
+		File chartDir = createMockChart();
+		InstallCommand readOnly = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver,
+				readOnlyPolicy());
+
+		int exitCode = new CommandLine(readOnly).execute("my-release", chartDir.getAbsolutePath());
+
+		assertNotEquals(CommandLine.ExitCode.OK, exitCode, "install must be refused in READ_ONLY");
+		verify(installAction, never()).install(any(InstallOptions.class));
 	}
 
 	@Test

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RollbackCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RollbackCommandTest.java
@@ -2,6 +2,9 @@ package org.alexmond.jhelm.app.command;
 
 import org.alexmond.jhelm.core.action.RollbackAction;
 import org.alexmond.jhelm.core.action.RollbackOptions;
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,8 +13,11 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class RollbackCommandTest {
@@ -27,7 +33,7 @@ class RollbackCommandTest {
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		rollbackCommand = new RollbackCommand(rollbackAction, kubeService);
+		rollbackCommand = new RollbackCommand(rollbackAction, kubeService, enabledPolicy());
 	}
 
 	@Test
@@ -54,6 +60,28 @@ class RollbackCommandTest {
 
 		CommandLine cmd = new CommandLine(rollbackCommand);
 		cmd.execute("my-release", "1");
+	}
+
+	@Test
+	void testRollbackBlockedInReadOnlyMode() throws Exception {
+		RollbackCommand readOnlyCommand = new RollbackCommand(rollbackAction, kubeService, readOnlyPolicy());
+
+		CommandLine cmd = new CommandLine(readOnlyCommand);
+		int exitCode = cmd.execute("my-release", "1", "-n", "default");
+
+		assertNotEquals(CommandLine.ExitCode.OK, exitCode, "rollback must be refused in READ_ONLY");
+		verify(rollbackAction, never()).rollback(any(RollbackOptions.class));
+	}
+
+	private static JhelmSecurityPolicy enabledPolicy() {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(JhelmAccessMode.FULL);
+		props.setApiKey("test-key");
+		return new JhelmSecurityPolicy(props);
+	}
+
+	private static JhelmSecurityPolicy readOnlyPolicy() {
+		return new JhelmSecurityPolicy(new JhelmSecurityProperties());
 	}
 
 }

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/TestCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/TestCommandTest.java
@@ -5,6 +5,9 @@ import java.util.List;
 import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.TestAction.TestResult;
 import org.alexmond.jhelm.core.action.TestAction.TestStatus;
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
 import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.ResourceStatus;
@@ -14,9 +17,12 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class TestCommandTest {
@@ -29,7 +35,18 @@ class TestCommandTest {
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		testCommand = new TestCommand(testAction);
+		testCommand = new TestCommand(testAction, enabledPolicy());
+	}
+
+	private static JhelmSecurityPolicy enabledPolicy() {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(JhelmAccessMode.FULL);
+		props.setApiKey("test-key");
+		return new JhelmSecurityPolicy(props);
+	}
+
+	private static JhelmSecurityPolicy readOnlyPolicy() {
+		return new JhelmSecurityPolicy(new JhelmSecurityProperties());
 	}
 
 	@Test
@@ -98,6 +115,18 @@ class TestCommandTest {
 
 		CommandLine cmd = new CommandLine(testCommand);
 		cmd.execute("my-release", "--timeout", "60");
+	}
+
+	@Test
+	void testTestBlockedInReadOnlyMode() throws Exception {
+		// #653: READ_ONLY (the default) must refuse the cluster-mutating test and not run
+		// it.
+		TestCommand readOnly = new TestCommand(testAction, readOnlyPolicy());
+
+		int exitCode = new CommandLine(readOnly).execute("my-release", "-n", "default");
+
+		assertNotEquals(CommandLine.ExitCode.OK, exitCode, "test must be refused in READ_ONLY");
+		verify(testAction, never()).test(anyString(), anyString(), anyInt());
 	}
 
 }

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UninstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UninstallCommandTest.java
@@ -2,15 +2,21 @@ package org.alexmond.jhelm.app.command;
 
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UninstallOptions;
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 class UninstallCommandTest {
 
@@ -22,7 +28,18 @@ class UninstallCommandTest {
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		uninstallCommand = new UninstallCommand(uninstallAction);
+		uninstallCommand = new UninstallCommand(uninstallAction, enabledPolicy());
+	}
+
+	private static JhelmSecurityPolicy enabledPolicy() {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(JhelmAccessMode.FULL);
+		props.setApiKey("test-key");
+		return new JhelmSecurityPolicy(props);
+	}
+
+	private static JhelmSecurityPolicy readOnlyPolicy() {
+		return new JhelmSecurityPolicy(new JhelmSecurityProperties());
 	}
 
 	@Test
@@ -47,6 +64,18 @@ class UninstallCommandTest {
 
 		CommandLine cmd = new CommandLine(uninstallCommand);
 		cmd.execute("my-release");
+	}
+
+	@Test
+	void testUninstallBlockedInReadOnlyMode() throws Exception {
+		// #653: READ_ONLY (the default) must refuse a cluster-mutating uninstall and not
+		// run it.
+		UninstallCommand readOnly = new UninstallCommand(uninstallAction, readOnlyPolicy());
+
+		int exitCode = new CommandLine(readOnly).execute("my-release", "-n", "default");
+
+		assertNotEquals(CommandLine.ExitCode.OK, exitCode, "uninstall must be refused in READ_ONLY");
+		verify(uninstallAction, never()).uninstall(any(UninstallOptions.class));
 	}
 
 }

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -12,6 +12,9 @@ import org.alexmond.jhelm.core.action.RollbackOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.action.UpgradeOptions;
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
 import org.alexmond.jhelm.core.exception.WaitTimeoutException;
 
 import java.util.HashMap;
@@ -75,7 +78,18 @@ class UpgradeCommandTest {
 			.build();
 		when(chartResolver.resolve(anyString(), anyBoolean(), any())).thenReturn(defaultChart);
 		upgradeCommand = new UpgradeCommand(kubeService, installAction, uninstallAction, upgradeAction, rollbackAction,
-				chartResolver);
+				chartResolver, enabledPolicy());
+	}
+
+	private static JhelmSecurityPolicy enabledPolicy() {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(JhelmAccessMode.FULL);
+		props.setApiKey("test-key");
+		return new JhelmSecurityPolicy(props);
+	}
+
+	private static JhelmSecurityPolicy readOnlyPolicy() {
+		return new JhelmSecurityPolicy(new JhelmSecurityProperties());
 	}
 
 	@Test
@@ -89,6 +103,20 @@ class UpgradeCommandTest {
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "-n", "default");
+	}
+
+	@Test
+	void testUpgradeBlockedInReadOnlyMode() throws Exception {
+		// #653: READ_ONLY (the default) must refuse a cluster-mutating upgrade and not
+		// run it.
+		File chartDir = createMockChart();
+		UpgradeCommand readOnly = new UpgradeCommand(kubeService, installAction, uninstallAction, upgradeAction,
+				rollbackAction, chartResolver, readOnlyPolicy());
+
+		int exitCode = new CommandLine(readOnly).execute("my-release", chartDir.getAbsolutePath());
+
+		assertNotEquals(CommandLine.ExitCode.OK, exitCode, "upgrade must be refused in READ_ONLY");
+		verify(upgradeAction, never()).upgrade(any(UpgradeOptions.class));
 	}
 
 	@Test


### PR DESCRIPTION
## Problem
The CLI logged `jhelm security: READ_ONLY — mutating operations are disabled` but **never enforced it** — `install`/`upgrade`/`uninstall`/`rollback`/`test` performed real cluster mutations in the default `READ_ONLY` mode. The deny-by-default gate that protects the REST (`AccessModeInterceptor`) and MCP (`OnMutatingEnabledCondition`) adapters was not applied to the CLI, so the advertised guarantee didn't hold and the startup banner was actively misleading (#653).

## Fix
The CLI now honors the same unified `JhelmSecurityPolicy`. A new `MutatingGuard` refuses the five cluster-mutating commands unless mutating operations are enabled (`jhelm.security.mode=FULL` **and** an `api-key`), printing the same deny-by-default message the REST adapter uses and exiting non-zero. The gated set matches exactly what REST (`@MutatingOperation`) and MCP (`ReleaseMutatingTools`) gate: **install, upgrade, uninstall, rollback, test**. Read commands are unaffected.

## Verification
End-to-end against the issue's repro:

| Scenario | Result |
|---|---|
| `install`/`uninstall`/`rollback`/`test` in READ_ONLY (default) | **refused, exit 1**, deny message |
| `template` / `lint` (read) in READ_ONLY | work |
| mutating cmd with `mode=FULL` + `api-key` | guard passes, proceeds |

- New tests: each mutating command asserts a non-zero exit in READ_ONLY **and** that its action is never invoked; existing tests construct with an enabled policy.
- Full **210-test jhelm-cli suite green**; PMD + checkstyle clean.
- Security docs updated to note the CLI honors the access mode.

The existing startup banner is now **accurate**.

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)