### PR TITLE
refactor: promote OutputFormat to jhelm-core for REST/MCP reuse (#686)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/HistoryCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/HistoryCommand.java
@@ -2,7 +2,7 @@ package org.alexmond.jhelm.app.command;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
-import org.alexmond.jhelm.app.output.OutputFormat;
+import org.alexmond.jhelm.core.output.OutputFormat;
 import org.alexmond.jhelm.core.action.HistoryAction;
 import org.alexmond.jhelm.core.model.Release;
 import org.springframework.stereotype.Component;

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -9,7 +9,7 @@ import java.util.concurrent.Callable;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
-import org.alexmond.jhelm.app.output.OutputFormat;
+import org.alexmond.jhelm.core.output.OutputFormat;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoCommand.java
@@ -2,7 +2,7 @@ package org.alexmond.jhelm.app.command;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
-import org.alexmond.jhelm.app.output.OutputFormat;
+import org.alexmond.jhelm.core.output.OutputFormat;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.core.model.RepositoryConfig;
 import org.springframework.stereotype.Component;

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchHubCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/SearchHubCommand.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 
 import org.alexmond.jhelm.app.output.CliOutput;
-import org.alexmond.jhelm.app.output.OutputFormat;
+import org.alexmond.jhelm.core.output.OutputFormat;
 import org.alexmond.jhelm.core.action.SearchHubAction;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/StatusCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/StatusCommand.java
@@ -2,7 +2,7 @@ package org.alexmond.jhelm.app.command;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
-import org.alexmond.jhelm.app.output.OutputFormat;
+import org.alexmond.jhelm.core.output.OutputFormat;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.alexmond.jhelm.core.action.StatusAction;

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -9,7 +9,7 @@ import java.util.concurrent.Callable;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
-import org.alexmond.jhelm.app.output.OutputFormat;
+import org.alexmond.jhelm.core.output.OutputFormat;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.RollbackAction;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/output/OutputFormat.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/output/OutputFormat.java
@@ -1,4 +1,4 @@
-package org.alexmond.jhelm.app.output;
+package org.alexmond.jhelm.core.output;
 
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/output/OutputFormatTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/output/OutputFormatTest.java
@@ -1,4 +1,4 @@
-package org.alexmond.jhelm.app.output;
+package org.alexmond.jhelm.core.output;
 
 import java.time.OffsetDateTime;
 import java.util.List;


### PR DESCRIPTION
First slice of #686 — the enabling refactor.

The Helm-shaped output helper (snake_case release/history maps + JSON/YAML mappers) lived in `jhelm-cli`, so only the CLI could produce `helm ... -o json`-shaped output. This moves it to `jhelm-core` (`org.alexmond.jhelm.core.output.OutputFormat`) so **REST and MCP can share the one implementation** — the prerequisite for bringing Helm-shaped output to all three surfaces.

## Pure move
- Identical logic, new package.
- CLI command imports updated (status/history/install/upgrade/repo/search-hub).
- `OutputFormatTest` moved to core alongside it (5 tests, green).
- No behavior change — `OutputFormat` only depends on the core `Release` model + Jackson 3, both already on the core classpath.

## Next slices of #686
- REST: offer the Helm-shaped representation (opt-in, to avoid breaking existing `ReleaseDto` clients) + OpenAPI.
- MCP: return structured Helm-shaped results instead of prose strings.
- Mirror the new CLI options (template flags, install `-g`/`--description`/`--labels`) as REST fields / MCP params.

Part of #686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)