### PR TITLE
feat(api): install --description / --labels on REST and MCP (#686)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -27,6 +27,8 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
 * *MCP tools return structured JSON* -- `helm_list`, `helm_status`, and `helm_history` now
   return Helm-shaped JSON (array of rows / nested `info` object) instead of prose text, so agents
   can parse them directly (#686).
+* *Install options on the API* -- the REST install endpoints and the MCP `helm_install` tool
+  accept `description` and `labels`, mirroring the CLI's `--description`/`--labels` (#686).
 
 == 1.1.0
 

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingTools.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingTools.java
@@ -72,7 +72,10 @@ public class ReleaseMutatingTools {
 	public String install(@McpToolParam(description = "Path to the chart directory to install") String chartPath,
 			@McpToolParam(description = "Release name to create") String name,
 			@McpToolParam(description = "Target Kubernetes namespace") String namespace,
-			@McpToolParam(description = "Render only without applying to the cluster when true") boolean dryRun) {
+			@McpToolParam(description = "Render only without applying to the cluster when true") boolean dryRun,
+			@McpToolParam(required = false, description = "Custom release description") String description,
+			@McpToolParam(required = false,
+					description = "Custom labels to store on the release (key=value)") Map<String, String> labels) {
 		Chart chart = this.chartLoader.load(new File(chartPath));
 		Release release = this.installAction.install(InstallOptions.builder()
 			.chart(chart)
@@ -81,6 +84,8 @@ public class ReleaseMutatingTools {
 			.values(Map.of())
 			.revision(1)
 			.dryRun(dryRun)
+			.description(description)
+			.labels((labels != null) ? labels : Map.of())
 			.build());
 		return renderReleaseSummary("Installed", release, dryRun);
 	}

--- a/jhelm-mcp/src/test/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingToolsTest.java
+++ b/jhelm-mcp/src/test/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingToolsTest.java
@@ -1,0 +1,106 @@
+package org.alexmond.jhelm.mcp.tools;
+
+import java.io.File;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.action.GetAction;
+import org.alexmond.jhelm.core.action.InstallAction;
+import org.alexmond.jhelm.core.action.InstallOptions;
+import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.TestAction;
+import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
+import org.alexmond.jhelm.core.service.ChartLoader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class ReleaseMutatingToolsTest {
+
+	@Mock
+	private InstallAction installAction;
+
+	@Mock
+	private UpgradeAction upgradeAction;
+
+	@Mock
+	private UninstallAction uninstallAction;
+
+	@Mock
+	private RollbackAction rollbackAction;
+
+	@Mock
+	private TestAction testAction;
+
+	@Mock
+	private GetAction getAction;
+
+	@Mock
+	private ChartLoader chartLoader;
+
+	private ReleaseMutatingTools tools;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		this.tools = new ReleaseMutatingTools(this.installAction, this.upgradeAction, this.uninstallAction,
+				this.rollbackAction, this.testAction, this.getAction, this.chartLoader);
+	}
+
+	@Test
+	void installPassesDescriptionAndLabels() {
+		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("1.0.0").build()).build();
+		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
+		Release release = Release.builder()
+			.name("my-release")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.info(Release.ReleaseInfo.builder()
+				.status(ReleaseStatus.DEPLOYED)
+				.lastDeployed(OffsetDateTime.now())
+				.build())
+			.build();
+		ArgumentCaptor<InstallOptions> captor = ArgumentCaptor.forClass(InstallOptions.class);
+		when(this.installAction.install(captor.capture())).thenReturn(release);
+
+		this.tools.install("/charts/nginx", "my-release", "default", false, "rollout A", Map.of("team", "payments"));
+
+		assertEquals("rollout A", captor.getValue().getDescription());
+		assertEquals("payments", captor.getValue().getLabels().get("team"));
+	}
+
+	@Test
+	void installToleratesNullLabels() {
+		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("1.0.0").build()).build();
+		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
+		Release release = Release.builder()
+			.name("my-release")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.info(Release.ReleaseInfo.builder()
+				.status(ReleaseStatus.DEPLOYED)
+				.lastDeployed(OffsetDateTime.now())
+				.build())
+			.build();
+		ArgumentCaptor<InstallOptions> captor = ArgumentCaptor.forClass(InstallOptions.class);
+		when(this.installAction.install(captor.capture())).thenReturn(release);
+
+		this.tools.install("/charts/nginx", "my-release", "default", false, null, null);
+
+		assertEquals(Map.of(), captor.getValue().getLabels());
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
@@ -182,6 +182,8 @@ public class ReleaseController {
 				.values(values)
 				.revision(1)
 				.dryRun(request.isDryRun())
+				.description(request.getDescription())
+				.labels((request.getLabels() != null) ? request.getLabels() : Map.of())
 				.build());
 			return ResponseEntity.status(HttpStatus.CREATED).body(OutputFormat.release(release));
 		}
@@ -210,6 +212,8 @@ public class ReleaseController {
 				.values(values)
 				.revision(1)
 				.dryRun(request.isDryRun())
+				.description(request.getDescription())
+				.labels((request.getLabels() != null) ? request.getLabels() : Map.of())
 				.build());
 			return ResponseEntity.status(HttpStatus.CREATED).body(OutputFormat.release(release));
 		}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallRequest.java
@@ -35,4 +35,10 @@ public class InstallRequest {
 	@Schema(description = "Simulate an install without applying", defaultValue = "false")
 	private boolean dryRun;
 
+	@Schema(description = "Custom release description (stored on the release)")
+	private String description;
+
+	@Schema(description = "Custom labels to store on the release Secret")
+	private Map<String, String> labels;
+
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallUploadRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/InstallUploadRequest.java
@@ -27,4 +27,10 @@ public class InstallUploadRequest {
 	@Schema(description = "Simulate an install without applying", defaultValue = "false")
 	private boolean dryRun;
 
+	@Schema(description = "Custom release description (stored on the release)")
+	private String description;
+
+	@Schema(description = "Custom labels to store on the release Secret")
+	private Map<String, String> labels;
+
 }

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
@@ -211,12 +211,16 @@ class ReleaseControllerTest {
 		MockMultipartFile chartFile = new MockMultipartFile("chart", "nginx-1.0.0.tgz", "application/gzip",
 				new byte[] { 1, 2, 3 });
 		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json", """
-				{"releaseName": "my-release"}
+				{"releaseName": "my-release", "description": "upload A", "labels": {"team": "payments"}}
 				""".getBytes());
 
 		this.mockMvc.perform(multipart("/api/v1/releases/upload").file(chartFile).file(requestPart))
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.name").value("my-release"));
+
+		verify(this.installAction)
+			.install(argThat((InstallOptions options) -> "upload A".equals(options.getDescription())
+					&& "payments".equals(options.getLabels().get("team"))));
 	}
 
 	@Test

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
@@ -156,6 +156,27 @@ class ReleaseControllerTest {
 	}
 
 	@Test
+	void installPassesDescriptionAndLabels() throws Exception {
+		stubPull();
+		Chart chart = Chart.builder().metadata(ChartMetadata.builder().name("nginx").version("1.0.0").build()).build();
+		when(this.chartLoader.load(any(File.class))).thenReturn(chart);
+		when(this.installAction.install(any(InstallOptions.class))).thenReturn(sampleRelease());
+
+		this.mockMvc
+			.perform(post("/api/v1/releases").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartRef": "bitnami/nginx", "releaseName": "my-release",
+						 "description": "rollout A", "labels": {"team": "payments"}}
+						"""))
+			.andExpect(status().isCreated());
+
+		verify(this.installAction)
+			.install(argThat((InstallOptions options) -> "rollout A".equals(options.getDescription())
+					&& "payments".equals(options.getLabels().get("team"))));
+	}
+
+	@Test
 	void installRejectsMissingChartRef() throws Exception {
 		this.mockMvc
 			.perform(post("/api/v1/releases").contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Mirrors the CLI's install `--description`/`--labels` (from #680) on the API surfaces, keeping CLI + REST + MCP in lockstep — the "mirror new options" part of #686.

## What
- **REST** `InstallRequest` + `InstallUploadRequest` gain `description` and `labels`; `ReleaseController` threads them into `InstallOptions`.
- **MCP** `helm_install` gains optional `description` and `labels` params (null labels tolerated → empty map).

## Tests
- `ReleaseControllerTest` — the fields reach `InstallOptions` (argThat).
- New `ReleaseMutatingToolsTest` — MCP install params + null-labels default.

## #686 remaining
Template render flags (`--show-only`, `--skip-tests`, `--include-crds`, `--is-upgrade`) on REST `ChartController` + MCP `helm_template`. After that #686 closes.

Part of #686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)