### PR TITLE
feat(mcp): structured Helm-shaped output from release read tools (#686)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -24,6 +24,9 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
   CLI (#686). *Breaking:* clients reading the old fields must migrate (e.g. `status` moves from
   `$.status` to `$.info.status`; list `chartName` becomes `chart`; history `version` becomes
   `revision`).
+* *MCP tools return structured JSON* -- `helm_list`, `helm_status`, and `helm_history` now
+  return Helm-shaped JSON (array of rows / nested `info` object) instead of prose text, so agents
+  can parse them directly (#686).
 
 == 1.1.0
 

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseReadTools.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseReadTools.java
@@ -1,6 +1,7 @@
 package org.alexmond.jhelm.mcp.tools;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.alexmond.jhelm.core.action.HistoryAction;
 import org.alexmond.jhelm.core.action.ListAction;
 import org.alexmond.jhelm.core.action.StatusAction;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.output.OutputFormat;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.McpToolParam;
 
@@ -35,19 +37,12 @@ public class ReleaseReadTools {
 	 * @return a human-readable, newline-separated summary of releases
 	 */
 	@McpTool(name = "helm_list",
-			description = "List the Helm releases deployed in a Kubernetes namespace (like 'helm list'), returning "
-					+ "each release's name, namespace, revision and status. Read-only; does not modify the cluster.")
-	public String list(@McpToolParam(description = "Kubernetes namespace to list releases in") String namespace) {
-		List<Release> releases = this.listAction.list(namespace);
-		if (releases.isEmpty()) {
-			return "No releases found in namespace: " + namespace;
-		}
-		StringBuilder sb = new StringBuilder();
-		sb.append("NAME\tNAMESPACE\tREVISION\tSTATUS\n");
-		for (Release release : releases) {
-			appendReleaseLine(sb, release);
-		}
-		return sb.toString();
+			description = "List the Helm releases deployed in a Kubernetes namespace (like 'helm list -o json'), "
+					+ "returning a JSON array of releases (name, namespace, revision, updated, status, chart, "
+					+ "app_version). Empty array when none. Read-only; does not modify the cluster.")
+	public List<Map<String, Object>> list(
+			@McpToolParam(description = "Kubernetes namespace to list releases in") String namespace) {
+		return this.listAction.list(namespace).stream().map(OutputFormat::listRow).toList();
 	}
 
 	/**
@@ -57,15 +52,15 @@ public class ReleaseReadTools {
 	 * @return a human-readable status summary, or a not-found message
 	 */
 	@McpTool(name = "helm_status",
-			description = "Get the status of a single Helm release (like 'helm status'), including its revision, "
-					+ "deployment status and chart. Read-only; does not modify the cluster.")
-	public String status(@McpToolParam(description = "Release name") String name,
+			description = "Get the status of a single Helm release (like 'helm status -o json') as a JSON object "
+					+ "with nested 'info' (status, description, timestamps), version, namespace and manifest. Returns "
+					+ "an object with an 'error' field when the release is not found. Read-only; does not modify the "
+					+ "cluster.")
+	public Map<String, Object> status(@McpToolParam(description = "Release name") String name,
 			@McpToolParam(description = "Kubernetes namespace") String namespace) {
-		Optional<Release> release = this.statusAction.status(name, namespace);
-		if (release.isEmpty()) {
-			return notFound(name, namespace);
-		}
-		return renderReleaseDetail(release.get());
+		return this.statusAction.status(name, namespace)
+			.map(OutputFormat::release)
+			.orElseGet(() -> Map.of("error", notFound(name, namespace)));
 	}
 
 	/**
@@ -75,20 +70,12 @@ public class ReleaseReadTools {
 	 * @return a human-readable, newline-separated summary of revisions
 	 */
 	@McpTool(name = "helm_history",
-			description = "List the revision history of a Helm release (like 'helm history'), one line per "
-					+ "revision. Read-only; does not modify the cluster.")
-	public String history(@McpToolParam(description = "Release name") String name,
+			description = "List the revision history of a Helm release (like 'helm history -o json') as a JSON array, "
+					+ "one object per revision (revision, updated, status, chart, app_version, description). Empty "
+					+ "array when the release is not found. Read-only; does not modify the cluster.")
+	public List<Map<String, Object>> history(@McpToolParam(description = "Release name") String name,
 			@McpToolParam(description = "Kubernetes namespace") String namespace) {
-		List<Release> revisions = this.historyAction.history(name, namespace);
-		if (revisions.isEmpty()) {
-			return notFound(name, namespace);
-		}
-		StringBuilder sb = new StringBuilder();
-		sb.append("NAME\tNAMESPACE\tREVISION\tSTATUS\n");
-		for (Release revision : revisions) {
-			appendReleaseLine(sb, revision);
-		}
-		return sb.toString();
+		return this.historyAction.history(name, namespace).stream().map(OutputFormat::historyRow).toList();
 	}
 
 	/**
@@ -129,43 +116,6 @@ public class ReleaseReadTools {
 			return notFound(name, namespace);
 		}
 		return this.getAction.getManifest(release.get());
-	}
-
-	private static void appendReleaseLine(StringBuilder sb, Release release) {
-		sb.append(release.getName()).append('\t').append(release.getNamespace()).append('\t');
-		sb.append(release.getVersion()).append('\t').append(statusOf(release)).append('\n');
-	}
-
-	private static String renderReleaseDetail(Release release) {
-		StringBuilder sb = new StringBuilder();
-		sb.append("Name: ").append(release.getName());
-		sb.append("\nNamespace: ").append(release.getNamespace());
-		sb.append("\nRevision: ").append(release.getVersion());
-		sb.append("\nStatus: ").append(statusOf(release));
-		Release.ReleaseInfo info = release.getInfo();
-		if (info != null) {
-			if (info.getDescription() != null) {
-				sb.append("\nDescription: ").append(info.getDescription());
-			}
-			if (info.getLastDeployed() != null) {
-				sb.append("\nLast deployed: ").append(info.getLastDeployed());
-			}
-		}
-		if (release.getChart() != null && release.getChart().getMetadata() != null) {
-			sb.append("\nChart: ")
-				.append(release.getChart().getMetadata().getName())
-				.append('-')
-				.append(release.getChart().getMetadata().getVersion());
-		}
-		sb.append('\n');
-		return sb.toString();
-	}
-
-	private static String statusOf(Release release) {
-		if (release.getInfo() != null && release.getInfo().getStatus() != null) {
-			return release.getInfo().getStatus().getValue();
-		}
-		return "unknown";
 	}
 
 	private static String notFound(String name, String namespace) {

--- a/jhelm-mcp/src/test/java/org/alexmond/jhelm/mcp/tools/ReleaseReadToolsTest.java
+++ b/jhelm-mcp/src/test/java/org/alexmond/jhelm/mcp/tools/ReleaseReadToolsTest.java
@@ -1,0 +1,103 @@
+package org.alexmond.jhelm.mcp.tools;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.alexmond.jhelm.core.action.GetAction;
+import org.alexmond.jhelm.core.action.HistoryAction;
+import org.alexmond.jhelm.core.action.ListAction;
+import org.alexmond.jhelm.core.action.StatusAction;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+class ReleaseReadToolsTest {
+
+	@Mock
+	private ListAction listAction;
+
+	@Mock
+	private StatusAction statusAction;
+
+	@Mock
+	private GetAction getAction;
+
+	@Mock
+	private HistoryAction historyAction;
+
+	private ReleaseReadTools tools;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		this.tools = new ReleaseReadTools(this.listAction, this.statusAction, this.getAction, this.historyAction);
+	}
+
+	private static Release sampleRelease() {
+		ChartMetadata md = ChartMetadata.builder().name("nginx").version("1.0.0").appVersion("1.25").build();
+		Chart chart = Chart.builder().metadata(md).build();
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.status(ReleaseStatus.DEPLOYED)
+			.description("Install complete")
+			.lastDeployed(OffsetDateTime.parse("2026-07-05T10:00:00Z"))
+			.build();
+		return Release.builder().name("my-release").namespace("default").version(1).chart(chart).info(info).build();
+	}
+
+	@Test
+	void listReturnsHelmShapedRows() {
+		when(this.listAction.list("default")).thenReturn(List.of(sampleRelease()));
+
+		List<Map<String, Object>> rows = this.tools.list("default");
+
+		assertEquals(1, rows.size());
+		assertEquals("my-release", rows.get(0).get("name"));
+		assertEquals("nginx-1.0.0", rows.get(0).get("chart"));
+		assertEquals(1, rows.get(0).get("revision"));
+	}
+
+	@Test
+	void statusReturnsNestedInfoObject() {
+		when(this.statusAction.status("my-release", "default")).thenReturn(Optional.of(sampleRelease()));
+
+		Map<String, Object> result = this.tools.status("my-release", "default");
+
+		assertEquals("my-release", result.get("name"));
+		Object info = result.get("info");
+		assertInstanceOf(Map.class, info);
+		assertEquals("deployed", ((Map<?, ?>) info).get("status"));
+	}
+
+	@Test
+	void statusNotFoundReturnsErrorObject() {
+		when(this.statusAction.status("missing", "default")).thenReturn(Optional.empty());
+
+		Map<String, Object> result = this.tools.status("missing", "default");
+
+		assertTrue(String.valueOf(result.get("error")).contains("missing"), result.toString());
+	}
+
+	@Test
+	void historyReturnsHelmShapedRows() {
+		when(this.historyAction.history("my-release", "default")).thenReturn(List.of(sampleRelease()));
+
+		List<Map<String, Object>> rows = this.tools.history("my-release", "default");
+
+		assertEquals(1, rows.size());
+		assertEquals(1, rows.get(0).get("revision"));
+		assertEquals("1.25", rows.get(0).get("app_version"));
+	}
+
+}


### PR DESCRIPTION
Third slice of #686. `helm_list` / `helm_status` / `helm_history` returned prose strings (tab tables, `Name: … Status: …` blocks) — poor for agent consumption. They now return the shared `OutputFormat` Helm shapes:

- `helm_list` → JSON array of list rows (`name`, `namespace`, `revision`, `updated`, `status`, `chart`, `app_version`)
- `helm_status` → nested-`info` release object (or an `{error}` object when not found)
- `helm_history` → JSON array of history rows

Tool descriptions updated to advertise the JSON shape. `helm_get_values` / `helm_get_manifest` stay as YAML text (Helm returns those as text too). The prose helpers are removed.

## Tests
New `ReleaseReadToolsTest` covers the list/status/history shapes and the not-found error object.

## #686 remaining
Mirror the new CLI options (template flags, install `-g`/`--description`/`--labels`) as REST request fields / MCP tool params — then #686 closes.

Part of #686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)