### PR TITLE
feat(cli): install --description / --labels (#680)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -1,5 +1,24 @@
 = Changelog
 
+== 1.2.0
+
+Closing CLI flag-parity gaps with Helm across the `template`, `install`, and query commands, so
+more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI Flag Parity].
+
+=== Helm parity
+
+* *Machine-readable output on more commands* -- `-o table\|json\|yaml` now covers `status`,
+  `history`, `install`, `upgrade`, `repo list`, and `search hub`, emitting Helm-shaped output
+  (nested `info`, snake_case keys) for scripts and agents (#678).
+* *`template` source markers* -- rendered manifests carry a Helm-style
+  `# Source: <chart>/templates/<file>` marker before each document (#679).
+* *`template` render-control flags* -- `-s`/`--show-only`, `--output-dir`, `--skip-tests`,
+  `--include-crds`, and `--is-upgrade` (#679).
+* *`install --generate-name`* -- omit the release name and pass `-g`/`--generate-name` to
+  auto-generate `<chart>-<timestamp>`, as Helm does (#680).
+* *`install --description` / `--labels`* -- store a custom release description and custom labels
+  on the release Secret (#680).
+
 == 1.1.0
 
 The first release to extend *beyond Helm parity*: a Spring-Boot-style value-management layer —

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -31,7 +31,9 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | `-o`, `--output` | ✅ | `table` (default human summary), `json`, `yaml`. JSON/YAML emit the Helm-shaped release object (nested `info`, snake_case keys).
 | `--version`, `--repo`, `--username`/`--password` (install from a repo) | ✗ | Install from an added repo/OCI ref; inline repo+auth flags aren't wired.
 | `-g`, `--generate-name` (install) | ✅ | Omit the NAME positional and pass `-g` to auto-generate `<chart>-<timestamp>` (like Helm). Errors if both a name and `-g` are given, or if neither is.
-| `--description`, `--labels`, `--set-literal`, `--dependency-update` | ✗ | Not yet wired.
+| `--description` (install) | ✅ | Custom release description stored on the release (falls back to `Install complete`).
+| `--labels` (install) | ✅ | `key=value` labels (comma-separated or repeatable) added to the release Secret; the reserved `owner`/`name`/`status`/`version` labels are never overridden.
+| `--set-literal`, `--dependency-update` | ✗ | Not yet wired.
 |===
 
 == uninstall
@@ -137,8 +139,8 @@ Beyond the per-command tables above, these commonly-used Helm options are not ye
 * *`list`* — `-A`/`--all-namespaces`, `-l`/`--selector`, `-a`/`--all`, the status filters,
   `--max`/`--offset`/`--filter`.
 * *`install`/`upgrade`* — install-from-repo (`--version`/`--repo`/`--username`/`--password`),
-  `--description`, `--labels`, `--set-literal`, `--dependency-update`;
-  `upgrade --cleanup-on-fail`. (`-g`/`--generate-name` is now supported on `install`.)
+  `--set-literal`, `--dependency-update`; `upgrade --cleanup-on-fail`; `--description`/`--labels`
+  on `upgrade` (supported on `install`). (`-g`/`--generate-name` is supported on `install`.)
 * *`uninstall`/`rollback`* — `--wait`/`--timeout`/`--cascade` (uninstall);
   `--force`/`--cleanup-on-fail`/`--recreate-pods`/`--wait-for-jobs` (rollback).
 * *`pull`* — `--untar`/`--untardir`, `--verify`/`--prov`/`--keyring`, `--devel`.

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.app.command;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -127,6 +128,13 @@ public class InstallCommand implements Callable<Integer> {
 	@CommandLine.Option(names = { "--create-namespace" }, description = "create the release namespace if not present")
 	private boolean createNamespace;
 
+	@Option(names = { "--description" }, description = "custom release description (stored on the release)")
+	private String description;
+
+	@Option(names = { "--labels" }, split = ",",
+			description = "labels to add to the release Secret (key=value, comma-separated or repeatable)")
+	private Map<String, String> labels = new LinkedHashMap<>();
+
 	@CommandLine.Option(names = { "-o", "--output" }, defaultValue = "table",
 			description = "output format: table (default human summary), json, or yaml")
 	private String output;
@@ -185,6 +193,8 @@ public class InstallCommand implements Callable<Integer> {
 				.serverDryRun(serverDryRun)
 				.noHooks(noHooks)
 				.createNamespace(createNamespace)
+				.description(description)
+				.labels(labels)
 				.build());
 			release = applyCliPostRenderers(release);
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -142,6 +142,21 @@ class InstallCommandTest {
 	}
 
 	@Test
+	void testDescriptionAndLabelsReachInstallOptions() throws Exception {
+		File chartDir = createMockChart();
+		ArgumentCaptor<InstallOptions> captor = ArgumentCaptor.forClass(InstallOptions.class);
+		when(installAction.install(captor.capture())).thenReturn(createMockRelease("my-release", 1));
+
+		int exit = new CommandLine(installCommand).execute("my-release", chartDir.getAbsolutePath(), "--description",
+				"my rollout", "--labels", "team=payments,env=prod");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		assertEquals("my rollout", captor.getValue().getDescription());
+		assertEquals("payments", captor.getValue().getLabels().get("team"));
+		assertEquals("prod", captor.getValue().getLabels().get("env"));
+	}
+
+	@Test
 	void testMissingNameWithoutGenerateNameIsUsageError() throws Exception {
 		File chartDir = createMockChart();
 		int exit = new CommandLine(installCommand).execute(chartDir.getAbsolutePath());

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallAction.java
@@ -87,19 +87,24 @@ public class InstallAction {
 		}
 		this.valueEncryptor.decryptValues(values);
 
+		String defaultDescription = options.isDryRun() ? "Dry run complete" : "Install complete";
+		String description = (options.getDescription() != null && !options.getDescription().isBlank())
+				? options.getDescription() : defaultDescription;
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(OffsetDateTime.now())
 			.lastDeployed(OffsetDateTime.now())
 			.status((options.isDryRun()) ? ReleaseStatus.PENDING_INSTALL : ReleaseStatus.DEPLOYED)
-			.description(options.isDryRun() ? "Dry run complete" : "Install complete")
+			.description(description)
 			.build();
 
+		Map<String, String> labels = options.getLabels();
 		Release release = Release.builder()
 			.name(options.getReleaseName())
 			.namespace(options.getNamespace())
 			.version(options.getRevision())
 			.chart(chart)
 			.info(info)
+			.labels((labels != null && !labels.isEmpty()) ? new HashMap<>(labels) : null)
 			// Persist the user-supplied values (Helm's release "config").
 			.config(Release.MapConfig.builder()
 				.values((overrideValues != null) ? new HashMap<>(overrideValues) : new HashMap<>())

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/InstallOptions.java
@@ -62,4 +62,17 @@ public final class InstallOptions {
 	 */
 	private final boolean createNamespace;
 
+	/**
+	 * Custom release description (Helm's {@code --description}). When {@code null} or
+	 * blank, the standard {@code "Install complete"} description is used.
+	 */
+	private final String description;
+
+	/**
+	 * Custom labels to store on the release Secret (Helm's {@code --labels}). Defaults to
+	 * an empty map.
+	 */
+	@Builder.Default
+	private final Map<String, String> labels = Map.of();
+
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Release.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/model/Release.java
@@ -47,6 +47,12 @@ public class Release {
 
 	private String manifest;
 
+	/**
+	 * Custom labels on the release, stored on the {@code sh.helm.release.v1.*} Secret
+	 * (Helm's {@code --labels}). Omitted from the wire format when {@code null}.
+	 */
+	private Map<String, String> labels;
+
 	@JsonPOJOBuilder(withPrefix = "")
 	public static class ReleaseBuilder {
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/InstallActionTest.java
@@ -11,6 +11,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -122,6 +123,46 @@ class InstallActionTest {
 		assertNotNull(release.getConfig());
 		assertEquals(3, release.getConfig().getValues().get("replicaCount"));
 		assertEquals(Map.of("tag", "v2"), release.getConfig().getValues().get("image"));
+	}
+
+	@Test
+	void testInstallAppliesCustomDescriptionAndLabels() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("---\n");
+
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.revision(1)
+			.dryRun(true)
+			.description("initial rollout")
+			.labels(Map.of("team", "payments"))
+			.build());
+
+		assertEquals("initial rollout", release.getInfo().getDescription());
+		assertEquals("payments", release.getLabels().get("team"));
+	}
+
+	@Test
+	void testInstallUsesDefaultDescriptionWhenNoneGiven() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("---\n");
+
+		Release release = installAction.install(InstallOptions.builder()
+			.chart(chart)
+			.releaseName("my-release")
+			.namespace("default")
+			.revision(1)
+			.dryRun(true)
+			.build());
+
+		assertEquals("Dry run complete", release.getInfo().getDescription());
+		assertNull(release.getLabels());
 	}
 
 	@Test

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Objects;
 import java.util.Comparator;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.nio.charset.StandardCharsets;
 
@@ -66,6 +67,10 @@ import java.nio.charset.StandardCharsets;
  */
 @Slf4j
 public class HelmKubeService implements KubeService {
+
+	// Storage labels Helm's own tooling queries on; custom --labels must not override
+	// these.
+	private static final Set<String> RESERVED_RELEASE_LABELS = Set.of("owner", "name", "status", "version");
 
 	/** Configured Kubernetes API client used for all cluster operations. */
 	private final ApiClient apiClient;
@@ -116,14 +121,23 @@ public class HelmKubeService implements KubeService {
 		try {
 			byte[] encoded = encodeRelease(release);
 
-			V1Secret secret = new V1Secret()
-				.metadata(new V1ObjectMeta().name(name)
-					.namespace(release.getNamespace())
-					.putLabelsItem("owner", "helm")
-					.putLabelsItem("name", release.getName())
-					.putLabelsItem("status",
-							(release.getInfo().getStatus() != null) ? release.getInfo().getStatus().getValue() : null)
-					.putLabelsItem("version", String.valueOf(release.getVersion())))
+			V1ObjectMeta metadata = new V1ObjectMeta().name(name)
+				.namespace(release.getNamespace())
+				.putLabelsItem("owner", "helm")
+				.putLabelsItem("name", release.getName())
+				.putLabelsItem("status",
+						(release.getInfo().getStatus() != null) ? release.getInfo().getStatus().getValue() : null)
+				.putLabelsItem("version", String.valueOf(release.getVersion()));
+			// Custom labels (Helm's --labels) are added on top, but never override the
+			// reserved storage labels Helm's own tooling queries on.
+			if (release.getLabels() != null) {
+				release.getLabels().forEach((key, value) -> {
+					if (!RESERVED_RELEASE_LABELS.contains(key)) {
+						metadata.putLabelsItem(key, value);
+					}
+				});
+			}
+			V1Secret secret = new V1Secret().metadata(metadata)
 				.type("helm.sh/release.v1")
 				.putDataItem("release", encoded);
 

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
@@ -52,6 +52,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.zip.GZIPOutputStream;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -185,6 +186,28 @@ class HelmKubeServiceTest {
 
 		kubeService.storeRelease(release);
 		verify(mockCoreV1Api).createNamespacedSecret(eq("default"), any(V1Secret.class));
+	}
+
+	@Test
+	void testStoreReleaseAddsCustomLabelsWithoutOverridingReserved() throws Exception {
+		Release release = createTestRelease("myapp", "default", 1, "deployed").toBuilder()
+			.labels(Map.of("team", "payments", "owner", "not-me"))
+			.build();
+
+		ArgumentCaptor<V1Secret> captor = ArgumentCaptor.forClass(V1Secret.class);
+		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
+			mockCoreV1Api = mock;
+			var req = mock(CoreV1Api.APIcreateNamespacedSecretRequest.class);
+			when(req.execute()).thenReturn(new V1Secret());
+			when(mock.createNamespacedSecret(eq("default"), any(V1Secret.class))).thenReturn(req);
+		});
+
+		kubeService.storeRelease(release);
+
+		verify(mockCoreV1Api).createNamespacedSecret(eq("default"), captor.capture());
+		Map<String, String> secretLabels = captor.getValue().getMetadata().getLabels();
+		assertEquals("payments", secretLabels.get("team"), "custom label is stored");
+		assertEquals("helm", secretLabels.get("owner"), "reserved 'owner' label is not overridden by --labels");
 	}
 
 	@Test


### PR DESCRIPTION
Second slice of #680. Helm lets `install` stamp a custom release description and custom labels on the release storage Secret; jhelm hardcoded the description and had no labels.

## What
- `Release` gains a `labels` map — Helm's wire-format field, omitted when null (round-trips with `helm`).
- `InstallOptions` carries `description` + `labels`; `InstallAction` uses the custom description when given (else the standard default) and sets release labels.
- `HelmKubeService.storeRelease` adds custom labels to the Secret metadata but **never overrides** the reserved `owner`/`name`/`status`/`version` labels Helm's tooling queries on.
- `InstallCommand` adds `--description` and `--labels key=val` (comma-separated or repeatable).

## Changelog
Starts the **1.2.0** changelog section with this session's parity work (next release is 1.2.0).

## Tests
- `InstallActionTest` — custom + default description, labels on the release.
- `HelmKubeServiceTest` — custom labels land on the Secret; reserved labels are not overridden.
- `InstallCommandTest` — both flags reach `InstallOptions`.

## Scope note
This slice is `install`-only; `upgrade --description`/`--labels` and `--set-literal`/`--dependency-update` remain in #680.

Part of #680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)