### PR TITLE
feat(cli): extend -o json|yaml output-format parity to more commands

### DIFF
--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -28,7 +28,9 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | `--post-renderer` | ✅ |
 | `--force` (upgrade) | ✅ | Delete-and-recreate strategy: existing resources are deleted before the new manifest is applied. May cause downtime or data loss for stateful resources — use with care.
 | `--wait-for-jobs` | ✅ | Accepted for Helm compatibility; implies `--wait`. jhelm's `--wait` already waits for Job completion.
+| `-o`, `--output` | ✅ | `table` (default human summary), `json`, `yaml`. JSON/YAML emit the Helm-shaped release object (nested `info`, snake_case keys).
 | `--version`, `--repo`, `--username`/`--password` (install from a repo) | ✗ | Install from an added repo/OCI ref; inline repo+auth flags aren't wired.
+| `-g`/`--generate-name`, `--description`, `--labels`, `--set-literal`, `--dependency-update` | ✗ | Not yet wired; the release name is a required positional.
 |===
 
 == uninstall
@@ -63,11 +65,13 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 
 | rollback | `-n`, `--no-hooks`, `--wait`, `--timeout` | ✅
 | rollback | `--force`, `--cleanup-on-fail`, `--recreate-pods`, `--wait-for-jobs` | ✗
-| status | `-n`, `--show-resources` | ✅
-| status | `--revision`, `-o/--output` | ✗
-| history | `-n` | ✅
-| history | `-o/--output`, `--max` | ✗
+| status | `-n`, `--show-resources`, `-o/--output` | ✅
+| status | `--revision` | ✗
+| history | `-n`, `-o/--output`, `--max` | ✅
 |===
+
+`status -o json|yaml` emits the Helm-shaped release object (nested `info`, plus a `resources`
+array when `--show-resources` is set); `history -o json|yaml` emits the Helm history array.
 
 == get
 
@@ -82,6 +86,8 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | Command | jhelm | Notes
 
 | `repo add`, `repo list`, `repo remove` | ✅ |
+| `repo list -o table\|json\|yaml` | ✅ | Machine-readable repo listing (`name`, `url`).
+| `search hub -o table\|json\|yaml` | ✅ | Machine-readable Artifact Hub results.
 | `repo update [name...]` | ✅ | Refreshes all repos, or the named ones.
 | `repo add` auth (`--username`, `--password`, `--ca-file`) | ✗ |
 | `registry login` (`-u`, `-p`, `--password-stdin`) / `logout` | ✅ |
@@ -100,8 +106,30 @@ Most scripts work unchanged. Watch for these deliberate differences:
 * *`--dry-run`* — use the bare flag; the `=client|server` value form is not parsed.
 * *`list -A`* — not supported; iterate namespaces, or pass `-n`.
 * *`--force` / `--wait-for-jobs`* — not yet supported on install/upgrade/rollback.
