### PR TITLE
feat(cli): template --show-only / --output-dir / --skip-tests (#679)

### DIFF
--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -81,11 +81,19 @@ array when `--show-resources` is set); `history -o json|yaml` emits the Helm his
 
 == template
 
-`jhelm template` renders to stdout like `helm template`, and now emits a Helm-style
+`jhelm template` renders to stdout like `helm template`, and emits a Helm-style
 `# Source: <chart>/templates/<file>` marker before each document, so the output records which
-template produced each manifest (and downstream tooling can split by source). The
-render-control flags (`-s`/`--show-only`, `--output-dir`, `--include-crds`, `--skip-tests`,
-`--is-upgrade`) are still being wired — see "Other known gaps".
+template produced each manifest.
+
+[cols="2,1,3"]
+|===
+| Helm flag | jhelm | Notes
+
+| `-s`, `--show-only` | ✅ | Repeatable; keeps only documents rendered from the named template(s) (e.g. `templates/deployment.yaml`), matched by trailing path segment. Errors if a requested template matches nothing, like Helm.
+| `--output-dir` | ✅ | Writes each document to `<dir>/<chart>/templates/<file>` (grouped by source) instead of stdout, printing one `wrote <path>` line per file.
+| `--skip-tests` | ✅ | Drops documents carrying a `helm.sh/hook: test` annotation.
+| `--include-crds`, `--is-upgrade` | ✗ | Still being wired — see "Other known gaps".
+|===
 
 == repo / registry / pull
 
@@ -124,8 +132,8 @@ Most scripts work unchanged. Watch for these deliberate differences:
 Beyond the per-command tables above, these commonly-used Helm options are not yet wired
 (tracked for follow-up):
 
-* *`template`* — `-s`/`--show-only`, `--output-dir`, `--include-crds`, `--skip-tests`,
-  `--is-upgrade`.
+* *`template`* — `--include-crds`, `--is-upgrade` (`-s`/`--show-only`, `--output-dir`,
+  `--skip-tests` are now supported — see the `template` section).
 * *`list`* — `-A`/`--all-namespaces`, `-l`/`--selector`, `-a`/`--all`, the status filters,
   `--max`/`--offset`/`--filter`.
 * *`install`/`upgrade`* — install-from-repo (`--version`/`--repo`/`--username`/`--password`),

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
@@ -1,5 +1,9 @@
 package org.alexmond.jhelm.app.command;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -11,6 +15,7 @@ import org.alexmond.jhelm.core.action.TemplateAction;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
+import org.alexmond.jhelm.core.util.RenderedManifest;
 import org.alexmond.jhelm.core.util.ValuesOverrides;
 import org.alexmond.jhelm.core.util.ValuesProfiles;
 import org.springframework.stereotype.Component;
@@ -76,6 +81,17 @@ public class TemplateCommand implements Callable<Integer> {
 					+ "(comma-separated or repeatable; additive to the built-in default set)")
 	private List<String> apiVersions = new ArrayList<>();
 
