### PR TITLE
fix: jhelm test hangs on Succeeded pod; handle terminal pod phases

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ResourceStatus.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/ResourceStatus.java
@@ -32,4 +32,11 @@ public class ResourceStatus {
 	 */
 	private String message;
 
+	/**
+	 * {@code true} if the resource has reached a terminal <em>failure</em> state it
+	 * cannot recover from (e.g. a Pod whose phase is {@code Failed}). A waiter should
+	 * stop and fail fast rather than poll to the timeout. Defaults to {@code false}.
+	 */
+	private boolean terminal;
+
 }

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
@@ -652,20 +652,39 @@ public class HelmKubeService implements KubeService {
 	private ResourceStatus checkPod(String namespace, String name) throws ApiException {
 		CoreV1Api api = new CoreV1Api(apiClient);
 		V1Pod pod = api.readNamespacedPod(name, namespace).execute();
-		boolean isReady = "Running".equals(pod.getStatus().getPhase()) && pod.getStatus().getConditions() != null
-				&& pod.getStatus()
-					.getConditions()
-					.stream()
-					.filter((c) -> "Ready".equals(c.getType()))
-					.anyMatch((c) -> "True".equals(c.getStatus()));
-		String message = isReady ? "ready" : pod.getStatus().getPhase();
+		String phase = pod.getStatus().getPhase();
+		// A completion-style pod (e.g. a `helm test` hook with restartPolicy: Never)
+		// terminates in Succeeded/Failed and never reaches Running, so treat the terminal
+		// phases as done: Succeeded = ready/passed, Failed = a terminal failure the
+		// waiter
+		// should fail fast on rather than poll to the timeout (#666 follow-up). A
+		// long-lived
+		// pod is ready only when Running with a True Ready condition.
+		boolean readyCondition = pod.getStatus().getConditions() != null && pod.getStatus()
+			.getConditions()
+			.stream()
+			.filter((c) -> "Ready".equals(c.getType()))
+			.anyMatch((c) -> "True".equals(c.getStatus()));
+		boolean isReady = isPodReady(phase, readyCondition);
+		boolean terminal = "Failed".equals(phase);
+		String message = isReady ? "ready" : phase;
 		return ResourceStatus.builder()
 			.kind("Pod")
 			.name(name)
 			.namespace(namespace)
 			.ready(isReady)
+			.terminal(terminal)
 			.message(message)
 			.build();
+	}
+
+	// A pod counts as ready/done when it has Succeeded (a completion pod, e.g. a `helm
+	// test`
+	// hook, exits 0) or is Running with a True Ready condition (a long-lived pod). Failed
+	// is
+	// handled separately as terminal. Package-private for testing.
+	static boolean isPodReady(String phase, boolean readyCondition) {
+		return "Succeeded".equals(phase) || ("Running".equals(phase) && readyCondition);
 	}
 
 	/**
@@ -681,6 +700,17 @@ public class HelmKubeService implements KubeService {
 			boolean allReady = statuses.stream().allMatch(ResourceStatus::isReady);
 			if (allReady) {
 				return;
+			}
+
+			// A resource in a terminal failure state (e.g. a Failed test/hook pod) will
+			// never
+			// become ready — fail fast instead of polling to the timeout.
+			List<ResourceStatus> failed = statuses.stream().filter((s) -> s.isTerminal() && !s.isReady()).toList();
+			if (!failed.isEmpty()) {
+				String msg = failed.stream()
+					.map((s) -> s.getKind() + "/" + s.getName() + ": " + s.getMessage())
+					.collect(Collectors.joining(", "));
+				throw new WaitTimeoutException("Resource(s) terminally failed: " + msg, failed);
 			}
 
 			long remaining = deadline - System.currentTimeMillis();

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServicePodStatusTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServicePodStatusTest.java
@@ -1,0 +1,50 @@
+package org.alexmond.jhelm.kube.service.internal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the pod-phase readiness decision behind {@code waitForReady}. A
+ * completion-style pod (e.g. a {@code helm test} hook, {@code restartPolicy: Never})
+ * terminates in {@code Succeeded} and never reaches {@code Running}, so
+ * {@code jhelm test} used to poll it until the wait timed out. {@code Succeeded} must
+ * count as done; {@code Failed} is handled separately as a terminal failure the waiter
+ * fails fast on.
+ */
+class HelmKubeServicePodStatusTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			// phase, readyCondition, expectedReady
+			"Succeeded, false, true", // completion pod exited 0 — done even without a
+										// Ready condition
+			"Succeeded, true, true", "Running, true, true", // long-lived pod, Running +
+															// Ready
+			"Running, false, false", // Running but not yet Ready
+			"Pending, false, false", "Failed, false, false", // terminal failure is not
+																// "ready"
+			"Unknown, false, false" })
+	void testPodReadiness(String phase, boolean readyCondition, boolean expectedReady) {
+		assertTrue(HelmKubeService.isPodReady(phase, readyCondition) == expectedReady,
+				phase + "/readyCondition=" + readyCondition + " should be ready=" + expectedReady);
+	}
+
+	@Test
+	void testSucceededIsReadyRegardlessOfReadyCondition() {
+		// The key regression: a test-hook pod reaches Succeeded with no Ready condition,
+		// and
+		// must still be treated as done rather than polled to the timeout.
+		assertTrue(HelmKubeService.isPodReady("Succeeded", false));
+	}
+
+	@Test
+	void testFailedIsNotReady() {
+		// Failed is never ready; the waiter treats it as a terminal failure (fail fast).
+		assertFalse(HelmKubeService.isPodReady("Failed", false));
+	}
+
+}

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
@@ -20,6 +20,7 @@ import io.kubernetes.client.openapi.models.V1ReplicaSetSpec;
 import io.kubernetes.client.openapi.models.V1ReplicaSetStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodStatus;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretList;
