### PR TITLE
feat(api): template render controls on REST and MCP (#686)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -29,6 +29,9 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
   can parse them directly (#686).
 * *Install options on the API* -- the REST install endpoints and the MCP `helm_install` tool
   accept `description` and `labels`, mirroring the CLI's `--description`/`--labels` (#686).
+* *Template render controls on the API* -- the REST template endpoints and the MCP
+  `helm_template` tool accept `showOnly`, `skipTests`, `includeCrds`, and `isUpgrade`, mirroring
+  the CLI's `--show-only`/`--skip-tests`/`--include-crds`/`--is-upgrade` (#686).
 
 == 1.1.0
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/TemplateAction.java
@@ -15,6 +15,7 @@ import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.PostRenderProcessor;
 import org.alexmond.jhelm.core.service.ValueEncryptor;
+import org.alexmond.jhelm.core.util.RenderedManifest;
 import org.alexmond.jhelm.core.util.ValuesLoader;
 import org.alexmond.jhelm.core.util.ValuesProfiles;
 
@@ -129,6 +130,37 @@ public class TemplateAction {
 			}
 		}
 
+		return manifest;
+	}
+
+	/**
+	 * Renders a chart and applies the {@code helm template} manifest-level controls in
+	 * one call, so REST and MCP callers get the same behaviour as the CLI without
+	 * repeating the post-processing: the install/upgrade posture, CRD inclusion, dropping
+	 * test hooks, and selecting specific templates.
+	 * @param chartPath path to the chart directory or archive
+	 * @param releaseName the release name ({@code .Release.Name})
+	 * @param namespace the release namespace
+	 * @param overrides value overrides merged over the chart defaults
+	 * @param isUpgrade render with {@code .Release.IsUpgrade=true} instead of install
+	 * posture
+	 * @param includeCrds prepend the chart's {@code crds/} manifests
+	 * @param skipTests drop documents carrying a {@code helm.sh/hook: test} annotation
+	 * @param showOnly keep only documents from these template paths (empty/{@code null} =
+	 * all); errors if a requested template matches nothing
+	 * @return the rendered, filtered manifest
+	 */
+	public String renderWithControls(String chartPath, String releaseName, String namespace,
+			Map<String, Object> overrides, boolean isUpgrade, boolean includeCrds, boolean skipTests,
+			List<String> showOnly) {
+		String manifest = render(chartPath, releaseName, namespace, overrides, ValuesProfiles.none(), null, List.of(),
+				isUpgrade, includeCrds);
+		if (skipTests) {
+			manifest = RenderedManifest.skipTests(manifest);
+		}
+		if (showOnly != null && !showOnly.isEmpty()) {
+			manifest = RenderedManifest.showOnly(manifest, showOnly);
+		}
 		return manifest;
 	}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/TemplateActionRenderControlTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/TemplateActionRenderControlTest.java
