### PR TITLE
fix(cli): default to FULL (read-write) like helm; FULL unlocks without api-key (#657, #654)

### DIFF
--- a/docs/modules/ROOT/pages/security.adoc
+++ b/docs/modules/ROOT/pages/security.adoc
@@ -2,10 +2,16 @@
 
 jhelm exposes Helm operations over two network surfaces -- the xref:rest-api.adoc[REST API]
 and the xref:mcp.adoc[MCP server] -- which share a single, unified security model under
-`jhelm.security.*`. The CLI honors the same access mode: in the default `READ_ONLY` posture
-its cluster-mutating commands (`install`, `upgrade`, `uninstall`, `rollback`, `test`) are
-refused, so it behaves consistently with the adapters (set `mode=FULL` + an `api-key` to
-enable them).
+`jhelm.security.*`.
+
+The **standalone CLI** honors the same `jhelm.security.mode`, but with a helm-like default: it
+runs in `FULL` (read-write) mode out of the box, so `install` / `upgrade` / `uninstall` /
+`rollback` / `test` work immediately, gated only by your kubeconfig and the cluster's RBAC --
+exactly as `helm` behaves. Set `jhelm.security.mode=READ_ONLY` (via `-Djhelm.security.mode` or
+the `JHELM_SECURITY_MODE` env var) to lock a CLI down -- for a shared workstation or an
+AI-agent guardrail -- and those five commands are then refused with a non-zero exit. The CLI
+needs no `api-key`: that credential is validated against an HTTP header, which a local CLI never
+presents, so it applies only to the network-exposed REST/MCP adapters below.
 
 The design in one line: *MCP runs local-first, the REST API is deny-by-default behind an API
 key, read-only is the default everywhere, and Spring Security is the bring-your-own upgrade

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/HelmJavaApplication.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/HelmJavaApplication.java
@@ -1,9 +1,15 @@
 package org.alexmond.jhelm.app;
 
+import lombok.extern.slf4j.Slf4j;
+
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import picocli.CommandLine;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.IFactory;
@@ -15,6 +21,7 @@ import picocli.CommandLine.IFactory;
  * {@link JHelmCommand} for parsing and execution. The process exit code reported back to
  * the shell is the Picocli execution result.
  */
+@Slf4j
 @SpringBootApplication
 public class HelmJavaApplication implements CommandLineRunner, ExitCodeGenerator {
 
@@ -62,6 +69,29 @@ public class HelmJavaApplication implements CommandLineRunner, ExitCodeGenerator
 	@Override
 	public int getExitCode() {
 		return exitCode;
+	}
+
+	/**
+	 * Logs the CLI's security posture at startup, overriding the core banner (which is
+	 * written for the network adapters, where {@code FULL} without an API key means
+	 * disabled). For the standalone CLI, {@code FULL} alone enables mutations — the local
+	 * kubeconfig is the trust boundary, like {@code helm} — so this reports the posture
+	 * the CLI actually enforces.
+	 * @param policy the resolved security policy
+	 * @return an application runner that logs the posture once
+	 */
+	@Bean
+	public ApplicationRunner jhelmSecurityPostureLogger(JhelmSecurityPolicy policy) {
+		return (args) -> {
+			if (policy.mode() == JhelmAccessMode.FULL) {
+				log.info(
+						"jhelm security: FULL — mutating operations enabled (local kubeconfig is the trust boundary).");
+			}
+			else {
+				log.info("jhelm security: READ_ONLY — mutating operations are disabled "
+						+ "(set jhelm.security.mode=FULL to enable).");
+			}
+		};
 	}
 
 }

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/MutatingGuard.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/MutatingGuard.java
@@ -1,22 +1,29 @@
 package org.alexmond.jhelm.app.command;
 
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
 import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 
 /**
  * Shared deny-by-default gate for cluster-mutating CLI commands.
  * <p>
- * Mirrors the {@code jhelm-rest} / {@code jhelm-mcp} adapters: the cluster-mutating
- * operations (install, upgrade, uninstall, rollback, test) run only when the unified
- * {@link JhelmSecurityPolicy} has mutating operations enabled — that is,
- * {@code jhelm.security.mode=FULL} <em>and</em> an API key are configured. In the default
- * {@code READ_ONLY} posture the command refuses, so the CLI's behavior matches the
- * access-mode banner it logs at startup rather than silently mutating the cluster.
+ * The cluster-mutating operations (install, upgrade, uninstall, rollback, test) run only
+ * when the unified {@link JhelmSecurityPolicy} is in {@link JhelmAccessMode#FULL FULL}
+ * mode; in the default {@link JhelmAccessMode#READ_ONLY READ_ONLY} posture the command
+ * refuses, so the CLI's behavior matches the access-mode banner it logs at startup rather
+ * than silently mutating the cluster.
+ * <p>
+ * Unlike the network-exposed {@code jhelm-rest} / {@code jhelm-mcp} adapters — which
+ * additionally require a valid API key on each request — the standalone CLI unlocks on
+ * {@code mode=FULL} <em>alone</em>. The API key is a transport credential validated
+ * against an HTTP header; a local CLI presents no such header, and its kubeconfig is
+ * already the trust boundary (the same model as {@code helm}), so demanding an
+ * otherwise-unused key would add friction with no security value.
  */
 final class MutatingGuard {
 
-	static final String DISABLED_MESSAGE = "mutating operations are disabled — set jhelm.security.mode=FULL "
-			+ "and jhelm.security.api-key to enable";
+	static final String DISABLED_MESSAGE = "mutating operations are disabled in READ_ONLY mode — set "
+			+ "jhelm.security.mode=FULL to enable (e.g. -Djhelm.security.mode=FULL or JHELM_SECURITY_MODE=FULL)";
 
 	private MutatingGuard() {
 	}
@@ -31,7 +38,7 @@ final class MutatingGuard {
 	 * if it may proceed
 	 */
 	static boolean blocked(JhelmSecurityPolicy policy) {
-		if (policy.mutatingEnabled()) {
+		if (policy.mode() == JhelmAccessMode.FULL) {
 			return false;
 		}
 		CliOutput.errPrintln(CliOutput.error(DISABLED_MESSAGE));

--- a/jhelm-cli/src/main/resources/application.properties
+++ b/jhelm-cli/src/main/resources/application.properties
@@ -1,3 +1,11 @@
+# Access mode for the standalone CLI. Unlike the network-exposed REST/MCP adapters —
+# which stay READ_ONLY + api-key by default (deny-by-default for a listening server) —
+# the CLI defaults to FULL, so install/upgrade/uninstall/rollback/test work out of the
+# box just like `helm`. The local kubeconfig (and the cluster's RBAC) is the trust
+# boundary. Set jhelm.security.mode=READ_ONLY to lock a CLI down (shared workstation,
+# agent guardrail); that posture is enforced by MutatingGuard, not just logged.
+jhelm.security.mode=FULL
+
 # The jhelm banner is printed explicitly to stderr by JHelmCommand when invoked
 # with no subcommand, so that command output on stdout (e.g. `jhelm template`
 # piped to a file) stays clean. Disable Spring's automatic stdout banner here.

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/HelmJavaApplicationTests.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/HelmJavaApplicationTests.java
@@ -1,11 +1,14 @@
 package org.alexmond.jhelm.app;
 
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -19,8 +22,20 @@ class HelmJavaApplicationTests {
 	@Autowired(required = false)
 	private HelmJavaApplication application;
 
+	@Autowired
+	private JhelmSecurityPolicy securityPolicy;
+
 	@Test
 	void contextLoads() {
+	}
+
+	@Test
+	void testCliDefaultsToFullMode() {
+		// #657/#654: the standalone CLI defaults to FULL (read-write) like helm, unlike
+		// the
+		// READ_ONLY default the network adapters use. Set from jhelm-cli
+		// application.properties.
+		assertEquals(JhelmAccessMode.FULL, securityPolicy.mode(), "CLI must default to FULL (read-write)");
 	}
 
 	@Test

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -134,6 +134,24 @@ class InstallCommandTest {
 	}
 
 	@Test
+	void testInstallAllowedInFullModeWithoutApiKey() throws Exception {
+		// #657: the standalone CLI unlocks mutations with mode=FULL alone — no api-key
+		// (the kubeconfig is the trust boundary, like helm). REST/MCP still require a
+		// key.
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(JhelmAccessMode.FULL);
+		File chartDir = createMockChart();
+		when(installAction.install(any(InstallOptions.class))).thenReturn(createMockRelease("my-release", 1));
+		InstallCommand full = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver,
+				new JhelmSecurityPolicy(props));
+
+		int exitCode = new CommandLine(full).execute("my-release", chartDir.getAbsolutePath(), "-n", "default");
+
+		assertEquals(CommandLine.ExitCode.OK, exitCode, "FULL mode must enable install without an api-key");
+		verify(installAction).install(any(InstallOptions.class));
+	}
+
+	@Test
 	void testInstallWaitTimeoutExitsNonZero() throws Exception {
 		// Regression for #647: a --wait readiness timeout printed an error but exited 0,
 		// so callers could not detect the failed rollout. It must now exit non-zero.


### PR DESCRIPTION
Follow-up to #653/#658, driven by the observation that **real helm has no read-only mode** — it's read-write by default, gated only by your kubeconfig + cluster RBAC. Two refinements:

## 1. helm-parity default (the CLI was surprising)
The shared `jhelm.security.mode` defaults to `READ_ONLY` — correct for the network-exposed REST/MCP adapters (deny-by-default for a listening server), but wrong for a local CLI, where it meant `jhelm install` **refused out of the box**. The CLI now defaults to **`FULL`** (one line in `jhelm-cli` `application.properties`), so it behaves like helm. `READ_ONLY` becomes an **opt-in guardrail** (shared workstation, AI-agent sandbox) that's genuinely enforced by the `MutatingGuard` from #653.

## 2. FULL unlocks the CLI without an api-key (#657)
`mutatingEnabled()` requires `FULL` **and** an api-key, but the key is an HTTP-header credential a local CLI never presents — requiring it would be friction with zero security value. `MutatingGuard` now gates on **`mode==FULL` alone**; the api-key requirement stays on REST/MCP, where a header is actually validated.

## Banner stays honest
To avoid reintroducing the exact log-vs-behavior mismatch #653 fixed, the CLI overrides the core posture banner (which reads FULL-without-key as "disabled") with one reporting what the CLI actually enforces — via the core banner's `@ConditionalOnMissingBean(name="jhelmSecurityPostureLogger")` hook.

## Verification

| Config | Behavior | Banner |
|---|---|---|
| **default** (no config) | `install` **runs** (helm-like) | `FULL — mutating operations enabled` |
| `mode=READ_ONLY` (`-D`/env) | 5 mutating cmds **refused, exit 1** | `READ_ONLY — mutating operations are disabled` |
| `template`/`lint`/… | work in either mode | — |

Full **jhelm-cli suite green (212 tests)**, incl. new tests: default-mode-is-FULL (context) and FULL-without-api-key-allows-install.

**Closes #657** · **Closes #654** (READ_ONLY now enforced at the CLI edge, matching REST/MCP; embedded-library callers compose their own policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)