### PR TITLE
feat(cli): template --include-crds / --is-upgrade (#679)

### DIFF
--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -92,7 +92,8 @@ template produced each manifest.
 | `-s`, `--show-only` | ✅ | Repeatable; keeps only documents rendered from the named template(s) (e.g. `templates/deployment.yaml`), matched by trailing path segment. Errors if a requested template matches nothing, like Helm.
 | `--output-dir` | ✅ | Writes each document to `<dir>/<chart>/templates/<file>` (grouped by source) instead of stdout, printing one `wrote <path>` line per file.
 | `--skip-tests` | ✅ | Drops documents carrying a `helm.sh/hook: test` annotation.
-| `--include-crds`, `--is-upgrade` | ✗ | Still being wired — see "Other known gaps".
+| `--include-crds` | ✅ | Prepends the chart's top-level `crds/` manifests (un-templated, as Helm renders them), each with its own `# Source:` marker. Helm excludes CRDs from `template` by default.
+| `--is-upgrade` | ✅ | Renders with `.Release.IsUpgrade=true` / `.Release.IsInstall=false` (the default posture is install).
 |===
 
 == repo / registry / pull
@@ -132,8 +133,6 @@ Most scripts work unchanged. Watch for these deliberate differences:
 Beyond the per-command tables above, these commonly-used Helm options are not yet wired
 (tracked for follow-up):
 
-* *`template`* — `--include-crds`, `--is-upgrade` (`-s`/`--show-only`, `--output-dir`,
-  `--skip-tests` are now supported — see the `template` section).
 * *`list`* — `-A`/`--all-namespaces`, `-l`/`--selector`, `-a`/`--all`, the status filters,
   `--max`/`--offset`/`--filter`.
 * *`install`/`upgrade`* — install-from-repo (`--version`/`--repo`/`--username`/`--password`),

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
@@ -92,6 +92,13 @@ public class TemplateCommand implements Callable<Integer> {
 	@Option(names = { "--skip-tests" }, description = "skip tests from the rendered output (chart test hooks)")
 	private boolean skipTests;
 
+	@Option(names = { "--include-crds" }, description = "include CRDs (the chart's crds/ manifests) in the output")
+	private boolean includeCrds;
+
+	@Option(names = { "--is-upgrade" },
+			description = "set .Release.IsUpgrade instead of .Release.IsInstall when rendering")
+	private boolean isUpgrade;
+
 	/**
 	 * Creates the command.
 	 * @param templateAction the action that renders chart templates
@@ -117,7 +124,7 @@ public class TemplateCommand implements Callable<Integer> {
 					configServer.overrideNone(), configServer.overrideSystemProperties(), setValues, setStringValues,
 					setFileValues, setJsonValues);
 			String manifest = templateAction.render(chartPath, name, namespace, overrides, profiles, kubeVersion,
-					apiVersions);
+					apiVersions, isUpgrade, includeCrds);
 			for (String renderer : postRenderers) {
 				manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
 			}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/TemplateCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/TemplateCommandTest.java
@@ -24,9 +24,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class TemplateCommandTest {
@@ -97,8 +99,37 @@ class TemplateCommandTest {
 			""";
 
 	private void stubRender(String manifest) {
-		when(templateAction.render(anyString(), anyString(), anyString(), anyMap(), any(), any(), anyList()))
+		when(templateAction.render(anyString(), anyString(), anyString(), anyMap(), any(), any(), anyList(),
+				anyBoolean(), anyBoolean()))
 			.thenReturn(manifest);
+	}
+
+	@Test
+	void testIncludeCrdsAndIsUpgradeReachTheAction() {
+		stubRender(MULTI_DOC);
+		ArgumentCaptor<Boolean> isUpgrade = ArgumentCaptor.forClass(Boolean.class);
+		ArgumentCaptor<Boolean> includeCrds = ArgumentCaptor.forClass(Boolean.class);
+
+		new CommandLine(templateCommand).execute("r", "/chart", "--is-upgrade", "--include-crds");
+
+		verify(templateAction).render(anyString(), anyString(), anyString(), anyMap(), any(), any(), anyList(),
+				isUpgrade.capture(), includeCrds.capture());
+		assertEquals(true, isUpgrade.getValue());
+		assertEquals(true, includeCrds.getValue());
+	}
+
+	@Test
+	void testRenderControlFlagsDefaultFalse() {
+		stubRender(MULTI_DOC);
+		ArgumentCaptor<Boolean> isUpgrade = ArgumentCaptor.forClass(Boolean.class);
+		ArgumentCaptor<Boolean> includeCrds = ArgumentCaptor.forClass(Boolean.class);
+
+		new CommandLine(templateCommand).execute("r", "/chart");
+
+		verify(templateAction).render(anyString(), anyString(), anyString(), anyMap(), any(), any(), anyList(),
+				isUpgrade.capture(), includeCrds.capture());
+		assertEquals(false, isUpgrade.getValue());
+		assertEquals(false, includeCrds.getValue());
 	}
 
 	@Test
@@ -147,7 +178,8 @@ class TemplateCommandTest {
 		TemplateCommand command = new TemplateCommand(templateAction, props,
 				new ConfigServerValuesLoader(new ConfigServerProperties(), null));
 		ArgumentCaptor<ValuesProfiles> captor = ArgumentCaptor.forClass(ValuesProfiles.class);
-		when(templateAction.render(anyString(), anyString(), anyString(), anyMap(), captor.capture(), any(), anyList()))
+		when(templateAction.render(anyString(), anyString(), anyString(), anyMap(), captor.capture(), any(), anyList(),
+				anyBoolean(), anyBoolean()))
 			.thenReturn("---\n");
 		new CommandLine(command).execute(args);
 		return captor.getValue();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
@@ -75,6 +75,32 @@ public class TemplateAction {
 	 */
 	public String render(String chartPath, String releaseName, String namespace, Map<String, Object> overrides,
 			ValuesProfiles profiles, String kubeVersion, List<String> apiVersions) {
+		return render(chartPath, releaseName, namespace, overrides, profiles, kubeVersion, apiVersions, false, false);
+	}
+
+	/**
+	 * Renders a chart with the full set of {@code helm template} controls: active value
+	 * profiles, an explicit {@code .Capabilities} override, the install/upgrade posture
+	 * ({@code .Release.IsInstall}/{@code .Release.IsUpgrade}), and optional inclusion of
+	 * the chart's un-templated {@code crds/} manifests.
+	 * @param chartPath path to the chart directory or archive
+	 * @param releaseName the release name ({@code .Release.Name})
+	 * @param namespace the release namespace
+	 * @param overrides value overrides merged over the chart defaults
+	 * @param profiles the active value profiles
+	 * @param kubeVersion the {@code .Capabilities.KubeVersion} override, or {@code null}
+	 * for the engine default
+	 * @param apiVersions extra API group/versions for
+	 * {@code .Capabilities.APIVersions.Has}
+	 * @param isUpgrade render as an upgrade ({@code .Release.IsUpgrade=true},
+	 * {@code IsInstall=false}) instead of the default install posture
+	 * @param includeCrds prepend the chart's {@code crds/} manifests to the output (Helm
+	 * excludes them from {@code template} by default)
+	 * @return the rendered manifest
+	 */
+	public String render(String chartPath, String releaseName, String namespace, Map<String, Object> overrides,
+			ValuesProfiles profiles, String kubeVersion, List<String> apiVersions, boolean isUpgrade,
+			boolean includeCrds) {
 		Chart chart = this.chartLoader.load(new File(chartPath), profiles);
 
 		Map<String, Object> values = new HashMap<>(chart.getValues());
@@ -84,12 +110,15 @@ public class TemplateAction {
 		ReleaseContext releaseContext = ReleaseContext.builder()
 			.name(releaseName)
 			.namespace(namespace)
-			.install(true)
-			.upgrade(false)
+			.install(!isUpgrade)
+			.upgrade(isUpgrade)
 			.revision(1)
 			.build();
 
 		String manifest = engine.render(chart, values, releaseContext, new Capabilities(kubeVersion, apiVersions));
+		if (includeCrds) {
+			manifest = renderCrds(chart) + manifest;
+		}
 
 		for (PostRenderProcessor processor : postRenderProcessors) {
 			try {
@@ -101,6 +130,24 @@ public class TemplateAction {
 		}
 
 		return manifest;
+	}
+
+	// Emits the chart's crds/ manifests as un-templated documents, each with a Helm-style
+	// `# Source: <chart>/crds/<file>` marker, matching `helm template --include-crds`.
+	// CRDs are
+	// raw YAML in Helm — they are not run through the template engine.
+	private String renderCrds(Chart chart) {
+		StringBuilder sb = new StringBuilder();
+		String chartName = chart.getMetadata().getName();
+		for (Chart.Crd crd : chart.getCrds()) {
+			String data = crd.getData().strip();
+			if (data.isEmpty()) {
+				continue;
+			}
+			sb.append("# Source: ").append(chartName).append("/crds/").append(crd.getName()).append('\n');
+			sb.append(data).append("\n---\n");
+		}
+		return sb.toString();
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/TemplateActionRenderControlTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/TemplateActionRenderControlTest.java
@@ -1,0 +1,84 @@
+package org.alexmond.jhelm.core.action;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.Engine;
+import org.alexmond.jhelm.core.util.ValuesProfiles;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Real-engine coverage for the {@code --include-crds} and {@code --is-upgrade} render
+ * controls on {@link TemplateAction}.
+ */
+class TemplateActionRenderControlTest {
+
+	private final TemplateAction templateAction = new TemplateAction(new Engine(), new ChartLoader());
+
+	@TempDir
+	Path chartDir;
+
+	@BeforeEach
+	void writeChart() throws Exception {
+		Files.writeString(chartDir.resolve("Chart.yaml"), """
+				apiVersion: v2
+				name: crdchart
+				version: 1.0.0
+				""");
+		Path templates = Files.createDirectories(chartDir.resolve("templates"));
+		Files.writeString(templates.resolve("cm.yaml"), """
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: cm
+				data:
+				  upgrade: "{{ .Release.IsUpgrade }}"
+				""");
+		Path crds = Files.createDirectories(chartDir.resolve("crds"));
+		Files.writeString(crds.resolve("widget.yaml"), """
+				apiVersion: apiextensions.k8s.io/v1
+				kind: CustomResourceDefinition
+				metadata:
+				  name: widgets.example.com
+				""");
+	}
+
+	private String render(boolean isUpgrade, boolean includeCrds) {
+		return templateAction.render(chartDir.toString(), "r", "default", new HashMap<>(), ValuesProfiles.none(), null,
+				List.of(), isUpgrade, includeCrds);
+	}
+
+	@Test
+	void testCrdsExcludedByDefault() {
+		String manifest = render(false, false);
+		assertFalse(manifest.contains("CustomResourceDefinition"), manifest);
+		assertTrue(manifest.contains("kind: ConfigMap"), manifest);
+	}
+
+	@Test
+	void testIncludeCrdsEmitsCrdWithSourceMarker() {
+		String manifest = render(false, true);
+		assertTrue(manifest.contains("# Source: crdchart/crds/widget.yaml"), manifest);
+		assertTrue(manifest.contains("kind: CustomResourceDefinition"), manifest);
+		assertTrue(manifest.contains("kind: ConfigMap"), manifest);
+	}
+
+	@Test
+	void testIsInstallByDefault() {
+		assertTrue(render(false, false).contains("upgrade: \"false\""), "default posture is install");
+	}
+
+	@Test
+	void testIsUpgradeFlipsReleaseFlag() {
+		assertTrue(render(true, false).contains("upgrade: \"true\""), "--is-upgrade sets .Release.IsUpgrade");
+	}
+
+}


### PR DESCRIPTION
Final slice of #679 (closes it). Builds on #688 (Source markers) and #689 (show-only/output-dir/skip-tests).

## What
A new `TemplateAction.render` overload carries the install/upgrade posture and CRD inclusion; two flags wired in `TemplateCommand`:

- **`--is-upgrade`** — render with `.Release.IsUpgrade=true` / `.Release.IsInstall=false` (default posture stays install).
- **`--include-crds`** — prepend the chart's top-level `crds/` manifests, **un-templated** (Helm does not run CRDs through the template engine), each with its own `# Source: <chart>/crds/<file>` marker. Helm excludes CRDs from `template` by default, which jhelm already did.

The existing 7-arg `render` delegates to the new 9-arg overload with `(false, false)`, so **REST/MCP callers are unaffected** (their CRD/posture support lands in #686).

## Tests
- `TemplateActionRenderControlTest` — real engine over a `@TempDir` chart with a `crds/` dir and an `.Release.IsUpgrade` template: CRDs excluded by default / included with the marker; install-vs-upgrade posture flips `.Release.IsUpgrade`.
- `TemplateCommandTest` — both flags reach the action and default to `false`.

## Docs
`cli-parity.adoc` template table completed; the template entry in "Other known gaps" is removed (all its flags now supported).

## Scope note
`--include-crds` emits the **top-level** chart's `crds/`. Subchart CRD aggregation can follow if a chart needs it.

Closes #679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)