### PR TITLE
feat(values): encrypted values + encrypt/decrypt tool + sample config server (#674)

### DIFF
--- a/docs/modules/ROOT/pages/value-profiles.adoc
+++ b/docs/modules/ROOT/pages/value-profiles.adoc
@@ -116,6 +116,22 @@ in local files. It consumes the server's structured Environment endpoint
 (`GET {uri}/{application}/{profiles}[/{label}]`) and reuses the active profiles from above for
 the `{profiles}` path segment. Disabled by default.
 
+[NOTE]
+====
+*Beyond Helm parity.* Everything else in jhelm renders byte-for-byte like Go Helm. The config
+server (and the <<encrypted-values,encrypted values>> below) is the first deliberate step
+*past* parity: one opt-in source that adds three things Helm has no story for —
+
+* *central storage* — one server holds the values for every release, versioned in git;
+* *security* — the server sits behind auth/TLS, and secrets travel as ciphertext;
+* *profiles* — the same `-P` profiles pick per-environment overlays server-side.
+
+It stays inert unless you enable it, so charts that don't use it are unaffected. We don't
+re-document Spring Cloud Config here — see its
+https://docs.spring.io/spring-cloud-config/reference/[reference docs]; the runnable, secured
+`jhelm-config-server-sample` module is a working starting point.
+====
+
 The server returns each document/file as a flat property source (dotted and `[i]`-indexed
 keys), highest precedence first. jhelm strips the `spring.config.activate.*` /
 `jhelm.config.activate.*` directives from each source (the server does not), un-flattens the
@@ -164,3 +180,83 @@ repositories): the URL is validated, credentials are host-gated, and TLS follows
 a private/site-local config-server host is refused, closing the SSRF vector for a
 user-supplied URI. `fail-fast=false` (the default) logs a warning and continues with local
 values when the server is unreachable.