-* *Output* — `jhelm list -o json` and `jhelm get values -o json` produce Helm-shaped output for
-  scripts; other commands' `-o` support is still growing.
+* *Output* — `-o table|json|yaml` is supported on `list`, `get values`, `get metadata`,
+  `status`, `history`, `install`, `upgrade`, `repo list`, and `search hub`, producing
+  Helm-shaped output for scripts and agents. Commands where Helm has no `-o` (`template`,
+  `get manifest/notes/hooks`) don't add one.
+
+== Other known gaps
+
+Beyond the per-command tables above, these commonly-used Helm options are not yet wired
+(tracked for follow-up):
+
+* *`template`* — `-s`/`--show-only`, `--output-dir`, `--include-crds`, `--skip-tests`,
+  `--is-upgrade`.
+* *`list`* — `-A`/`--all-namespaces`, `-l`/`--selector`, `-a`/`--all`, the status filters,
+  `--max`/`--offset`/`--filter`.
+* *`install`/`upgrade`* — install-from-repo (`--version`/`--repo`/`--username`/`--password`),
+  `-g`/`--generate-name`, `--description`, `--labels`, `--set-literal`, `--dependency-update`;
+  `upgrade --cleanup-on-fail`.
+* *`uninstall`/`rollback`* — `--wait`/`--timeout`/`--cascade` (uninstall);
+  `--force`/`--cleanup-on-fail`/`--recreate-pods`/`--wait-for-jobs` (rollback).
+* *`pull`* — `--untar`/`--untardir`, `--verify`/`--prov`/`--keyring`, `--devel`.
+* *Global flags* — Helm's persistent flags (`--kube-context`, `--kubeconfig`,
+  `--kube-apiserver`, `--registry-config`, `--repository-config`, `--repository-cache`,
+  `--debug`) aren't accepted inline; jhelm resolves these via Spring properties / environment
+  variables instead.
 
 For sharing repositories, registry credentials, and releases with the `helm` binary itself, see
 xref:interoperability.adoc[Interoperability with Helm].

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/HistoryCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/HistoryCommand.java
@@ -2,12 +2,16 @@ package org.alexmond.jhelm.app.command;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.app.output.OutputFormat;
 import org.alexmond.jhelm.core.action.HistoryAction;
 import org.alexmond.jhelm.core.model.Release;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 /**
@@ -26,6 +30,14 @@ public class HistoryCommand implements Callable<Integer> {
 	@CommandLine.Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
 	private String namespace;
 
+	@CommandLine.Option(names = { "--max" }, defaultValue = "256",
+			description = "maximum number of revisions to include (most recent first)")
+	private int max;
+
+	@CommandLine.Option(names = { "-o", "--output" }, defaultValue = "table",
+			description = "output format: table, json, or yaml")
+	private String output;
+
 	/**
 	 * Creates the command.
 	 * @param historyAction the action that retrieves release history
@@ -35,18 +47,19 @@ public class HistoryCommand implements Callable<Integer> {
 	}
 
 	/**
-	 * Prints the release revision history as a table.
+	 * Prints the release revision history as a table, or as {@code json}/{@code yaml}.
 	 */
 	@Override
 	public Integer call() {
 		try {
 			List<Release> history = historyAction.history(name, namespace);
-			CliOutput.printf("%-10s %-30s %-10s %-20s %-30s\n", CliOutput.bold("REVISION"), CliOutput.bold("UPDATED"),
-					CliOutput.bold("STATUS"), CliOutput.bold("CHART"), CliOutput.bold("DESCRIPTION"));
-			for (Release r : history) {
-				String chartInfo = r.getChart().getMetadata().getName() + "-" + r.getChart().getMetadata().getVersion();
-				CliOutput.printf("%-10d %-30s %-10s %-20s %-30s\n", r.getVersion(), r.getInfo().getLastDeployed(),
-						r.getInfo().getStatus().getValue(), chartInfo, r.getInfo().getDescription());
+			if (max > 0 && history.size() > max) {
+				history = history.subList(history.size() - max, history.size());
+			}
+			switch (output.toLowerCase(Locale.ROOT)) {
+				case "json" -> System.out.println(OutputFormat.json(toRows(history)));
+				case "yaml" -> System.out.print(OutputFormat.yaml(toRows(history)));
+				default -> printTable(history);
 			}
 			return CommandLine.ExitCode.OK;
 		}
@@ -54,6 +67,24 @@ public class HistoryCommand implements Callable<Integer> {
 			CliOutput.errPrintln(CliOutput.error("Error fetching history: " + ex.getMessage()));
 			return CommandLine.ExitCode.SOFTWARE;
 		}
+	}
+
+	private void printTable(List<Release> history) {
+		CliOutput.printf("%-10s %-30s %-10s %-20s %-30s\n", CliOutput.bold("REVISION"), CliOutput.bold("UPDATED"),
+				CliOutput.bold("STATUS"), CliOutput.bold("CHART"), CliOutput.bold("DESCRIPTION"));
+		for (Release r : history) {
+			String chartInfo = r.getChart().getMetadata().getName() + "-" + r.getChart().getMetadata().getVersion();
+			CliOutput.printf("%-10d %-30s %-10s %-20s %-30s\n", r.getVersion(), r.getInfo().getLastDeployed(),
+					r.getInfo().getStatus().getValue(), chartInfo, r.getInfo().getDescription());
+		}
+	}
+
+	private static List<Map<String, Object>> toRows(List<Release> history) {
+		List<Map<String, Object>> rows = new ArrayList<>();
+		for (Release r : history) {
+			rows.add(OutputFormat.historyRow(r));
+		}
+		return rows;
 	}
 
 }

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Callable;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.app.output.OutputFormat;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;
@@ -116,6 +117,10 @@ public class InstallCommand implements Callable<Integer> {
 	@CommandLine.Option(names = { "--create-namespace" }, description = "create the release namespace if not present")
 	private boolean createNamespace;
 
+	@CommandLine.Option(names = { "-o", "--output" }, defaultValue = "table",
+			description = "output format: table (default human summary), json, or yaml")
+	private String output;
+
 	/**
 	 * Creates the command.
 	 * @param installAction the action that performs the install
@@ -167,6 +172,21 @@ public class InstallCommand implements Callable<Integer> {
 				.build());
 			release = applyCliPostRenderers(release);
 
+			if (!dryRunEnabled && (wait || atomic || waitForJobs)) {
+				kubeService.waitForReady(namespace, release.getManifest(), timeout);
+			}
+
+			if (OutputFormat.isJson(output) || OutputFormat.isYaml(output)) {
+				Map<String, Object> map = OutputFormat.release(release);
+				if (OutputFormat.isJson(output)) {
+					System.out.println(OutputFormat.json(map));
+				}
+				else {
+					System.out.print(OutputFormat.yaml(map));
+				}
+				return CommandLine.ExitCode.OK;
+			}
+
 			if (dryRunEnabled) {
 				CliOutput.println(CliOutput.bold("NAME:") + " " + release.getName());
 				CliOutput.println(CliOutput.bold("LAST DEPLOYED:") + " " + release.getInfo().getLastDeployed());
@@ -177,9 +197,6 @@ public class InstallCommand implements Callable<Integer> {
 			}
 			else {
 				CliOutput.println(CliOutput.success("Release \"" + name + "\" has been installed."));
-				if (wait || atomic || waitForJobs) {
-					kubeService.waitForReady(namespace, release.getManifest(), timeout);
-				}
 			}
 			return CommandLine.ExitCode.OK;
 		}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoCommand.java
@@ -2,13 +2,18 @@ package org.alexmond.jhelm.app.command;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.app.output.OutputFormat;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.core.model.RepositoryConfig;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 /**
@@ -81,6 +86,10 @@ public class RepoCommand implements Callable<Integer> {
 
 		private final RepoManager repoManager;
 
+		@CommandLine.Option(names = { "-o", "--output" }, defaultValue = "table",
+				description = "output format: table, json, or yaml")
+		private String output;
+
 		/**
 		 * Creates the command.
 		 * @param repoManager the repository manager that supplies the configured
@@ -94,9 +103,10 @@ public class RepoCommand implements Callable<Integer> {
 		public Integer call() {
 			try {
 				RepositoryConfig config = repoManager.loadConfig();
-				CliOutput.printf("%-20s\t%-50s\n", CliOutput.bold("NAME"), CliOutput.bold("URL"));
-				for (RepositoryConfig.Repository repo : config.getRepositories()) {
-					CliOutput.printf("%-20s\t%-50s\n", repo.getName(), repo.getUrl());
+				switch (output.toLowerCase(Locale.ROOT)) {
+					case "json" -> System.out.println(OutputFormat.json(toRows(config)));
+					case "yaml" -> System.out.print(OutputFormat.yaml(toRows(config)));
+					default -> printTable(config);
 				}
 				return CommandLine.ExitCode.OK;
 			}
@@ -104,6 +114,24 @@ public class RepoCommand implements Callable<Integer> {
 				CliOutput.errPrintln(CliOutput.error("Error listing repositories: " + ex.getMessage()));
 				return CommandLine.ExitCode.SOFTWARE;
 			}
+		}
+
+		private void printTable(RepositoryConfig config) {
+			CliOutput.printf("%-20s\t%-50s\n", CliOutput.bold("NAME"), CliOutput.bold("URL"));
+			for (RepositoryConfig.Repository repo : config.getRepositories()) {
+				CliOutput.printf("%-20s\t%-50s\n", repo.getName(), repo.getUrl());
+			}
+		}
+
+		private static List<Map<String, Object>> toRows(RepositoryConfig config) {
+			List<Map<String, Object>> rows = new ArrayList<>();
+			for (RepositoryConfig.Repository repo : config.getRepositories()) {
+				Map<String, Object> row = new LinkedHashMap<>();
+				row.put("name", repo.getName());
+				row.put("url", repo.getUrl());
+				rows.add(row);
+			}
+			return rows;
 		}
 
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchHubCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchHubCommand.java
@@ -1,9 +1,14 @@
 package org.alexmond.jhelm.app.command;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.app.output.OutputFormat;
 import org.alexmond.jhelm.core.action.SearchHubAction;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
@@ -29,6 +34,10 @@ public class SearchHubCommand implements Callable<Integer> {
 			description = "print charts repository URL")
 	private boolean listRepoUrl;
 
+	@CommandLine.Option(names = { "-o", "--output" }, defaultValue = "table",
+			description = "output format: table, json, or yaml")
+	private String output;
+
 	/**
 	 * Creates the command.
 	 * @param searchHubAction the action that queries Artifact Hub
@@ -41,11 +50,18 @@ public class SearchHubCommand implements Callable<Integer> {
 	public Integer call() {
 		try {
 			List<SearchHubAction.HubResult> results = searchHubAction.search(keyword, 25);
-			if (results.isEmpty()) {
-				CliOutput.println("No results found for \"" + keyword + "\"");
-				return CommandLine.ExitCode.OK;
+			switch (output.toLowerCase(Locale.ROOT)) {
+				case "json" -> System.out.println(OutputFormat.json(toRows(results)));
+				case "yaml" -> System.out.print(OutputFormat.yaml(toRows(results)));
+				default -> {
+					if (results.isEmpty()) {
+						CliOutput.println("No results found for \"" + keyword + "\"");
+					}
+					else {
+						printTable(results);
+					}
+				}
 			}
-			printTable(results);
 			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
@@ -64,6 +80,21 @@ public class SearchHubCommand implements Callable<Integer> {
 			CliOutput
 				.println(String.format("%-40s\t%-8s\t%-12s\t%s", url, r.getVersion(), r.getAppVersion(), description));
 		}
+	}
+
+	// Mirrors the fields Helm emits for `helm search hub -o json/yaml`.
+	private static List<Map<String, Object>> toRows(List<SearchHubAction.HubResult> results) {
+		List<Map<String, Object>> rows = new ArrayList<>();
+		for (SearchHubAction.HubResult r : results) {
+			Map<String, Object> row = new LinkedHashMap<>();
+			row.put("url", r.getUrl());
+			row.put("version", r.getVersion());
+			row.put("app_version", r.getAppVersion());
+			row.put("description", r.getDescription());
+			row.put("repository", r.getRepoUrl());
+			rows.add(row);
+		}
+		return rows;
 	}
 
 	private String truncate(String value, int maxWidth) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/StatusCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/StatusCommand.java
@@ -2,14 +2,18 @@ package org.alexmond.jhelm.app.command;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.app.output.OutputFormat;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.alexmond.jhelm.core.action.StatusAction;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
@@ -34,12 +38,29 @@ public class StatusCommand implements Callable<Integer> {
 	@CommandLine.Option(names = { "--show-resources" }, description = "show resource readiness status")
 	private boolean showResources;
 
+	@CommandLine.Option(names = { "-o", "--output" }, defaultValue = "table",
+			description = "output format: table, json, or yaml")
+	private String output;
+
 	/**
 	 * Creates the command.
 	 * @param statusAction the action that retrieves release status
 	 */
 	public StatusCommand(StatusAction statusAction) {
 		this.statusAction = statusAction;
+	}
+
+	private static List<Map<String, Object>> resourceRows(List<ResourceStatus> statuses) {
+		List<Map<String, Object>> rows = new ArrayList<>();
+		for (ResourceStatus rs : statuses) {
+			Map<String, Object> row = new LinkedHashMap<>();
+			row.put("kind", rs.getKind());
+			row.put("name", rs.getName());
+			row.put("ready", rs.isReady());
+			row.put("message", rs.getMessage());
+			rows.add(row);
+		}
+		return rows;
 	}
 
 	private static String colorizeStatus(String status) {
@@ -64,6 +85,20 @@ public class StatusCommand implements Callable<Integer> {
 			}
 
 			Release r = releaseOpt.get();
+			if (OutputFormat.isJson(output) || OutputFormat.isYaml(output)) {
+				Map<String, Object> map = OutputFormat.release(r);
+				if (showResources) {
+					map.put("resources", resourceRows(statusAction.getResourceStatuses(r)));
+				}
+				if (OutputFormat.isJson(output)) {
+					System.out.println(OutputFormat.json(map));
+				}
+				else {
+					System.out.print(OutputFormat.yaml(map));
+				}
+				return CommandLine.ExitCode.OK;
+			}
+
 			CliOutput.println(CliOutput.bold("NAME:") + " " + r.getName());
 			CliOutput.println(CliOutput.bold("LAST DEPLOYED:") + " " + r.getInfo().getLastDeployed());
 			CliOutput.println(CliOutput.bold("NAMESPACE:") + " " + r.getNamespace());

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Callable;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.app.output.OutputFormat;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.RollbackAction;
@@ -144,6 +145,10 @@ public class UpgradeCommand implements Callable<Integer> {
 	@Option(names = { "--no-hooks" }, description = "prevent hooks from running during this operation")
 	private boolean noHooks;
 
+	@CommandLine.Option(names = { "-o", "--output" }, defaultValue = "table",
+			description = "output format: table (default human summary), json, or yaml")
+	private String output;
+
 	@CommandLine.Option(names = { "--history-max" }, defaultValue = "10",
 			description = "limit the maximum number of revisions saved per release (0 = no limit)")
 	private int historyMax;
@@ -202,14 +207,16 @@ public class UpgradeCommand implements Callable<Integer> {
 					wasInstall = true;
 					Release release = installAction.install(buildInstallOptions(chart, overrides));
 					release = applyCliPostRenderers(release);
-					if (dryRunEnabled) {
-						printRelease(release);
+					if (!dryRunEnabled && (wait || atomic || waitForJobs)) {
+						kubeService.waitForReady(namespace, release.getManifest(), timeout);
 					}
-					else {
-						CliOutput
-							.println(CliOutput.success("Release \"" + name + "\" does not exist. Installing it now."));
-						if (wait || atomic || waitForJobs) {
-							kubeService.waitForReady(namespace, release.getManifest(), timeout);
+					if (!emitMachineOutput(release)) {
+						if (dryRunEnabled) {
+							printRelease(release);
+						}
+						else {
+							CliOutput.println(
+									CliOutput.success("Release \"" + name + "\" does not exist. Installing it now."));
 						}
 					}
 				}
@@ -228,13 +235,15 @@ public class UpgradeCommand implements Callable<Integer> {
 				.upgrade(buildUpgradeOptions(currentReleaseOpt.get(), chart, overrides, strategy));
 			upgradedRelease = applyCliPostRenderers(upgradedRelease);
 
-			if (dryRunEnabled) {
-				printRelease(upgradedRelease);
+			if (!dryRunEnabled && (wait || atomic || waitForJobs)) {
+				kubeService.waitForReady(namespace, upgradedRelease.getManifest(), timeout);
 			}
-			else {
-				CliOutput.println(CliOutput.success("Release \"" + name + "\" has been upgraded. Happy Helming!"));
-				if (wait || atomic || waitForJobs) {
-					kubeService.waitForReady(namespace, upgradedRelease.getManifest(), timeout);
+			if (!emitMachineOutput(upgradedRelease)) {
+				if (dryRunEnabled) {
+					printRelease(upgradedRelease);
+				}
+				else {
+					CliOutput.println(CliOutput.success("Release \"" + name + "\" has been upgraded. Happy Helming!"));
 				}
 			}
 			return CommandLine.ExitCode.OK;
@@ -328,6 +337,21 @@ public class UpgradeCommand implements Callable<Integer> {
 		CliOutput.println(CliOutput.bold("STATUS:") + " " + release.getInfo().getStatus().getValue());
 		CliOutput.println(CliOutput.bold("REVISION:") + " " + release.getVersion());
 		CliOutput.println("\n" + CliOutput.bold("MANIFEST:") + "\n" + release.getManifest());
+	}
+
+	// Emits the release as json/yaml when -o requests it; returns true if it did.
+	private boolean emitMachineOutput(Release release) {
+		if (!OutputFormat.isJson(output) && !OutputFormat.isYaml(output)) {
+			return false;
+		}
+		Map<String, Object> map = OutputFormat.release(release);
+		if (OutputFormat.isJson(output)) {
+			System.out.println(OutputFormat.json(map));
+		}
+		else {
+			System.out.print(OutputFormat.yaml(map));
+		}
+		return true;
 	}
 
 	/**

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/output/OutputFormat.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/output/OutputFormat.java
@@ -1,0 +1,108 @@
+package org.alexmond.jhelm.app.output;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.model.Release;
+
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
+
+/**
+ * Shared machine-readable output helpers for {@code -o json|yaml}, matching Helm's
+ * {@code helm ... -o} formats. Centralizes the JSON/YAML mappers and the Helm-shaped
+ * (snake_case) release maps so every command renders identically.
+ */
+public final class OutputFormat {
+
+	private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
+
+	private static final YAMLMapper YAML_MAPPER = YAMLMapper
+		.builder(YAMLFactory.builder().disable(YAMLWriteFeature.WRITE_DOC_START_MARKER).build())
+		.build();
+
+	private OutputFormat() {
+	}
+
+	/**
+	 * @param output the requested output format
+	 * @return {@code true} if it is {@code json}
+	 */
+	public static boolean isJson(String output) {
+		return "json".equalsIgnoreCase(output);
+	}
+
+	/**
+	 * @param output the requested output format
+	 * @return {@code true} if it is {@code yaml}
+	 */
+	public static boolean isYaml(String output) {
+		return "yaml".equalsIgnoreCase(output);
+	}
+
+	/**
+	 * Serializes a value as JSON.
+	 * @param value the value to serialize
+	 * @return the JSON string
+	 */
+	public static String json(Object value) {
+		return JSON_MAPPER.writeValueAsString(value);
+	}
+
+	/**
+	 * Serializes a value as YAML (no leading {@code ---} document marker).
+	 * @param value the value to serialize
+	 * @return the YAML string
+	 */
+	public static String yaml(Object value) {
+		return YAML_MAPPER.writeValueAsString(value);
+	}
+
+	/**
+	 * Builds a Helm-shaped release map ({@code helm status/get -o json} form), with a
+	 * nested {@code info} object and the rendered manifest.
+	 * @param release the release
+	 * @return an ordered, snake_case map mirroring Helm's release JSON
+	 */
+	public static Map<String, Object> release(Release release) {
+		Map<String, Object> map = new LinkedHashMap<>();
+		map.put("name", release.getName());
+		map.put("namespace", release.getNamespace());
+		map.put("version", release.getVersion());
+		Release.ReleaseInfo info = release.getInfo();
+		if (info != null) {
+			Map<String, Object> infoMap = new LinkedHashMap<>();
+			infoMap.put("first_deployed", (info.getFirstDeployed() != null) ? info.getFirstDeployed().toString() : "");
+			infoMap.put("last_deployed", (info.getLastDeployed() != null) ? info.getLastDeployed().toString() : "");
+			infoMap.put("deleted", (info.getDeleted() != null) ? info.getDeleted().toString() : "");
+			infoMap.put("description", (info.getDescription() != null) ? info.getDescription() : "");
+			infoMap.put("status", (info.getStatus() != null) ? info.getStatus().getValue() : "");
+			infoMap.put("notes", (info.getNotes() != null) ? info.getNotes() : "");
+			map.put("info", infoMap);
+		}
+		map.put("manifest", (release.getManifest() != null) ? release.getManifest() : "");
+		return map;
+	}
+
+	/**
+	 * Builds a Helm-shaped history-row map ({@code helm history -o json} form).
+	 * @param release the release revision
+	 * @return an ordered, snake_case map mirroring Helm's history JSON entries
+	 */
+	public static Map<String, Object> historyRow(Release release) {
+		Map<String, Object> map = new LinkedHashMap<>();
+		map.put("revision", release.getVersion());
+		Release.ReleaseInfo info = release.getInfo();
+		map.put("updated", (info != null && info.getLastDeployed() != null) ? info.getLastDeployed().toString() : "");
+		map.put("status", (info != null && info.getStatus() != null) ? info.getStatus().getValue() : "");
+		map.put("chart",
+				release.getChart().getMetadata().getName() + "-" + release.getChart().getMetadata().getVersion());
+		String appVersion = release.getChart().getMetadata().getAppVersion();
+		map.put("app_version", (appVersion != null) ? appVersion : "");
+		map.put("description", (info != null && info.getDescription() != null) ? info.getDescription() : "");
+		return map;
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/HistoryCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/HistoryCommandTest.java
@@ -11,9 +11,14 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -53,6 +58,28 @@ class HistoryCommandTest {
 
 		CommandLine cmd = new CommandLine(historyCommand);
 		cmd.execute("my-release");
+	}
+
+	@Test
+	void testHistoryOutputJsonIsArrayOfHelmRows() throws Exception {
+		when(historyAction.history(anyString(), anyString())).thenReturn(Arrays.asList(
+				createMockRelease("my-release", 1, "Initial install"), createMockRelease("my-release", 2, "Upgrade")));
+
+		PrintStream originalOut = System.out;
+		ByteArrayOutputStream captured = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+		int exit;
+		try {
+			exit = new CommandLine(historyCommand).execute("my-release", "-o", "json");
+		}
+		finally {
+			System.setOut(originalOut);
+		}
+		String out = captured.toString(StandardCharsets.UTF_8).strip();
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		assertTrue(out.startsWith("[") && out.endsWith("]"), out);
+		assertTrue(out.contains("\"revision\":2"), out);
+		assertTrue(out.contains("\"app_version\":"), out);
 	}
 
 	private Release createMockRelease(String name, int version, String description) {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -1,5 +1,9 @@
 package org.alexmond.jhelm.app.command;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.alexmond.jhelm.core.config.ConfigServerProperties;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
@@ -97,6 +101,27 @@ class InstallCommandTest {
 		int exitCode = cmd.execute("my-release", chartDir.getAbsolutePath(), "-n", "default");
 
 		assertEquals(CommandLine.ExitCode.OK, exitCode);
+	}
+
+	@Test
+	void testInstallCommandOutputJson() throws Exception {
+		File chartDir = createMockChart();
+		when(installAction.install(any(InstallOptions.class))).thenReturn(createMockRelease("my-release", 1));
+
+		PrintStream originalOut = System.out;
+		ByteArrayOutputStream captured = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+		int exitCode;
+		try {
+			exitCode = new CommandLine(installCommand).execute("my-release", chartDir.getAbsolutePath(), "-o", "json");
+		}
+		finally {
+			System.setOut(originalOut);
+		}
+		String out = captured.toString(StandardCharsets.UTF_8);
+		assertEquals(CommandLine.ExitCode.OK, exitCode);
+		assertTrue(out.contains("\"name\":\"my-release\""), out);
+		assertTrue(out.contains("\"info\":{"), out);
 	}
 
 	@Test

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RepoCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RepoCommandTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -90,6 +91,23 @@ class RepoCommandTest {
 		assertTrue(output.contains("URL"));
 		assertTrue(output.contains("bitnami"));
 		assertTrue(output.contains("stable"));
+	}
+
+	@Test
+	void testListCommandOutputJson() throws IOException {
+		RepositoryConfig config = new RepositoryConfig();
+		RepositoryConfig.Repository repo1 = new RepositoryConfig.Repository();
+		repo1.setName("bitnami");
+		repo1.setUrl("https://charts.bitnami.com/bitnami");
+		config.setRepositories(Arrays.asList(repo1));
+		when(repoManager.loadConfig()).thenReturn(config);
+
+		int exit = new CommandLine(listCommand).execute("-o", "json");
+		String output = outputStream.toString().strip();
+		assertEquals(0, exit);
+		assertTrue(output.startsWith("[") && output.endsWith("]"), output);
+		assertTrue(output.contains("\"name\":\"bitnami\""), output);
+		assertTrue(output.contains("\"url\":\"https://charts.bitnami.com/bitnami\""), output);
 	}
 
 	@Test

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/SearchHubCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/SearchHubCommandTest.java
@@ -105,6 +105,24 @@ class SearchHubCommandTest {
 	}
 
 	@Test
+	void testSearchHubOutputJson() throws Exception {
+		when(searchHubAction.search(anyString(), anyInt())).thenReturn(List.of(sampleResult()));
+
+		String out = captureStdout(() -> new CommandLine(searchHubCommand).execute("nginx", "-o", "json")).strip();
+		assertTrue(out.startsWith("[") && out.endsWith("]"), out);
+		assertTrue(out.contains("\"app_version\":\"1.25.0\""), out);
+		assertTrue(out.contains("\"repository\":"), out);
+	}
+
+	@Test
+	void testSearchHubOutputYamlEmptyList() throws Exception {
+		when(searchHubAction.search(anyString(), anyInt())).thenReturn(List.of());
+
+		String out = captureStdout(() -> new CommandLine(searchHubCommand).execute("nope", "-o", "yaml")).strip();
+		assertEquals("[]", out);
+	}
+
+	@Test
 	void testSearchHubError() throws Exception {
 		when(searchHubAction.search(anyString(), anyInt())).thenThrow(new JhelmException("connection failed"));
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/StatusCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/StatusCommandTest.java
@@ -12,9 +12,14 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -91,6 +96,27 @@ class StatusCommandTest {
 
 		CommandLine cmd = new CommandLine(statusCommand);
 		cmd.execute("my-release", "--show-resources");
+	}
+
+	@Test
+	void testStatusOutputJsonNestsInfoObject() throws Exception {
+		Release release = createMockRelease();
+		when(statusAction.status(anyString(), anyString())).thenReturn(Optional.of(release));
+
+		PrintStream originalOut = System.out;
+		ByteArrayOutputStream captured = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+		int exit;
+		try {
+			exit = new CommandLine(statusCommand).execute("my-release", "-o", "json");
+		}
+		finally {
+			System.setOut(originalOut);
+		}
+		String out = captured.toString(StandardCharsets.UTF_8);
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		assertTrue(out.contains("\"info\":{"), "info is a nested JSON object: " + out);
+		assertTrue(out.contains("\"status\":\"deployed\""), out);
 	}
 
 	private Release createMockRelease() {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -28,11 +28,15 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -107,6 +111,29 @@ class UpgradeCommandTest {
 
 		CommandLine cmd = new CommandLine(upgradeCommand);
 		cmd.execute("my-release", chartDir.getAbsolutePath(), "-n", "default");
+	}
+
+	@Test
+	void testUpgradeCommandOutputJson() throws Exception {
+		File chartDir = createMockChart();
+		when(kubeService.getRelease(anyString(), anyString()))
+			.thenReturn(Optional.of(createMockRelease("my-release", 1)));
+		when(upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(createMockRelease("my-release", 2));
+
+		PrintStream originalOut = System.out;
+		ByteArrayOutputStream captured = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+		int exitCode;
+		try {
+			exitCode = new CommandLine(upgradeCommand).execute("my-release", chartDir.getAbsolutePath(), "-o", "json");
+		}
+		finally {
+			System.setOut(originalOut);
+		}
+		String out = captured.toString(StandardCharsets.UTF_8);
+		assertEquals(CommandLine.ExitCode.OK, exitCode);
+		assertTrue(out.contains("\"version\":2"), out);
+		assertTrue(out.contains("\"info\":{"), out);
 	}
 
 	@Test

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/output/OutputFormatTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/output/OutputFormatTest.java
@@ -1,0 +1,100 @@
+package org.alexmond.jhelm.app.output;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the Helm-shaped {@code -o json|yaml} output: {@code info} is a nested object
+ * with snake_case keys (matching {@code helm status -o json}), and the JSON/YAML
+ * serialize the nested structure rather than a Java object.
+ */
+class OutputFormatTest {
+
+	private static Release sampleRelease() {
+		ChartMetadata md = new ChartMetadata();
+		md.setName("demo");
+		md.setVersion("1.0.0");
+		md.setAppVersion("2.1");
+		Chart chart = new Chart();
+		chart.setMetadata(md);
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.lastDeployed(OffsetDateTime.parse("2026-07-05T10:00:00Z"))
+			.description("Install complete")
+			.status(ReleaseStatus.DEPLOYED)
+			.notes("NOTES: hi")
+			.build();
+		return Release.builder()
+			.name("myrel")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.info(info)
+			.manifest("apiVersion: v1\nkind: ConfigMap")
+			.build();
+	}
+
+	@Test
+	void testReleaseInfoIsANestedObjectWithSnakeCaseKeys() {
+		Map<String, Object> map = OutputFormat.release(sampleRelease());
+
+		// The top-level scalars.
+		assertEquals("myrel", map.get("name"));
+		assertEquals("default", map.get("namespace"));
+		assertEquals(1, map.get("version"));
+
+		// info is a nested map (serializes to a JSON object / YAML mapping), not a
+		// scalar.
+		Object infoValue = map.get("info");
+		assertInstanceOf(Map.class, infoValue, "info must be a nested object");
+		@SuppressWarnings("unchecked")
+		Map<String, Object> info = (Map<String, Object>) infoValue;
+		assertTrue(info.containsKey("first_deployed"), "snake_case first_deployed");
+		assertTrue(info.containsKey("last_deployed"), "snake_case last_deployed");
+		assertEquals("deployed", info.get("status"));
+		assertEquals("Install complete", info.get("description"));
+	}
+
+	@Test
+	void testReleaseJsonNestsInfoAsAnObject() {
+		String json = OutputFormat.json(OutputFormat.release(sampleRelease()));
+		// The nested object is real JSON, e.g.
+		// "info":{"first_deployed":...,"status":"deployed"...}
+		assertTrue(json.contains("\"info\":{"), "info renders as a JSON object, not a stringified POJO: " + json);
+		assertTrue(json.contains("\"status\":\"deployed\""), json);
+		assertTrue(json.contains("\"first_deployed\":"), json);
+	}
+
+	@Test
+	void testReleaseYamlNestsInfoAsAMapping() {
+		String yaml = OutputFormat.yaml(OutputFormat.release(sampleRelease()));
+		assertTrue(yaml.contains("info:"), yaml);
+		assertTrue(yaml.contains("  status: \"deployed\"") || yaml.contains("  status: deployed"), yaml);
+	}
+
+	@Test
+	void testHistoryRowHelmShape() {
+		Map<String, Object> row = OutputFormat.historyRow(sampleRelease());
+		assertEquals(1, row.get("revision"));
+		assertEquals("deployed", row.get("status"));
+		assertEquals("demo-1.0.0", row.get("chart"));
+		assertEquals("2.1", row.get("app_version"));
+	}
+
+	@Test
+	void testJsonIsAnArrayForRowLists() {
+		String json = OutputFormat.json(List.of(OutputFormat.historyRow(sampleRelease())));
+		assertTrue(json.startsWith("[") && json.endsWith("]"), json);
+	}
+
+}


### PR DESCRIPTION
First slice of the CLI-parity re-review program. Extends `-o table|json|yaml` to every command where Helm has it but jhelm didn't: **status, history, install, upgrade, repo list, search hub** (jhelm previously had it only on `list` and `get`).

## How this was missed
The original parity review documented `status`/`history` `-o` as `✗ not yet supported` (known, deferred), but **install/upgrade/repo-list/search-hub never got an `-o` row in the parity table at all** — a true omission. The review bucketed output-format as a "read/query" concern and didn't carry it to the mutating/other commands, even though Helm attaches `-o` there too.

## Changes
- **`OutputFormat`** helper — centralizes the JSON/YAML mappers and the Helm-shaped (snake_case, nested `info`) release + history maps, so every command renders identically to `helm ... -o`.
- **status** — `-o table|json|yaml`; json/yaml emit the release object (+ a `resources` array under `--show-resources`).
- **history** — `-o table|json|yaml` + `--max`.
- **install / upgrade** — `-o table|json|yaml` emit the release object; the readiness wait is hoisted before output so `-o json` reflects post-wait state.
- **repo list, search hub** — `-o table|json|yaml`.
- **Docs** — `cli-parity.adoc` flips the implemented rows to ✅ and adds an "Other known gaps" section capturing the rest of the re-review findings.

## Output shape
`-o json` emits Helm's shape (nested `info` object, snake_case keys), e.g. `status -o json` → `{"name":…,"info":{"first_deployed":…,"status":"deployed",…},"manifest":…}`.

## Testing
- `OutputFormatTest` — `info` nests as a JSON object (not a stringified POJO), snake_case keys, arrays for row lists.
- `StatusCommandTest` — `status -o json` end-to-end through Picocli.
- Full `clean install` green across all 13 modules.

Follow-up parity issues (template `--show-only`, `list -A/--selector`, install-from-repo, REST/MCP output parity, …) are tracked as separate tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)