@@ -42,6 +42,21 @@ class TemplateActionRenderControlTest {
 				data:
 				  upgrade: "{{ .Release.IsUpgrade }}"
 				""");
+		Files.writeString(templates.resolve("svc.yaml"), """
+				apiVersion: v1
+				kind: Service
+				metadata:
+				  name: svc
+				""");
+		Path tests = Files.createDirectories(templates.resolve("tests"));
+		Files.writeString(tests.resolve("test-connection.yaml"), """
+				apiVersion: v1
+				kind: Pod
+				metadata:
+				  name: test
+				  annotations:
+				    "helm.sh/hook": test
+				""");
 		Path crds = Files.createDirectories(chartDir.resolve("crds"));
 		Files.writeString(crds.resolve("widget.yaml"), """
 				apiVersion: apiextensions.k8s.io/v1
@@ -79,6 +94,30 @@ class TemplateActionRenderControlTest {
 	@Test
 	void testIsUpgradeFlipsReleaseFlag() {
 		assertTrue(render(true, false).contains("upgrade: \"true\""), "--is-upgrade sets .Release.IsUpgrade");
+	}
+
+	@Test
+	void testRenderWithControlsSkipTestsDropsTestHook() {
+		String manifest = templateAction.renderWithControls(chartDir.toString(), "r", "default", new HashMap<>(), false,
+				false, true, List.of());
+		assertFalse(manifest.contains("kind: Pod"), manifest);
+		assertTrue(manifest.contains("kind: ConfigMap"), manifest);
+	}
+
+	@Test
+	void testRenderWithControlsShowOnlySelectsTemplate() {
+		String manifest = templateAction.renderWithControls(chartDir.toString(), "r", "default", new HashMap<>(), false,
+				false, false, List.of("templates/svc.yaml"));
+		assertTrue(manifest.contains("kind: Service"), manifest);
+		assertFalse(manifest.contains("kind: ConfigMap"), manifest);
+	}
+
+	@Test
+	void testRenderWithControlsIncludeCrdsAndSkipTests() {
+		String manifest = templateAction.renderWithControls(chartDir.toString(), "r", "default", new HashMap<>(), false,
+				true, true, List.of());
+		assertTrue(manifest.contains("kind: CustomResourceDefinition"), manifest);
+		assertFalse(manifest.contains("kind: Pod"), manifest);
 	}
 
 }

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ChartTools.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ChartTools.java
@@ -36,8 +36,15 @@ public class ChartTools {
 	public String template(
 			@McpToolParam(description = "Path to the chart directory or packaged .tgz archive") String chartPath,
 			@McpToolParam(description = "Release name to use while rendering") String releaseName,
-			@McpToolParam(description = "Target Kubernetes namespace") String namespace) {
-		return this.templateAction.render(chartPath, releaseName, namespace);
+			@McpToolParam(description = "Target Kubernetes namespace") String namespace,
+			@McpToolParam(required = false,
+					description = "Keep only documents from these template paths (e.g. templates/deployment.yaml)") List<String> showOnly,
+			@McpToolParam(required = false, description = "Drop chart test hooks from the output") boolean skipTests,
+			@McpToolParam(required = false, description = "Include the chart's crds/ manifests") boolean includeCrds,
+			@McpToolParam(required = false,
+					description = "Render with .Release.IsUpgrade instead of .Release.IsInstall") boolean isUpgrade) {
+		return this.templateAction.renderWithControls(chartPath, releaseName, namespace, Map.of(), isUpgrade,
+				includeCrds, skipTests, showOnly);
 	}
 
 	/**

--- a/jhelm-mcp/src/test/java/org/alexmond/jhelm/mcp/tools/ChartToolsTest.java
+++ b/jhelm-mcp/src/test/java/org/alexmond/jhelm/mcp/tools/ChartToolsTest.java
@@ -1,0 +1,71 @@
+package org.alexmond.jhelm.mcp.tools;
+
+import java.util.List;
+
+import org.alexmond.jhelm.core.action.LintAction;
+import org.alexmond.jhelm.core.action.ShowAction;
+import org.alexmond.jhelm.core.action.TemplateAction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class ChartToolsTest {
+
+	@Mock
+	private TemplateAction templateAction;
+
+	@Mock
+	private ShowAction showAction;
+
+	@Mock
+	private LintAction lintAction;
+
+	private ChartTools tools;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		this.tools = new ChartTools(this.templateAction, this.showAction, this.lintAction);
+	}
+
+	@Test
+	void templatePassesRenderControls() {
+		ArgumentCaptor<Boolean> isUpgrade = ArgumentCaptor.forClass(Boolean.class);
+		ArgumentCaptor<Boolean> includeCrds = ArgumentCaptor.forClass(Boolean.class);
+		ArgumentCaptor<Boolean> skipTests = ArgumentCaptor.forClass(Boolean.class);
+		ArgumentCaptor<List<String>> showOnly = ArgumentCaptor.forClass(List.class);
+		when(this.templateAction.renderWithControls(anyString(), anyString(), anyString(), anyMap(),
+				isUpgrade.capture(), includeCrds.capture(), skipTests.capture(), showOnly.capture()))
+			.thenReturn("kind: Deployment");
+
+		String out = this.tools.template("/charts/nginx", "r", "default", List.of("templates/deployment.yaml"), true,
+				true, true);
+
+		assertEquals("kind: Deployment", out);
+		assertEquals(true, isUpgrade.getValue());
+		assertEquals(true, includeCrds.getValue());
+		assertEquals(true, skipTests.getValue());
+		assertEquals(List.of("templates/deployment.yaml"), showOnly.getValue());
+	}
+
+	@Test
+	void templateDefaultsAreNoOp() {
+		when(this.templateAction.renderWithControls(anyString(), anyString(), anyString(), anyMap(), anyBoolean(),
+				anyBoolean(), anyBoolean(), any()))
+			.thenReturn("kind: ConfigMap");
+
+		String out = this.tools.template("/charts/nginx", "r", "default", null, false, false, false);
+
+		assertEquals("kind: ConfigMap", out);
+	}
+
+}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ChartController.java
@@ -87,8 +87,9 @@ public class ChartController {
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-template-")) {
 			String chartPath = pullChart(request.getChartRef(), request.getVersion(), tempDir);
 			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
-			String manifest = this.templateAction.render(chartPath, request.getReleaseName(), request.getNamespace(),
-					values);
+			String manifest = this.templateAction.renderWithControls(chartPath, request.getReleaseName(),
+					request.getNamespace(), values, request.isUpgrade(), request.isIncludeCrds(), request.isSkipTests(),
+					request.getShowOnly());
 			return ResponseEntity.ok(manifest);
 		}
 	}
@@ -111,8 +112,9 @@ public class ChartController {
 			this.repoManager.untar(tgzFile, tempDir.path().toFile());
 			String chartPath = ChartLoader.findChartDir(tempDir.path()).toString();
 			Map<String, Object> values = ValuesOverrides.safeValues(request.getValues());
-			String manifest = this.templateAction.render(chartPath, request.getReleaseName(), request.getNamespace(),
-					values);
+			String manifest = this.templateAction.renderWithControls(chartPath, request.getReleaseName(),
+					request.getNamespace(), values, request.isUpgrade(), request.isIncludeCrds(), request.isSkipTests(),
+					request.getShowOnly());
 			return ResponseEntity.ok(manifest);
 		}
 	}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TemplateRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TemplateRequest.java
@@ -2,8 +2,10 @@ package org.alexmond.jhelm.rest.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -30,5 +32,18 @@ public class TemplateRequest {
 
 	@Schema(description = "Override values for the chart")
 	private Map<String, Object> values;
+
+	@Schema(description = "Keep only documents rendered from these template paths (e.g. templates/deployment.yaml)")
+	private List<String> showOnly;
+
+	@Schema(description = "Drop chart test hooks from the output", defaultValue = "false")
+	private boolean skipTests;
+
+	@Schema(description = "Include the chart's crds/ manifests in the output", defaultValue = "false")
+	private boolean includeCrds;
+
+	@Schema(description = "Render with .Release.IsUpgrade instead of .Release.IsInstall", defaultValue = "false")
+	@JsonProperty("isUpgrade")
+	private boolean isUpgrade;
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TemplateUploadRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/TemplateUploadRequest.java
@@ -1,7 +1,9 @@
 package org.alexmond.jhelm.rest.dto;
 
+import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -20,5 +22,18 @@ public class TemplateUploadRequest {
 
 	@Schema(description = "Override values for the chart")
 	private Map<String, Object> values;
+
+	@Schema(description = "Keep only documents rendered from these template paths (e.g. templates/deployment.yaml)")
+	private List<String> showOnly;
+
+	@Schema(description = "Drop chart test hooks from the output", defaultValue = "false")
+	private boolean skipTests;
+
+	@Schema(description = "Include the chart's crds/ manifests in the output", defaultValue = "false")
+	private boolean includeCrds;
+
+	@Schema(description = "Render with .Release.IsUpgrade instead of .Release.IsInstall", defaultValue = "false")
+	@JsonProperty("isUpgrade")
+	private boolean isUpgrade;
 
 }

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ChartControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ChartControllerTest.java
@@ -1,6 +1,7 @@
 package org.alexmond.jhelm.rest.controller;
 
 import java.io.File;
+import java.util.List;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -22,6 +23,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -58,7 +60,8 @@ class ChartControllerTest {
 	@Test
 	void templateRendersManifest() throws Exception {
 		stubPull();
-		when(this.templateAction.render(anyString(), eq("my-release"), eq("default"), anyMap()))
+		when(this.templateAction.renderWithControls(anyString(), eq("my-release"), eq("default"), anyMap(),
+				anyBoolean(), anyBoolean(), anyBoolean(), any()))
 			.thenReturn("apiVersion: v1\nkind: ConfigMap");
 
 		this.mockMvc
@@ -69,6 +72,24 @@ class ChartControllerTest {
 						"""))
 			.andExpect(status().isOk())
 			.andExpect(content().string("apiVersion: v1\nkind: ConfigMap"));
+	}
+
+	@Test
+	void templatePassesRenderControls() throws Exception {
+		stubPull();
+		when(this.templateAction.renderWithControls(anyString(), eq("my-release"), eq("default"), anyMap(), eq(true),
+				eq(true), eq(true), eq(List.of("templates/deployment.yaml"))))
+			.thenReturn("apiVersion: apps/v1\nkind: Deployment");
+
+		this.mockMvc
+			.perform(post("/api/v1/charts/template").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"chartRef": "bitnami/nginx", "releaseName": "my-release", "isUpgrade": true,
+						 "includeCrds": true, "skipTests": true, "showOnly": ["templates/deployment.yaml"]}
+						"""))
+			.andExpect(status().isOk())
+			.andExpect(content().string("apiVersion: apps/v1\nkind: Deployment"));
 	}
 
 	@Test
@@ -86,7 +107,8 @@ class ChartControllerTest {
 	@Test
 	void templateUploadRendersManifest() throws Exception {
 		stubUntar();
-		when(this.templateAction.render(anyString(), eq("RELEASE-NAME"), eq("default"), anyMap()))
+		when(this.templateAction.renderWithControls(anyString(), eq("RELEASE-NAME"), eq("default"), anyMap(),
+				anyBoolean(), anyBoolean(), anyBoolean(), any()))
 			.thenReturn("apiVersion: v1\nkind: Service");
 
 		MockMultipartFile chartFile = new MockMultipartFile("chart", "nginx-1.0.0.tgz", "application/gzip",


### PR DESCRIPTION
Mirrors the CLI's `helm template` render controls onto the REST + MCP surfaces, closing the last scope item of #686 (CLI + REST + MCP in lockstep).

## What
- **New `TemplateAction.renderWithControls(...)`** applies all manifest-level controls in one call — install/upgrade posture, `--include-crds`, `--skip-tests`, `--show-only` — so REST and MCP get the CLI's exact behaviour without duplicating post-processing.
- **REST** `TemplateRequest` + `TemplateUploadRequest` gain `showOnly`, `skipTests`, `includeCrds`, `isUpgrade`; `ChartController.template`/`templateUpload` route through `renderWithControls`.
  - `isUpgrade` is pinned to the `isUpgrade` JSON key with `@JsonProperty` — Lombok's `isXxx()` getter would otherwise make Jackson bind the key `upgrade`.
- **MCP** `helm_template` gains the same four optional params.

`--output-dir` is intentionally CLI-only (writes server-side files; no meaning over an API).

## Tests
- Core `TemplateActionRenderControlTest` — `renderWithControls` skip-tests / show-only / include-crds over the real engine.
- REST `ChartControllerTest` — controls reach `renderWithControls`, incl. the JSON-key binding.
- New MCP `ChartToolsTest` — params captured.

Closes #686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)