### PR TITLE
docs(readme): fix dead .html link to the Spring Boot Starter guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -141,7 +141,7 @@ String manifest = templateAction.render(
         Map.of("replicaCount", 3, "image", Map.of("tag", "1.2.3")));
 ----
 
-See the https://www.alexmond.org/jhelm/current/spring-boot-starter.html[Spring Boot Starter]
+See the {url-docs}spring-boot-starter/[Spring Boot Starter]
 guide for the full action API and configuration properties.
 
 === As a CLI


### PR DESCRIPTION
The README linked `…/jhelm/current/spring-boot-starter.html`, which **404s** under the docs hub's indexify serving (pages are extensionless dirs). GA4 confirms legacy `.html` landings for jhelm; `performance.html` already had a hub `_redirects` 301 but `spring-boot-starter.html` had none, so this README link was dead.

Fix: use the `{url-docs}spring-boot-starter/` clean form, matching the other links in the README. A companion hub `_redirects` 301 (separate PR on the docs repo) catches anyone who already clicked the old link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)