### PR TITLE
feat(engine): emit Helm-style "# Source:" markers in rendered manifests (#679)

### DIFF
--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -79,6 +79,14 @@ array when `--show-resources` is set); `history -o json|yaml` emits the Helm his
 `-n/--namespace` and `--revision`; `get values` and `get metadata` take `-o/--output`
 (yaml/json), and `get values` takes `-a/--all`. This mirrors Helm's `get` subcommands.
 
+== template
+
+`jhelm template` renders to stdout like `helm template`, and now emits a Helm-style
+`# Source: <chart>/templates/<file>` marker before each document, so the output records which
+template produced each manifest (and downstream tooling can split by source). The
+render-control flags (`-s`/`--show-only`, `--output-dir`, `--include-crds`, `--skip-tests`,
+`--is-upgrade`) are still being wired — see "Other known gaps".
+
 == repo / registry / pull
 
 [cols="2,1,3"]

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -907,6 +907,11 @@ public class Engine {
 				factory.execute(helmStyleName, context, writer);
 				String rendered = writer.toString();
 				if (rendered != null && !rendered.isBlank()) {
+					// Emit a Helm-style source marker so the manifest records which
+					// template
+					// produced each document (enables `--show-only` / `--output-dir` and
+					// matches `helm template` output).
+					sb.append("# Source: ").append(helmStyleName).append('\n');
 					if (!rendered.trim().endsWith("---")) {
 						sb.append(rendered);
 						if (!rendered.endsWith("\n")) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/TemplateSourceMarkerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/TemplateSourceMarkerTest.java
@@ -1,0 +1,59 @@
+package org.alexmond.jhelm.core;
+
+import java.io.File;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.Engine;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The rendered manifest carries a Helm-style {@code # Source: <chart>/templates/<file>}
+ * marker before each document, matching {@code helm template} output. These markers
+ * record which template produced each document and enable {@code --show-only} /
+ * {@code --output-dir}.
+ */
+class TemplateSourceMarkerTest {
+
+	private final ChartLoader chartLoader = new ChartLoader();
+
+	private final Engine engine = new Engine();
+
+	private final InstallAction installAction = new InstallAction(engine, null);
+
+	private String render(String chartName) throws Exception {
+		Chart chart = chartLoader.load(new File("src/test/resources/test-charts/" + chartName));
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("test-release")
+			.namespace("default")
+			.values(Map.of())
+			.revision(1)
+			.dryRun(true)
+			.build());
+		return release.getManifest();
+	}
+
+	@Test
+	void testSourceMarkerEmittedForTemplate() throws Exception {
+		String manifest = render("minimal");
+		assertTrue(manifest.contains("# Source: minimal/templates/configmap.yaml"),
+				"expected Helm-style source marker; got:\n" + manifest);
+	}
+
+	@Test
+	void testSourceMarkerPrecedesTheDocumentContent() throws Exception {
+		String manifest = render("minimal");
+		int marker = manifest.indexOf("# Source: minimal/templates/configmap.yaml");
+		int kind = manifest.indexOf("kind: ConfigMap");
+		assertTrue(marker >= 0 && kind > marker,
+				"source marker must precede the document it labels; got:\n" + manifest);
+	}
+
+}


### PR DESCRIPTION
First slice of #679. `helm template` prefixes every rendered document with `# Source: <chart>/templates/<file>`; jhelm emitted none. This adds the marker — a standalone Helm-parity win for `jhelm template` output, and the **prerequisite** for `--show-only` / `--output-dir` (which select/split documents by source path), coming in the next slice.

## Change
One line in `Engine.renderChartTemplates`: prepend `# Source: <helmStyleName>` before each rendered document. The engine already computes `helmStyleName = <chart>/templates/<file>`, so no new bookkeeping.

## Why it's safe (no golden-test breakage)
The marker is a YAML comment, so anything that parses the manifest semantically ignores it:
- apply / wait paths parse YAML (comments dropped).
- the `KpsComparisonTest` parity harness splits on `---` and parses each doc as YAML, skipping comment-only docs — so jhelm now *matches* Helm (which has these markers) more closely, not less.

Verified: full `jhelm-core` + `jhelm-cli` suites green (minus the network-dependent `KpsComparisonTest`, which runs in the CI `parity` job against real `helm`).

## Tests
`TemplateSourceMarkerTest` — the marker is emitted for a rendered template and precedes its document.

## Docs
`cli-parity.adoc` gains a `template` section noting the markers; the render-control flags remain tracked under #679 "Other known gaps".

Part of #679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)