### PR TITLE
feat(values): fetch chart values from a Spring Cloud Config Server (#671)

### DIFF
--- a/docs/modules/ROOT/pages/value-profiles.adoc
+++ b/docs/modules/ROOT/pages/value-profiles.adoc
@@ -107,3 +107,60 @@ chart values.yaml (+ gated docs + sidecars)
   directory to resolve `values-<profile>.yaml` against).
 * With no active profile, loading is unchanged from earlier releases — the feature is
   inert until a profile is activated.
+
+== Fetching values from a Spring Cloud Config Server
+
+jhelm can also fetch values from a https://docs.spring.io/spring-cloud-config/reference/[Spring
+Cloud Config Server], so environment configuration can live centrally (git-backed) instead of
+in local files. It consumes the server's structured Environment endpoint
+(`GET {uri}/{application}/{profiles}[/{label}]`) and reuses the active profiles from above for
+the `{profiles}` path segment. Disabled by default.
+
+The server returns each document/file as a flat property source (dotted and `[i]`-indexed
+keys), highest precedence first. jhelm strips the `spring.config.activate.*` /
+`jhelm.config.activate.*` directives from each source (the server does not), un-flattens the
+keys into nested maps/lists, and merges the sources first-wins.
+
+=== Enabling and precedence
+
+Setting `--config-server-uri` (or `jhelm.config-server.enabled=true` + `uri`) turns it on. By
+default the config server sits between local files and `--set` — matching Spring Boot's
+config-data model, where command-line args outrank imported config-server values:
+
+[source,text]
+----
+chart values < -f / profile files < CONFIG SERVER < --set family
+----
+
+Two flags mirror Spring's knobs:
+
+* `jhelm.config-server.override-none=true` — config server drops to the *lowest* precedence
+  (every local file and `--set` wins). Mirrors `spring.cloud.config.override-none`.
+* `jhelm.config-server.override-system-properties=true` — config server moves *above* the
+  `--set` family. Mirrors `spring.cloud.config.override-system-properties`.
+
+=== CLI options (on `template`/`install`/`upgrade`)
+
+[cols="1,2",options="header"]
+|===
+| Option | Meaning
+| `--config-server-uri` | config-server base URI (enables the source)
+| `--config-name`       | application name (default: release name)
+| `--config-label`      | label / git branch (default: server default)
+| `--config-username` / `--config-password` | basic auth
+| `--config-token`      | bearer token (takes precedence over basic auth)
+| `--config-fail-fast`  | abort if the server is unreachable (default: warn and continue)
+|===
+
+The matching properties are `jhelm.config-server.{enabled,uri,name,label,username,password,token,fail-fast,override-none,override-system-properties}`;
+a CLI option overrides the corresponding property. Because these bind via Spring, the config
+server is available to the library, REST, and MCP surfaces too, not only the CLI.
+
+=== Security
+
+The config-server fetch uses jhelm's SSRF-guarded HTTP path (the same one used for chart
+repositories): the URL is validated, credentials are host-gated, and TLS follows
+`jhelm.insecure-skip-tls-verify`. In server mode (`jhelm.security.block-private-networks=true`)
+a private/site-local config-server host is refused, closing the SSRF vector for a
+user-supplied URI. `fail-fast=false` (the default) logs a warning and continues with local
+values when the server is unreachable.

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ConfigServerCliOptions.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ConfigServerCliOptions.java
@@ -1,0 +1,44 @@
+package org.alexmond.jhelm.app.command;
+
+import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
+import picocli.CommandLine.Option;
+
+/**
+ * Shared {@code --config-*} options for fetching chart values from a Spring Cloud Config
+ * Server. Mixed into {@code template}/{@code install}/{@code upgrade}. Each option
+ * overrides the corresponding {@code jhelm.config-server.*} property; an unset option
+ * (including the {@code null} {@code --config-fail-fast}) defers to the property.
+ */
+public class ConfigServerCliOptions {
+
+	@Option(names = { "--config-server-uri" },
+			description = "Spring Cloud Config Server base URI; setting it enables the config-server source")
+	private String uri;
+
+	@Option(names = { "--config-name" }, description = "config-server application name (default: release name)")
+	private String name;
+
+	@Option(names = { "--config-label" }, description = "config-server label (e.g. a git branch)")
+	private String label;
+
+	@Option(names = { "--config-username" }, description = "config-server basic-auth username")
+	private String username;
+
+	@Option(names = { "--config-password" }, description = "config-server basic-auth password")
+	private String password;
+
+	@Option(names = { "--config-token" }, description = "config-server bearer token (takes precedence over basic auth)")
+	private String token;
+
+	@Option(names = { "--config-fail-fast" },
+			description = "abort if the config server is unreachable (default: warn and continue)")
+	private Boolean failFast;
+
+	/**
+	 * @return these CLI overrides as a loader options record
+	 */
+	public ConfigServerValuesLoader.Options toOptions() {
+		return new ConfigServerValuesLoader.Options(uri, name, label, username, password, token, failFast);
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -16,6 +16,7 @@ import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.util.ValuesOverrides;
@@ -45,6 +46,11 @@ public class InstallCommand implements Callable<Integer> {
 	private final JhelmSecurityPolicy securityPolicy;
 
 	private final JhelmCoreProperties coreProperties;
+
+	private final ConfigServerValuesLoader configServerValuesLoader;
+
+	@CommandLine.Mixin
+	private final ConfigServerCliOptions configServerOptions = new ConfigServerCliOptions();
 
 	@CommandLine.Parameters(index = "0", description = "release name")
 	private String name;
@@ -121,13 +127,15 @@ public class InstallCommand implements Callable<Integer> {
 	 * mutating operations are enabled
 	 */
 	public InstallCommand(InstallAction installAction, UninstallAction uninstallAction, KubeService kubeService,
-			ChartResolver chartResolver, JhelmSecurityPolicy securityPolicy, JhelmCoreProperties coreProperties) {
+			ChartResolver chartResolver, JhelmSecurityPolicy securityPolicy, JhelmCoreProperties coreProperties,
+			ConfigServerValuesLoader configServerValuesLoader) {
 		this.installAction = installAction;
 		this.uninstallAction = uninstallAction;
 		this.kubeService = kubeService;
 		this.chartResolver = chartResolver;
 		this.securityPolicy = securityPolicy;
 		this.coreProperties = coreProperties;
+		this.configServerValuesLoader = configServerValuesLoader;
 	}
 
 	@Override
@@ -139,8 +147,11 @@ public class InstallCommand implements Callable<Integer> {
 			boolean dryRunEnabled = resolveDryRun();
 			ValuesProfiles profiles = ValuesProfiles
 				.of(profileNames.isEmpty() ? coreProperties.getProfiles().getActive() : profileNames);
+			ConfigServerValuesLoader.Result configServer = configServerValuesLoader.load(name, profiles.active(),
+					configServerOptions.toOptions());
 			Chart chart = chartResolver.resolve(chartPath, verify, keyring, profiles);
-			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, profiles, setValues, setStringValues,
+			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, profiles, configServer.values(),
+					configServer.overrideNone(), configServer.overrideSystemProperties(), setValues, setStringValues,
 					setFileValues, setJsonValues);
 
 			Release release = installAction.install(InstallOptions.builder()

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.TemplateAction;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
+import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
 import org.alexmond.jhelm.core.util.ValuesOverrides;
 import org.alexmond.jhelm.core.util.ValuesProfiles;
@@ -28,6 +29,11 @@ public class TemplateCommand implements Callable<Integer> {
 	private final TemplateAction templateAction;
 
 	private final JhelmCoreProperties coreProperties;
+
+	private final ConfigServerValuesLoader configServerValuesLoader;
+
+	@CommandLine.Mixin
+	private final ConfigServerCliOptions configServerOptions = new ConfigServerCliOptions();
 
 	@CommandLine.Parameters(index = "0", description = "release name")
 	private String name;
@@ -74,10 +80,14 @@ public class TemplateCommand implements Callable<Integer> {
 	 * Creates the command.
 	 * @param templateAction the action that renders chart templates
 	 * @param coreProperties core config, for the default active value profiles
+	 * @param configServerValuesLoader loads chart values from a config server (disabled
+	 * by default)
 	 */
-	public TemplateCommand(TemplateAction templateAction, JhelmCoreProperties coreProperties) {
+	public TemplateCommand(TemplateAction templateAction, JhelmCoreProperties coreProperties,
+			ConfigServerValuesLoader configServerValuesLoader) {
 		this.templateAction = templateAction;
 		this.coreProperties = coreProperties;
+		this.configServerValuesLoader = configServerValuesLoader;
 	}
 
 	@Override
@@ -85,7 +95,10 @@ public class TemplateCommand implements Callable<Integer> {
 		try {
 			ValuesProfiles profiles = ValuesProfiles
 				.of(profileNames.isEmpty() ? coreProperties.getProfiles().getActive() : profileNames);
-			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, profiles, setValues, setStringValues,
+			ConfigServerValuesLoader.Result configServer = configServerValuesLoader.load(name, profiles.active(),
+					configServerOptions.toOptions());
+			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, profiles, configServer.values(),
+					configServer.overrideNone(), configServer.overrideSystemProperties(), setValues, setStringValues,
 					setFileValues, setJsonValues);
 			String manifest = templateAction.render(chartPath, name, namespace, overrides, profiles, kubeVersion,
 					apiVersions);

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -24,6 +24,7 @@ import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
 import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.util.ValuesOverrides;
 import org.alexmond.jhelm.core.util.ValuesProfiles;
 import org.springframework.stereotype.Component;
@@ -55,6 +56,11 @@ public class UpgradeCommand implements Callable<Integer> {
 	private final JhelmSecurityPolicy securityPolicy;
 
 	private final JhelmCoreProperties coreProperties;
+
+	private final ConfigServerValuesLoader configServerValuesLoader;
+
+	@CommandLine.Mixin
+	private final ConfigServerCliOptions configServerOptions = new ConfigServerCliOptions();
 
 	@CommandLine.Parameters(index = "0", description = "release name")
 	private String name;
@@ -159,7 +165,8 @@ public class UpgradeCommand implements Callable<Integer> {
 	 */
 	public UpgradeCommand(KubeService kubeService, InstallAction installAction, UninstallAction uninstallAction,
 			UpgradeAction upgradeAction, RollbackAction rollbackAction, ChartResolver chartResolver,
-			JhelmSecurityPolicy securityPolicy, JhelmCoreProperties coreProperties) {
+			JhelmSecurityPolicy securityPolicy, JhelmCoreProperties coreProperties,
+			ConfigServerValuesLoader configServerValuesLoader) {
 		this.kubeService = kubeService;
 		this.installAction = installAction;
 		this.uninstallAction = uninstallAction;
@@ -168,6 +175,7 @@ public class UpgradeCommand implements Callable<Integer> {
 		this.chartResolver = chartResolver;
 		this.securityPolicy = securityPolicy;
 		this.coreProperties = coreProperties;
+		this.configServerValuesLoader = configServerValuesLoader;
 	}
 
 	@Override
@@ -182,8 +190,11 @@ public class UpgradeCommand implements Callable<Integer> {
 			Optional<Release> currentReleaseOpt = kubeService.getRelease(name, namespace);
 			ValuesProfiles profiles = ValuesProfiles
 				.of(profileNames.isEmpty() ? coreProperties.getProfiles().getActive() : profileNames);
+			ConfigServerValuesLoader.Result configServer = configServerValuesLoader.load(name, profiles.active(),
+					configServerOptions.toOptions());
 			Chart chart = chartResolver.resolve(chartPath, verify, keyring, profiles);
-			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, profiles, setValues, setStringValues,
+			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, profiles, configServer.values(),
+					configServer.overrideNone(), configServer.overrideSystemProperties(), setValues, setStringValues,
 					setFileValues, setJsonValues);
 
 			if (currentReleaseOpt.isEmpty()) {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -1,6 +1,8 @@
 package org.alexmond.jhelm.app.command;
 
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
+import org.alexmond.jhelm.core.config.ConfigServerProperties;
+import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.service.KubeService;
@@ -70,7 +72,7 @@ class InstallCommandTest {
 			.build();
 		when(chartResolver.resolve(anyString(), anyBoolean(), any())).thenReturn(defaultChart);
 		installCommand = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver, enabledPolicy(),
-				new JhelmCoreProperties());
+				new JhelmCoreProperties(), new ConfigServerValuesLoader(new ConfigServerProperties(), null));
 	}
 
 	private static JhelmSecurityPolicy enabledPolicy() {
@@ -126,7 +128,8 @@ class InstallCommandTest {
 		// run it.
 		File chartDir = createMockChart();
 		InstallCommand readOnly = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver,
-				readOnlyPolicy(), new JhelmCoreProperties());
+				readOnlyPolicy(), new JhelmCoreProperties(),
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null));
 
 		int exitCode = new CommandLine(readOnly).execute("my-release", chartDir.getAbsolutePath());
 
@@ -144,7 +147,8 @@ class InstallCommandTest {
 		File chartDir = createMockChart();
 		when(installAction.install(any(InstallOptions.class))).thenReturn(createMockRelease("my-release", 1));
 		InstallCommand full = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver,
-				new JhelmSecurityPolicy(props), new JhelmCoreProperties());
+				new JhelmSecurityPolicy(props), new JhelmCoreProperties(),
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null));
 
 		int exitCode = new CommandLine(full).execute("my-release", chartDir.getAbsolutePath(), "-n", "default");
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/TemplateCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/TemplateCommandTest.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import org.alexmond.jhelm.core.action.TemplateAction;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
+import org.alexmond.jhelm.core.config.ConfigServerProperties;
+import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.util.ValuesProfiles;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,7 +31,8 @@ class TemplateCommandTest {
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		templateCommand = new TemplateCommand(templateAction, new JhelmCoreProperties());
+		templateCommand = new TemplateCommand(templateAction, new JhelmCoreProperties(),
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null));
 	}
 
 	@Test
@@ -72,7 +75,8 @@ class TemplateCommandTest {
 	}
 
 	private ValuesProfiles runAndCaptureProfiles(JhelmCoreProperties props, String... args) {
-		TemplateCommand command = new TemplateCommand(templateAction, props);
+		TemplateCommand command = new TemplateCommand(templateAction, props,
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null));
 		ArgumentCaptor<ValuesProfiles> captor = ArgumentCaptor.forClass(ValuesProfiles.class);
 		when(templateAction.render(anyString(), anyString(), anyString(), anyMap(), captor.capture(), any(), anyList()))
 			.thenReturn("---\n");

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -1,6 +1,8 @@
 package org.alexmond.jhelm.app.command;
 
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
+import org.alexmond.jhelm.core.config.ConfigServerProperties;
+import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
@@ -79,7 +81,8 @@ class UpgradeCommandTest {
 			.build();
 		when(chartResolver.resolve(anyString(), anyBoolean(), any())).thenReturn(defaultChart);
 		upgradeCommand = new UpgradeCommand(kubeService, installAction, uninstallAction, upgradeAction, rollbackAction,
-				chartResolver, enabledPolicy(), new JhelmCoreProperties());
+				chartResolver, enabledPolicy(), new JhelmCoreProperties(),
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null));
 	}
 
 	private static JhelmSecurityPolicy enabledPolicy() {
@@ -112,7 +115,8 @@ class UpgradeCommandTest {
 		// run it.
 		File chartDir = createMockChart();
 		UpgradeCommand readOnly = new UpgradeCommand(kubeService, installAction, uninstallAction, upgradeAction,
-				rollbackAction, chartResolver, readOnlyPolicy(), new JhelmCoreProperties());
+				rollbackAction, chartResolver, readOnlyPolicy(), new JhelmCoreProperties(),
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null));
 
 		int exitCode = new CommandLine(readOnly).execute("my-release", chartDir.getAbsolutePath());
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.core;
 import java.util.List;
 
 import org.alexmond.jhelm.core.cache.TemplateCache;
+import org.alexmond.jhelm.core.config.ConfigServerProperties;
 import org.alexmond.jhelm.core.config.JhelmAccessMode;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
@@ -35,6 +36,8 @@ import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.action.VerifyAction;
 import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.ConfigServerClient;
+import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.service.LifecycleListener;
@@ -52,7 +55,8 @@ import org.apache.hc.client5.http.impl.classic.HttpClients;
  */
 @Slf4j
 @AutoConfiguration(after = JhelmMetricsAutoConfiguration.class)
-@EnableConfigurationProperties({ JhelmCoreProperties.class, JhelmSecurityProperties.class })
+@EnableConfigurationProperties({ JhelmCoreProperties.class, JhelmSecurityProperties.class,
+		ConfigServerProperties.class })
 public class JhelmCoreAutoConfiguration {
 
 	/**
@@ -108,6 +112,33 @@ public class JhelmCoreAutoConfiguration {
 				: new RepoManager(registryManager, props.isInsecureSkipTlsVerify(), blockPrivate);
 		repoManager.setMetrics(metrics.getIfAvailable());
 		return repoManager;
+	}
+
+	/**
+	 * Client that fetches chart values from a Spring Cloud Config Server over the shared
+	 * SSRF-guarded HTTP path.
+	 * @param repoManager provides the SSRF-guarded HTTP client factory
+	 * @return the config-server client bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public ConfigServerClient configServerClient(RepoManager repoManager) {
+		return new ConfigServerClient(repoManager);
+	}
+
+	/**
+	 * Resolves and fetches config-server values (merging {@code jhelm.config-server.*}
+	 * with per-command overrides), honoring fail-fast and the precedence flags. Disabled
+	 * by default.
+	 * @param configServerProperties the config-server configuration
+	 * @param configServerClient the config-server client
+	 * @return the config-server values loader bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public ConfigServerValuesLoader configServerValuesLoader(ConfigServerProperties configServerProperties,
+			ConfigServerClient configServerClient) {
+		return new ConfigServerValuesLoader(configServerProperties, configServerClient);
 	}
 
 	/**

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/ConfigServerProperties.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/ConfigServerProperties.java
@@ -1,0 +1,66 @@
+package org.alexmond.jhelm.core.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for fetching chart values from a Spring Cloud Config Server. Field names
+ * mirror the Spring Cloud Config client ({@code spring.cloud.config.*}). Disabled by
+ * default, so binding these properties without setting {@link #enabled} + {@link #uri} is
+ * a no-op.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jhelm.config-server")
+public class ConfigServerProperties {
+
+	/** Whether to fetch values from a config server. Defaults to {@code false}. */
+	private boolean enabled;
+
+	/** Base URI of the config server, e.g. {@code https://config.example.com}. */
+	private String uri;
+
+	/**
+	 * Config-server application name (the {@code {application}} path segment). Defaults
+	 * to the release name when unset.
+	 */
+	private String name;
+
+	/**
+	 * Config-server label (the optional {@code {label}} path segment, e.g. a git branch).
+	 * Omitted from the URL when unset, letting the server use its default.
+	 */
+	private String label;
+
+	/** Basic-auth username. */
+	private String username;
+
+	/** Basic-auth password. */
+	private String password;
+
+	/** Bearer token (mutually exclusive with basic auth; used when set). */
+	private String token;
+
+	/**
+	 * When {@code true}, a config-server fetch failure aborts the operation; otherwise a
+	 * warning is logged and rendering continues with local values only. Defaults to
+	 * {@code false}, matching Spring's {@code spring.cloud.config.fail-fast}.
+	 */
+	private boolean failFast;
+
+	/**
+	 * When {@code true}, config-server values drop to the <em>lowest</em> precedence —
+	 * every local {@code -f} file and {@code --set} wins over them. Mirrors
+	 * {@code spring.cloud.config.override-none}. Defaults to {@code false}.
+	 */
+	private boolean overrideNone;
+
+	/**
+	 * When {@code true}, config-server values move <em>above</em> the {@code --set}
+	 * family, so the remote values win over command-line overrides. Mirrors
+	 * {@code spring.cloud.config.override-system-properties}. Defaults to {@code false}.
+	 */
+	private boolean overrideSystemProperties;
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Environment.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Environment.java
@@ -1,0 +1,56 @@
+package org.alexmond.jhelm.core.model;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Mirror of the Spring Cloud Config Server structured Environment response ({@code GET
+ * /{application}/{profiles}[/{label}]}).
+ * <p>
+ * {@link #propertySources} is ordered <em>highest precedence first</em>; each source's
+ * {@code source} map is flat (dotted and {@code [i]}-indexed keys), not hierarchical. See
+ * {@code PropertySourceMapper} for the un-flatten / strip / first-wins merge that turns
+ * this into a nested values map.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Environment {
+
+	private String name;
+
+	private List<String> profiles = new ArrayList<>();
+
+	private String label;
+
+	private String version;
+
+	private String state;
+
+	private List<PropertySource> propertySources = new ArrayList<>();
+
+	/**
+	 * One document or file from the config server, with a flat (dotted/indexed) source
+	 * map.
+	 */
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class PropertySource {
+
+		private String name;
+
+		private Map<String, Object> source = new LinkedHashMap<>();
+
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ConfigServerClient.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ConfigServerClient.java
@@ -1,0 +1,116 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.model.Environment;
+import org.alexmond.jhelm.core.model.RepositoryConfig;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.core5.http.HttpEntity;
+
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Fetches the structured Environment JSON from a Spring Cloud Config Server ({@code GET
+ * {uri}/{application}/{profiles}[/{label}]}).
+ * <p>
+ * The fetch rides the shared SSRF-guarded HTTP path ({@link RepoHttpClientFactory} from
+ * {@link RepoManager}): the URL is validated against the {@code block-private-networks}
+ * policy (#630), credentials are host-gated, and TLS follows the global
+ * {@code insecure-skip-tls-verify} setting — the config-server URI is user/operator
+ * supplied, so it must not use the unguarded {@code java.net.http} path.
+ */
+@Slf4j
+public class ConfigServerClient {
+
+	private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
+
+	private final RepoManager repoManager;
+
+	/**
+	 * @param repoManager provides the shared SSRF-guarded HTTP client factory
+	 */
+	public ConfigServerClient(RepoManager repoManager) {
+		this.repoManager = repoManager;
+	}
+
+	/**
+	 * Fetch and parse the Environment for the given request.
+	 * @param request the resolved config-server request
+	 * @return the parsed {@link Environment}
+	 * @throws IOException on connection failure, a non-2xx response, or a parse error
+	 */
+	public Environment fetch(ConfigServerRequest request) throws IOException {
+		String url = buildUrl(request);
+		HttpGet get = new HttpGet(url);
+		get.setHeader("User-Agent", "jhelm");
+
+		RepositoryConfig.Repository repo = authRepository(request, url, get);
+
+		if (log.isInfoEnabled()) {
+			log.info("Fetching values from config server: {}", url);
+		}
+		return repoManager.httpClientFactory().executeGet(get, repo, (response) -> {
+			int code = response.getCode();
+			if (code == 401 || code == 403) {
+				throw new IOException("Config server authentication failed (" + code + " " + response.getReasonPhrase()
+						+ ") for " + url);
+			}
+			if (code < 200 || code >= 300) {
+				throw new IOException(
+						"Config server returned " + code + " " + response.getReasonPhrase() + " for " + url);
+			}
+			HttpEntity entity = response.getEntity();
+			if (entity == null) {
+				return new Environment();
+			}
+			try (InputStream in = entity.getContent()) {
+				byte[] body = in.readAllBytes();
+				return JSON_MAPPER.readValue(new String(body, StandardCharsets.UTF_8), Environment.class);
+			}
+		});
+	}
+
+	/**
+	 * Applies auth to the request and returns the {@link RepositoryConfig.Repository}
+	 * passed to {@code executeGet} (its URL host-gates basic-auth credentials). A bearer
+	 * token, when present, is set directly and takes precedence over basic auth.
+	 */
+	private RepositoryConfig.Repository authRepository(ConfigServerRequest request, String url, HttpGet get) {
+		if (request.token() != null && !request.token().isBlank()) {
+			get.setHeader("Authorization", "Bearer " + request.token());
+			// No username on the repo, so RepoHttpClientFactory won't overwrite the
+			// header.
+			return RepositoryConfig.Repository.builder().url(url).build();
+		}
+		return RepositoryConfig.Repository.builder()
+			.url(url)
+			.username(request.username())
+			.password(request.password())
+			.build();
+	}
+
+	static String buildUrl(ConfigServerRequest request) {
+		String base = request.uri();
+		if (base == null || base.isBlank()) {
+			throw new IllegalArgumentException("config server URI is required");
+		}
+		while (base.endsWith("/")) {
+			base = base.substring(0, base.length() - 1);
+		}
+		List<String> profiles = request.profiles();
+		String profileSegment = (profiles == null || profiles.isEmpty()) ? "default" : String.join(",", profiles);
+		StringBuilder url = new StringBuilder(base).append('/')
+			.append(request.application())
+			.append('/')
+			.append(profileSegment);
+		if (request.label() != null && !request.label().isBlank()) {
+			url.append('/').append(request.label());
+		}
+		return url.toString();
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ConfigServerRequest.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ConfigServerRequest.java
@@ -1,0 +1,20 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.List;
+
+/**
+ * A resolved config-server fetch request: the effective values after merging
+ * {@code jhelm.config-server.*} properties with per-command {@code --config-*} overrides.
+ *
+ * @param uri config-server base URI (no trailing path)
+ * @param application the {@code {application}} path segment (release name by default)
+ * @param profiles active profiles for the {@code {profiles}} segment (comma-joined; empty
+ * falls back to {@code default})
+ * @param label optional {@code {label}} segment (git branch); {@code null}/blank omits it
+ * @param username basic-auth username, or {@code null}
+ * @param password basic-auth password, or {@code null}
+ * @param token bearer token (takes precedence over basic auth), or {@code null}
+ */
+public record ConfigServerRequest(String uri, String application, List<String> profiles, String label, String username,
+		String password, String token) {
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ConfigServerValuesLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ConfigServerValuesLoader.java
@@ -1,0 +1,123 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.config.ConfigServerProperties;
+import org.alexmond.jhelm.core.exception.JhelmException;
+import org.alexmond.jhelm.core.model.Environment;
+import org.alexmond.jhelm.core.util.PropertySourceMapper;
+
+/**
+ * Resolves the effective config-server request (merging {@link ConfigServerProperties}
+ * with per-command {@code --config-*} overrides), fetches the Environment, and reduces it
+ * to a nested values map. Honors {@code fail-fast} (abort vs warn-and-continue) and
+ * surfaces the precedence flags ({@code override-none} /
+ * {@code override-system-properties}) so the caller can place the values correctly in the
+ * override chain.
+ * <p>
+ * A reusable component: the CLI drives it today; library/REST/MCP callers can too.
+ * Disabled by default — when neither the property nor a {@code --config-server-uri}
+ * enables it, it returns an empty result and makes no network call.
+ */
+@Slf4j
+public class ConfigServerValuesLoader {
+
+	private final ConfigServerProperties properties;
+
+	private final ConfigServerClient client;
+
+	public ConfigServerValuesLoader(ConfigServerProperties properties, ConfigServerClient client) {
+		this.properties = properties;
+		this.client = client;
+	}
+
+	/**
+	 * Fetch config-server values for a release.
+	 * @param releaseName the release name, used as the default config-server application
+	 * name
+	 * @param activeProfiles the active profiles (from {@code --profile}/#670)
+	 * @param overrides per-command {@code --config-*} overrides (may be empty)
+	 * @return the fetched values plus precedence flags; empty values when disabled or on
+	 * a non-fatal fetch failure
+	 * @throws JhelmException when the fetch fails and {@code fail-fast} is set
+	 */
+	public Result load(String releaseName, List<String> activeProfiles, Options overrides) {
+		Options cli = (overrides != null) ? overrides : Options.none();
+		String uri = firstNonBlank(cli.uri(), properties.getUri());
+		boolean enabled = properties.isEnabled() || (cli.uri() != null && !cli.uri().isBlank());
+		if (!enabled || uri == null || uri.isBlank()) {
+			return new Result(Map.of(), properties.isOverrideNone(), properties.isOverrideSystemProperties());
+		}
+
+		String application = firstNonBlank(cli.name(), properties.getName(), releaseName);
+		ConfigServerRequest request = new ConfigServerRequest(uri, application, activeProfiles,
+				firstNonBlank(cli.label(), properties.getLabel()),
+				firstNonBlank(cli.username(), properties.getUsername()),
+				firstNonBlank(cli.password(), properties.getPassword()),
+				firstNonBlank(cli.token(), properties.getToken()));
+		boolean failFast = (cli.failFast() != null) ? cli.failFast() : properties.isFailFast();
+
+		Map<String, Object> values;
+		try {
+			Environment environment = client.fetch(request);
+			values = PropertySourceMapper.toValues(environment);
+		}
+		catch (Exception ex) {
+			if (failFast) {
+				throw new JhelmException("Config server fetch failed: " + ex.getMessage(), ex);
+			}
+			if (log.isWarnEnabled()) {
+				log.warn("Config server fetch failed, continuing with local values only: {}", ex.getMessage());
+			}
+			values = Map.of();
+		}
+		return new Result(values, properties.isOverrideNone(), properties.isOverrideSystemProperties());
+	}
+
+	private static String firstNonBlank(String... values) {
+		for (String value : values) {
+			if (value != null && !value.isBlank()) {
+				return value;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Per-command {@code --config-*} overrides. A {@code null} field defers to the
+	 * corresponding {@link ConfigServerProperties} value.
+	 *
+	 * @param uri overrides {@code jhelm.config-server.uri}
+	 * @param name overrides {@code jhelm.config-server.name}
+	 * @param label overrides {@code jhelm.config-server.label}
+	 * @param username overrides {@code jhelm.config-server.username}
+	 * @param password overrides {@code jhelm.config-server.password}
+	 * @param token overrides {@code jhelm.config-server.token}
+	 * @param failFast overrides {@code jhelm.config-server.fail-fast}
+	 */
+	public record Options(String uri, String name, String label, String username, String password, String token,
+			Boolean failFast) {
+
+		/**
+		 * @return an all-{@code null} override set (defer entirely to properties).
+		 */
+		public static Options none() {
+			return new Options(null, null, null, null, null, null, null);
+		}
+
+	}
+
+	/**
+	 * The resolved config-server values and where they sit in the override chain.
+	 *
+	 * @param values the fetched, un-flattened values (empty when disabled or non-fatal
+	 * failure)
+	 * @param overrideNone config-server drops to lowest precedence
+	 * @param overrideSystemProperties config-server outranks the {@code --set} family
+	 */
+	public record Result(Map<String, Object> values, boolean overrideNone, boolean overrideSystemProperties) {
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -217,6 +217,18 @@ public class RepoManager {
 		ociClient = new OciRegistryClient(httpClient, blockPrivateNetworks);
 	}
 
+	/**
+	 * The SSRF-guarded HTTP client factory (validates fetch URLs, host-gates credentials,
+	 * applies TLS per the global {@code insecureSkipTlsVerify} /
+	 * {@code blockPrivateNetworks} policy). Shared with {@code ConfigServerClient} so a
+	 * config-server fetch rides the same audited path as repository index/chart
+	 * downloads.
+	 * @return the shared HTTP client factory
+	 */
+	RepoHttpClientFactory httpClientFactory() {
+		return httpClientFactory;
+	}
+
 	RepositoryConfig.Repository getRepository(String name) throws IOException {
 		RepositoryConfig config = loadConfig();
 		return config.getRepositories().stream().filter((r) -> r.getName().equals(name)).findFirst().orElse(null);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/PropertySourceMapper.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/PropertySourceMapper.java
@@ -1,0 +1,171 @@
+package org.alexmond.jhelm.core.util;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.model.Environment;
+
+/**
+ * Turns a Spring Cloud Config Server {@link Environment} into a nested values map.
+ * <p>
+ * Each {@code propertySource} carries a flat map of dotted / {@code [i]}-indexed keys.
+ * For every source this mapper:
+ * <ol>
+ * <li><b>strips</b> activation directives ({@code spring.config.activate.*} and
+ * {@code jhelm.config.activate.*}) so they never reach {@code .Values} — the server does
+ * not remove them itself;</li>
+ * <li><b>un-flattens</b> the remaining dotted / indexed keys into nested maps and
+ * lists.</li>
+ * </ol>
+ * Sources are then merged <b>first-wins</b> (the config server lists them highest
+ * precedence first), matching the server's own ordering.
+ */
+public final class PropertySourceMapper {
+
+	private static final String SPRING_ACTIVATE_PREFIX = "spring.config.activate.";
+
+	private static final String JHELM_ACTIVATE_PREFIX = "jhelm.config.activate.";
+
+	private PropertySourceMapper() {
+	}
+
+	/**
+	 * Reduce an Environment to a single nested values map (strip + un-flatten +
+	 * first-wins merge of its property sources).
+	 * @param environment the parsed config-server response (may be {@code null})
+	 * @return the merged nested values ({@code {}} if there are no sources)
+	 */
+	public static Map<String, Object> toValues(Environment environment) {
+		Map<String, Object> result = new LinkedHashMap<>();
+		if (environment == null || environment.getPropertySources() == null) {
+			return result;
+		}
+		List<Environment.PropertySource> sources = environment.getPropertySources();
+		// propertySources are highest-first; merge from lowest to highest so the highest
+		// (index 0) is applied last and wins.
+		for (int i = sources.size() - 1; i >= 0; i--) {
+			Environment.PropertySource source = sources.get(i);
+			if (source == null || source.getSource() == null) {
+				continue;
+			}
+			ValuesLoader.deepMerge(result, unflatten(source.getSource()));
+		}
+		return result;
+	}
+
+	/**
+	 * Un-flatten a single flat (dotted / indexed) source map into nested maps and lists,
+	 * dropping activation-directive keys.
+	 * @param flat the flat source map
+	 * @return the nested map
+	 */
+	static Map<String, Object> unflatten(Map<String, Object> flat) {
+		Map<String, Object> root = new LinkedHashMap<>();
+		for (Map.Entry<String, Object> entry : flat.entrySet()) {
+			String key = entry.getKey();
+			if (isActivationKey(key)) {
+				continue;
+			}
+			setPath(root, parseKey(key), 0, entry.getValue());
+		}
+		return root;
+	}
+
+	private static boolean isActivationKey(String key) {
+		return key.startsWith(SPRING_ACTIVATE_PREFIX) || key.startsWith(JHELM_ACTIVATE_PREFIX);
+	}
+
+	/**
+	 * Parse a flat key such as {@code a.b[0].c} into an ordered token list (map keys and
+	 * list indices).
+	 */
+	private static List<Token> parseKey(String key) {
+		List<Token> tokens = new ArrayList<>();
+		for (String part : key.split("\\.", -1)) {
+			int bracket = part.indexOf('[');
+			String name = (bracket < 0) ? part : part.substring(0, bracket);
+			if (!name.isEmpty()) {
+				tokens.add(Token.key(name));
+			}
+			if (bracket >= 0) {
+				// one or more [i] index groups, e.g. x[0][1]
+				String rest = part.substring(bracket);
+				for (String idx : rest.split("]")) {
+					String digits = idx.replace("[", "").trim();
+					if (!digits.isEmpty()) {
+						tokens.add(Token.index(Integer.parseInt(digits)));
+					}
+				}
+			}
+		}
+		return tokens;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static void setPath(Object node, List<Token> tokens, int idx, Object value) {
+		Token token = tokens.get(idx);
+		boolean last = idx == tokens.size() - 1;
+		if (token.index < 0) {
+			Map<String, Object> map = (Map<String, Object>) node;
+			if (last) {
+				map.put(token.name, value);
+				return;
+			}
+			Object child = getOrCreate(map.get(token.name), tokens.get(idx + 1));
+			map.put(token.name, child);
+			setPath(child, tokens, idx + 1, value);
+		}
+		else {
+			List<Object> list = (List<Object>) node;
+			pad(list, token.index);
+			if (last) {
+				list.set(token.index, value);
+				return;
+			}
+			Object child = getOrCreate(list.get(token.index), tokens.get(idx + 1));
+			list.set(token.index, child);
+			setPath(child, tokens, idx + 1, value);
+		}
+	}
+
+	private static Object getOrCreate(Object existing, Token next) {
+		if (next.index < 0) {
+			return (existing instanceof Map) ? existing : new LinkedHashMap<>();
+		}
+		return (existing instanceof List) ? existing : new ArrayList<>();
+	}
+
+	private static void pad(List<Object> list, int index) {
+		while (list.size() <= index) {
+			list.add(null);
+		}
+	}
+
+	/**
+	 * A single segment of a flat key: either a map key ({@code index < 0}) or a list
+	 * index.
+	 */
+	private static final class Token {
+
+		private final String name;
+
+		private final int index;
+
+		private Token(String name, int index) {
+			this.name = name;
+			this.index = index;
+		}
+
+		static Token key(String name) {
+			return new Token(name, -1);
+		}
+
+		static Token index(int index) {
+			return new Token(null, index);
+		}
+
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesOverrides.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesOverrides.java
@@ -100,6 +100,64 @@ public final class ValuesOverrides {
 	 */
 	public static Map<String, Object> parse(List<String> files, ValuesProfiles profiles, List<String> setArgs,
 			List<String> setStringArgs, List<String> setFileArgs, List<String> setJsonArgs) throws IOException {
+		return parse(files, profiles, null, false, false, setArgs, setStringArgs, setFileArgs, setJsonArgs);
+	}
+
+	/**
+	 * Build a merged override map that also folds in values fetched from a config server,
+	 * honoring the config-server precedence flags. The default order (increasing
+	 * precedence) is: {@code -f} files &rarr; config server &rarr; {@code --set} family.
+	 * The flags mirror Spring Cloud Config:
+	 * <ul>
+	 * <li>{@code overrideNone} &mdash; config server drops to the <em>lowest</em>
+	 * precedence (files and {@code --set} win).</li>
+	 * <li>{@code overrideSystemProperties} &mdash; config server moves <em>above</em> the
+	 * {@code --set} family (remote wins over the command line).</li>
+	 * </ul>
+	 * These apply within the override map only; chart defaults (merged by the action)
+	 * always sit below.
+	 * @param files paths to YAML values files; {@code null} or empty means none
+	 * @param profiles the active value profiles applied to each file
+	 * @param configServerValues values fetched from a config server; {@code null}/empty
+	 * means none
+	 * @param overrideNone config server drops to lowest precedence
+	 * @param overrideSystemProperties config server outranks the {@code --set} family
+	 * @param setArgs {@code key=value} strings, coerced to typed scalars
+	 * @param setStringArgs {@code key=value} strings kept as raw strings
+	 * @param setFileArgs {@code key=path} strings whose value is the file contents
+	 * @param setJsonArgs {@code key=json} strings whose value is parsed as JSON
+	 * @return merged override map
+	 * @throws IOException if any values file cannot be read
+	 */
+	public static Map<String, Object> parse(List<String> files, ValuesProfiles profiles,
+			Map<String, Object> configServerValues, boolean overrideNone, boolean overrideSystemProperties,
+			List<String> setArgs, List<String> setStringArgs, List<String> setFileArgs, List<String> setJsonArgs)
+			throws IOException {
+		Map<String, Object> fileValues = loadFiles(files, profiles);
+		Map<String, Object> configValues = (configServerValues != null) ? configServerValues : Map.of();
+		Map<String, Object> merged = new HashMap<>();
+		if (overrideNone) {
+			// config server = defaults: lowest precedence.
+			ValuesLoader.deepMerge(merged, configValues);
+			ValuesLoader.deepMerge(merged, fileValues);
+			applySetFamily(merged, setArgs, setStringArgs, setFileArgs, setJsonArgs);
+		}
+		else if (overrideSystemProperties) {
+			// config server above the --set family.
+			ValuesLoader.deepMerge(merged, fileValues);
+			applySetFamily(merged, setArgs, setStringArgs, setFileArgs, setJsonArgs);
+			ValuesLoader.deepMerge(merged, configValues);
+		}
+		else {
+			// default: files < config server < --set.
+			ValuesLoader.deepMerge(merged, fileValues);
+			ValuesLoader.deepMerge(merged, configValues);
+			applySetFamily(merged, setArgs, setStringArgs, setFileArgs, setJsonArgs);
+		}
+		return merged;
+	}
+
+	private static Map<String, Object> loadFiles(List<String> files, ValuesProfiles profiles) throws IOException {
 		Map<String, Object> merged = new HashMap<>();
 		if (files != null) {
 			for (String path : files) {
@@ -113,6 +171,11 @@ public final class ValuesOverrides {
 				ValuesLoader.deepMerge(merged, fileValues);
 			}
 		}
+		return merged;
+	}
+
+	private static void applySetFamily(Map<String, Object> merged, List<String> setArgs, List<String> setStringArgs,
+			List<String> setFileArgs, List<String> setJsonArgs) {
 		if (setArgs != null) {
 			for (String arg : setArgs) {
 				applySet(merged, arg);
@@ -133,7 +196,6 @@ public final class ValuesOverrides {
 				applySetJson(merged, arg);
 			}
 		}
-		return merged;
 	}
 
 	/**

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ConfigServerClientTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ConfigServerClientTest.java
@@ -1,0 +1,67 @@
+package org.alexmond.jhelm.core.service;
+
+import java.net.URI;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * URL construction and SSRF-guard routing for {@link ConfigServerClient}. Full
+ * request/parse round-trips are covered by {@code ConfigServerValuesLoaderTest} (mocked
+ * client) and the live-server grounding; a real HTTP round-trip here is impossible
+ * because the SSRF guard refuses loopback.
+ */
+class ConfigServerClientTest {
+
+	private static ConfigServerRequest request(String uri, List<String> profiles, String label) {
+		return new ConfigServerRequest(uri, "myapp", profiles, label, null, null, null);
+	}
+
+	@Test
+	void testUrlWithProfilesAndLabel() {
+		assertEquals("http://cfg/myapp/prod,eu/main",
+				ConfigServerClient.buildUrl(request("http://cfg", List.of("prod", "eu"), "main")));
+	}
+
+	@Test
+	void testUrlOmitsLabelWhenAbsent() {
+		assertEquals("http://cfg/myapp/prod",
+				ConfigServerClient.buildUrl(request("http://cfg", List.of("prod"), null)));
+	}
+
+	@Test
+	void testUrlFallsBackToDefaultProfile() {
+		assertEquals("http://cfg/myapp/default", ConfigServerClient.buildUrl(request("http://cfg", List.of(), null)));
+	}
+
+	@Test
+	void testUrlStripsTrailingSlash() {
+		assertEquals("http://cfg/myapp/prod",
+				ConfigServerClient.buildUrl(request("http://cfg/", List.of("prod"), null)));
+	}
+
+	@Test
+	void testFetchIsSsrfGuarded() {
+		// The fetch must ride the SSRF-guarded path (not the unguarded java.net.http
+		// one): a
+		// non-routable target is refused at the guard before any connection. The wildcard
+		// address is always blocked, regardless of block-private-networks.
+		ConfigServerClient client = new ConfigServerClient(new RepoManager(null, false, false));
+		ConfigServerRequest req = request("http://0.0.0.0:8888", List.of("default"), null);
+		assertThrows(SecurityException.class, () -> client.fetch(req));
+	}
+
+	@Test
+	void testGuardValidatesTheBuiltUrl() {
+		// A routable host passes the guard the client uses (it would then simply
+		// connect),
+		// confirming the URL the client builds is what gets validated.
+		ConfigServerRequest req = request("http://config.example.com:8888", List.of("prod"), "main");
+		assertDoesNotThrow(() -> UrlSecurity.validateFetchUrl(URI.create(ConfigServerClient.buildUrl(req)), true));
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ConfigServerValuesLoaderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ConfigServerValuesLoaderTest.java
@@ -1,0 +1,133 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.config.ConfigServerProperties;
+import org.alexmond.jhelm.core.exception.JhelmException;
+import org.alexmond.jhelm.core.model.Environment;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Request resolution (properties merged with per-command overrides), fail-fast behavior,
+ * and precedence-flag surfacing for {@link ConfigServerValuesLoader}. The HTTP boundary
+ * ({@link ConfigServerClient}) is mocked.
+ */
+class ConfigServerValuesLoaderTest {
+
+	private final ConfigServerClient client = mock(ConfigServerClient.class);
+
+	private final ConfigServerProperties properties = new ConfigServerProperties();
+
+	private final ConfigServerValuesLoader loader = new ConfigServerValuesLoader(properties, client);
+
+	private static Environment environmentWith(Map<String, Object> flatSource) {
+		Environment env = new Environment();
+		Environment.PropertySource ps = new Environment.PropertySource();
+		ps.setSource(flatSource);
+		env.setPropertySources(List.of(ps));
+		return env;
+	}
+
+	@Test
+	void testDisabledByDefaultMakesNoCall() throws IOException {
+		ConfigServerValuesLoader.Result result = loader.load("rel", List.of("prod"),
+				ConfigServerValuesLoader.Options.none());
+		assertTrue(result.values().isEmpty(), "disabled -> empty values");
+		verify(client, never()).fetch(any());
+	}
+
+	@Test
+	void testEnabledViaPropertyFetchesAndMapsWithDefaultName() throws IOException {
+		properties.setEnabled(true);
+		properties.setUri("http://cfg");
+		ArgumentCaptor<ConfigServerRequest> captor = ArgumentCaptor.forClass(ConfigServerRequest.class);
+		when(client.fetch(captor.capture())).thenReturn(environmentWith(Map.of("image.tag", "prod")));
+
+		ConfigServerValuesLoader.Result result = loader.load("my-release", List.of("prod"),
+				ConfigServerValuesLoader.Options.none());
+
+		ConfigServerRequest req = captor.getValue();
+		assertEquals("my-release", req.application(), "application defaults to the release name");
+		assertEquals(List.of("prod"), req.profiles(), "active profiles flow into the request");
+		assertEquals("prod", ((Map<?, ?>) result.values().get("image")).get("tag"), "fetched values are un-flattened");
+	}
+
+	@Test
+	void testCliUriEnablesEvenWhenPropertyDisabled() throws IOException {
+		when(client.fetch(any())).thenReturn(new Environment());
+		ArgumentCaptor<ConfigServerRequest> captor = ArgumentCaptor.forClass(ConfigServerRequest.class);
+		when(client.fetch(captor.capture())).thenReturn(new Environment());
+
+		loader.load("rel", List.of(),
+				new ConfigServerValuesLoader.Options("http://cli", null, null, null, null, null, null));
+
+		assertEquals("http://cli", captor.getValue().uri());
+	}
+
+	@Test
+	void testCliOverridesWinOverProperties() throws IOException {
+		properties.setEnabled(true);
+		properties.setUri("http://prop");
+		properties.setName("prop-name");
+		properties.setToken("prop-token");
+		ArgumentCaptor<ConfigServerRequest> captor = ArgumentCaptor.forClass(ConfigServerRequest.class);
+		when(client.fetch(captor.capture())).thenReturn(new Environment());
+
+		loader.load("rel", List.of(), new ConfigServerValuesLoader.Options("http://cli", "cli-name", "cli-label", null,
+				null, "cli-token", null));
+
+		ConfigServerRequest req = captor.getValue();
+		assertEquals("http://cli", req.uri());
+		assertEquals("cli-name", req.application());
+		assertEquals("cli-label", req.label());
+		assertEquals("cli-token", req.token());
+	}
+
+	@Test
+	void testFailFastAbortsOnFetchError() throws IOException {
+		properties.setEnabled(true);
+		properties.setUri("http://cfg");
+		properties.setFailFast(true);
+		when(client.fetch(any())).thenThrow(new IOException("connection refused"));
+
+		assertThrows(JhelmException.class,
+				() -> loader.load("rel", List.of(), ConfigServerValuesLoader.Options.none()));
+	}
+
+	@Test
+	void testNonFailFastWarnsAndContinues() throws IOException {
+		properties.setEnabled(true);
+		properties.setUri("http://cfg");
+		properties.setFailFast(false);
+		when(client.fetch(any())).thenThrow(new IOException("connection refused"));
+
+		ConfigServerValuesLoader.Result result = loader.load("rel", List.of(), ConfigServerValuesLoader.Options.none());
+		assertTrue(result.values().isEmpty(), "fetch failure with fail-fast=false yields empty values, no throw");
+	}
+
+	@Test
+	void testPrecedenceFlagsSurfaced() throws IOException {
+		properties.setEnabled(true);
+		properties.setUri("http://cfg");
+		properties.setOverrideNone(true);
+		properties.setOverrideSystemProperties(true);
+		when(client.fetch(any())).thenReturn(new Environment());
+
+		ConfigServerValuesLoader.Result result = loader.load("rel", List.of(), ConfigServerValuesLoader.Options.none());
+		assertTrue(result.overrideNone());
+		assertTrue(result.overrideSystemProperties());
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/PropertySourceMapperTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/PropertySourceMapperTest.java
@@ -1,0 +1,125 @@
+package org.alexmond.jhelm.core.util;
+
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.model.Environment;
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Parses a Spring Cloud Config Server Environment JSON (shape captured from a live
+ * server) and verifies {@link PropertySourceMapper}: activation-key stripping,
+ * dotted/indexed un-flattening, and first-wins merge of {@code propertySources}.
+ */
+class PropertySourceMapperTest {
+
+	private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+	// Highest-precedence first: sidecar file, then two multi-doc documents. Each document
+	// still carries the activation key the server did not strip. Mixes dotted and
+	// [i]-indexed
+	// keys.
+	private static final String ENV_JSON = """
+			{
+			  "name": "myapp",
+			  "profiles": ["prod"],
+			  "label": "main",
+			  "version": "abc123",
+			  "state": "",
+			  "propertySources": [
+			    {
+			      "name": "myapp-prod.yml",
+			      "source": {
+			        "replicas": 5,
+			        "image.tag": "prod",
+			        "spring.config.activate.on-profile": "prod"
+			      }
+			    },
+			    {
+			      "name": "myapp.yml (document #1)",
+			      "source": {
+			        "replicas": 3,
+			        "spring.config.activate.on-profile": "prod"
+			      }
+			    },
+			    {
+			      "name": "myapp.yml (document #0)",
+			      "source": {
+			        "replicas": 1,
+			        "image.tag": "base",
+			        "ports[0]": 8080,
+			        "ports[1]": 8443,
+			        "servers[0].name": "a",
+			        "servers[0].port": 1,
+			        "servers[1].name": "b"
+			      }
+			    }
+			  ]
+			}
+			""";
+
+	private Map<String, Object> mapped() {
+		Environment env = MAPPER.readValue(ENV_JSON, Environment.class);
+		return PropertySourceMapper.toValues(env);
+	}
+
+	@Test
+	void testFirstSourceWins() {
+		Map<String, Object> values = mapped();
+		assertEquals(5, values.get("replicas"), "highest-precedence source (index 0) wins");
+	}
+
+	@Test
+	void testHigherSourceOverridesNestedKey() {
+		Map<String, Object> values = mapped();
+		assertEquals("prod", ((Map<?, ?>) values.get("image")).get("tag"),
+				"sidecar image.tag overrides the base document's");
+	}
+
+	@Test
+	void testDottedKeysUnflattenToNestedMaps() {
+		// image.tag came only as a flat dotted key; it must become {image: {tag: ...}}.
+		Map<String, Object> values = mapped();
+		assertTrue(values.get("image") instanceof Map, "dotted key un-flattens to a nested map");
+	}
+
+	@Test
+	void testIndexedKeysUnflattenToLists() {
+		Map<String, Object> values = mapped();
+		assertEquals(List.of(8080, 8443), values.get("ports"), "ports[i] scalars become a list");
+
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> servers = (List<Map<String, Object>>) values.get("servers");
+		assertEquals(2, servers.size(), "servers[i].* becomes a list of maps");
+		assertEquals("a", servers.get(0).get("name"));
+		assertEquals(1, servers.get(0).get("port"));
+		assertEquals("b", servers.get(1).get("name"));
+	}
+
+	@Test
+	void testActivationKeysStripped() {
+		Map<String, Object> values = mapped();
+		assertFalse(values.containsKey("spring"), "no spring.config.activate.* residue in .Values");
+		assertFalse(values.toString().contains("on-profile"), "activation directive fully stripped");
+	}
+
+	@Test
+	void testEmptyPropertySourcesYieldEmptyMap() {
+		Environment env = MAPPER.readValue("""
+				{ "name": "x", "profiles": ["default"], "propertySources": [] }
+				""", Environment.class);
+		assertTrue(PropertySourceMapper.toValues(env).isEmpty(), "no sources -> empty map");
+	}
+
+	@Test
+	void testNullEnvironmentYieldsEmptyMap() {
+		assertTrue(PropertySourceMapper.toValues(null).isEmpty());
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesOverridesConfigServerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesOverridesConfigServerTest.java
@@ -1,0 +1,67 @@
+package org.alexmond.jhelm.core.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Precedence of config-server values in {@link ValuesOverrides#parse} relative to
+ * {@code -f} files and the {@code --set} family, including the {@code override-none} /
+ * {@code override-system-properties} flags.
+ */
+class ValuesOverridesConfigServerTest {
+
+	@TempDir
+	File dir;
+
+	private List<String> file;
+
+	// file: a=file, d=fileD ; config server: a=cs, b=cs, d=csD ; --set: a=set
+	private final Map<String, Object> configServer = Map.of("a", "cs", "b", "cs", "d", "csD");
+
+	private final List<String> set = List.of("a=set");
+
+	@BeforeEach
+	void setUp() throws IOException {
+		File f = new File(dir, "values.yaml");
+		Files.writeString(f.toPath(), "a: file\nd: fileD\n");
+		file = List.of(f.getPath());
+	}
+
+	private Map<String, Object> parse(boolean overrideNone, boolean overrideSystemProperties) throws IOException {
+		return ValuesOverrides.parse(file, ValuesProfiles.none(), configServer, overrideNone, overrideSystemProperties,
+				set, null, null, null);
+	}
+
+	@Test
+	void testDefaultOrderFilesThenConfigServerThenSet() throws IOException {
+		Map<String, Object> out = parse(false, false);
+		assertEquals("set", out.get("a"), "--set is highest by default");
+		assertEquals("cs", out.get("b"), "config-server-only key present");
+		assertEquals("csD", out.get("d"), "config server overrides the file by default");
+	}
+
+	@Test
+	void testOverrideNoneDropsConfigServerBelowFiles() throws IOException {
+		Map<String, Object> out = parse(true, false);
+		assertEquals("set", out.get("a"), "--set still wins");
+		assertEquals("cs", out.get("b"), "config-server-only key still present (lowest, but no competitor)");
+		assertEquals("fileD", out.get("d"), "override-none: local file beats config server");
+	}
+
+	@Test
+	void testOverrideSystemPropertiesLiftsConfigServerAboveSet() throws IOException {
+		Map<String, Object> out = parse(false, true);
+		assertEquals("cs", out.get("a"), "override-system-properties: config server beats --set");
+		assertEquals("csD", out.get("d"), "config server still beats the file");
+	}
+
+}


### PR DESCRIPTION
Implements #671 — a profile-aware, SSRF-guarded **Spring Cloud Config Server** values source, building on the #670 profile model. Environment configuration can live centrally (git-backed) instead of in local `-f` files.

## What

Consumes the structured Environment endpoint `GET {uri}/{application}/{profiles}[/{label}]`. For each property source (the server lists them **highest-precedence first**):

1. **strip** the `spring.config.activate.*` / `jhelm.config.activate.*` directives — the server does **not** remove them, so `.Values` would otherwise be polluted;
2. **un-flatten** dotted (`a.b.c`) and indexed (`x[0]`, `x[0].y`) keys into nested maps/lists;
3. merge the sources **first-wins**.

The active profiles from #670 supply the `{profiles}` path segment.

## Precedence

Config-data faithful (command-line args outrank imported config-server values):

```
chart values < -f / profile files < CONFIG SERVER < --set family
```

Two flags mirror Spring: `override-none` (server drops to lowest) and `override-system-properties` (server moves above `--set`).

## Security

The fetch rides jhelm's **shared SSRF-guarded HTTP path** (`RepoHttpClientFactory`, from #629/#630), **not** the unguarded `java.net.http` used by `loadFromUrl`: the URL is validated, credentials are host-gated, and TLS follows `insecure-skip-tls-verify`. In server mode (`block-private-networks=true`) a private/site-local config-server host is refused — closing the SSRF vector for a user-supplied URI. Basic auth and bearer token supported. `fail-fast=false` (default) warns and continues with local values.

## Surface

- Properties `jhelm.config-server.{enabled,uri,name,label,username,password,token,fail-fast,override-none,override-system-properties}` — bind for library/REST/MCP too.
- CLI `--config-server-uri/--config-name/--config-label/--config-username/--config-password/--config-token/--config-fail-fast` on `template`/`install`/`upgrade` (a `ConfigServerCliOptions` mixin).
- **Disabled by default → zero behavior change** (verified: sample/REST/MCP contexts load unchanged).

## Tests

- `PropertySourceMapperTest` — un-flatten (dotted + indexed), first-wins merge, activation-key stripping, empty/null — on the JSON shape captured from a live server.
- `ConfigServerClientTest` — URL construction (profiles comma-join, optional label, default profile, trailing slash) + SSRF-guard routing.
- `ConfigServerValuesLoaderTest` — request resolution (properties ⊕ CLI overrides), default name = release name, fail-fast abort vs warn-and-continue, precedence-flag surfacing.
- `ValuesOverridesConfigServerTest` — the three precedence orderings.

**Grounded end-to-end against a live git-backed Spring Cloud Config Server**: `default` vs `prod` profiles (server-side `on-profile` gating), sidecar + prod-doc first-wins merge, dotted/indexed un-flatten, no directive leak, default-name-from-release, and **byte-identical cross-source parity** between a config-server fetch and the same multi-doc file read locally via `-f`. Full `./mvnw clean install` green (all gates, helm-parity included).

Depends on #670 (merged). Target: 1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)