### PR TITLE
docs: prep 1.0.2

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 = jhelm
-:jhelm-version: 1.0.1
+:jhelm-version: 1.0.2
 :url-docs: https://www.alexmond.org/jhelm/current/
 :url-docs-mcp: https://www.alexmond.org/jhelm/current/mcp/
 :url-docs-rest: https://www.alexmond.org/jhelm/current/rest-api/

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -1,5 +1,23 @@
 = Changelog
 
+== 1.0.2
+
+A maintenance release fixing two bugs found in triage. No public API changes.
+
+=== Fixes
+
+* *`lookup` returns the full resource and queries the live cluster* -- the `lookup` template
+  function now returns the whole object (including `Secret`/`ConfigMap` `data` as base64), and
+  is wired to the live Kubernetes API in the CLI and any `jhelm-kube`-backed app, as Helm does
+  during install/upgrade. Previously it silently returned the empty stub (and, even when
+  reached, only the resource's metadata), which regenerated the reuse-existing-password idiom
+  `index $existing.data "key" \| b64dec` on every upgrade and corrupted bundled-database
+  passwords (#663).
+* *CLI reports the real build version* -- `jhelm --version`, `-V`, `jhelm version` and
+  `jhelm env` now report the actual build version (sourced from Spring Boot build-info, the
+  same source Actuator's `/actuator/info` uses) instead of a hardcoded `0.0.1`. The REST
+  OpenAPI document reports the same (#662).
+
 == 1.0.1
 
 A maintenance release: bug fixes across the Kubernetes layer and the CLI, plus CLI startup

--- a/docs/modules/ROOT/pages/helm-functions.adoc
+++ b/docs/modules/ROOT/pages/helm-functions.adoc
@@ -115,15 +115,18 @@ Use `must*` variants when strict validation is required (e.g., CI pipelines).
 | Function | Description
 
 | `lookup`
-| Query Kubernetes API for resources. Syntax: `lookup "apiVersion" "kind" "namespace" "name"`. Returns empty map when no `KubernetesProvider` is available.
+| Query the Kubernetes API for resources, returning the *whole* object (metadata, `data`, `spec`, `status`, ...) as a nested map -- `Secret`/`ConfigMap` `data` values are base64 strings, so the reuse-existing-password idiom `index $existing.data "key" \| b64dec` works. Syntax: `lookup "apiVersion" "kind" "namespace" "name"` (empty `name` lists the kind). Returns an empty map when the resource is absent or no cluster is reachable.
 
 | `kubeVersion`
-| Returns Kubernetes cluster version info as a Map with keys `Major`, `Minor`, `GitVersion`. Returns stub `v1.28.0` when no provider is available.
+| Returns Kubernetes cluster version info as a Map with keys `Major`, `Minor`, `GitVersion`. Returns stub `v1.35.0` when no cluster is reachable.
 |===
 
-NOTE: Kubernetes functions require a `KubernetesProvider` implementation.
-When using `ServiceLoader` auto-discovery (default), stub implementations are used.
-Wire a real provider via `GoTemplate.Builder` or Spring auto-configuration in `jhelm-kube`.
+NOTE: In the CLI and any `jhelm-kube`-backed application these functions query the *live*
+cluster (as Helm does during install/upgrade) -- the Spring auto-configuration wires a
+cluster-backed `KubernetesProvider` into the engine automatically. Without a wired provider
+(for example the standalone `gotmpl4j` engine, or when the API server is unreachable),
+`lookup` returns an empty map and `kubeVersion` returns the stub -- so offline `template`
+rendering still works. A provider can also be supplied manually via `GoTemplate.Builder`.
 
 == Reference
 

--- a/docs/modules/ROOT/pages/roadmap.adoc
+++ b/docs/modules/ROOT/pages/roadmap.adoc
@@ -34,8 +34,9 @@ at once: a *broad real-world conformance bar* and a *stable, extraction-ready en
   coalescing.
 
 | Real cluster
-| `.Capabilities` populated from the live cluster; `template --kube-version` /
-  `--api-versions` overrides for offline rendering.
+| `.Capabilities` populated from the live cluster and the `lookup` function querying it
+  (returning full resource data, as Helm does during install/upgrade); `template
+  --kube-version` / `--api-versions` overrides for offline rendering.
 
 | Provenance & security
 | Chart signing / verification (PGP), opt-in SSRF protection for server mode, and host-gated


### PR DESCRIPTION
Release-prep for **1.0.2** (patch — fixes #662 and #663, merged in #664).

- **changelog** — add the `== 1.0.2` section (both fixes).
- **helm-functions** — `lookup` now returns the whole resource and queries the live cluster in CLI/`jhelm-kube` setups (empty-stub only when no cluster is wired); corrected the stale `kubeVersion` stub (`v1.28.0` → `v1.35.0`).
- **roadmap** — note `lookup` querying the live cluster under "Real cluster".
- **README** — bump `:jhelm-version:` `1.0.1` → `1.0.2` (literal, asciidoctor-substituted into install snippets).

Docs-only; `docs/antora.yml` uses `version: true` so API links track the tag automatically. No module changes → API links unchanged. Build gate: `./mvnw test` was green at #664 merge; nothing compilable changed since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)