### PR TITLE
chore(cli): quiet picocli-spring log noise (#656) + fix README storage wording (#655)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ the Go-based Helm binary.
 
 | `jhelm-core` | Chart model, loader, repository manager, rendering engine, and action API. The main entry point for library users.
 | `jhelm-gotemplate-helm` | Helm-specific template functions (`include`, `tpl`, `required`, `toYaml`, `lookup`, …) layered on top of gotmpl4j.
-| `jhelm-kube` | Kubernetes client integration -- apply/delete resources, ConfigMap-based release storage, async operations.
+| `jhelm-kube` | Kubernetes client integration -- apply/delete resources, Helm-compatible Secret-based release storage, async operations.
 | `jhelm-rest` | Spring MVC REST API over jhelm operations, with OpenAPI documentation (pure library -- bring your own auto-configuration).
 | `jhelm-rest-starter` | Spring Boot starter that auto-configures the `jhelm-rest` API, with a `READ_ONLY`/`FULL` access mode gating cluster-mutating endpoints.
 | `jhelm-mcp` | Model Context Protocol server exposing jhelm operations as AI-agent tools (built on Spring AI), mirroring the REST operation set.

--- a/jhelm-cli/src/main/resources/application.properties
+++ b/jhelm-cli/src/main/resources/application.properties
@@ -6,6 +6,14 @@
 # agent guardrail); that posture is enforced by MutatingGuard, not just logged.
 jhelm.security.mode=FULL
 
+# picocli-spring's PicocliSpringFactory logs a benign INFO line via java.util.logging
+# whenever it asks the Spring context for a type it doesn't manage — e.g. the backing
+# List for a multi-value option like `--set` — then transparently falls back to picocli's
+# own factory ("Unable to get bean of class interface java.util.List ... using fallback
+# factory"). The fallback works and the command runs fine, but the message reads like an
+# error/stacktrace on every such invocation. Quiet that one logger to WARN.
+logging.level.picocli.spring=WARN
+
 # The jhelm banner is printed explicitly to stderr by JHelmCommand when invoked
 # with no subcommand, so that command output on stdout (e.g. `jhelm template`
 # piped to a file) stays clean. Disable Spring's automatic stdout banner here.


### PR DESCRIPTION
Two small, verified polish fixes.

### #656 — benign `BeanCreationException` noise on every `--set`-style command
`picocli.spring.PicocliSpringFactory` logs an INFO line via `java.util.logging` when it asks the Spring context for a type it doesn't manage (the backing `List` for a multi-value option like `--set`), then transparently falls back to picocli's own factory. The command runs fine, but the line reads like a stacktrace:

```
INFO picocli.spring.PicocliSpringFactory : Unable to get bean of class interface java.util.List
from ApplicationContext, using fallback factory ... (BeanCreationException: ... interface)
```

Fix: quiet that one logger to `WARN` in `jhelm-cli` `application.properties`. **Verified** — the line is gone from `install --set` output while the rendered manifest and the security banner remain.

### #655 — README mislabels jhelm-kube release storage
The module table said "**ConfigMap**-based release storage", but jhelm stores/reads releases as gzip+base64 **Helm-compatible Secrets** (`sh.helm.release.v1.*`) — which is what enables jhelm↔helm interop. Corrected to "**Helm-compatible Secret-based** release storage".

Config + docs only; no code paths changed.

**Closes #656** · **Closes #655**

🤖 Generated with [Claude Code](https://claude.com/claude-code)