### PR TITLE
docs: prep 1.1.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 = jhelm
-:jhelm-version: 1.0.2
+:jhelm-version: 1.1.0
 :url-docs: https://www.alexmond.org/jhelm/current/
 :url-docs-mcp: https://www.alexmond.org/jhelm/current/mcp/
 :url-docs-rest: https://www.alexmond.org/jhelm/current/rest-api/
@@ -61,6 +61,10 @@ the Go-based Helm binary.
   Spring AI), mirroring the REST operation set with the same `READ_ONLY`/`FULL` access mode.
 * *JSON Schema validation* -- validates chart values against `values.schema.json` (Draft-07).
 * *Async Kubernetes operations* -- Java 21 virtual threads via `AsyncKubeService`.
+* *Value management beyond Helm* -- Spring-Boot-style value profiles (per-environment
+  overlays via `-P`/`--profile`), values sourced from a central Spring Cloud Config Server,
+  and `{cipher}`-encrypted secret values decrypted at render time (with `jhelm encrypt` /
+  `jhelm decrypt`). All opt-in; charts that don't use them render byte-for-byte as Go Helm.
 
 == Modules
 
@@ -76,7 +80,7 @@ the Go-based Helm binary.
 | `jhelm-mcp` | Model Context Protocol server exposing jhelm operations as AI-agent tools (built on Spring AI), mirroring the REST operation set.
 | `jhelm-mcp-starter` | Spring Boot starter that auto-configures the `jhelm-mcp` server, with a `READ_ONLY`/`FULL` access mode.
 | `jhelm-plugin` | Maven plugin for packaging charts as part of a build.
-| `jhelm-cli` | Standalone CLI (Spring Boot + Picocli) -- 22 Helm-compatible commands.
+| `jhelm-cli` | Standalone CLI (Spring Boot + Picocli) -- 22 Helm-compatible commands plus `encrypt`/`decrypt` for secret values.
 |===
 
 The Go template + Sprig engine lives in the separate

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -1,5 +1,36 @@
 = Changelog
 
+== 1.1.0
+
+The first release to extend *beyond Helm parity*: a Spring-Boot-style value-management layer —
+profiles, a Spring Cloud Config Server source, and encrypted secret values — layered on top of
+the Helm-compatible core. Every addition is opt-in; charts that don't use these features render
+byte-for-byte as Go Helm.
+
+=== Features
+
+* *Value profiles* -- keep environment-specific values (dev, staging, prod, …) in one place and
+  activate them at render/install/upgrade time with `-P`/`--profile`, mirroring Spring Boot.
+  Profiles come from `---`-separated documents gated by `spring.config.activate.on-profile` or
+  from `values-<profile>.yaml` sidecars, and apply to a chart's own `values.yaml` and to `-f`
+  files (#670).
+* *Values from a Spring Cloud Config Server* -- fetch values from a central, git-backed
+  https://docs.spring.io/spring-cloud-config/reference/[Spring Cloud Config Server] over jhelm's
+  SSRF-guarded HTTP path, reusing the active profiles for the requested profile and slotting into
+  the override order the way Spring Boot's config-data model does. Disabled by default (#671).
+* *Encrypted values* -- `{cipher}<hex>` secret tokens in any values source are decrypted at
+  render time when `jhelm.encrypt.key` is set, byte-compatible with Spring Cloud Config's
+  encryption. Ships a `jhelm encrypt` / `jhelm decrypt` CLI tool and a runnable, secured
+  `jhelm-config-server-sample` module as a DevOps starting point and test fixture. Inert unless a
+  key is configured (#674).
+
+=== Fixes
+
+* *`jhelm test` no longer hangs on a completed pod* -- terminal pod phases (`Succeeded`/`Failed`)
+  are handled instead of being waited on indefinitely (#668).
+* *Manifests apply/delete as unstructured maps* -- resources are applied and deleted as
+  unstructured maps rather than typed models, fixing kinds the typed path mishandled (#666).
+
 == 1.0.2
 
 A maintenance release fixing two bugs found in triage. No public API changes.


### PR DESCRIPTION
Release prep for **1.1.0** (minor bump — three new opt-in value-management features since 1.0.2, plus two fixes).

- **changelog.adoc** — add the `1.1.0` section (Features: value profiles #670, config-server values #671, encrypted values #674; Fixes: #668, #666), framed as the first release beyond Helm parity.
- **README.adoc** — bump `:jhelm-version:` to `1.1.0` (drives the `{jhelm-version}` install snippets), add a "value management beyond Helm" feature bullet, and note the new `encrypt`/`decrypt` CLI commands.

Docs-only; no code changes since the last green `clean install`. After merge, the release workflow is triggered with `releaseVersion=1.1.0` / `nextVersion=1.1.1-SNAPSHOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)