@@ -708,6 +709,56 @@ class HelmKubeServiceTest {
 		});
 
 		assertThrows(KubernetesOperationException.class, () -> kubeService.delete("default", yaml));
+	}
+
+	@Test
+	void testWaitForReadyReturnsForSucceededPod() throws Exception {
+		// A completion-style pod (e.g. a `helm test` hook, restartPolicy: Never)
+		// terminates
+		// in Succeeded and never reaches Running; waitForReady must treat it as done
+		// rather
+		// than poll to the timeout (the regression that made `jhelm test` hang).
+		String yaml = """
+				apiVersion: v1
+				kind: Pod
+				metadata:
+				  name: test-pod
+				  namespace: default
+				""";
+
+		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
+			mockCoreV1Api = mock;
+			var req = mock(CoreV1Api.APIreadNamespacedPodRequest.class);
+			when(req.execute()).thenReturn(new V1Pod().status(new V1PodStatus().phase("Succeeded")));
+			when(mock.readNamespacedPod("test-pod", "default")).thenReturn(req);
+		});
+
+		assertDoesNotThrow(() -> kubeService.waitForReady("default", yaml, 5));
+	}
+
+	@Test
+	void testWaitForReadyFailsFastForFailedPod() throws Exception {
+		// A Failed pod is terminal — waitForReady must throw immediately, not after the
+		// full
+		// 30s timeout. The large timeout is the assertion: a poll-to-timeout would hang.
+		String yaml = """
+				apiVersion: v1
+				kind: Pod
+				metadata:
+				  name: test-pod
+				  namespace: default
+				""";
+
+		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
+			mockCoreV1Api = mock;
+			var req = mock(CoreV1Api.APIreadNamespacedPodRequest.class);
+			when(req.execute()).thenReturn(new V1Pod().status(new V1PodStatus().phase("Failed")));
+			when(mock.readNamespacedPod("test-pod", "default")).thenReturn(req);
+		});
+
+		WaitTimeoutException ex = assertThrows(WaitTimeoutException.class,
+				() -> kubeService.waitForReady("default", yaml, 30));
+		assertTrue(ex.getMessage().contains("terminally failed"));
 	}
 
 	@Test


### PR DESCRIPTION
## The bug
`jhelm test` never completed for a normal test hook. A `helm test` hook Pod runs `restartPolicy: Never`, executes its command, and terminates in phase **`Succeeded`** — it never enters `Running`.

But `checkPod` treated a Pod as ready **only** when its phase was `Running` with a True `Ready` condition:
```java
boolean isReady = "Running".equals(pod.getStatus().getPhase()) && ...Ready condition...;
```
So a `Succeeded` pod reported `ready=false` **forever**, and `waitForReady` polled it (logging `Waiting for Pod/...: Succeeded`) until the timeout elapsed before failing. **The common case — a test that passes — could not succeed.**

## Fix
`checkPod` now handles the **terminal pod phases**:
| phase | result |
|---|---|
| `Succeeded` | **ready** — a completion pod that exited 0 is done/passed |
| `Failed` | **terminal failure** — waiter fails fast (new `ResourceStatus.terminal` flag) |
| `Running` + Ready condition | ready (unchanged, long-lived pods) |

`waitForReady` checks for terminally-failed resources each poll and **throws immediately**, so a failed `helm test` hook reports `FAILED` promptly (`TestAction` already catches `WaitTimeoutException` → `FAILED`) instead of after the full wait.

The phase decision is extracted to a package-private `isPodReady(phase, readyCondition)`, unit-tested across all phases.

## Verification
- **End-to-end on an ephemeral kind cluster**: `jhelm test` against a passing hook pod now runs to `All tests passed` in seconds (`Pod passed` in the logs). Before this change it logged `Waiting for Pod: Succeeded` to the timeout.
- `HelmKubeServicePodStatusTest` — `Succeeded`/`Running`/`Pending`/`Failed`/`Unknown` phase matrix; full `jhelm-kube` suite green (260 tests).

Found while verifying the #666 apply fix (#667) on a real cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)