+	@Option(names = { "-s", "--show-only" }, description = "only show manifests rendered from the given template(s) "
+			+ "(e.g. templates/deployment.yaml; repeatable)")
+	private List<String> showOnly = new ArrayList<>();
+
+	@Option(names = { "--output-dir" },
+			description = "write the rendered templates into files under this directory instead of stdout")
+	private String outputDir;
+
+	@Option(names = { "--skip-tests" }, description = "skip tests from the rendered output (chart test hooks)")
+	private boolean skipTests;
+
 	/**
 	 * Creates the command.
 	 * @param templateAction the action that renders chart templates
@@ -105,12 +121,38 @@ public class TemplateCommand implements Callable<Integer> {
 			for (String renderer : postRenderers) {
 				manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
 			}
-			CliOutput.println(manifest);
+			if (skipTests) {
+				manifest = RenderedManifest.skipTests(manifest);
+			}
+			if (!showOnly.isEmpty()) {
+				manifest = RenderedManifest.showOnly(manifest, showOnly);
+			}
+			if (outputDir != null) {
+				writeToDir(manifest);
+			}
+			else {
+				CliOutput.println(manifest);
+			}
 			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error rendering template: " + ex.getMessage()));
 			return CommandLine.ExitCode.SOFTWARE;
+		}
+	}
+
+	// Writes each rendered document into <outputDir>/<chart>/templates/<file>, grouping
+	// documents by their source template (as `helm template --output-dir` does), and
+	// prints one
+	// `wrote <path>` line per file.
+	private void writeToDir(String manifest) throws IOException {
+		Path base = Path.of(outputDir);
+		for (Map.Entry<String, String> entry : RenderedManifest.groupBySource(manifest).entrySet()) {
+			String source = entry.getKey();
+			Path target = source.isEmpty() ? base.resolve("manifest.yaml") : base.resolve(source);
+			Files.createDirectories(target.getParent());
+			Files.writeString(target, entry.getValue(), StandardCharsets.UTF_8);
+			CliOutput.println("wrote " + target);
 		}
 	}
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/TemplateCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/TemplateCommandTest.java
@@ -1,5 +1,10 @@
 package org.alexmond.jhelm.app.command;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.alexmond.jhelm.core.action.TemplateAction;
@@ -9,12 +14,15 @@ import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.util.ValuesProfiles;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -72,6 +80,67 @@ class TemplateCommandTest {
 		props.getProfiles().setActive(List.of("dev"));
 		ValuesProfiles captured = runAndCaptureProfiles(props, "-P", "prod", "r", "/chart");
 		assertEquals(List.of("prod"), captured.active(), "--profile takes precedence over the property");
+	}
+
+	private static final String MULTI_DOC = """
+			# Source: mychart/templates/configmap.yaml
+			kind: ConfigMap
+			---
+			# Source: mychart/templates/deployment.yaml
+			kind: Deployment
+			---
+			# Source: mychart/templates/tests/test-connection.yaml
+			kind: Pod
+			metadata:
+			  annotations:
+			    "helm.sh/hook": test
+			""";
+
+	private void stubRender(String manifest) {
+		when(templateAction.render(anyString(), anyString(), anyString(), anyMap(), any(), any(), anyList()))
+			.thenReturn(manifest);
+	}
+
+	@Test
+	void testShowOnlyFiltersRenderedOutput() {
+		stubRender(MULTI_DOC);
+		String out = captureStdout(() -> new CommandLine(templateCommand).execute("r", "/chart", "--show-only",
+				"templates/deployment.yaml"));
+		assertTrue(out.contains("kind: Deployment"), out);
+		assertFalse(out.contains("kind: ConfigMap"), out);
+	}
+
+	@Test
+	void testSkipTestsDropsTestHookDocument() {
+		stubRender(MULTI_DOC);
+		String out = captureStdout(() -> new CommandLine(templateCommand).execute("r", "/chart", "--skip-tests"));
+		assertFalse(out.contains("kind: Pod"), out);
+		assertTrue(out.contains("kind: ConfigMap"), out);
+		assertTrue(out.contains("kind: Deployment"), out);
+	}
+
+	@Test
+	void testOutputDirWritesPerSourceFiles(@TempDir Path dir) throws Exception {
+		stubRender(MULTI_DOC);
+		String out = captureStdout(
+				() -> new CommandLine(templateCommand).execute("r", "/chart", "--output-dir", dir.toString()));
+		Path deployment = dir.resolve("mychart/templates/deployment.yaml");
+		assertTrue(Files.exists(deployment), "expected " + deployment + "; stdout:\n" + out);
+		assertTrue(Files.readString(deployment).contains("kind: Deployment"));
+		assertTrue(out.contains("wrote "), out);
+	}
+
+	private static String captureStdout(Runnable action) {
+		PrintStream original = System.out;
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(buffer, true, StandardCharsets.UTF_8));
+		try {
+			action.run();
+		}
+		finally {
+			System.setOut(original);
+		}
+		return buffer.toString(StandardCharsets.UTF_8);
 	}
 
 	private ValuesProfiles runAndCaptureProfiles(JhelmCoreProperties props, String... args) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/RenderedManifest.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/RenderedManifest.java
@@ -1,0 +1,147 @@
+package org.alexmond.jhelm.core.util;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Post-processes a rendered manifest string using its Helm-style
+ * {@code # Source: <chart>/templates/<file>} markers: filter to selected templates
+ * ({@code --show-only}), drop chart test hooks ({@code --skip-tests}), and group
+ * documents by source template ({@code --output-dir}). The engine emits one
+ * {@code # Source:} marker per template block, so a document produced after an
+ * in-template {@code ---} inherits the marker of the block it belongs to.
+ */
+public final class RenderedManifest {
+
+	private static final Pattern SOURCE = Pattern.compile("(?m)^# Source: (.+)$");
+
+	// Matches the test-hook annotation Helm's `--skip-tests` filters on: `helm.sh/hook:
+	// test`
+	// (and the legacy `test-success` / `test-failure` values), with optional quoting.
+	private static final Pattern TEST_HOOK = Pattern.compile("(?m)helm\\.sh/hook[\"']?\\s*:\\s*[\"']?\\s*test");
+
+	private RenderedManifest() {
+	}
+
+	/**
+	 * Splits a rendered manifest into documents on {@code ---} separators, attributing
+	 * each to its {@code # Source:} marker (a document without its own marker inherits
+	 * the previous one's).
+	 * @param manifest the rendered manifest, or {@code null}
+	 * @return the documents in order (empty if the manifest is blank)
+	 */
+	public static List<Document> parse(String manifest) {
+		List<Document> docs = new ArrayList<>();
+		if (manifest == null || manifest.isBlank()) {
+			return docs;
+		}
+		String lastSource = null;
+		for (String chunk : manifest.split("\\r?\\n---\\r?\\n")) {
+			if (chunk.isBlank()) {
+				continue;
+			}
+			Matcher matcher = SOURCE.matcher(chunk);
+			String source = matcher.find() ? matcher.group(1).trim() : lastSource;
+			lastSource = source;
+			docs.add(new Document(source, chunk.strip()));
+		}
+		return docs;
+	}
+
+	/**
+	 * Joins documents back into a manifest string, separating them with {@code ---} and
+	 * no trailing separator (matching the engine's cleaned output).
+	 * @param docs the documents to join
+	 * @return the joined manifest
+	 */
+	public static String join(List<Document> docs) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < docs.size(); i++) {
+			if (i > 0) {
+				sb.append("---\n");
+			}
+			sb.append(docs.get(i).text()).append('\n');
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Keeps only the documents whose source matches one of the requested template paths.
+	 * A request matches a source when it equals the full source path or is a trailing
+	 * path segment of it (so {@code templates/foo.yaml} selects
+	 * {@code mychart/templates/foo.yaml}). Mirrors {@code helm template --show-only},
+	 * including its error when a requested template matches nothing.
+	 * @param manifest the rendered manifest
+	 * @param templates the requested template paths (repeatable {@code --show-only}
+	 * values)
+	 * @return the filtered manifest, documents ordered by the request order
+	 * @throws IllegalArgumentException if a requested template matches no rendered
+	 * document
+	 */
+	public static String showOnly(String manifest, List<String> templates) {
+		List<Document> docs = parse(manifest);
+		List<Document> selected = new ArrayList<>();
+		for (String request : templates) {
+			String normalized = request.replace('\\', '/').strip();
+			List<Document> matches = docs.stream().filter((doc) -> matchesSource(doc.source(), normalized)).toList();
+			if (matches.isEmpty()) {
+				throw new IllegalArgumentException("could not find template " + request + " in chart");
+			}
+			selected.addAll(matches);
+		}
+		return join(selected);
+	}
+
+	private static boolean matchesSource(String source, String request) {
+		if (source == null) {
+			return false;
+		}
+		return source.equals(request) || source.endsWith("/" + request);
+	}
+
+	/**
+	 * Drops documents carrying a Helm test-hook annotation ({@code helm.sh/hook: test}),
+	 * mirroring {@code helm template --skip-tests}.
+	 * @param manifest the rendered manifest
+	 * @return the manifest with test-hook documents removed
+	 */
+	public static String skipTests(String manifest) {
+		List<Document> kept = parse(manifest).stream().filter((doc) -> !TEST_HOOK.matcher(doc.text()).find()).toList();
+		return join(kept);
+	}
+
+	/**
+	 * Groups the manifest's documents by source template path, preserving order, so each
+	 * group can be written to its own file under an output directory. Documents without a
+	 * source are grouped under the empty key.
+	 * @param manifest the rendered manifest
+	 * @return an ordered map of source path to the joined documents rendered from it
+	 */
+	public static Map<String, String> groupBySource(String manifest) {
+		Map<String, List<Document>> bySource = new LinkedHashMap<>();
+		for (Document doc : parse(manifest)) {
+			bySource.computeIfAbsent((doc.source() != null) ? doc.source() : "", (key) -> new ArrayList<>()).add(doc);
+		}
+		Map<String, String> result = new LinkedHashMap<>();
+		bySource.forEach((source, docs) -> result.put(source, join(docs)));
+		return result;
+	}
+
+	/**
+	 * A single manifest document: the source template path it was rendered from (may be
+	 * {@code null} for content emitted without a marker) and its full text including the
+	 * marker line.
+	 *
+	 * @param source the {@code <chart>/templates/<file>} path, or {@code null} if
+	 * unattributed
+	 * @param text the document text (marker line included), stripped of surrounding
+	 * whitespace
+	 */
+	public record Document(String source, String text) {
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/RenderedManifestTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/RenderedManifestTest.java
@@ -1,0 +1,106 @@
+package org.alexmond.jhelm.core.util;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RenderedManifestTest {
+
+	private static final String MANIFEST = """
+			# Source: mychart/templates/configmap.yaml
+			apiVersion: v1
+			kind: ConfigMap
+			metadata:
+			  name: cm
+			---
+			# Source: mychart/templates/deployment.yaml
+			apiVersion: apps/v1
+			kind: Deployment
+			metadata:
+			  name: dep
+			---
+			# Source: mychart/templates/tests/test-connection.yaml
+			apiVersion: v1
+			kind: Pod
+			metadata:
+			  name: test
+			  annotations:
+			    "helm.sh/hook": test
+			""";
+
+	@Test
+	void testParseAttributesEachDocumentToItsSource() {
+		List<RenderedManifest.Document> docs = RenderedManifest.parse(MANIFEST);
+		assertEquals(3, docs.size());
+		assertEquals("mychart/templates/configmap.yaml", docs.get(0).source());
+		assertEquals("mychart/templates/deployment.yaml", docs.get(1).source());
+		assertEquals("mychart/templates/tests/test-connection.yaml", docs.get(2).source());
+	}
+
+	@Test
+	void testParseCarriesSourceForwardToUnmarkedDocuments() {
+		// A template that emits two documents gets one marker; the second inherits it.
+		String multi = """
+				# Source: c/templates/multi.yaml
+				kind: A
+				---
+				kind: B
+				""";
+		List<RenderedManifest.Document> docs = RenderedManifest.parse(multi);
+		assertEquals(2, docs.size());
+		assertEquals("c/templates/multi.yaml", docs.get(0).source());
+		assertEquals("c/templates/multi.yaml", docs.get(1).source());
+	}
+
+	@Test
+	void testShowOnlyMatchesByTrailingPathSegment() {
+		String out = RenderedManifest.showOnly(MANIFEST, List.of("templates/deployment.yaml"));
+		assertTrue(out.contains("kind: Deployment"), out);
+		assertFalse(out.contains("kind: ConfigMap"), out);
+		assertTrue(out.contains("# Source: mychart/templates/deployment.yaml"), out);
+	}
+
+	@Test
+	void testShowOnlyMatchesFullSourcePath() {
+		String out = RenderedManifest.showOnly(MANIFEST, List.of("mychart/templates/configmap.yaml"));
+		assertTrue(out.contains("kind: ConfigMap"), out);
+		assertFalse(out.contains("kind: Deployment"), out);
+	}
+
+	@Test
+	void testShowOnlyOrdersByRequest() {
+		String out = RenderedManifest.showOnly(MANIFEST,
+				List.of("templates/deployment.yaml", "templates/configmap.yaml"));
+		assertTrue(out.indexOf("kind: Deployment") < out.indexOf("kind: ConfigMap"), out);
+	}
+
+	@Test
+	void testShowOnlyThrowsWhenTemplateMatchesNothing() {
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> RenderedManifest.showOnly(MANIFEST, List.of("templates/missing.yaml")));
+		assertTrue(ex.getMessage().contains("templates/missing.yaml"), ex.getMessage());
+	}
+
+	@Test
+	void testSkipTestsDropsHookTestDocuments() {
+		String out = RenderedManifest.skipTests(MANIFEST);
+		assertFalse(out.contains("kind: Pod"), out);
+		assertTrue(out.contains("kind: ConfigMap"), out);
+		assertTrue(out.contains("kind: Deployment"), out);
+	}
+
+	@Test
+	void testGroupBySourceKeysByTemplatePath() {
+		Map<String, String> grouped = RenderedManifest.groupBySource(MANIFEST);
+		assertEquals(3, grouped.size());
+		assertTrue(grouped.containsKey("mychart/templates/deployment.yaml"));
+		assertTrue(grouped.get("mychart/templates/deployment.yaml").contains("kind: Deployment"));
+	}
+
+}


### PR DESCRIPTION
Second slice of #679, building on the `# Source:` markers merged in #688.

## What
A reusable `RenderedManifest` util in **jhelm-core** parses a rendered manifest by its `# Source:` markers, plus three Helm `template` flags wired into `TemplateCommand`:

- **`-s`/`--show-only`** (repeatable) — keep only documents from the named template(s), matched by trailing path segment (`templates/deployment.yaml` selects `mychart/templates/deployment.yaml`). Errors if a request matches nothing, like Helm.
- **`--output-dir`** — write each document to `<dir>/<chart>/templates/<file>` (grouped by source) instead of stdout, printing one `wrote <path>` line per file.
- **`--skip-tests`** — drop documents annotated `helm.sh/hook: test`.

The util lives in jhelm-core (not the CLI) so **#686** can reuse it for the REST/MCP `template` surface.

## Not in this slice
`--include-crds` and `--is-upgrade` need render-context/engine changes — next slice of #679.

## Tests
- `RenderedManifestTest` — parse (incl. source carry-forward for multi-doc templates), show-only (trailing-segment + full-path match, request ordering, match-nothing error), skip-tests, group-by-source.
- `TemplateCommandTest` — `--show-only`, `--skip-tests`, `--output-dir` (writes per-source files under a `@TempDir`).

## Docs
`cli-parity.adoc` gains a `template` flag table; the gaps list trims to the two remaining flags.

Part of #679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)