+
+[#encrypted-values]
+== Encrypted values (`+{cipher}+`)
+
+Secrets in values don't have to be plaintext. Any string value of the form `+{cipher}<hex>+` is
+a Spring Cloud Config encrypted token; when a decryption key is configured, jhelm decrypts it
+*at render time*, after values are merged and before templates run. This works the same whether
+the token comes from a `-f` values file, a chart's own `values.yaml`, or a config-server
+response — so you can commit ciphertext to git and keep the plaintext off disk and off the
+wire.
+
+With no key configured, `+{cipher}+` strings are left untouched (rendered verbatim), so the
+feature is inert until you opt in.
+
+=== Enabling
+
+Set a symmetric key:
+
+[cols="1,2",options="header"]
+|===
+| Property | Meaning
+| `jhelm.encrypt.key`           | symmetric key; setting it enables decryption
+| `jhelm.encrypt.salt`          | hex salt (default `deadbeef`, matching Spring Cloud)
+| `jhelm.encrypt.fail-on-error` | `true` (default) aborts on an undecryptable token; `false` logs a warning and leaves the token in place
+|===
+
+The key binds via Spring, so it can come from an environment variable
+(`JHELM_ENCRYPT_KEY=…`), a mounted `application.yaml`, or your secret store — the usual Spring
+Boot externalized-config channels. It applies to `template`, `install`, and `upgrade` across the
+CLI, library, REST, and MCP surfaces.
+
+=== Encrypting and decrypting from the CLI
+
+[source,bash]
+----
+# encrypt a value into a {cipher} token (reads jhelm.encrypt.key, or pass --key)
+jhelm encrypt "s3cret-password"
+jhelm encrypt "s3cret-password" --key my-key      # explicit key
+echo -n "s3cret" | jhelm encrypt                  # value from stdin
+
+# decrypt a token back to plaintext (prefix optional)
+jhelm decrypt "{cipher}f0e1d2c3…"
+----
+
+Drop the token into a values file and render as usual:
+
+[source,yaml]
+----
+# secrets.yaml
+db:
+  password: '{cipher}f0e1d2c3…'   # quote it — YAML treats a bare { as a flow map
+----
+
+[source,bash]
+----
+JHELM_ENCRYPT_KEY=my-key jhelm template my-release ./chart -f secrets.yaml
+----
+
+=== Spring Cloud parity
+
+jhelm uses the same primitive as Spring Cloud Config's `EncryptorFactory` for a plain-text key
+(`Encryptors.text(key, salt)`, default salt `deadbeef`), so tokens are byte-compatible in both
+directions: a token minted by a config server's `POST /encrypt` decrypts with `jhelm decrypt`,
+and a `jhelm encrypt` token decrypts via the server's `POST /decrypt`. This is the symmetric
+(shared-key) scheme; keystore/RSA `+{cipher}+` tokens are not yet supported.
+
+By default a config server *decrypts* `+{cipher}+` values before serving them. To keep secrets
+encrypted on the wire and let jhelm decrypt them client-side, set
+`spring.cloud.config.server.encrypt.enabled=false` on the server — the approach the
+`jhelm-config-server-sample` module ships, so the plaintext never leaves the operator's machine.
+
+=== Security notes
+
+* The key is as sensitive as the secrets it protects — supply it from a secret store or
+  environment variable, never commit it. jhelm reads it only from configuration, never writes
+  or logs it.
+* Decryption failures are hard errors by default (`fail-on-error=true`) so a wrong key or a
+  corrupted token fails the render rather than silently shipping ciphertext into a manifest.
+* Rendered manifests contain the *plaintext* secret — treat `template` output and installed
+  release data with the same care as any other secret material.

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
@@ -21,6 +21,8 @@ import org.alexmond.jhelm.app.command.ShowCommand;
 import org.alexmond.jhelm.app.command.StatusCommand;
 import org.alexmond.jhelm.app.command.TemplateCommand;
 import org.alexmond.jhelm.app.command.TestCommand;
+import org.alexmond.jhelm.app.command.DecryptCommand;
+import org.alexmond.jhelm.app.command.EncryptCommand;
 import org.alexmond.jhelm.app.command.EnvCommand;
 import org.alexmond.jhelm.app.command.UninstallCommand;
 import org.alexmond.jhelm.app.command.VersionCommand;
@@ -54,7 +56,7 @@ import picocli.CommandLine;
 				RollbackCommand.class, ShowCommand.class, GetCommand.class, TestCommand.class, DependencyCommand.class,
 				PullCommand.class, PushCommand.class, PackageCommand.class, VerifyCommand.class, LintCommand.class,
 				RepoCommand.class, RegistryCommand.class, PluginCommand.class, SearchCommand.class,
-				VersionCommand.class, EnvCommand.class })
+				VersionCommand.class, EnvCommand.class, EncryptCommand.class, DecryptCommand.class })
 public class JHelmCommand implements Callable<Integer> {
 
 	private final Environment environment;

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/DecryptCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/DecryptCommand.java
@@ -1,0 +1,55 @@
+package org.alexmond.jhelm.app.command;
+
+import java.util.concurrent.Callable;
+
+import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.config.JhelmEncryptProperties;
+import org.alexmond.jhelm.core.service.ValueEncryptor;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/**
+ * Implements {@code jhelm decrypt}, turning a {@code {cipher}} token (with or without the
+ * prefix) back into plaintext — useful for verifying a value encrypted for a config
+ * server or a jhelm values file.
+ */
+@Component
+@CommandLine.Command(name = "decrypt", mixinStandardHelpOptions = true,
+		description = "Decrypt a {cipher} token back to plaintext")
+public class DecryptCommand implements Callable<Integer> {
+
+	private final JhelmEncryptProperties encryptProperties;
+
+	@Parameters(index = "0", arity = "0..1", description = "token to decrypt (read from stdin if omitted)")
+	private String value;
+
+	@Option(names = { "--key" }, description = "symmetric key (default: jhelm.encrypt.key)")
+	private String key;
+
+	@Option(names = { "--salt" }, description = "hex salt (default: jhelm.encrypt.salt, or deadbeef)")
+	private String salt;
+
+	/**
+	 * Creates the command.
+	 * @param encryptProperties the configured {@code jhelm.encrypt.*} defaults
+	 */
+	public DecryptCommand(JhelmEncryptProperties encryptProperties) {
+		this.encryptProperties = encryptProperties;
+	}
+
+	@Override
+	public Integer call() {
+		try {
+			ValueEncryptor encryptor = EncryptSupport.resolve(key, salt, encryptProperties);
+			CliOutput.println(encryptor.decrypt(EncryptSupport.readInput(value)));
+			return CommandLine.ExitCode.OK;
+		}
+		catch (Exception ex) {
+			CliOutput.errPrintln(CliOutput.error("Error decrypting value: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
+		}
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/EncryptCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/EncryptCommand.java
@@ -1,0 +1,56 @@
+package org.alexmond.jhelm.app.command;
+
+import java.util.concurrent.Callable;
+
+import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.config.JhelmEncryptProperties;
+import org.alexmond.jhelm.core.service.ValueEncryptor;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/**
+ * Implements {@code jhelm encrypt}, turning a plaintext value into a
+ * {@code {cipher}<hex>} token. The token is interchangeable with Spring Cloud Config:
+ * paste it into a config-server repo or drop it into a jhelm values file, and jhelm
+ * decrypts it at render time with the same key.
+ */
+@Component
+@CommandLine.Command(name = "encrypt", mixinStandardHelpOptions = true,
+		description = "Encrypt a value into a {cipher} token (compatible with Spring Cloud Config)")
+public class EncryptCommand implements Callable<Integer> {
+
+	private final JhelmEncryptProperties encryptProperties;
+
+	@Parameters(index = "0", arity = "0..1", description = "value to encrypt (read from stdin if omitted)")
+	private String value;
+
+	@Option(names = { "--key" }, description = "symmetric key (default: jhelm.encrypt.key)")
+	private String key;
+
+	@Option(names = { "--salt" }, description = "hex salt (default: jhelm.encrypt.salt, or deadbeef)")
+	private String salt;
+
+	/**
+	 * Creates the command.
+	 * @param encryptProperties the configured {@code jhelm.encrypt.*} defaults
+	 */
+	public EncryptCommand(JhelmEncryptProperties encryptProperties) {
+		this.encryptProperties = encryptProperties;
+	}
+
+	@Override
+	public Integer call() {
+		try {
+			ValueEncryptor encryptor = EncryptSupport.resolve(key, salt, encryptProperties);
+			CliOutput.println(encryptor.encrypt(EncryptSupport.readInput(value)));
+			return CommandLine.ExitCode.OK;
+		}
+		catch (Exception ex) {
+			CliOutput.errPrintln(CliOutput.error("Error encrypting value: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
+		}
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/EncryptSupport.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/EncryptSupport.java
@@ -1,0 +1,47 @@
+package org.alexmond.jhelm.app.command;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.alexmond.jhelm.core.config.JhelmEncryptProperties;
+import org.alexmond.jhelm.core.service.ValueEncryptor;
+
+/**
+ * Shared helpers for the {@code encrypt} / {@code decrypt} commands: resolve the
+ * effective key/salt (CLI flags override {@code jhelm.encrypt.*}) and read the value from
+ * an argument or stdin.
+ */
+final class EncryptSupport {
+
+	private EncryptSupport() {
+	}
+
+	/**
+	 * Build a {@link ValueEncryptor} from CLI overrides falling back to configured
+	 * properties. A blank key yields a disabled encryptor that throws a clear error on
+	 * use.
+	 * @param key {@code --key} override, or {@code null}
+	 * @param salt {@code --salt} override, or {@code null}
+	 * @param properties the configured {@code jhelm.encrypt.*} values
+	 * @return the encryptor
+	 */
+	static ValueEncryptor resolve(String key, String salt, JhelmEncryptProperties properties) {
+		String effectiveKey = (key != null && !key.isBlank()) ? key : properties.getKey();
+		String effectiveSalt = (salt != null && !salt.isBlank()) ? salt : properties.getSalt();
+		return new ValueEncryptor(effectiveKey, effectiveSalt, true);
+	}
+
+	/**
+	 * Return the value argument, or the trimmed contents of stdin when it is omitted.
+	 * @param value the positional value argument, or {@code null}
+	 * @return the input to (de/en)crypt
+	 * @throws IOException if stdin cannot be read
+	 */
+	static String readInput(String value) throws IOException {
+		if (value != null) {
+			return value;
+		}
+		return new String(System.in.readAllBytes(), StandardCharsets.UTF_8).strip();
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/EncryptDecryptCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/EncryptDecryptCommandTest.java
@@ -1,0 +1,71 @@
+package org.alexmond.jhelm.app.command;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.alexmond.jhelm.core.config.JhelmEncryptProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises {@code jhelm encrypt} / {@code jhelm decrypt} through the real Picocli
+ * command line: round-trip, {@code --key} override, and the missing-key error.
+ */
+class EncryptDecryptCommandTest {
+
+	private final PrintStream originalOut = System.out;
+
+	private final ByteArrayOutputStream captured = new ByteArrayOutputStream();
+
+	@AfterEach
+	void restoreOut() {
+		System.setOut(this.originalOut);
+	}
+
+	private String run(Object command, String... args) {
+		this.captured.reset();
+		System.setOut(new PrintStream(this.captured, true, StandardCharsets.UTF_8));
+		int exit = new CommandLine(command).execute(args);
+		System.setOut(this.originalOut);
+		assertEquals(CommandLine.ExitCode.OK, exit, "command should succeed");
+		return this.captured.toString(StandardCharsets.UTF_8).strip();
+	}
+
+	private static JhelmEncryptProperties propsWithKey(String key) {
+		JhelmEncryptProperties props = new JhelmEncryptProperties();
+		props.setKey(key);
+		return props;
+	}
+
+	@Test
+	void testEncryptThenDecryptRoundTrip() {
+		JhelmEncryptProperties props = propsWithKey("cli-key");
+		String token = run(new EncryptCommand(props), "hunter2");
+		assertTrue(token.startsWith("{cipher}"), "encrypt emits a {cipher} token");
+		assertNotEquals("hunter2", token, "the token is not the plaintext");
+
+		String plain = run(new DecryptCommand(props), token);
+		assertEquals("hunter2", plain, "decrypt returns the original plaintext");
+	}
+
+	@Test
+	void testKeyFlagOverridesProperty() {
+		// Encrypt with the --key flag (no configured key), decrypt with the same flag.
+		String token = run(new EncryptCommand(new JhelmEncryptProperties()), "s", "--key", "flag-key");
+		String plain = run(new DecryptCommand(new JhelmEncryptProperties()), token, "--key", "flag-key");
+		assertEquals("s", plain);
+	}
+
+	@Test
+	void testMissingKeyFails() {
+		int exit = new CommandLine(new EncryptCommand(new JhelmEncryptProperties())).execute("value");
+		assertEquals(CommandLine.ExitCode.SOFTWARE, exit, "no key configured or passed -> failure exit code");
+	}
+
+}

--- a/jhelm-config-server-sample/README.md
+++ b/jhelm-config-server-sample/README.md
@@ -1,0 +1,81 @@
+# jhelm-config-server-sample
+
+A ready-to-run **Spring Cloud Config Server**, with **HTTP basic auth** and **`{cipher}`
+encryption** turned on, that serves example jhelm values. It exists for two reasons:
+
+1. **A working example for DevOps** — a minimal, secured config server you can copy as a
+   starting point for serving Helm/jhelm values centrally.
+2. **A test fixture** — jhelm's own tests ground against it to prove config-server value
+   sourcing and client-side `{cipher}` decryption behave identically to Spring Cloud.
+
+> This is a **demo**. The credentials and encryption key below are placeholders — replace
+> them (and front the server with TLS) before using anything like this for real.
+
+## What it demonstrates
+
+- **Central storage** — values live in one place (`src/main/resources/config/`), not scattered
+  across `-f values.yaml` files on every operator's laptop.
+- **Profiles** — a base document plus a `prod` overlay (via `spring.config.activate.on-profile`)
+  and a `demo-prod.yml` sidecar, merged server-side per requested profile.
+- **Security** — every endpoint requires basic auth.
+- **Encryption** — secrets are stored as `{cipher}` tokens. This server serves them
+  **verbatim** (`spring.cloud.config.server.encrypt.enabled: false`) so **jhelm decrypts them
+  client-side** with the matching key — the plaintext never travels the wire.
+
+## Run it
+
+```bash
+./mvnw -pl jhelm-config-server-sample spring-boot:run
+```
+
+It listens on `http://localhost:8888`. Demo credentials: `configuser` / `configpass`.
+Demo encryption key: `jhelm-demo-encrypt-key`.
+
+Fetch the merged `prod` config directly to see what jhelm receives:
+
+```bash
+curl -u configuser:configpass http://localhost:8888/demo/prod
+```
+
+You'll see `tier: prod`, `replicas: 3`, `region: eu-west-1`, and a `password` still in
+`{cipher}…` form.
+
+## Point jhelm at it
+
+```bash
+jhelm template my-release ./my-chart \
+  --config-server-uri http://localhost:8888 \
+  --config-name       demo \
+  --profile           prod \
+  --config-username   configuser \
+  --config-password   configpass
+```
+
+The `--profile` flag is the same one that selects local value profiles (see the value-profiles
+docs) — it's forwarded to the config server as the requested profile, so `--profile prod`
+returns the `prod` overlay above. `--config-name` sets the config-server application name
+(defaults to the release name).
+
+To have jhelm decrypt the `{cipher}` secret at render time, give it the same key (via the
+`jhelm.encrypt.key` property / `JHELM_ENCRYPT_KEY` env, or per-run):
+
+```bash
+JHELM_ENCRYPT_KEY=jhelm-demo-encrypt-key jhelm template my-release ./my-chart \
+  --config-server-uri http://localhost:8888 --config-name demo --profile prod \
+  --config-username configuser --config-password configpass
+```
+
+## Encrypt / decrypt values yourself
+
+The same `{cipher}` tokens work in a plain jhelm `-f values.yaml` file too — the config server
+is optional. Use the jhelm CLI to mint them:
+
+```bash
+jhelm encrypt "s3cret" --key jhelm-demo-encrypt-key      # -> {cipher}…
+jhelm decrypt "{cipher}…" --key jhelm-demo-encrypt-key   # -> s3cret
+```
+
+Both read the key from `jhelm.encrypt.key` when `--key` is omitted, and accept the value on
+stdin. The tokens are byte-compatible with Spring Cloud Config's own `/encrypt` endpoint (both
+use `Encryptors.text(key, salt)` with the default `deadbeef` salt), so a token minted by this
+server's `POST /encrypt` decrypts with `jhelm decrypt`, and vice versa.

--- a/jhelm-config-server-sample/pom.xml
+++ b/jhelm-config-server-sample/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.alexmond</groupId>
+		<artifactId>jhelm-parent</artifactId>
+		<version>1.0.3-SNAPSHOT</version>
+	</parent>
+	<artifactId>jhelm-config-server-sample</artifactId>
+	<name>jhelm-config-server-sample</name>
+	<description>Sample Spring Cloud Config Server (security + encryption enabled) for jhelm value profiles</description>
+
+	<properties>
+		<!-- Not published; skip Javadoc (and its doclint enforcement) for the sample. -->
+		<maven.javadoc.skip>true</maven.javadoc.skip>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-config-server</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/jhelm-config-server-sample/src/main/java/org/alexmond/jhelm/configserver/sample/ConfigServerSecurityConfig.java
+++ b/jhelm-config-server-sample/src/main/java/org/alexmond/jhelm/configserver/sample/ConfigServerSecurityConfig.java
@@ -1,0 +1,33 @@
+package org.alexmond.jhelm.configserver.sample;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Secures the config server with stateless HTTP basic auth (the default user from
+ * {@code spring.security.user.*}). CSRF is disabled so the {@code /encrypt} and
+ * {@code /decrypt} POST endpoints work with a plain {@code curl}, which is how a config
+ * server is normally driven.
+ */
+@Configuration
+public class ConfigServerSecurityConfig {
+
+	/**
+	 * @param http the security builder
+	 * @return a filter chain requiring authentication on every request, basic auth, CSRF
+	 * off
+	 * @throws Exception if the chain cannot be built
+	 */
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests((requests) -> requests.anyRequest().authenticated())
+			.httpBasic(Customizer.withDefaults());
+		return http.build();
+	}
+
+}

--- a/jhelm-config-server-sample/src/main/java/org/alexmond/jhelm/configserver/sample/JhelmConfigServerSampleApplication.java
+++ b/jhelm-config-server-sample/src/main/java/org/alexmond/jhelm/configserver/sample/JhelmConfigServerSampleApplication.java
@@ -1,0 +1,30 @@
+package org.alexmond.jhelm.configserver.sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
+
+/**
+ * A runnable Spring Cloud Config Server for jhelm value profiles, with <b>security</b>
+ * (HTTP basic auth) and <b>encryption</b> ({@code encrypt.key}) enabled. It serves the
+ * example configs under {@code src/main/resources/config/} — a base document, a
+ * {@code prod} profile (gated with {@code spring.config.activate.on-profile}), a
+ * {@code -prod} sidecar, and {@code {cipher}} secrets.
+ * <p>
+ * Intended both as a DevOps starting point and as the fixture jhelm's tests ground
+ * against. See the module README for how to run it and point jhelm at it.
+ */
+@SpringBootApplication
+@EnableConfigServer
+@SuppressWarnings("PMD.UseUtilityClass")
+public class JhelmConfigServerSampleApplication {
+
+	/**
+	 * Application entry point.
+	 * @param args command-line arguments passed to Spring Boot
+	 */
+	public static void main(String[] args) {
+		SpringApplication.run(JhelmConfigServerSampleApplication.class, args);
+	}
+
+}

--- a/jhelm-config-server-sample/src/main/resources/application.yml
+++ b/jhelm-config-server-sample/src/main/resources/application.yml
@@ -1,0 +1,36 @@
+server:
+  port: 8888
+
+spring:
+  application:
+    name: jhelm-config-server-sample
+  # The config server's "native" backend serves configs from the classpath/filesystem
+  # instead of a Git repo — self-contained, ideal for a demo and for tests.
+  profiles:
+    active: native
+  cloud:
+    config:
+      server:
+        native:
+          search-locations: classpath:/config/
+        encrypt:
+          # Serve {cipher} tokens verbatim so the CLIENT (jhelm) decrypts them. This
+          # showcases jhelm's client-side decryption and keeps the key off the wire.
+          # Set to true to have the server decrypt values before serving instead.
+          enabled: false
+  # HTTP basic auth. Demo credentials — change them for any real deployment.
+  security:
+    user:
+      name: configuser
+      password: configpass
+      roles: USER
+
+# Symmetric key used for {cipher} encrypt/decrypt. This MUST match the key jhelm uses
+# (jhelm.encrypt.key / --key) for client-side decryption to succeed. Demo value — replace
+# with a strong secret from your secret store in production.
+encrypt:
+  key: jhelm-demo-encrypt-key
+
+logging:
+  level:
+    org.springframework.cloud.config: INFO

--- a/jhelm-config-server-sample/src/main/resources/config/demo-prod.yml
+++ b/jhelm-config-server-sample/src/main/resources/config/demo-prod.yml
@@ -1,0 +1,9 @@
+# The `-prod` profile SIDECAR for the application "demo".
+#
+# Spring Cloud Config supports two ways to express profile-specific config: an
+# on-profile document inside demo.yml (see there) and a separate demo-<profile>.yml
+# file like this one. Both are returned for the "prod" profile; this sidecar layers
+# on top and is handy for values that only exist in prod.
+demo:
+  region: eu-west-1
+  monitoring: true

--- a/jhelm-config-server-sample/src/main/resources/config/demo.yml
+++ b/jhelm-config-server-sample/src/main/resources/config/demo.yml
@@ -1,0 +1,24 @@
+# Example jhelm values served by the config server for the application "demo".
+#
+# This is the BASE document. It is returned for every profile; profile-specific
+# documents (below, and the demo-prod.yml sidecar) are layered on top with higher
+# precedence. jhelm merges the config-server response into the chart's values the
+# same way as a -f values file.
+#
+# The `password` is a {cipher} token. Because this server runs with
+# `spring.cloud.config.server.encrypt.enabled: false`, it serves the token AS-IS
+# and jhelm decrypts it at render time (client-side) when jhelm.encrypt.key is set.
+# Flip that flag to true to have the server decrypt before serving instead.
+demo:
+  replicas: 1
+  tier: base
+  image: nginx:1.27
+  password: '{cipher}60fcae5de58b2612f3277d44b2afc2a7c449ea0180bce3b0ba8ab1e6301c0b507af00180ae5766d1bda46b4e86aee2d1'
+---
+# The `prod` profile overlay, gated with Spring's on-profile activation. Returned
+# only when the client requests the "prod" profile (jhelm --config-profile prod).
+spring.config.activate.on-profile: prod
+demo:
+  replicas: 3
+  tier: prod
+  password: '{cipher}53b8d44afea102ed1d05eda29a6bef5aad55097cd2bd0a78f2c00d2ef2d628e9039d0601a7fb6d41df8b0bd69f454ea9'

--- a/jhelm-config-server-sample/src/test/java/org/alexmond/jhelm/configserver/sample/JhelmConfigServerSampleApplicationTest.java
+++ b/jhelm-config-server-sample/src/test/java/org/alexmond/jhelm/configserver/sample/JhelmConfigServerSampleApplicationTest.java
@@ -1,0 +1,51 @@
+package org.alexmond.jhelm.configserver.sample;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Boots the sample config server and checks the three things that make it a useful jhelm
+ * fixture and DevOps example: it requires authentication, it serves the profile-merged
+ * values, and it hands back {@code {cipher}} tokens verbatim (client-side decryption)
+ * rather than decrypting them server-side.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class JhelmConfigServerSampleApplicationTest {
+
+	@LocalServerPort
+	private int port;
+
+	private final RestClient rest = RestClient.create();
+
+	private String url(String path) {
+		return "http://localhost:" + this.port + path;
+	}
+
+	@Test
+	void testUnauthenticatedRequestIsRejected() {
+		assertThrows(HttpClientErrorException.Unauthorized.class,
+				() -> this.rest.get().uri(url("/demo/default")).retrieve().toBodilessEntity(), "security is enabled");
+	}
+
+	@Test
+	void testServesProfileMergedValuesWithEncryptedTokenVerbatim() {
+		String body = this.rest.get()
+			.uri(url("/demo/prod"))
+			.headers((headers) -> headers.setBasicAuth("configuser", "configpass"))
+			.retrieve()
+			.body(String.class);
+
+		assertNotNull(body);
+		assertTrue(body.contains("prod"), "the prod profile overlay is present");
+		assertTrue(body.contains("eu-west-1"), "the demo-prod.yml sidecar is merged in");
+		assertTrue(body.contains("{cipher}"), "the encrypted secret is served as-is for client-side decryption");
+	}
+
+}

--- a/jhelm-core/pom.xml
+++ b/jhelm-core/pom.xml
@@ -68,6 +68,10 @@
             <artifactId>bcpg-jdk18on</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <optional>true</optional>

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -6,6 +6,7 @@ import org.alexmond.jhelm.core.cache.TemplateCache;
 import org.alexmond.jhelm.core.config.ConfigServerProperties;
 import org.alexmond.jhelm.core.config.JhelmAccessMode;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
+import org.alexmond.jhelm.core.config.JhelmEncryptProperties;
 import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
 import org.alexmond.jhelm.core.metrics.JhelmMetrics;
@@ -39,6 +40,7 @@ import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.ConfigServerClient;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.service.Engine;
+import org.alexmond.jhelm.core.service.ValueEncryptor;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.service.LifecycleListener;
 import org.alexmond.jhelm.core.service.PostRenderProcessor;
@@ -55,8 +57,8 @@ import org.apache.hc.client5.http.impl.classic.HttpClients;
  */
 @Slf4j
 @AutoConfiguration(after = JhelmMetricsAutoConfiguration.class)
-@EnableConfigurationProperties({ JhelmCoreProperties.class, JhelmSecurityProperties.class,
-		ConfigServerProperties.class })
+@EnableConfigurationProperties({ JhelmCoreProperties.class, JhelmSecurityProperties.class, ConfigServerProperties.class,
+		JhelmEncryptProperties.class })
 public class JhelmCoreAutoConfiguration {
 
 	/**
@@ -139,6 +141,19 @@ public class JhelmCoreAutoConfiguration {
 	public ConfigServerValuesLoader configServerValuesLoader(ConfigServerProperties configServerProperties,
 			ConfigServerClient configServerClient) {
 		return new ConfigServerValuesLoader(configServerProperties, configServerClient);
+	}
+
+	/**
+	 * Decrypts {@code {cipher}} values in resolved chart values. A no-op unless
+	 * {@code jhelm.encrypt.key} is set.
+	 * @param encryptProperties the value-encryption configuration
+	 * @return the value encryptor bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public ValueEncryptor valueEncryptor(JhelmEncryptProperties encryptProperties) {
+		return new ValueEncryptor(encryptProperties.getKey(), encryptProperties.getSalt(),
+				encryptProperties.isFailOnError());
 	}
 
 	/**
@@ -231,12 +246,13 @@ public class JhelmCoreAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public TemplateAction templateAction(Engine engine, ChartLoader chartLoader,
-			ObjectProvider<List<PostRenderProcessor>> postRenderProcessors) {
+			ObjectProvider<List<PostRenderProcessor>> postRenderProcessors, ValueEncryptor valueEncryptor) {
 		TemplateAction action = new TemplateAction(engine, chartLoader);
 		List<PostRenderProcessor> processors = postRenderProcessors.getIfAvailable();
 		if (processors != null) {
 			action.setPostRenderProcessors(processors);
 		}
+		action.setValueEncryptor(valueEncryptor);
 		return action;
 	}
 
@@ -279,7 +295,8 @@ public class JhelmCoreAutoConfiguration {
 	@ConditionalOnBean(KubeService.class)
 	public InstallAction installAction(Engine engine, KubeService kubeService,
 			ObjectProvider<List<PostRenderProcessor>> postRenderProcessors,
-			ObjectProvider<List<LifecycleListener>> lifecycleListeners, ObjectProvider<JhelmMetrics> metrics) {
+			ObjectProvider<List<LifecycleListener>> lifecycleListeners, ObjectProvider<JhelmMetrics> metrics,
+			ValueEncryptor valueEncryptor) {
 		InstallAction action = new InstallAction(engine, kubeService);
 		List<PostRenderProcessor> processors = postRenderProcessors.getIfAvailable();
 		if (processors != null) {
@@ -290,6 +307,7 @@ public class JhelmCoreAutoConfiguration {
 			action.setLifecycleListeners(listeners);
 		}
 		action.setMetrics(metrics.getIfAvailable());
+		action.setValueEncryptor(valueEncryptor);
 		return action;
 	}
 
@@ -307,7 +325,8 @@ public class JhelmCoreAutoConfiguration {
 	@ConditionalOnBean(KubeService.class)
 	public UpgradeAction upgradeAction(Engine engine, KubeService kubeService,
 			ObjectProvider<List<PostRenderProcessor>> postRenderProcessors,
-			ObjectProvider<List<LifecycleListener>> lifecycleListeners, ObjectProvider<JhelmMetrics> metrics) {
+			ObjectProvider<List<LifecycleListener>> lifecycleListeners, ObjectProvider<JhelmMetrics> metrics,
+			ValueEncryptor valueEncryptor) {
 		UpgradeAction action = new UpgradeAction(engine, kubeService);
 		List<PostRenderProcessor> processors = postRenderProcessors.getIfAvailable();
 		if (processors != null) {
@@ -318,6 +337,7 @@ public class JhelmCoreAutoConfiguration {
 			action.setLifecycleListeners(listeners);
 		}
 		action.setMetrics(metrics.getIfAvailable());
+		action.setValueEncryptor(valueEncryptor);
 		return action;
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -21,6 +21,7 @@ import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.service.LifecycleListener;
+import org.alexmond.jhelm.core.service.ValueEncryptor;
 import org.alexmond.jhelm.core.service.LifecyclePhase;
 import org.alexmond.jhelm.core.service.PostRenderProcessor;
 import org.alexmond.jhelm.core.util.HookExecutor;
@@ -49,6 +50,9 @@ public class InstallAction {
 
 	@Setter
 	private JhelmMetrics metrics;
+
+	@Setter
+	private ValueEncryptor valueEncryptor = new ValueEncryptor(null, null, true);
 
 	/**
 	 * Installs a chart as a new release. Chart default values are merged with the
@@ -81,6 +85,7 @@ public class InstallAction {
 		if (overrideValues != null) {
 			ValuesLoader.deepMerge(values, overrideValues);
 		}
+		this.valueEncryptor.decryptValues(values);
 
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now())

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
@@ -14,6 +14,7 @@ import org.alexmond.jhelm.core.model.ReleaseContext;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.PostRenderProcessor;
+import org.alexmond.jhelm.core.service.ValueEncryptor;
 import org.alexmond.jhelm.core.util.ValuesLoader;
 import org.alexmond.jhelm.core.util.ValuesProfiles;
 
@@ -26,6 +27,9 @@ public class TemplateAction {
 
 	@Setter
 	private List<PostRenderProcessor> postRenderProcessors = List.of();
+
+	@Setter
+	private ValueEncryptor valueEncryptor = new ValueEncryptor(null, null, true);
 
 	public String render(String chartPath, String releaseName, String namespace) {
 		return render(chartPath, releaseName, namespace, new HashMap<>());
@@ -75,6 +79,7 @@ public class TemplateAction {
 
 		Map<String, Object> values = new HashMap<>(chart.getValues());
 		ValuesLoader.deepMerge(values, overrides);
+		this.valueEncryptor.decryptValues(values);
 
 		ReleaseContext releaseContext = ReleaseContext.builder()
 			.name(releaseName)

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -20,6 +20,7 @@ import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.service.LifecycleListener;
+import org.alexmond.jhelm.core.service.ValueEncryptor;
 import org.alexmond.jhelm.core.service.LifecyclePhase;
 import org.alexmond.jhelm.core.service.PostRenderProcessor;
 import org.alexmond.jhelm.core.util.HookExecutor;
@@ -43,6 +44,9 @@ public class UpgradeAction {
 
 	@Setter
 	private JhelmMetrics metrics;
+
+	@Setter
+	private ValueEncryptor valueEncryptor = new ValueEncryptor(null, null, true);
 
 	/**
 	 * Upgrades a release, resolving values according to the configured
@@ -69,6 +73,7 @@ public class UpgradeAction {
 		ResolvedValues resolved = resolveValues(currentRelease, newChart, options.getValues(),
 				options.getValueStrategy());
 		Map<String, Object> renderValues = resolved.render();
+		this.valueEncryptor.decryptValues(renderValues);
 		Map<String, Object> configValues = resolved.config();
 
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmEncryptProperties.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmEncryptProperties.java
@@ -1,0 +1,40 @@
+package org.alexmond.jhelm.core.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for decrypting {@code {cipher}} values. Mirrors Spring Cloud Config's
+ * symmetric {@code encrypt.*} settings so a token produced by a config server's
+ * {@code /encrypt} endpoint (or the {@code jhelm encrypt} tool) decrypts identically.
+ * <p>
+ * Disabled until {@link #key} is set; with no key, {@code {cipher}} values pass through
+ * untouched and rendering is unchanged.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jhelm.encrypt")
+public class JhelmEncryptProperties {
+
+	/**
+	 * Symmetric key used to decrypt (and encrypt) {@code {cipher}} values. Setting it
+	 * enables decryption. Must match the key used to encrypt the values (e.g. the config
+	 * server's {@code encrypt.key}).
+	 */
+	private String key;
+
+	/**
+	 * Hex-encoded salt for key derivation. Must match the encrypting side (Spring Cloud's
+	 * {@code encrypt.salt}); defaults to Spring's default of {@code deadbeef}.
+	 */
+	private String salt = "deadbeef";
+
+	/**
+	 * Whether an undecryptable {@code {cipher}} value aborts the operation. When
+	 * {@code false}, the value is left untouched and a warning is logged. Defaults to
+	 * {@code true}.
+	 */
+	private boolean failOnError = true;
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ValueEncryptor.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/ValueEncryptor.java
@@ -1,0 +1,157 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.core.exception.JhelmException;
+import org.springframework.security.crypto.encrypt.Encryptors;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+
+/**
+ * Encrypts and decrypts {@code {cipher}} values using the same symmetric primitive as
+ * Spring Cloud Config ({@code Encryptors.text(key, salt)}), so tokens are interchangeable
+ * between a config server's {@code /encrypt} endpoint, the {@code jhelm encrypt} tool,
+ * and values files.
+ * <p>
+ * Disabled when no key is configured: {@link #decryptValues(Map)} is then a no-op and
+ * {@code {cipher}} values pass through unchanged.
+ */
+@Slf4j
+public class ValueEncryptor {
+
+	/** Marker prefix identifying an encrypted value, matching Spring Cloud Config. */
+	public static final String CIPHER_PREFIX = "{cipher}";
+
+	private final boolean failOnError;
+
+	private final TextEncryptor encryptor;
+
+	/**
+	 * @param key symmetric key; {@code null}/blank disables encryption
+	 * @param salt hex salt for key derivation (must match the encrypting side)
+	 * @param failOnError whether an undecryptable value aborts rather than passing
+	 * through
+	 */
+	public ValueEncryptor(String key, String salt, boolean failOnError) {
+		this.failOnError = failOnError;
+		this.encryptor = (key != null && !key.isBlank()) ? Encryptors.text(key, salt) : null;
+	}
+
+	/**
+	 * @return {@code true} when a key is configured and (de/en)cryption is available
+	 */
+	public boolean isEnabled() {
+		return this.encryptor != null;
+	}
+
+	/**
+	 * Encrypt a plaintext value into a {@code {cipher}<hex>} token.
+	 * @param plaintext the value to encrypt
+	 * @return the {@code {cipher}}-prefixed token
+	 * @throws JhelmException if no key is configured
+	 */
+	public String encrypt(String plaintext) {
+		requireEnabled();
+		return CIPHER_PREFIX + this.encryptor.encrypt(plaintext);
+	}
+
+	/**
+	 * Decrypt a value, tolerating either a bare hex ciphertext or a
+	 * {@code {cipher}}-prefixed token.
+	 * @param value the token (with or without the {@code {cipher}} prefix)
+	 * @return the decrypted plaintext
+	 * @throws JhelmException if no key is configured or the value cannot be decrypted
+	 */
+	public String decrypt(String value) {
+		requireEnabled();
+		String cipher = value.startsWith(CIPHER_PREFIX) ? value.substring(CIPHER_PREFIX.length()) : value;
+		try {
+			return this.encryptor.decrypt(cipher);
+		}
+		catch (RuntimeException ex) {
+			throw new JhelmException("Failed to decrypt value: " + ex.getMessage(), ex);
+		}
+	}
+
+	/**
+	 * Recursively decrypt every {@code {cipher}} string leaf in a values tree, in place.
+	 * A no-op when disabled. On a decryption failure the value is left untouched and a
+	 * warning logged, unless {@code fail-on-error} is set (then it throws).
+	 * @param values the merged values map (mutated in place)
+	 * @return the same map, for chaining
+	 */
+	public Map<String, Object> decryptValues(Map<String, Object> values) {
+		if (isEnabled() && values != null) {
+			decryptMap(values);
+		}
+		return values;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void decryptMap(Map<String, Object> map) {
+		for (Map.Entry<String, Object> entry : map.entrySet()) {
+			Object value = entry.getValue();
+			if (value instanceof String str) {
+				if (str.startsWith(CIPHER_PREFIX)) {
+					entry.setValue(decryptLeaf(str));
+				}
+			}
+			else if (value instanceof Map<?, ?> nested) {
+				decryptMap((Map<String, Object>) nested);
+			}
+			else if (value instanceof List<?> list) {
+				decryptList((List<Object>) list);
+			}
+		}
+	}
+
+	private void decryptList(List<Object> list) {
+		for (int i = 0; i < list.size(); i++) {
+			Object value = list.get(i);
+			if (value instanceof String str) {
+				if (str.startsWith(CIPHER_PREFIX)) {
+					list.set(i, decryptLeaf(str));
+				}
+			}
+			else if (value instanceof Map<?, ?> nested) {
+				decryptMap(castMap(nested));
+			}
+			else if (value instanceof List<?> nestedList) {
+				decryptList(castList(nestedList));
+			}
+		}
+	}
+
+	private Object decryptLeaf(String token) {
+		try {
+			return decrypt(token);
+		}
+		catch (RuntimeException ex) {
+			if (this.failOnError) {
+				throw ex;
+			}
+			if (log.isWarnEnabled()) {
+				log.warn("Leaving an undecryptable {cipher} value untouched: {}", ex.getMessage());
+			}
+			return token;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> castMap(Map<?, ?> map) {
+		return (Map<String, Object>) map;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static List<Object> castList(List<?> list) {
+		return (List<Object>) list;
+	}
+
+	private void requireEnabled() {
+		if (!isEnabled()) {
+			throw new JhelmException("No encryption key configured (set jhelm.encrypt.key or pass --key)");
+		}
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ValueEncryptorTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/ValueEncryptorTest.java
@@ -1,0 +1,89 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.exception.JhelmException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Symmetric encrypt/decrypt round-trip, the recursive {@code {cipher}} decryption pass
+ * over a values tree, and disabled / fail-on-error behavior for {@link ValueEncryptor}.
+ */
+class ValueEncryptorTest {
+
+	private final ValueEncryptor enc = new ValueEncryptor("test-key", "deadbeef", true);
+
+	@Test
+	void testEncryptDecryptRoundTrip() {
+		String token = enc.encrypt("s3cret");
+		assertTrue(token.startsWith(ValueEncryptor.CIPHER_PREFIX), "encrypt prefixes with {cipher}");
+		assertEquals("s3cret", enc.decrypt(token), "decrypt reverses encrypt");
+	}
+
+	@Test
+	void testDecryptAcceptsBareCiphertext() {
+		String bare = enc.encrypt("hello").substring(ValueEncryptor.CIPHER_PREFIX.length());
+		assertEquals("hello", enc.decrypt(bare), "decrypt tolerates a token without the {cipher} prefix");
+	}
+
+	@Test
+	void testDecryptValuesWalksNestedMapsAndLists() {
+		String secret = enc.encrypt("db-pass");
+		String tokenInList = enc.encrypt("item0");
+
+		Map<String, Object> values = new LinkedHashMap<>();
+		values.put("plain", "unchanged");
+		Map<String, Object> db = new LinkedHashMap<>();
+		db.put("password", secret);
+		values.put("db", db);
+		List<Object> list = new ArrayList<>();
+		list.add(tokenInList);
+		list.add("literal");
+		values.put("items", list);
+
+		enc.decryptValues(values);
+
+		assertEquals("unchanged", values.get("plain"), "non-cipher strings are untouched");
+		assertEquals("db-pass", ((Map<?, ?>) values.get("db")).get("password"), "nested map cipher decrypted");
+		assertEquals("item0", ((List<?>) values.get("items")).get(0), "list cipher decrypted");
+		assertEquals("literal", ((List<?>) values.get("items")).get(1), "list literal untouched");
+	}
+
+	@Test
+	void testDisabledIsNoOp() {
+		ValueEncryptor disabled = new ValueEncryptor(null, "deadbeef", true);
+		assertFalse(disabled.isEnabled());
+
+		Map<String, Object> values = new LinkedHashMap<>();
+		values.put("password", "{cipher}deadbeefdeadbeef");
+		disabled.decryptValues(values);
+		assertEquals("{cipher}deadbeefdeadbeef", values.get("password"), "no key -> cipher values pass through");
+
+		assertThrows(JhelmException.class, () -> disabled.encrypt("x"), "encrypt without a key throws");
+	}
+
+	@Test
+	void testFailOnErrorTrueThrows() {
+		Map<String, Object> values = new LinkedHashMap<>();
+		values.put("bad", "{cipher}not-valid-ciphertext");
+		assertThrows(RuntimeException.class, () -> enc.decryptValues(values), "undecryptable value aborts");
+	}
+
+	@Test
+	void testFailOnErrorFalseLeavesValueUntouched() {
+		ValueEncryptor lenient = new ValueEncryptor("test-key", "deadbeef", false);
+		Map<String, Object> values = new LinkedHashMap<>();
+		values.put("bad", "{cipher}not-valid-ciphertext");
+		lenient.decryptValues(values);
+		assertEquals("{cipher}not-valid-ciphertext", values.get("bad"), "lenient mode leaves the token in place");
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>
         <bouncycastle.version>1.84</bouncycastle.version>
+        <!-- Only the config-server sample uses Spring Cloud; 2025.1.x (Oakwood) targets Boot 4.0. -->
+        <spring-cloud.version>2025.1.2</spring-cloud.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <chicory.version>1.7.5</chicory.version>
         <swagger-annotations.version>2.2.52</swagger-annotations.version>
@@ -89,6 +91,7 @@
         <module>jhelm-sample</module>
         <module>jhelm-rest-sample</module>
         <module>jhelm-mcp-sample</module>
+        <module>jhelm-config-server-sample</module>
     </modules>
 
     <dependencyManagement>
@@ -318,6 +321,7 @@
                             <excludeArtifact>jhelm-sample</excludeArtifact>
                             <excludeArtifact>jhelm-rest-sample</excludeArtifact>
                             <excludeArtifact>jhelm-mcp-sample</excludeArtifact>
+                            <excludeArtifact>jhelm-config-server-sample</excludeArtifact>
                         </excludeArtifacts>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Closes #674.

The **first deliberate step beyond Helm parity.** Everything else in jhelm renders byte-for-byte like Go Helm; this adds one opt-in capability — encrypted secrets in values — plus the tooling and a working, secured config server to go with it. Charts that don't use it are unaffected.

## What's here

**Core `{cipher}` decryption**
- `ValueEncryptor` decrypts `{cipher}<hex>` tokens at render time (after values merge, before templating), using `spring-security-crypto`'s `Encryptors.text(key, salt)` — the same primitive Spring Cloud Config's `EncryptorFactory` uses for a plain-text key, so tokens are **byte-compatible in both directions**.
- `jhelm.encrypt.{key,salt,fail-on-error}` (`JhelmEncryptProperties`). Disabled until a key is set — `{cipher}` strings pass through verbatim otherwise (Helm-identical).
- Hooked into `template`/`install`/`upgrade` post-merge; registered as a bean so the library, REST, MCP, and CLI surfaces all pick it up.

**CLI tool**
- `jhelm encrypt` / `jhelm decrypt` — key from `jhelm.encrypt.*` or `--key`/`--salt`, value from an argument or stdin.

**Sample config server** (`jhelm-config-server-sample`)
- `@EnableConfigServer` + HTTP basic auth + `encrypt.key`, native backend with a base document, a `prod` on-profile overlay, a `demo-prod.yml` sidecar, and `{cipher}` secrets served **verbatim** (`encrypt.enabled=false`) so jhelm decrypts them client-side — plaintext never hits the wire. Doubles as a DevOps starting point and jhelm's own test fixture. Excluded from Central like the other samples.

## Why (for DevOps)

The config server + encryption unlock three things Helm has no story for: **central storage** (one git-backed server for every release's values), **security** (auth/TLS + ciphertext secrets), and **profiles** (the same `-P` profiles select per-environment overlays server-side). We don't re-document Spring Cloud Config — the docs point at its reference and ship the runnable sample instead.

## Testing

- Unit: `ValueEncryptor` round-trip / nested-tree decrypt / fail-on-error / disabled-no-op; CLI encrypt↔decrypt round-trip + missing-key error.
- Integration: the sample server boots, rejects unauthenticated requests, and serves the profile-merged values with the `{cipher}` token intact.
- **Grounded end-to-end** against the running sample server: server `POST /encrypt` ↔ `jhelm decrypt` parity **both directions**, and `jhelm template` fetching the `prod` values through the server with client-side `{cipher}` decryption (`password: prod-db-password`); without the key the token passes through unchanged.
- Full `./mvnw clean install` green across all 13 modules (tests + coverage + PMD + checkstyle + format).

## Docs

`value-profiles.adoc` gains a "beyond Helm parity" callout and an `encrypted-values` section (enabling, CLI usage, Spring Cloud parity, security notes).

## Follow-ups (not in scope)

- Keystore/RSA `{cipher}` tokens (`spring-security-rsa`, not in the Boot BOM) — only the symmetric shared-key scheme is supported here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)