### PR TITLE
feat(cli): upgrade --description / --labels (#680)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -18,6 +18,8 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
   auto-generate `<chart>-<timestamp>`, as Helm does (#680).
 * *`install --description` / `--labels`* -- store a custom release description and custom labels
   on the release Secret (#680).
+* *`upgrade --description` / `--labels`* -- set the new revision's description and labels;
+  without `--labels`, the previous release's labels are carried forward, matching Helm (#680).
 * *REST releases API now returns Helm-shaped JSON* -- the `/releases` list/status/history and
   install/upgrade responses now use Helm's `-o json` schema (snake_case, nested `info`) instead
   of jhelm's internal DTO, so REST consumers see the same shape as `helm ... -o json` and the

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -33,6 +33,8 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | `-g`, `--generate-name` (install) | ✅ | Omit the NAME positional and pass `-g` to auto-generate `<chart>-<timestamp>` (like Helm). Errors if both a name and `-g` are given, or if neither is.
 | `--description` (install) | ✅ | Custom release description stored on the release (falls back to `Install complete`).
 | `--labels` (install) | ✅ | `key=value` labels (comma-separated or repeatable) added to the release Secret; the reserved `owner`/`name`/`status`/`version` labels are never overridden.
+| `--description` (upgrade) | ✅ | Custom description for the new revision (falls back to `Upgrade complete`).
+| `--labels` (upgrade) | ✅ | `key=value` labels for the new revision; without it, the previous release's labels are carried forward (like Helm).
 | `--set-literal`, `--dependency-update` | ✗ | Not yet wired.
 |===
 
@@ -139,8 +141,8 @@ Beyond the per-command tables above, these commonly-used Helm options are not ye
 * *`list`* — `-A`/`--all-namespaces`, `-l`/`--selector`, `-a`/`--all`, the status filters,
   `--max`/`--offset`/`--filter`.
 * *`install`/`upgrade`* — install-from-repo (`--version`/`--repo`/`--username`/`--password`),
-  `--set-literal`, `--dependency-update`; `upgrade --cleanup-on-fail`; `--description`/`--labels`
-  on `upgrade` (supported on `install`). (`-g`/`--generate-name` is supported on `install`.)
+  `--set-literal`, `--dependency-update`; `upgrade --cleanup-on-fail`.
+  (`-g`/`--generate-name` is supported on `install`; `--description`/`--labels` on both.)
 * *`uninstall`/`rollback`* — `--wait`/`--timeout`/`--cascade` (uninstall);
   `--force`/`--cleanup-on-fail`/`--recreate-pods`/`--wait-for-jobs` (rollback).
 * *`pull`* — `--untar`/`--untardir`, `--verify`/`--prov`/`--keyring`, `--devel`.

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -153,6 +153,13 @@ public class UpgradeCommand implements Callable<Integer> {
 			description = "limit the maximum number of revisions saved per release (0 = no limit)")
 	private int historyMax;
 
+	@Option(names = { "--description" }, description = "add a custom description to the new revision")
+	private String description;
+
+	@Option(names = { "--labels" }, split = ",",
+			description = "labels to apply to the release Secret (key=value, comma-separated)")
+	private Map<String, String> labels;
+
 	/**
 	 * Creates the command.
 	 * @param kubeService the Kubernetes service used to look up releases and wait for
@@ -316,6 +323,8 @@ public class UpgradeCommand implements Callable<Integer> {
 			.noHooks(noHooks)
 			.maxHistory(historyMax)
 			.force(force)
+			.description(description)
+			.labels((labels != null) ? labels : Map.of())
 			.build();
 	}
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -211,6 +211,23 @@ class UpgradeCommandTest {
 	}
 
 	@Test
+	void testUpgradeDescriptionAndLabelsAreWiredIntoOptions() throws Exception {
+		File chartDir = createMockChart();
+		when(kubeService.getRelease(anyString(), anyString()))
+			.thenReturn(Optional.of(createMockRelease("my-release", 1)));
+		when(upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(createMockRelease("my-release", 2));
+		ArgumentCaptor<UpgradeOptions> opts = ArgumentCaptor.forClass(UpgradeOptions.class);
+
+		new CommandLine(upgradeCommand).execute("my-release", chartDir.getAbsolutePath(), "--description", "rollout B",
+				"--labels", "team=payments,tier=web");
+
+		verify(upgradeAction).upgrade(opts.capture());
+		assertEquals("rollout B", opts.getValue().getDescription());
+		assertEquals("payments", opts.getValue().getLabels().get("team"));
+		assertEquals("web", opts.getValue().getLabels().get("tier"));
+	}
+
+	@Test
 	void testUpgradeInvalidDryRunModeIsHandled() throws Exception {
 		File chartDir = createMockChart();
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -76,12 +76,20 @@ public class UpgradeAction {
 		this.valueEncryptor.decryptValues(renderValues);
 		Map<String, Object> configValues = resolved.config();
 
+		String defaultDescription = options.isDryRun() ? "Dry run complete" : "Upgrade complete";
+		String description = (options.getDescription() != null && !options.getDescription().isBlank())
+				? options.getDescription() : defaultDescription;
 		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
 			.firstDeployed(currentRelease.getInfo().getFirstDeployed())
 			.lastDeployed(OffsetDateTime.now())
 			.status((options.isDryRun()) ? ReleaseStatus.PENDING_UPGRADE : ReleaseStatus.DEPLOYED)
-			.description(options.isDryRun() ? "Dry run complete" : "Upgrade complete")
+			.description(description)
 			.build();
+
+		// Helm --labels replaces the revision's labels; with none supplied, the current
+		// release's labels are carried forward.
+		Map<String, String> labels = (options.getLabels() != null && !options.getLabels().isEmpty())
+				? options.getLabels() : currentRelease.getLabels();
 
 		Release newRelease = Release.builder()
 			.name(currentRelease.getName())
@@ -89,6 +97,7 @@ public class UpgradeAction {
 			.version(currentRelease.getVersion() + 1)
 			.chart(newChart)
 			.info(info)
+			.labels(labels)
 			// Persist the resolved user-supplied values (Helm's release "config"), so
 			// that
 			// `get values` reports them and a later upgrade can reuse them.

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeOptions.java
@@ -74,4 +74,18 @@ public final class UpgradeOptions {
 	 */
 	private final boolean force;
 
+	/**
+	 * Custom description for the new revision (Helm {@code --description}). When blank,
+	 * the default {@code "Upgrade complete"} (or {@code "Dry run complete"}) is used.
+	 */
+	private final String description;
+
+	/**
+	 * Custom labels to store on the new revision (Helm {@code --labels}). When empty, the
+	 * labels from the current release are carried forward, matching Helm. Defaults to an
+	 * empty map.
+	 */
+	@Builder.Default
+	private final Map<String, String> labels = Map.of();
+
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -124,6 +124,79 @@ class UpgradeActionTest {
 	}
 
 	@Test
+	void testUpgradeAppliesCustomDescriptionAndLabels() throws Exception {
+		Chart oldChart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
+			.values(new HashMap<>())
+			.build();
+		Release currentRelease = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(oldChart)
+			.labels(Map.of("team", "old"))
+			.info(Release.ReleaseInfo.builder()
+				.firstDeployed(OffsetDateTime.now().minusDays(1))
+				.status(ReleaseStatus.DEPLOYED)
+				.build())
+			.build();
+		Chart newChart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("2.0.0").build())
+			.values(new HashMap<>())
+			.build();
+		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("---\napiVersion: v1\nkind: Service");
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(newChart)
+			.description("rollout B")
+			.labels(Map.of("team", "payments"))
+			.build());
+
+		ArgumentCaptor<Release> stored = ArgumentCaptor.forClass(Release.class);
+		verify(kubeService).storeRelease(stored.capture());
+		assertEquals("rollout B", stored.getValue().getInfo().getDescription());
+		assertEquals("payments", stored.getValue().getLabels().get("team"));
+	}
+
+	@Test
+	void testUpgradeCarriesForwardLabelsWhenNoneSupplied() throws Exception {
+		Chart oldChart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
+			.values(new HashMap<>())
+			.build();
+		Release currentRelease = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(oldChart)
+			.labels(Map.of("team", "kept"))
+			.info(Release.ReleaseInfo.builder()
+				.firstDeployed(OffsetDateTime.now().minusDays(1))
+				.status(ReleaseStatus.DEPLOYED)
+				.build())
+			.build();
+		Chart newChart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("2.0.0").build())
+			.values(new HashMap<>())
+			.build();
+		when(engine.render(eq(newChart), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn("---\napiVersion: v1\nkind: Service");
+		doNothing().when(kubeService).apply(anyString(), anyString());
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		upgradeAction.upgrade(UpgradeOptions.builder().currentRelease(currentRelease).newChart(newChart).build());
+
+		ArgumentCaptor<Release> stored = ArgumentCaptor.forClass(Release.class);
+		verify(kubeService).storeRelease(stored.capture());
+		assertEquals("kept", stored.getValue().getLabels().get("team"));
+		assertEquals("Upgrade complete", stored.getValue().getInfo().getDescription());
+	}
+
+	@Test
 	void testUpgradeForceDeletesBeforeApply() throws Exception {
 		Chart oldChart = Chart.builder()
 			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())


### PR DESCRIPTION
Mirrors the install metadata options (#692) onto `upgrade`, continuing #680.

## What
- `UpgradeOptions` gains `description` and `labels`.
- `UpgradeAction`: custom description when non-blank (else `Upgrade complete`/`Dry run complete`); stores `--labels` on the new revision. **With no `--labels`, the current release's labels are carried forward** — matching Helm's upgrade behaviour.
- `UpgradeCommand` adds `--description` and `--labels` (`key=value`, comma-separated), threaded into `UpgradeOptions`.

## Tests
- `UpgradeActionTest` — custom description + labels stored; labels carried forward when none supplied.
- `UpgradeCommandTest` — options wired from the flags.

## #680 remaining
`--set-literal`, `--dependency-update` on install/upgrade, and install-from-repo (that last is #682's territory).

Part of #680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)