### PR TITLE
feat(cli): install -g/--generate-name (#680)

### DIFF
--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -30,7 +30,8 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | `--wait-for-jobs` | ✅ | Accepted for Helm compatibility; implies `--wait`. jhelm's `--wait` already waits for Job completion.
 | `-o`, `--output` | ✅ | `table` (default human summary), `json`, `yaml`. JSON/YAML emit the Helm-shaped release object (nested `info`, snake_case keys).
 | `--version`, `--repo`, `--username`/`--password` (install from a repo) | ✗ | Install from an added repo/OCI ref; inline repo+auth flags aren't wired.
-| `-g`/`--generate-name`, `--description`, `--labels`, `--set-literal`, `--dependency-update` | ✗ | Not yet wired; the release name is a required positional.
+| `-g`, `--generate-name` (install) | ✅ | Omit the NAME positional and pass `-g` to auto-generate `<chart>-<timestamp>` (like Helm). Errors if both a name and `-g` are given, or if neither is.
+| `--description`, `--labels`, `--set-literal`, `--dependency-update` | ✗ | Not yet wired.
 |===
 
 == uninstall
@@ -136,8 +137,8 @@ Beyond the per-command tables above, these commonly-used Helm options are not ye
 * *`list`* — `-A`/`--all-namespaces`, `-l`/`--selector`, `-a`/`--all`, the status filters,
   `--max`/`--offset`/`--filter`.
 * *`install`/`upgrade`* — install-from-repo (`--version`/`--repo`/`--username`/`--password`),
-  `-g`/`--generate-name`, `--description`, `--labels`, `--set-literal`, `--dependency-update`;
-  `upgrade --cleanup-on-fail`.
+  `--description`, `--labels`, `--set-literal`, `--dependency-update`;
+  `upgrade --cleanup-on-fail`. (`-g`/`--generate-name` is now supported on `install`.)
 * *`uninstall`/`rollback`* — `--wait`/`--timeout`/`--cascade` (uninstall);
   `--force`/`--cleanup-on-fail`/`--recreate-pods`/`--wait-for-jobs` (rollback).
 * *`pull`* — `--untar`/`--untardir`, `--verify`/`--prov`/`--keyring`, `--devel`.

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -20,6 +20,7 @@ import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
 import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.core.util.ReleaseNames;
 import org.alexmond.jhelm.core.util.ValuesOverrides;
 import org.alexmond.jhelm.core.util.ValuesProfiles;
 import org.springframework.stereotype.Component;
@@ -53,11 +54,20 @@ public class InstallCommand implements Callable<Integer> {
 	@CommandLine.Mixin
 	private final ConfigServerCliOptions configServerOptions = new ConfigServerCliOptions();
 
-	@CommandLine.Parameters(index = "0", description = "release name")
+	@CommandLine.Parameters(arity = "1..2", paramLabel = "[NAME] CHART",
+			description = "release name (optional with -g/--generate-name) followed by the chart path")
+	private List<String> nameAndChart = new ArrayList<>();
+
+	// Resolved from nameAndChart at the start of call(): the release name (or a generated
+	// one)
+	// and the chart path.
 	private String name;
 
-	@CommandLine.Parameters(index = "1", description = "chart path")
 	private String chartPath;
+
+	@Option(names = { "-g", "--generate-name" },
+			description = "generate the release name (as <chart>-<timestamp>); the NAME positional is then omitted")
+	private boolean generateName;
 
 	@Option(names = { "--verify" }, description = "verify the packaged chart's provenance before installing")
 	private boolean verify;
@@ -148,13 +158,19 @@ public class InstallCommand implements Callable<Integer> {
 		if (MutatingGuard.blocked(securityPolicy)) {
 			return CommandLine.ExitCode.SOFTWARE;
 		}
+		if (!resolvePositionals()) {
+			return CommandLine.ExitCode.USAGE;
+		}
 		try {
 			boolean dryRunEnabled = resolveDryRun();
 			ValuesProfiles profiles = ValuesProfiles
 				.of(profileNames.isEmpty() ? coreProperties.getProfiles().getActive() : profileNames);
+			Chart chart = chartResolver.resolve(chartPath, verify, keyring, profiles);
+			if (name == null) {
+				name = ReleaseNames.generateName(chart.getMetadata().getName());
+			}
 			ConfigServerValuesLoader.Result configServer = configServerValuesLoader.load(name, profiles.active(),
 					configServerOptions.toOptions());
-			Chart chart = chartResolver.resolve(chartPath, verify, keyring, profiles);
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, profiles, configServer.values(),
 					configServer.overrideNone(), configServer.overrideSystemProperties(), setValues, setStringValues,
 					setFileValues, setJsonValues);
@@ -176,28 +192,7 @@ public class InstallCommand implements Callable<Integer> {
 				kubeService.waitForReady(namespace, release.getManifest(), timeout);
 			}
 
-			if (OutputFormat.isJson(output) || OutputFormat.isYaml(output)) {
-				Map<String, Object> map = OutputFormat.release(release);
-				if (OutputFormat.isJson(output)) {
-					System.out.println(OutputFormat.json(map));
-				}
-				else {
-					System.out.print(OutputFormat.yaml(map));
-				}
-				return CommandLine.ExitCode.OK;
-			}
-
-			if (dryRunEnabled) {
-				CliOutput.println(CliOutput.bold("NAME:") + " " + release.getName());
-				CliOutput.println(CliOutput.bold("LAST DEPLOYED:") + " " + release.getInfo().getLastDeployed());
-				CliOutput.println(CliOutput.bold("NAMESPACE:") + " " + release.getNamespace());
-				CliOutput.println(CliOutput.bold("STATUS:") + " " + release.getInfo().getStatus().getValue());
-				CliOutput.println(CliOutput.bold("REVISION:") + " " + release.getVersion());
-				CliOutput.println("\n" + CliOutput.bold("MANIFEST:") + "\n" + release.getManifest());
-			}
-			else {
-				CliOutput.println(CliOutput.success("Release \"" + name + "\" has been installed."));
-			}
+			emitResult(release, dryRunEnabled);
 			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
@@ -221,6 +216,57 @@ public class InstallCommand implements Callable<Integer> {
 			}
 			return CommandLine.ExitCode.SOFTWARE;
 		}
+	}
+
+	// Emits the install result: the Helm-shaped release object for -o json|yaml, else the
+	// human dry-run summary or the success line.
+	private void emitResult(Release release, boolean dryRunEnabled) {
+		if (OutputFormat.isJson(output) || OutputFormat.isYaml(output)) {
+			Map<String, Object> map = OutputFormat.release(release);
+			if (OutputFormat.isJson(output)) {
+				System.out.println(OutputFormat.json(map));
+			}
+			else {
+				System.out.print(OutputFormat.yaml(map));
+			}
+			return;
+		}
+		if (dryRunEnabled) {
+			CliOutput.println(CliOutput.bold("NAME:") + " " + release.getName());
+			CliOutput.println(CliOutput.bold("LAST DEPLOYED:") + " " + release.getInfo().getLastDeployed());
+			CliOutput.println(CliOutput.bold("NAMESPACE:") + " " + release.getNamespace());
+			CliOutput.println(CliOutput.bold("STATUS:") + " " + release.getInfo().getStatus().getValue());
+			CliOutput.println(CliOutput.bold("REVISION:") + " " + release.getVersion());
+			CliOutput.println("\n" + CliOutput.bold("MANIFEST:") + "\n" + release.getManifest());
+		}
+		else {
+			CliOutput.println(CliOutput.success("Release \"" + name + "\" has been installed."));
+		}
+	}
+
+	// Resolves the [NAME] CHART positionals into name/chartPath, honouring
+	// --generate-name.
+	// With --generate-name the NAME is omitted (single positional = chart) and the name
+	// is
+	// generated after the chart is resolved; otherwise both NAME and CHART are required.
+	private boolean resolvePositionals() {
+		if (nameAndChart.size() == 2) {
+			if (generateName) {
+				CliOutput.errPrintln(CliOutput.error("cannot set --generate-name and also specify a release name"));
+				return false;
+			}
+			this.name = nameAndChart.get(0);
+			this.chartPath = nameAndChart.get(1);
+		}
+		else {
+			this.chartPath = nameAndChart.get(0);
+			if (!generateName) {
+				CliOutput.errPrintln(CliOutput.error("must either provide a release name or specify --generate-name"));
+				return false;
+			}
+			this.name = null;
+		}
+		return true;
 	}
 
 	private Release applyCliPostRenderers(Release release) throws IOException {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -125,6 +125,37 @@ class InstallCommandTest {
 	}
 
 	@Test
+	void testGenerateNameProducesNameFromChart() throws Exception {
+		File chartDir = createMockChart();
+		Chart chart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
+			.values(new HashMap<>())
+			.build();
+		when(chartResolver.resolve(anyString(), anyBoolean(), any(), any())).thenReturn(chart);
+		ArgumentCaptor<InstallOptions> captor = ArgumentCaptor.forClass(InstallOptions.class);
+		when(installAction.install(captor.capture())).thenReturn(createMockRelease("mychart-1", 1));
+
+		int exit = new CommandLine(installCommand).execute(chartDir.getAbsolutePath(), "--generate-name");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		assertTrue(captor.getValue().getReleaseName().matches("mychart-\\d+"), captor.getValue().getReleaseName());
+	}
+
+	@Test
+	void testMissingNameWithoutGenerateNameIsUsageError() throws Exception {
+		File chartDir = createMockChart();
+		int exit = new CommandLine(installCommand).execute(chartDir.getAbsolutePath());
+		assertEquals(CommandLine.ExitCode.USAGE, exit);
+	}
+
+	@Test
+	void testGenerateNameConflictsWithExplicitName() throws Exception {
+		File chartDir = createMockChart();
+		int exit = new CommandLine(installCommand).execute("my-release", chartDir.getAbsolutePath(), "--generate-name");
+		assertEquals(CommandLine.ExitCode.USAGE, exit);
+	}
+
+	@Test
 	void testInstallCommandWithDryRun() throws Exception {
 		File chartDir = createMockChart();
 		Release release = createMockRelease("my-release", 1);

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ReleaseNames.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ReleaseNames.java
@@ -1,5 +1,7 @@
 package org.alexmond.jhelm.core.util;
 
+import java.time.Instant;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 /**
@@ -32,6 +34,30 @@ public final class ReleaseNames {
 	private static final Pattern NAMESPACE = Pattern.compile("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$");
 
 	private ReleaseNames() {
+	}
+
+	/**
+	 * Generates a release name for {@code --generate-name}, matching Helm's
+	 * {@code <chart-name>-<unix-timestamp>} scheme. The chart name is lowercased and
+	 * sanitized to RFC-1123, and truncated if needed so the result stays within the
+	 * 53-character limit.
+	 * @param chartName the chart's name, or {@code null}/blank to fall back to
+	 * {@code release}
+	 * @return a valid, unique-ish release name
+	 */
+	public static String generateName(String chartName) {
+		String base = (chartName != null && !chartName.isBlank()) ? chartName.toLowerCase(Locale.ROOT) : "release";
+		base = base.replaceAll("[^a-z0-9.-]", "-");
+		String suffix = "-" + Instant.now().getEpochSecond();
+		int maxBase = MAX_RELEASE_NAME - suffix.length();
+		if (base.length() > maxBase) {
+			base = base.substring(0, maxBase);
+		}
+		base = base.replaceAll("[.-]+$", "");
+		if (base.isEmpty()) {
+			base = "release";
+		}
+		return base + suffix;
 	}
 
 	/**

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ReleaseNamesTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ReleaseNamesTest.java
@@ -6,8 +6,28 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ReleaseNamesTest {
+
+	@Test
+	void generateNameUsesChartNameAndTimestamp() {
+		String name = ReleaseNames.generateName("mychart");
+		assertTrue(name.matches("mychart-\\d+"), name);
+		assertDoesNotThrow(() -> ReleaseNames.validateReleaseName(name));
+	}
+
+	@Test
+	void generateNameSanitizesAndBoundsLength() {
+		String name = ReleaseNames.generateName("My_Very-LONG.Chart_Name_" + "x".repeat(80));
+		assertTrue(name.length() <= 53, name);
+		assertDoesNotThrow(() -> ReleaseNames.validateReleaseName(name));
+	}
+
+	@Test
+	void generateNameFallsBackWhenChartNameBlank() {
+		assertTrue(ReleaseNames.generateName("  ").matches("release-\\d+"));
+	}
 
 	@ParameterizedTest
 	@ValueSource(strings = { "myrelease", "release-grafana-grafana", "a", "r1.2.3", "prom-1" })


### PR DESCRIPTION
First slice of #680. The release name was a required positional; Helm lets you omit it and pass `-g`/`--generate-name` to auto-generate one — common in CI and ephemeral installs.

## What
- `ReleaseNames.generateName(chartName)` — mirrors Helm's `<chart>-<unix-timestamp>` scheme, lowercasing/sanitizing to RFC-1123 and bounding to the 53-char limit.
- `InstallCommand` now takes `[NAME] CHART` as a `1..2` positional list: with `-g` the NAME is omitted (single positional = chart) and the name is generated **after** the chart resolves (so the chart's own name is available). Errors if both a name and `-g` are given, or if neither is. **The two-positional form is unchanged** — no regression.

## Tests
- `ReleaseNamesTest` — scheme, sanitize + length bound, blank fallback.
- `InstallCommandTest` — generated name matches `<chart>-<digits>`; missing-name and name+`-g` conflict are USAGE errors.

## Docs
`cli-parity.adoc` install/upgrade table splits `-g` out to ✅; gaps list trimmed.

## Not in this slice
`--description`, `--labels`, `--set-literal`, `--dependency-update` (and `--name-template`) — follow-up slices of #680.

Part of #680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)