### PR TITLE
fix: apply/delete manifests as unstructured maps (#666)

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -49,6 +49,10 @@
     <suppress checks="MethodLength" files="HelmChartTemplates\.java"/>
     <suppress checks="FileLength" files="HelmChartTemplates\.java"/>
 
+    <!-- HelmKubeService is the central cluster-operations service (store/get/list/apply/delete/
+         status/wait), just over the line limit; splitting it would fragment one cohesive surface -->
+    <suppress checks="FileLength" files="HelmKubeService\.java"/>
+
     <!-- ConversionFunctions is one cohesive registry of YAML/JSON/TOML conversion functions
          plus the Go-faithful serialization post-processing — long by nature -->
     <suppress checks="FileLength" files="ConversionFunctions\.java"/>

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
@@ -1,7 +1,6 @@
 package org.alexmond.jhelm.kube.service.internal;
 
 import java.io.IOException;
-import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.custom.V1Patch;
@@ -28,6 +27,9 @@ import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
 import io.kubernetes.client.util.generic.options.PatchOptions;
 import lombok.extern.slf4j.Slf4j;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.exception.ReleaseStorageException;
 import org.alexmond.jhelm.core.exception.WaitTimeoutException;
@@ -348,10 +350,11 @@ public class HelmKubeService implements KubeService {
 
 	private void applyManifest(String namespace, String yamlContent, boolean serverDryRun) {
 		try {
-			Iterable<Object> objects = Yaml.loadAll(yamlContent);
-			for (Object obj : objects) {
-				if (obj instanceof KubernetesObject k8sObj) {
-					applyResource(namespace, k8sObj, serverDryRun);
+			for (Object doc : loadUnstructured(yamlContent)) {
+				if (doc instanceof Map<?, ?> map) {
+					@SuppressWarnings("unchecked")
+					Map<String, Object> resource = (Map<String, Object>) map;
+					applyResource(namespace, resource, serverDryRun);
 				}
 			}
 		}
@@ -363,12 +366,14 @@ public class HelmKubeService implements KubeService {
 		}
 	}
 
-	private void applyResource(String namespace, KubernetesObject obj, boolean serverDryRun) throws ApiException {
-		String apiVersion = obj.getApiVersion();
+	private void applyResource(String namespace, Map<String, Object> resource, boolean serverDryRun)
+			throws ApiException {
+		String[] id = identify(resource);
+		String apiVersion = id[0];
+		String kind = id[1];
+		String name = id[2];
 		String group = apiVersion.contains("/") ? apiVersion.split("/")[0] : "";
 		String version = apiVersion.contains("/") ? apiVersion.split("/")[1] : apiVersion;
-		String kind = obj.getKind();
-		String name = obj.getMetadata().getName();
 		String plural = inferPlural(kind);
 		boolean namespaced = inferNamespaced(kind);
 
@@ -377,24 +382,56 @@ public class HelmKubeService implements KubeService {
 					version, name, namespaced ? " in namespace " + namespace : " (cluster-scoped)");
 		}
 
-		V1Patch patch = new V1Patch(Yaml.dump(obj));
+		V1Patch patch = new V1Patch(dumpUnstructured(resource));
 		PatchOptions options = new PatchOptions();
 		options.setFieldManager("helm");
 		options.setForce(true);
 		if (serverDryRun) {
 			options.setDryRun("All");
 		}
-		// DynamicKubernetesApi resolves the request path from the group, so core-group
-		// resources (empty group, e.g. Service/ConfigMap/Secret) hit /api/<version>
-		// while named groups hit /apis/<group>/<version>. CustomObjectsApi always emits
-		// /apis/<group>/... and 404s on the core group. Cluster-scoped kinds
-		// (ClusterRole/CRD/...) must skip the namespace segment or the API server rejects
-		// them, so the scope comes from the kind rather than the release namespace.
+		// DynamicKubernetesApi routes the core group (empty group) to /api/<version> and
+		// named groups to /apis/<group>/<version> (CustomObjectsApi would 404 the core
+		// group);
+		// cluster-scoped kinds skip the namespace segment based on the kind, not the
+		// release ns.
 		DynamicKubernetesApi api = new DynamicKubernetesApi(group, version, plural, apiClient);
 		KubernetesApiResponse<DynamicKubernetesObject> response = namespaced
 				? api.patch(namespace, name, V1Patch.PATCH_FORMAT_APPLY_YAML, patch, options)
 				: api.patch(name, V1Patch.PATCH_FORMAT_APPLY_YAML, patch, options);
 		response.throwsApiException();
+	}
+
+	// Parse manifests as UNSTRUCTURED maps, not typed io.kubernetes.client models: the
+	// typed
+	// round-trip materializes optional fields the manifest omits (e.g. V1PodSpec.overhead
+	// ->
+	// `overhead: {}`, which PodOverhead admission rejects, #666) and drops CRDs/unknown
+	// kinds
+	// (they deserialize as Map). SafeConstructor blocks arbitrary type instantiation via
+	// tags.
+	static Iterable<Object> loadUnstructured(String yamlContent) {
+		return new org.yaml.snakeyaml.Yaml(new SafeConstructor(new LoaderOptions())).loadAll(yamlContent);
+	}
+
+	static String dumpUnstructured(Map<String, Object> resource) {
+		DumperOptions options = new DumperOptions();
+		options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+		return new org.yaml.snakeyaml.Yaml(options).dump(resource);
+	}
+
+	// [apiVersion, kind, name] from an unstructured doc; shared by apply/delete/status so
+	// all
+	// three handle the same kinds (incl. CRDs). Throws if any field is absent.
+	@SuppressWarnings("unchecked")
+	private static String[] identify(Map<String, Object> resource) {
+		String apiVersion = (String) resource.get("apiVersion");
+		String kind = (String) resource.get("kind");
+		Object metadata = resource.get("metadata");
+		String name = (metadata instanceof Map<?, ?>) ? (String) ((Map<String, Object>) metadata).get("name") : null;
+		if (apiVersion == null || kind == null || name == null) {
+			throw new KubernetesOperationException("Manifest document missing apiVersion/kind/metadata.name");
+		}
+		return new String[] { apiVersion, kind, name };
 	}
 
 	/**
@@ -403,10 +440,11 @@ public class HelmKubeService implements KubeService {
 	@Override
 	public void delete(String namespace, String yamlContent) {
 		try {
-			Iterable<Object> objects = Yaml.loadAll(yamlContent);
-			for (Object obj : objects) {
-				if (obj instanceof KubernetesObject k8sObj) {
-					deleteResource(namespace, k8sObj);
+			for (Object doc : loadUnstructured(yamlContent)) {
+				if (doc instanceof Map<?, ?> map) {
+					@SuppressWarnings("unchecked")
+					Map<String, Object> resource = (Map<String, Object>) map;
+					deleteResource(namespace, resource);
 				}
 			}
 		}
@@ -418,11 +456,13 @@ public class HelmKubeService implements KubeService {
 		}
 	}
 
-	private void deleteResource(String namespace, KubernetesObject obj) throws ApiException {
-		String group = obj.getApiVersion().contains("/") ? obj.getApiVersion().split("/")[0] : "";
-		String version = obj.getApiVersion().contains("/") ? obj.getApiVersion().split("/")[1] : obj.getApiVersion();
-		String kind = obj.getKind();
-		String name = obj.getMetadata().getName();
+	private void deleteResource(String namespace, Map<String, Object> resource) throws ApiException {
+		String[] id = identify(resource);
+		String apiVersion = id[0];
+		String kind = id[1];
+		String name = id[2];
+		String group = apiVersion.contains("/") ? apiVersion.split("/")[0] : "";
+		String version = apiVersion.contains("/") ? apiVersion.split("/")[1] : apiVersion;
 		String plural = inferPlural(kind);
 		boolean namespaced = inferNamespaced(kind);
 
@@ -430,12 +470,7 @@ public class HelmKubeService implements KubeService {
 			log.info("Deleting {} {}{}", kind, name, namespaced ? " in namespace " + namespace : " (cluster-scoped)");
 		}
 
-		// As with apply, DynamicKubernetesApi targets /api/<version> for the core group;
-		// CustomObjectsApi 404s there, which previously made core-resource deletes
-		// silently
-		// no-op (the 404 was swallowed below as "already gone"). Cluster-scoped kinds
-		// skip
-		// the namespace segment based on the kind, not the release namespace.
+		// Same core-group vs named-group routing and kind-based scoping as applyResource.
 		DynamicKubernetesApi api = new DynamicKubernetesApi(group, version, plural, apiClient);
 		KubernetesApiResponse<DynamicKubernetesObject> response = namespaced ? api.delete(namespace, name)
 				: api.delete(name);
@@ -452,22 +487,25 @@ public class HelmKubeService implements KubeService {
 		List<ResourceStatus> statuses = new ArrayList<>();
 		Iterable<Object> objects;
 		try {
-			objects = Yaml.loadAll(manifest);
+			objects = loadUnstructured(manifest);
 		}
 		catch (Exception ex) {
 			throw new KubernetesOperationException("Failed to parse manifest", ex);
 		}
 		for (Object obj : objects) {
-			if (obj instanceof KubernetesObject k8sObj) {
-				statuses.add(checkResourceStatus(namespace, k8sObj));
+			if (obj instanceof Map<?, ?> map) {
+				@SuppressWarnings("unchecked")
+				Map<String, Object> resource = (Map<String, Object>) map;
+				statuses.add(checkResourceStatus(namespace, resource));
 			}
 		}
 		return statuses;
 	}
 
-	private ResourceStatus checkResourceStatus(String namespace, KubernetesObject obj) {
-		String kind = obj.getKind();
-		String name = obj.getMetadata().getName();
+	private ResourceStatus checkResourceStatus(String namespace, Map<String, Object> resource) {
+		String[] id = identify(resource);
+		String kind = id[1];
+		String name = id[2];
 		try {
 			return switch (kind) {
 				case "Deployment" -> checkDeployment(namespace, name);

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceApplyTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceApplyTest.java
@@ -1,0 +1,118 @@
+package org.alexmond.jhelm.kube.service.internal;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for #666: the apply path must carry <em>only</em> the fields the
+ * source manifest declares. Round-tripping a bare Pod through the typed
+ * {@code io.kubernetes.client} models materialized optional fields the manifest omits
+ * (notably {@code spec.overhead} as an empty object), which the PodOverhead/RuntimeClass
+ * admission controller then rejected — breaking {@code jhelm test} hook pods and
+ * bare-{@code Pod} applies. The unstructured (Map-based) path fixes it.
+ */
+class HelmKubeServiceApplyTest {
+
+	private static final String POD_YAML = """
+			apiVersion: v1
+			kind: Pod
+			metadata:
+			  name: test-connection
+			  annotations:
+			    helm.sh/hook: test
+			spec:
+			  restartPolicy: Never
+			  containers:
+			    - name: health
+			      image: curlimages/curl:8.11.1
+			      command: [sh, -c, "curl -sf http://svc:8080/login"]
+			""";
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> firstDocument(String yaml) {
+		Object doc = HelmKubeService.loadUnstructured(yaml).iterator().next();
+		return assertInstanceOf(Map.class, doc);
+	}
+
+	@Test
+	void testBarePodApplyBodyDoesNotInjectOverhead() {
+		Map<String, Object> resource = firstDocument(POD_YAML);
+		String applyBody = HelmKubeService.dumpUnstructured(resource);
+
+		// #666: the source Pod declares no `overhead` (and no `runtimeClassName`), so the
+		// applied body must not contain one — otherwise PodOverhead admission rejects it.
+		assertFalse(applyBody.contains("overhead"), "apply body must not inject spec.overhead:\n" + applyBody);
+		assertFalse(applyBody.contains("runtimeClassName"), "apply body must not inject runtimeClassName");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testUnstructuredRoundTripPreservesSourceFields() {
+		Map<String, Object> resource = firstDocument(POD_YAML);
+
+		assertEquals("v1", resource.get("apiVersion"));
+		assertEquals("Pod", resource.get("kind"));
+		Map<String, Object> spec = assertInstanceOf(Map.class, resource.get("spec"));
+		// Only the keys the manifest declared — nothing materialized alongside them.
+		assertEquals(java.util.Set.of("restartPolicy", "containers"), spec.keySet());
+
+		// The re-serialized body still parses back to the same spec keys.
+		Map<String, Object> reparsed = firstDocument(HelmKubeService.dumpUnstructured(resource));
+		Map<String, Object> reparsedSpec = assertInstanceOf(Map.class, reparsed.get("spec"));
+		assertEquals(spec.keySet(), reparsedSpec.keySet());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testCustomResourceParsesAsMapNotSkipped() {
+		// A CRD/custom kind the typed client doesn't know deserializes as a Map, so the
+		// unstructured path processes it. The old typed Yaml.loadAll + `instanceof
+		// KubernetesObject` check silently skipped these, so apply installed them but
+		// delete/status ignored them — a CRD that could be installed but not uninstalled.
+		String crd = """
+				apiVersion: cert-manager.io/v1
+				kind: Certificate
+				metadata:
+				  name: my-cert
+				spec:
+				  secretName: my-cert-tls
+				""";
+		Map<String, Object> resource = firstDocument(crd);
+		assertEquals("cert-manager.io/v1", resource.get("apiVersion"));
+		assertEquals("Certificate", resource.get("kind"));
+		Map<String, Object> metadata = assertInstanceOf(Map.class, resource.get("metadata"));
+		assertEquals("my-cert", metadata.get("name"));
+	}
+
+	@Test
+	void testMultiDocumentManifestParsesEachDocument() {
+		String multi = POD_YAML + "---\n" + POD_YAML.replace("test-connection", "test-two");
+		int count = 0;
+		for (Object doc : HelmKubeService.loadUnstructured(multi)) {
+			assertInstanceOf(Map.class, doc);
+			count++;
+		}
+		assertEquals(2, count);
+	}
+
+	@Test
+	void testSafeConstructorRejectsArbitraryTags() {
+		// SafeConstructor must not instantiate arbitrary Java types from YAML tags.
+		String malicious = "apiVersion: v1\nkind: Pod\nevil: !!java.net.URL [http://example.com]\n";
+		boolean threw = false;
+		try {
+			HelmKubeService.loadUnstructured(malicious).iterator().next();
+		}
+		catch (RuntimeException ex) {
+			threw = true;
+		}
+		assertTrue(threw, "SafeConstructor should refuse the !!java.net.URL tag");
+	}
+
+}


### PR DESCRIPTION
Fixes #666

## The bug
`jhelm test` (and any apply of a bare `kind: Pod`) failed on clusters with PodOverhead/RuntimeClass admission:
```
pods "..." is forbidden: pod rejected:
Pod Overhead set without corresponding RuntimeClass defined Overhead
```
`kubectl apply --dry-run=server` and go-helm's `helm test` applied the identical pod fine — so jhelm was *mutating* the manifest.

## Root cause
The apply path round-tripped each document through the typed `io.kubernetes.client` model (`Yaml.loadAll` → typed `V1Pod` → `Yaml.dump`), which **materializes optional fields the source omits** — notably `V1PodSpec.overhead` as an empty object (`overhead: {}`) — which the admission controller rejects.

## Fix
Parse and apply each document as an **unstructured Map** (SnakeYAML + `SafeConstructor`) and send exactly those fields as the SSA body. No omitted optional field is ever materialized — fixing the whole class of typed-round-trip normalization issues, not just `overhead`.

## Consistency follow-up (from the live-cluster audit)
`delete()` and `getResourceStatuses()` still used typed `Yaml.loadAll` + `instanceof KubernetesObject`, which **silently skipped CRDs/unknown kinds** (they deserialize as `Map`). With apply now handling those kinds, a CRD could be **installed but never uninstalled or status-tracked**. Both now use the same unstructured path via a shared `identify()` helper.

## Verification
On an ephemeral **kind** cluster (which reproduces the exact admission error):
- bare-Pod `helm test` hook now **applies and runs to `Succeeded`** (rejected before); applied Pod has **no `spec.overhead`**
- install→uninstall of regular resources **deletes cleanly** (delete() rewrite)
- `HelmKubeServiceApplyTest` (5 tests): no-overhead body, source-field preservation, CRD-parses-as-Map, multi-doc, SafeConstructor guard
- full `jhelm-kube` suite green

`HelmKubeService` gets a `FileLength` checkstyle suppression (it's the central cluster-ops service, just over the line limit — consistent with the existing `Engine`/`Parser`/`Executor` suppressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)