### PR TITLE
feat(cli): --set-literal on install/upgrade/template/lint (#680)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -20,6 +20,9 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
   on the release Secret (#680).
 * *`upgrade --description` / `--labels`* -- set the new revision's description and labels;
   without `--labels`, the previous release's labels are carried forward, matching Helm (#680).
+* *`--set-literal`* -- on `install`, `upgrade`, `template`, and `lint`: set a value taken fully
+  literally (no type coercion, no comma or escape interpretation), applied at the highest
+  precedence in the `--set` family (#680).
 * *REST releases API now returns Helm-shaped JSON* -- the `/releases` list/status/history and
   install/upgrade responses now use Helm's `-o json` schema (snake_case, nested `info`) instead
   of jhelm's internal DTO, so REST consumers see the same shape as `helm ... -o json` and the

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -35,7 +35,8 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | `--labels` (install) | ✅ | `key=value` labels (comma-separated or repeatable) added to the release Secret; the reserved `owner`/`name`/`status`/`version` labels are never overridden.
 | `--description` (upgrade) | ✅ | Custom description for the new revision (falls back to `Upgrade complete`).
 | `--labels` (upgrade) | ✅ | `key=value` labels for the new revision; without it, the previous release's labels are carried forward (like Helm).
-| `--set-literal`, `--dependency-update` | ✗ | Not yet wired.
+| `--set-literal` | ✅ | Sets a fully literal string value (no coercion/comma/escape handling), applied last; also on `template` and `lint`.
+| `--dependency-update` | ✗ | Not yet wired.
 |===
 
 == uninstall
@@ -141,8 +142,8 @@ Beyond the per-command tables above, these commonly-used Helm options are not ye
 * *`list`* — `-A`/`--all-namespaces`, `-l`/`--selector`, `-a`/`--all`, the status filters,
   `--max`/`--offset`/`--filter`.
 * *`install`/`upgrade`* — install-from-repo (`--version`/`--repo`/`--username`/`--password`),
-  `--set-literal`, `--dependency-update`; `upgrade --cleanup-on-fail`.
-  (`-g`/`--generate-name` is supported on `install`; `--description`/`--labels` on both.)
+  `--dependency-update`; `upgrade --cleanup-on-fail`.
+  (`-g`/`--generate-name` is supported on `install`; `--description`/`--labels`/`--set-literal` on both.)
 * *`uninstall`/`rollback`* — `--wait`/`--timeout`/`--cascade` (uninstall);
   `--force`/`--cleanup-on-fail`/`--recreate-pods`/`--wait-for-jobs` (rollback).
 * *`pull`* — `--untar`/`--untardir`, `--verify`/`--prov`/`--keyring`, `--devel`.

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -105,6 +105,10 @@ public class InstallCommand implements Callable<Integer> {
 	@Option(names = { "--set-json" }, description = "set JSON values on the command line (key=json)")
 	private List<String> setJsonValues = new ArrayList<>();
 
+	@Option(names = { "--set-literal" },
+			description = "set a literal STRING value on the command line (key=value, no coercion or escaping)")
+	private List<String> setLiteralValues = new ArrayList<>();
+
 	@Option(names = { "--wait" }, description = "wait until all resources are ready")
 	private boolean wait;
 
@@ -181,7 +185,7 @@ public class InstallCommand implements Callable<Integer> {
 					configServerOptions.toOptions());
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, profiles, configServer.values(),
 					configServer.overrideNone(), configServer.overrideSystemProperties(), setValues, setStringValues,
-					setFileValues, setJsonValues);
+					setFileValues, setJsonValues, setLiteralValues);
 
 			Release release = installAction.install(InstallOptions.builder()
 				.chart(chart)

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/LintCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/LintCommand.java
@@ -41,6 +41,10 @@ public class LintCommand implements Callable<Integer> {
 	@Option(names = { "--set-json" }, description = "set JSON values on the command line (key=json)")
 	private List<String> setJsonValues = new ArrayList<>();
 
+	@Option(names = { "--set-literal" },
+			description = "set a literal STRING value on the command line (key=value, no coercion or escaping)")
+	private List<String> setLiteralValues = new ArrayList<>();
+
 	@Option(names = { "--strict" }, defaultValue = "false", description = "fail on lint warnings")
 	private boolean strict;
 
@@ -56,7 +60,7 @@ public class LintCommand implements Callable<Integer> {
 	public Integer call() {
 		try {
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
-					setFileValues, setJsonValues);
+					setFileValues, setJsonValues, setLiteralValues);
 			LintAction.LintResult result = lintAction.lint(chartPath, overrides, strict);
 
 			CliOutput.println("==> Linting " + result.getChartPath());

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
@@ -69,6 +69,10 @@ public class TemplateCommand implements Callable<Integer> {
 	@Option(names = { "--set-json" }, description = "set JSON values on the command line (key=json)")
 	private List<String> setJsonValues = new ArrayList<>();
 
+	@Option(names = { "--set-literal" },
+			description = "set a literal STRING value on the command line (key=value, no coercion or escaping)")
+	private List<String> setLiteralValues = new ArrayList<>();
+
 	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
 
@@ -122,7 +126,7 @@ public class TemplateCommand implements Callable<Integer> {
 					configServerOptions.toOptions());
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, profiles, configServer.values(),
 					configServer.overrideNone(), configServer.overrideSystemProperties(), setValues, setStringValues,
-					setFileValues, setJsonValues);
+					setFileValues, setJsonValues, setLiteralValues);
 			String manifest = templateAction.render(chartPath, name, namespace, overrides, profiles, kubeVersion,
 					apiVersions, isUpgrade, includeCrds);
 			for (String renderer : postRenderers) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -109,6 +109,10 @@ public class UpgradeCommand implements Callable<Integer> {
 	@Option(names = { "--set-json" }, description = "set JSON values on the command line (key=json)")
 	private List<String> setJsonValues = new ArrayList<>();
 
+	@Option(names = { "--set-literal" },
+			description = "set a literal STRING value on the command line (key=value, no coercion or escaping)")
+	private List<String> setLiteralValues = new ArrayList<>();
+
 	@Option(names = { "--wait" }, description = "wait until all resources are ready")
 	private boolean wait;
 
@@ -207,7 +211,7 @@ public class UpgradeCommand implements Callable<Integer> {
 			Chart chart = chartResolver.resolve(chartPath, verify, keyring, profiles);
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, profiles, configServer.values(),
 					configServer.overrideNone(), configServer.overrideSystemProperties(), setValues, setStringValues,
-					setFileValues, setJsonValues);
+					setFileValues, setJsonValues, setLiteralValues);
 
 			if (currentReleaseOpt.isEmpty()) {
 				if (install) {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -157,6 +157,21 @@ class InstallCommandTest {
 	}
 
 	@Test
+	void testSetLiteralReachesInstallOptionsVerbatim() throws Exception {
+		File chartDir = createMockChart();
+		ArgumentCaptor<InstallOptions> captor = ArgumentCaptor.forClass(InstallOptions.class);
+		when(installAction.install(captor.capture())).thenReturn(createMockRelease("my-release", 1));
+
+		// The value keeps its commas and stays a string (no coercion), unlike --set.
+		int exit = new CommandLine(installCommand).execute("my-release", chartDir.getAbsolutePath(), "--set-literal",
+				"note=a,b,c", "--set-literal", "port=8080");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		assertEquals("a,b,c", captor.getValue().getValues().get("note"));
+		assertEquals("8080", captor.getValue().getValues().get("port"));
+	}
+
+	@Test
 	void testMissingNameWithoutGenerateNameIsUsageError() throws Exception {
 		File chartDir = createMockChart();
 		int exit = new CommandLine(installCommand).execute(chartDir.getAbsolutePath());

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesOverrides.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ValuesOverrides.java
@@ -29,6 +29,9 @@ import tools.jackson.databind.json.JsonMapper;
  * <li>{@code --set-string} — the value is always the raw string (no coercion).</li>
  * <li>{@code --set-file} — the value is the contents of the file at the given path.</li>
  * <li>{@code --set-json} — the value is parsed as JSON into a map, list or scalar.</li>
+ * <li>{@code --set-literal} — the value is always the raw string, taken fully literally
+ * (no coercion, no comma or escape interpretation), and applied last (highest
+ * precedence).</li>
  * </ul>
  */
 public final class ValuesOverrides {
@@ -56,7 +59,7 @@ public final class ValuesOverrides {
 	 * @throws IOException if any values file cannot be read
 	 */
 	public static Map<String, Object> parse(List<String> files, List<String> setArgs) throws IOException {
-		return parse(files, setArgs, null, null, null);
+		return parse(files, setArgs, null, null, null, null);
 	}
 
 	/**
@@ -75,12 +78,14 @@ public final class ValuesOverrides {
 	 * {@code null} or empty means none
 	 * @param setJsonArgs {@code key=json} strings whose value is parsed as JSON;
 	 * {@code null} or empty means none
+	 * @param setLiteralArgs {@code key=value} strings kept as fully literal raw strings,
+	 * applied last; {@code null} or empty means none
 	 * @return merged override map
 	 * @throws IOException if any values file cannot be read
 	 */
 	public static Map<String, Object> parse(List<String> files, List<String> setArgs, List<String> setStringArgs,
-			List<String> setFileArgs, List<String> setJsonArgs) throws IOException {
-		return parse(files, ValuesProfiles.none(), setArgs, setStringArgs, setFileArgs, setJsonArgs);
+			List<String> setFileArgs, List<String> setJsonArgs, List<String> setLiteralArgs) throws IOException {
+		return parse(files, ValuesProfiles.none(), setArgs, setStringArgs, setFileArgs, setJsonArgs, setLiteralArgs);
 	}
 
 	/**
@@ -95,12 +100,15 @@ public final class ValuesOverrides {
 	 * @param setStringArgs {@code key=value} strings kept as raw strings
 	 * @param setFileArgs {@code key=path} strings whose value is the file contents
 	 * @param setJsonArgs {@code key=json} strings whose value is parsed as JSON
+	 * @param setLiteralArgs {@code key=value} strings kept as fully literal raw strings
 	 * @return merged override map
 	 * @throws IOException if any values file cannot be read
 	 */
 	public static Map<String, Object> parse(List<String> files, ValuesProfiles profiles, List<String> setArgs,
-			List<String> setStringArgs, List<String> setFileArgs, List<String> setJsonArgs) throws IOException {
-		return parse(files, profiles, null, false, false, setArgs, setStringArgs, setFileArgs, setJsonArgs);
+			List<String> setStringArgs, List<String> setFileArgs, List<String> setJsonArgs, List<String> setLiteralArgs)
+			throws IOException {
+		return parse(files, profiles, null, false, false, setArgs, setStringArgs, setFileArgs, setJsonArgs,
+				setLiteralArgs);
 	}
 
 	/**
@@ -126,13 +134,14 @@ public final class ValuesOverrides {
 	 * @param setStringArgs {@code key=value} strings kept as raw strings
 	 * @param setFileArgs {@code key=path} strings whose value is the file contents
 	 * @param setJsonArgs {@code key=json} strings whose value is parsed as JSON
+	 * @param setLiteralArgs {@code key=value} strings kept as fully literal raw strings
 	 * @return merged override map
 	 * @throws IOException if any values file cannot be read
 	 */
 	public static Map<String, Object> parse(List<String> files, ValuesProfiles profiles,
 			Map<String, Object> configServerValues, boolean overrideNone, boolean overrideSystemProperties,
-			List<String> setArgs, List<String> setStringArgs, List<String> setFileArgs, List<String> setJsonArgs)
-			throws IOException {
+			List<String> setArgs, List<String> setStringArgs, List<String> setFileArgs, List<String> setJsonArgs,
+			List<String> setLiteralArgs) throws IOException {
 		Map<String, Object> fileValues = loadFiles(files, profiles);
 		Map<String, Object> configValues = (configServerValues != null) ? configServerValues : Map.of();
 		Map<String, Object> merged = new HashMap<>();
@@ -140,19 +149,19 @@ public final class ValuesOverrides {
 			// config server = defaults: lowest precedence.
 			ValuesLoader.deepMerge(merged, configValues);
 			ValuesLoader.deepMerge(merged, fileValues);
-			applySetFamily(merged, setArgs, setStringArgs, setFileArgs, setJsonArgs);
+			applySetFamily(merged, setArgs, setStringArgs, setFileArgs, setJsonArgs, setLiteralArgs);
 		}
 		else if (overrideSystemProperties) {
 			// config server above the --set family.
 			ValuesLoader.deepMerge(merged, fileValues);
-			applySetFamily(merged, setArgs, setStringArgs, setFileArgs, setJsonArgs);
+			applySetFamily(merged, setArgs, setStringArgs, setFileArgs, setJsonArgs, setLiteralArgs);
 			ValuesLoader.deepMerge(merged, configValues);
 		}
 		else {
 			// default: files < config server < --set.
 			ValuesLoader.deepMerge(merged, fileValues);
 			ValuesLoader.deepMerge(merged, configValues);
-			applySetFamily(merged, setArgs, setStringArgs, setFileArgs, setJsonArgs);
+			applySetFamily(merged, setArgs, setStringArgs, setFileArgs, setJsonArgs, setLiteralArgs);
 		}
 		return merged;
 	}
@@ -175,7 +184,7 @@ public final class ValuesOverrides {
 	}
 
 	private static void applySetFamily(Map<String, Object> merged, List<String> setArgs, List<String> setStringArgs,
-			List<String> setFileArgs, List<String> setJsonArgs) {
+			List<String> setFileArgs, List<String> setJsonArgs, List<String> setLiteralArgs) {
 		if (setArgs != null) {
 			for (String arg : setArgs) {
 				applySet(merged, arg);
@@ -194,6 +203,11 @@ public final class ValuesOverrides {
 		if (setJsonArgs != null) {
 			for (String arg : setJsonArgs) {
 				applySetJson(merged, arg);
+			}
+		}
+		if (setLiteralArgs != null) {
+			for (String arg : setLiteralArgs) {
+				applySetLiteral(merged, arg);
 			}
 		}
 	}
@@ -220,6 +234,18 @@ public final class ValuesOverrides {
 	 * @param arg the {@code key=value} string
 	 */
 	static void applySetString(Map<String, Object> target, String arg) {
+		applyTyped(target, arg, Function.identity());
+	}
+
+	/**
+	 * Parse a single {@code key=value} set argument and apply it to {@code target},
+	 * keeping the value as a fully literal raw string (Helm {@code --set-literal}). Only
+	 * the first {@code =} splits key from value, so commas, dots and backslashes in the
+	 * value are kept verbatim rather than interpreted.
+	 * @param target the map to merge into
+	 * @param arg the {@code key=value} string
+	 */
+	static void applySetLiteral(Map<String, Object> target, String arg) {
 		applyTyped(target, arg, Function.identity());
 	}
 

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesOverridesConfigServerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesOverridesConfigServerTest.java
@@ -38,7 +38,7 @@ class ValuesOverridesConfigServerTest {
 
 	private Map<String, Object> parse(boolean overrideNone, boolean overrideSystemProperties) throws IOException {
 		return ValuesOverrides.parse(file, ValuesProfiles.none(), configServer, overrideNone, overrideSystemProperties,
-				set, null, null, null);
+				set, null, null, null, null);
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesOverridesTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ValuesOverridesTest.java
@@ -158,6 +158,39 @@ class ValuesOverridesTest {
 		assertEquals("true", target.get("foo"));
 	}
 
+	// --- applySetLiteral (fully literal) ---
+
+	@Test
+	void testApplySetLiteralKeepsCommasVerbatim() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySetLiteral(target, "foo=a,b,c");
+		assertEquals("a,b,c", target.get("foo"));
+		assertInstanceOf(String.class, target.get("foo"));
+	}
+
+	@Test
+	void testApplySetLiteralIntegerStaysString() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySetLiteral(target, "foo=3");
+		assertEquals("3", target.get("foo"));
+		assertInstanceOf(String.class, target.get("foo"));
+	}
+
+	@Test
+	void testApplySetLiteralNestsOnDottedKey() {
+		Map<String, Object> target = new HashMap<>();
+		ValuesOverrides.applySetLiteral(target, "outer.inner=1.2.3");
+		Map<?, ?> outer = (Map<?, ?>) target.get("outer");
+		assertEquals("1.2.3", outer.get("inner"));
+	}
+
+	@Test
+	void testSetLiteralWinsOverSetJson() throws Exception {
+		Map<String, Object> result = ValuesOverrides.parse(null, null, null, null, List.of("replicas=3"),
+				List.of("replicas=literal"));
+		assertEquals("literal", result.get("replicas"));
+	}
+
 	// --- applySetFile ---
 
 	@Test
@@ -195,7 +228,7 @@ class ValuesOverridesTest {
 				tag: filetag
 				""");
 		Map<String, Object> result = ValuesOverrides.parse(List.of(f.toString()), List.of("replicas=2", "tag=settag"),
-				null, null, List.of("replicas=3"));
+				null, null, List.of("replicas=3"), null);
 		// set-json wins over set wins over file
 		assertEquals(3, result.get("replicas"));
 		// set wins over file


### PR DESCRIPTION
Adds Helm's `--set-literal`, continuing #680.

## What
The value after the first `=` is taken **fully literally** — no type coercion, no comma-as-separator, no escape interpretation; only the key path is dot-nested. Applied **last** in the `--set` family, so highest precedence.

- `ValuesOverrides` gains `applySetLiteral` + a `setLiteralArgs` group threaded through the `parse` overloads and `applySetFamily` (applied after `--set-json`).
- `InstallCommand`, `UpgradeCommand`, `TemplateCommand`, `LintCommand` each expose `--set-literal`.

In jhelm's value model `--set-string` already avoids comma-splitting; `--set-literal` makes that guarantee explicit and gives it top precedence, matching Helm.

## Tests
- `ValuesOverridesTest` — literal keeps commas verbatim, integers stay strings, dotted-key nesting, precedence over `--set-json`.
- `InstallCommandTest` — end-to-end: `--set-literal note=a,b,c port=8080` reaches values as strings.

## #680 remaining
`--dependency-update` (needs the DependencyResolver machinery) and install-from-repo (#682's territory).

Part of #680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)