### PR TITLE
docs: prep 1.0.1 release (changelog + README version)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 = jhelm
-:jhelm-version: 1.0.0
+:jhelm-version: 1.0.1
 :url-docs: https://www.alexmond.org/jhelm/current/
 :url-docs-mcp: https://www.alexmond.org/jhelm/current/mcp/
 :url-docs-rest: https://www.alexmond.org/jhelm/current/rest-api/

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -1,5 +1,43 @@
 = Changelog
 
+== 1.0.1
+
+A maintenance release: bug fixes across the Kubernetes layer and the CLI, plus CLI startup
+and ergonomics improvements. No public API changes.
+
+=== Fixes
+
+* *Cluster-scoped resources* -- kinds such as `ClusterRole`, `ClusterRoleBinding`,
+  `CustomResourceDefinition`, `Namespace`, `StorageClass` and `PriorityClass` are now applied
+  and deleted at the cluster scope instead of being forced through the namespaced API path,
+  which the API server rejected (#650).
+* *CLI exit codes* -- commands exit non-zero on failure (for example a `--wait` readiness
+  timeout), so scripts and CI can detect a failed operation instead of seeing a spurious
+  success (#647).
+
+=== CLI security
+
+* The CLI now honors `jhelm.security.mode` and defaults to `FULL` (read-write), matching
+  `helm` -- the local kubeconfig and cluster RBAC are the trust boundary. Setting
+  `jhelm.security.mode=READ_ONLY` refuses the cluster-mutating commands (`install`, `upgrade`,
+  `uninstall`, `rollback`, `test`) with a non-zero exit. The API key stays a REST/MCP concern
+  and is not required to unlock the CLI (#653, #654, #657).
+
+=== CLI ergonomics
+
+* Faster startup through lazy bean initialization and trimming auto-configurations a one-shot
+  CLI never uses (#649, #651).
+* Quieted a benign picocli-spring `INFO` line ("Unable to get bean of class interface
+  java.util.List ...") that surfaced on multi-value options such as `--set` and read like a
+  stacktrace (#656).
+
+=== Docs and build
+
+* The release workflow passes the GPG passphrase via `MAVEN_GPG_PASSPHRASE` rather than the
+  deprecated `-Dgpg.passphrase` (#646).
+* Corrected the `jhelm-kube` description: releases are stored as Helm-compatible Secrets, not
+  ConfigMaps (#655); fixed cross-project documentation links.
+
 == 1.0.0
 
 The first stable release. 1.0 draws a supported public API surface, hardens security and


### PR DESCRIPTION
Pre-release prep for **1.0.1** (patch — bug fixes + CLI improvements, no public API change).

- Bump README `:jhelm-version:` `1.0.0` → `1.0.1` (asciidoctor substitutes it into the install snippets).
- Add a `1.0.1` changelog section: cluster-scoped resource fix (#650), CLI exit codes (#647), CLI access-mode enforcement + helm-parity `FULL` default (#653/#654/#657), CLI startup/log ergonomics (#649/#651/#656), release/docs fixes (#646/#655).

Docs `api-*` links use `{page-component-version}` (no per-release bump) and match the published module set. `clean install` green across all modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)