### PR TITLE
feat(cli): --dependency-update on install/upgrade/template (#680)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -23,6 +23,10 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
 * *`--set-literal`* -- on `install`, `upgrade`, `template`, and `lint`: set a value taken fully
   literally (no type coercion, no comma or escape interpretation), applied at the highest
   precedence in the `--set` family (#680).
+* *`--dependency-update`* -- on `install`, `upgrade`, and `template`: update a local chart's
+  `charts/` from its `Chart.yaml` dependencies (like `helm dependency update`) before the
+  operation. The update flow is now a reusable `DependencyUpdateAction` shared with the
+  `dependency update` command (#680).
 * *REST releases API now returns Helm-shaped JSON* -- the `/releases` list/status/history and
   install/upgrade responses now use Helm's `-o json` schema (snake_case, nested `info`) instead
   of jhelm's internal DTO, so REST consumers see the same shape as `helm ... -o json` and the

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -36,7 +36,7 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | `--description` (upgrade) | ✅ | Custom description for the new revision (falls back to `Upgrade complete`).
 | `--labels` (upgrade) | ✅ | `key=value` labels for the new revision; without it, the previous release's labels are carried forward (like Helm).
 | `--set-literal` | ✅ | Sets a fully literal string value (no coercion/comma/escape handling), applied last; also on `template` and `lint`.
-| `--dependency-update` | ✗ | Not yet wired.
+| `--dependency-update` | ✅ | Updates a local chart's `charts/` from `Chart.yaml` before the operation; also on `template`. No-op for repo refs / `.tgz`.
 |===
 
 == uninstall
@@ -141,9 +141,9 @@ Beyond the per-command tables above, these commonly-used Helm options are not ye
 
 * *`list`* — `-A`/`--all-namespaces`, `-l`/`--selector`, `-a`/`--all`, the status filters,
   `--max`/`--offset`/`--filter`.
-* *`install`/`upgrade`* — install-from-repo (`--version`/`--repo`/`--username`/`--password`),
-  `--dependency-update`; `upgrade --cleanup-on-fail`.
-  (`-g`/`--generate-name` is supported on `install`; `--description`/`--labels`/`--set-literal` on both.)
+* *`install`/`upgrade`* — install-from-repo (`--version`/`--repo`/`--username`/`--password`);
+  `upgrade --cleanup-on-fail`.
+  (`-g`/`--generate-name` is supported on `install`; `--description`/`--labels`/`--set-literal`/`--dependency-update` on both.)
 * *`uninstall`/`rollback`* — `--wait`/`--timeout`/`--cascade` (uninstall);
   `--force`/`--cleanup-on-fail`/`--recreate-pods`/`--wait-for-jobs` (rollback).
 * *`pull`* — `--untar`/`--untardir`, `--verify`/`--prov`/`--keyring`, `--devel`.

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/DependencyCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/DependencyCommand.java
@@ -6,9 +6,9 @@ import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.ChartLock;
 import org.alexmond.jhelm.core.model.Dependency;
+import org.alexmond.jhelm.core.action.DependencyUpdateAction;
 import org.alexmond.jhelm.core.service.DependencyResolver;
 import org.alexmond.jhelm.core.service.RepoManager;
-import org.alexmond.jhelm.core.util.ValuesLoader;
 import org.alexmond.jhelm.core.model.ChartLock.LockDependency;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
@@ -228,34 +228,17 @@ public class DependencyCommand implements Callable<Integer> {
 					return CommandLine.ExitCode.SOFTWARE;
 				}
 
-				// Refresh repositories unless --skip-refresh
 				if (!skipRefresh) {
 					CliOutput.println("Hang tight while we grab the latest from your chart repositories...");
-					repoManager.updateAll();
-					CliOutput.println(CliOutput.success("...Successfully got an update from the chart repositories"));
 				}
+				CliOutput.println("Updating dependencies from Chart.yaml...");
+				ChartLock chartLock = new DependencyUpdateAction(repoManager).update(chartDir,
+						withTags.isEmpty() ? null : withTags, skipRefresh);
 
-				// Load Chart.yaml
-				ChartMetadata metadata = loadChartMetadata(chartDir);
-				if (metadata.getDependencies() == null || metadata.getDependencies().isEmpty()) {
+				if (chartLock.getDependencies().isEmpty()) {
 					CliOutput.println("No dependencies found in Chart.yaml");
 					return CommandLine.ExitCode.OK;
 				}
-
-				// Load values.yaml for condition evaluation
-				Map<String, Object> values = loadValues(chartDir);
-
-				// Resolve dependencies
-				DependencyResolver resolver = new DependencyResolver(repoManager);
-				ChartLock chartLock = resolver.resolveDependencies(metadata, values,
-						withTags.isEmpty() ? null : withTags);
-
-				// Download dependencies
-				CliOutput.println("Updating dependencies from Chart.yaml...");
-				resolver.downloadDependencies(chartDir, chartLock.getDependencies());
-
-				// Save Chart.lock
-				chartLock.toFile(chartDir);
 				CliOutput.println("Saving " + chartLock.getDependencies().size() + " charts");
 				CliOutput.println(CliOutput.success("Dependency update complete."));
 				return CommandLine.ExitCode.OK;
@@ -266,32 +249,6 @@ public class DependencyCommand implements Callable<Integer> {
 					log.debug("Dependency update error details", ex);
 				}
 				return CommandLine.ExitCode.SOFTWARE;
-			}
-		}
-
-		private ChartMetadata loadChartMetadata(File chartDir) {
-			File chartFile = new File(chartDir, "Chart.yaml");
-			if (!chartFile.exists()) {
-				throw new IllegalStateException("Chart.yaml not found in " + chartDir.getAbsolutePath());
-			}
-
-			YAMLMapper yamlMapper = YAMLMapper.builder().build();
-			return yamlMapper.readValue(chartFile, ChartMetadata.class);
-		}
-
-		private Map<String, Object> loadValues(File chartDir) {
-			try {
-				File valuesFile = new File(chartDir, "values.yaml");
-				if (!valuesFile.exists()) {
-					return new HashMap<>();
-				}
-				return ValuesLoader.load(valuesFile);
-			}
-			catch (Exception ex) {
-				if (log.isWarnEnabled()) {
-					log.warn("Failed to load values.yaml: {}", ex.getMessage());
-				}
-				return new HashMap<>();
 			}
 		}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.app.command;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -10,6 +11,7 @@ import java.util.concurrent.Callable;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.output.OutputFormat;
+import org.alexmond.jhelm.core.action.DependencyUpdateAction;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;
@@ -51,6 +53,8 @@ public class InstallCommand implements Callable<Integer> {
 	private final JhelmCoreProperties coreProperties;
 
 	private final ConfigServerValuesLoader configServerValuesLoader;
+
+	private final DependencyUpdateAction dependencyUpdateAction;
 
 	@CommandLine.Mixin
 	private final ConfigServerCliOptions configServerOptions = new ConfigServerCliOptions();
@@ -143,6 +147,10 @@ public class InstallCommand implements Callable<Integer> {
 			description = "output format: table (default human summary), json, or yaml")
 	private String output;
 
+	@Option(names = { "--dependency-update" },
+			description = "update dependencies from Chart.yaml to charts/ before installing (local chart dir only)")
+	private boolean dependencyUpdate;
+
 	/**
 	 * Creates the command.
 	 * @param installAction the action that performs the install
@@ -152,10 +160,14 @@ public class InstallCommand implements Callable<Integer> {
 	 * optional provenance verification
 	 * @param securityPolicy the unified access-mode policy; install is refused unless
 	 * mutating operations are enabled
+	 * @param coreProperties the core properties supplying default active profiles
+	 * @param configServerValuesLoader loads values from a Spring Cloud Config Server
+	 * @param dependencyUpdateAction updates chart dependencies when
+	 * {@code --dependency-update} is set
 	 */
 	public InstallCommand(InstallAction installAction, UninstallAction uninstallAction, KubeService kubeService,
 			ChartResolver chartResolver, JhelmSecurityPolicy securityPolicy, JhelmCoreProperties coreProperties,
-			ConfigServerValuesLoader configServerValuesLoader) {
+			ConfigServerValuesLoader configServerValuesLoader, DependencyUpdateAction dependencyUpdateAction) {
 		this.installAction = installAction;
 		this.uninstallAction = uninstallAction;
 		this.kubeService = kubeService;
@@ -163,6 +175,7 @@ public class InstallCommand implements Callable<Integer> {
 		this.securityPolicy = securityPolicy;
 		this.coreProperties = coreProperties;
 		this.configServerValuesLoader = configServerValuesLoader;
+		this.dependencyUpdateAction = dependencyUpdateAction;
 	}
 
 	@Override
@@ -177,6 +190,12 @@ public class InstallCommand implements Callable<Integer> {
 			boolean dryRunEnabled = resolveDryRun();
 			ValuesProfiles profiles = ValuesProfiles
 				.of(profileNames.isEmpty() ? coreProperties.getProfiles().getActive() : profileNames);
+			if (dependencyUpdate) {
+				File localChart = new File(chartPath);
+				if (localChart.isDirectory()) {
+					dependencyUpdateAction.update(localChart, List.of(), false);
+				}
+			}
 			Chart chart = chartResolver.resolve(chartPath, verify, keyring, profiles);
 			if (name == null) {
 				name = ReleaseNames.generateName(chart.getMetadata().getName());

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.app.command;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -11,6 +12,7 @@ import java.util.concurrent.Callable;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.action.DependencyUpdateAction;
 import org.alexmond.jhelm.core.action.TemplateAction;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
@@ -36,6 +38,8 @@ public class TemplateCommand implements Callable<Integer> {
 	private final JhelmCoreProperties coreProperties;
 
 	private final ConfigServerValuesLoader configServerValuesLoader;
+
+	private final DependencyUpdateAction dependencyUpdateAction;
 
 	@CommandLine.Mixin
 	private final ConfigServerCliOptions configServerOptions = new ConfigServerCliOptions();
@@ -72,6 +76,10 @@ public class TemplateCommand implements Callable<Integer> {
 	@Option(names = { "--set-literal" },
 			description = "set a literal STRING value on the command line (key=value, no coercion or escaping)")
 	private List<String> setLiteralValues = new ArrayList<>();
+
+	@Option(names = { "--dependency-update" },
+			description = "update dependencies from Chart.yaml to charts/ before rendering (local chart dir only)")
+	private boolean dependencyUpdate;
 
 	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
@@ -111,10 +119,11 @@ public class TemplateCommand implements Callable<Integer> {
 	 * by default)
 	 */
 	public TemplateCommand(TemplateAction templateAction, JhelmCoreProperties coreProperties,
-			ConfigServerValuesLoader configServerValuesLoader) {
+			ConfigServerValuesLoader configServerValuesLoader, DependencyUpdateAction dependencyUpdateAction) {
 		this.templateAction = templateAction;
 		this.coreProperties = coreProperties;
 		this.configServerValuesLoader = configServerValuesLoader;
+		this.dependencyUpdateAction = dependencyUpdateAction;
 	}
 
 	@Override
@@ -127,6 +136,12 @@ public class TemplateCommand implements Callable<Integer> {
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, profiles, configServer.values(),
 					configServer.overrideNone(), configServer.overrideSystemProperties(), setValues, setStringValues,
 					setFileValues, setJsonValues, setLiteralValues);
+			if (dependencyUpdate) {
+				File localChart = new File(chartPath);
+				if (localChart.isDirectory()) {
+					dependencyUpdateAction.update(localChart, List.of(), false);
+				}
+			}
 			String manifest = templateAction.render(chartPath, name, namespace, overrides, profiles, kubeVersion,
 					apiVersions, isUpgrade, includeCrds);
 			for (String renderer : postRenderers) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.app.command;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.concurrent.Callable;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.output.OutputFormat;
+import org.alexmond.jhelm.core.action.DependencyUpdateAction;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.RollbackAction;
@@ -59,6 +61,8 @@ public class UpgradeCommand implements Callable<Integer> {
 	private final JhelmCoreProperties coreProperties;
 
 	private final ConfigServerValuesLoader configServerValuesLoader;
+
+	private final DependencyUpdateAction dependencyUpdateAction;
 
 	@CommandLine.Mixin
 	private final ConfigServerCliOptions configServerOptions = new ConfigServerCliOptions();
@@ -157,6 +161,10 @@ public class UpgradeCommand implements Callable<Integer> {
 			description = "limit the maximum number of revisions saved per release (0 = no limit)")
 	private int historyMax;
 
+	@Option(names = { "--dependency-update" },
+			description = "update dependencies from Chart.yaml to charts/ before upgrading (local chart dir only)")
+	private boolean dependencyUpdate;
+
 	@Option(names = { "--description" }, description = "add a custom description to the new revision")
 	private String description;
 
@@ -182,7 +190,7 @@ public class UpgradeCommand implements Callable<Integer> {
 	public UpgradeCommand(KubeService kubeService, InstallAction installAction, UninstallAction uninstallAction,
 			UpgradeAction upgradeAction, RollbackAction rollbackAction, ChartResolver chartResolver,
 			JhelmSecurityPolicy securityPolicy, JhelmCoreProperties coreProperties,
-			ConfigServerValuesLoader configServerValuesLoader) {
+			ConfigServerValuesLoader configServerValuesLoader, DependencyUpdateAction dependencyUpdateAction) {
 		this.kubeService = kubeService;
 		this.installAction = installAction;
 		this.uninstallAction = uninstallAction;
@@ -192,6 +200,7 @@ public class UpgradeCommand implements Callable<Integer> {
 		this.securityPolicy = securityPolicy;
 		this.coreProperties = coreProperties;
 		this.configServerValuesLoader = configServerValuesLoader;
+		this.dependencyUpdateAction = dependencyUpdateAction;
 	}
 
 	@Override
@@ -208,6 +217,7 @@ public class UpgradeCommand implements Callable<Integer> {
 				.of(profileNames.isEmpty() ? coreProperties.getProfiles().getActive() : profileNames);
 			ConfigServerValuesLoader.Result configServer = configServerValuesLoader.load(name, profiles.active(),
 					configServerOptions.toOptions());
+			updateDependenciesIfRequested();
 			Chart chart = chartResolver.resolve(chartPath, verify, keyring, profiles);
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, profiles, configServer.values(),
 					configServer.overrideNone(), configServer.overrideSystemProperties(), setValues, setStringValues,
@@ -313,6 +323,17 @@ public class UpgradeCommand implements Callable<Integer> {
 			.serverDryRun(serverDryRun)
 			.noHooks(noHooks)
 			.build();
+	}
+
+	// Runs `dependency update` on a local chart directory before the upgrade when
+	// --dependency-update is set; a no-op for repo refs and .tgz archives.
+	private void updateDependenciesIfRequested() throws IOException {
+		if (dependencyUpdate) {
+			File localChart = new File(chartPath);
+			if (localChart.isDirectory()) {
+				dependencyUpdateAction.update(localChart, List.of(), false);
+			}
+		}
 	}
 
 	private UpgradeOptions buildUpgradeOptions(Release current, Chart chart, Map<String, Object> overrides,

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -12,6 +12,7 @@ import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ReleaseStatus;
+import org.alexmond.jhelm.core.action.DependencyUpdateAction;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.UninstallAction;
@@ -62,6 +63,9 @@ class InstallCommandTest {
 	@Mock
 	private ChartResolver chartResolver;
 
+	@Mock
+	private DependencyUpdateAction dependencyUpdateAction;
+
 	private InstallCommand installCommand;
 
 	@TempDir
@@ -76,7 +80,8 @@ class InstallCommandTest {
 			.build();
 		when(chartResolver.resolve(anyString(), anyBoolean(), any())).thenReturn(defaultChart);
 		installCommand = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver, enabledPolicy(),
-				new JhelmCoreProperties(), new ConfigServerValuesLoader(new ConfigServerProperties(), null));
+				new JhelmCoreProperties(), new ConfigServerValuesLoader(new ConfigServerProperties(), null),
+				dependencyUpdateAction);
 	}
 
 	private static JhelmSecurityPolicy enabledPolicy() {
@@ -157,6 +162,28 @@ class InstallCommandTest {
 	}
 
 	@Test
+	void testDependencyUpdateTriggersUpdateOnLocalChartDir() throws Exception {
+		File chartDir = createMockChart();
+		when(installAction.install(any(InstallOptions.class))).thenReturn(createMockRelease("my-release", 1));
+
+		int exit = new CommandLine(installCommand).execute("my-release", chartDir.getAbsolutePath(),
+				"--dependency-update");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		verify(dependencyUpdateAction).update(any(File.class), any(), eq(false));
+	}
+
+	@Test
+	void testNoDependencyUpdateWhenFlagAbsent() throws Exception {
+		File chartDir = createMockChart();
+		when(installAction.install(any(InstallOptions.class))).thenReturn(createMockRelease("my-release", 1));
+
+		new CommandLine(installCommand).execute("my-release", chartDir.getAbsolutePath());
+
+		verify(dependencyUpdateAction, never()).update(any(File.class), any(), anyBoolean());
+	}
+
+	@Test
 	void testSetLiteralReachesInstallOptionsVerbatim() throws Exception {
 		File chartDir = createMockChart();
 		ArgumentCaptor<InstallOptions> captor = ArgumentCaptor.forClass(InstallOptions.class);
@@ -215,7 +242,7 @@ class InstallCommandTest {
 		File chartDir = createMockChart();
 		InstallCommand readOnly = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver,
 				readOnlyPolicy(), new JhelmCoreProperties(),
-				new ConfigServerValuesLoader(new ConfigServerProperties(), null));
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction);
 
 		int exitCode = new CommandLine(readOnly).execute("my-release", chartDir.getAbsolutePath());
 
@@ -234,7 +261,7 @@ class InstallCommandTest {
 		when(installAction.install(any(InstallOptions.class))).thenReturn(createMockRelease("my-release", 1));
 		InstallCommand full = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver,
 				new JhelmSecurityPolicy(props), new JhelmCoreProperties(),
-				new ConfigServerValuesLoader(new ConfigServerProperties(), null));
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction);
 
 		int exitCode = new CommandLine(full).execute("my-release", chartDir.getAbsolutePath(), "-n", "default");
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/TemplateCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/TemplateCommandTest.java
@@ -1,12 +1,14 @@
 package org.alexmond.jhelm.app.command;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import org.alexmond.jhelm.core.action.DependencyUpdateAction;
 import org.alexmond.jhelm.core.action.TemplateAction;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.alexmond.jhelm.core.config.ConfigServerProperties;
@@ -27,6 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,13 +39,16 @@ class TemplateCommandTest {
 	@Mock
 	private TemplateAction templateAction;
 
+	@Mock
+	private DependencyUpdateAction dependencyUpdateAction;
+
 	private TemplateCommand templateCommand;
 
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
 		templateCommand = new TemplateCommand(templateAction, new JhelmCoreProperties(),
-				new ConfigServerValuesLoader(new ConfigServerProperties(), null));
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction);
 	}
 
 	@Test
@@ -133,6 +139,15 @@ class TemplateCommandTest {
 	}
 
 	@Test
+	void testDependencyUpdateTriggersUpdateOnLocalChartDir(@TempDir Path chartDir) throws Exception {
+		stubRender(MULTI_DOC);
+
+		new CommandLine(templateCommand).execute("r", chartDir.toString(), "--dependency-update");
+
+		verify(dependencyUpdateAction).update(any(File.class), any(), eq(false));
+	}
+
+	@Test
 	void testShowOnlyFiltersRenderedOutput() {
 		stubRender(MULTI_DOC);
 		String out = captureStdout(() -> new CommandLine(templateCommand).execute("r", "/chart", "--show-only",
@@ -176,7 +191,7 @@ class TemplateCommandTest {
 
 	private ValuesProfiles runAndCaptureProfiles(JhelmCoreProperties props, String... args) {
 		TemplateCommand command = new TemplateCommand(templateAction, props,
-				new ConfigServerValuesLoader(new ConfigServerProperties(), null));
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction);
 		ArgumentCaptor<ValuesProfiles> captor = ArgumentCaptor.forClass(ValuesProfiles.class);
 		when(templateAction.render(anyString(), anyString(), anyString(), anyMap(), captor.capture(), any(), anyList(),
 				anyBoolean(), anyBoolean()))

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -8,6 +8,7 @@ import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.core.action.DependencyUpdateAction;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.RollbackAction;
@@ -71,6 +72,9 @@ class UpgradeCommandTest {
 	@Mock
 	private ChartResolver chartResolver;
 
+	@Mock
+	private DependencyUpdateAction dependencyUpdateAction;
+
 	private UpgradeCommand upgradeCommand;
 
 	@TempDir
@@ -86,7 +90,7 @@ class UpgradeCommandTest {
 		when(chartResolver.resolve(anyString(), anyBoolean(), any())).thenReturn(defaultChart);
 		upgradeCommand = new UpgradeCommand(kubeService, installAction, uninstallAction, upgradeAction, rollbackAction,
 				chartResolver, enabledPolicy(), new JhelmCoreProperties(),
-				new ConfigServerValuesLoader(new ConfigServerProperties(), null));
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction);
 	}
 
 	private static JhelmSecurityPolicy enabledPolicy() {
@@ -143,7 +147,7 @@ class UpgradeCommandTest {
 		File chartDir = createMockChart();
 		UpgradeCommand readOnly = new UpgradeCommand(kubeService, installAction, uninstallAction, upgradeAction,
 				rollbackAction, chartResolver, readOnlyPolicy(), new JhelmCoreProperties(),
-				new ConfigServerValuesLoader(new ConfigServerProperties(), null));
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction);
 
 		int exitCode = new CommandLine(readOnly).execute("my-release", chartDir.getAbsolutePath());
 
@@ -208,6 +212,18 @@ class UpgradeCommandTest {
 
 		verify(upgradeAction).upgrade(opts.capture());
 		assertTrue(opts.getValue().isForce());
+	}
+
+	@Test
+	void testDependencyUpdateTriggersUpdateOnLocalChartDir() throws Exception {
+		File chartDir = createMockChart();
+		when(kubeService.getRelease(anyString(), anyString()))
+			.thenReturn(Optional.of(createMockRelease("my-release", 1)));
+		when(upgradeAction.upgrade(any(UpgradeOptions.class))).thenReturn(createMockRelease("my-release", 2));
+
+		new CommandLine(upgradeCommand).execute("my-release", chartDir.getAbsolutePath(), "--dependency-update");
+
+		verify(dependencyUpdateAction).update(any(File.class), any(), eq(false));
 	}
 
 	@Test

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.action.CreateAction;
 import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.HistoryAction;
+import org.alexmond.jhelm.core.action.DependencyUpdateAction;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.LintAction;
 import org.alexmond.jhelm.core.action.ListAction;
@@ -254,6 +255,19 @@ public class JhelmCoreAutoConfiguration {
 		}
 		action.setValueEncryptor(valueEncryptor);
 		return action;
+	}
+
+	/**
+	 * Provides the {@code helm dependency update} action, also used by the
+	 * {@code --dependency-update} flag on
+	 * {@code install}/{@code upgrade}/{@code template}.
+	 * @param repoManager the repository manager used to refresh and download dependencies
+	 * @return the dependency-update action bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public DependencyUpdateAction dependencyUpdateAction(RepoManager repoManager) {
+		return new DependencyUpdateAction(repoManager);
 	}
 
 	/**

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/DependencyUpdateAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/DependencyUpdateAction.java
@@ -1,0 +1,93 @@
+package org.alexmond.jhelm.core.action;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.model.ChartLock;
+import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.service.DependencyResolver;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.core.util.ValuesLoader;
+
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+/**
+ * Updates a chart's {@code charts/} directory from its {@code Chart.yaml} dependencies,
+ * resolving version constraints and writing {@code Chart.lock} — the reusable core of
+ * {@code helm dependency update}.
+ * <p>
+ * Extracted so the {@code dependency update} command and the {@code --dependency-update}
+ * flag on {@code install}/{@code upgrade}/{@code template} share one implementation.
+ */
+public class DependencyUpdateAction {
+
+	private final RepoManager repoManager;
+
+	private final DependencyResolver resolver;
+
+	/**
+	 * Creates the action.
+	 * @param repoManager the repository manager used to refresh caches and download
+	 * dependency charts
+	 */
+	public DependencyUpdateAction(RepoManager repoManager) {
+		this(repoManager, new DependencyResolver(repoManager));
+	}
+
+	/**
+	 * Creates the action with an explicit resolver (test seam).
+	 * @param repoManager the repository manager used to refresh caches
+	 * @param resolver the dependency resolver used to resolve and download dependencies
+	 */
+	DependencyUpdateAction(RepoManager repoManager, DependencyResolver resolver) {
+		this.repoManager = repoManager;
+		this.resolver = resolver;
+	}
+
+	/**
+	 * Resolves the chart's declared dependencies, downloads them into {@code charts/},
+	 * and writes {@code Chart.lock}.
+	 * @param chartDir the local chart directory
+	 * @param withTags dependency tags to enable ({@code null}/empty = none)
+	 * @param skipRefresh when {@code true}, skip refreshing the local repository cache
+	 * @return the resolved {@link ChartLock}; its dependency list is empty (and no lock
+	 * is written) when the chart declares no dependencies
+	 * @throws IOException if resolution or download fails
+	 */
+	public ChartLock update(File chartDir, List<String> withTags, boolean skipRefresh) throws IOException {
+		if (!chartDir.isDirectory()) {
+			throw new IllegalArgumentException("Chart directory not found: " + chartDir.getAbsolutePath());
+		}
+		if (!skipRefresh) {
+			this.repoManager.updateAll();
+		}
+		ChartMetadata metadata = loadChartMetadata(chartDir);
+		if (metadata.getDependencies() == null || metadata.getDependencies().isEmpty()) {
+			return ChartLock.builder().dependencies(List.of()).build();
+		}
+		Map<String, Object> values = loadValues(chartDir);
+		List<String> tags = (withTags == null || withTags.isEmpty()) ? null : withTags;
+		ChartLock lock = this.resolver.resolveDependencies(metadata, values, tags);
+		this.resolver.downloadDependencies(chartDir, lock.getDependencies());
+		lock.toFile(chartDir);
+		return lock;
+	}
+
+	private ChartMetadata loadChartMetadata(File chartDir) {
+		File chartFile = new File(chartDir, "Chart.yaml");
+		if (!chartFile.exists()) {
+			throw new IllegalStateException("Chart.yaml not found in " + chartDir.getAbsolutePath());
+		}
+		YAMLMapper yamlMapper = YAMLMapper.builder().build();
+		return yamlMapper.readValue(chartFile, ChartMetadata.class);
+	}
+
+	private Map<String, Object> loadValues(File chartDir) throws IOException {
+		File valuesFile = new File(chartDir, "values.yaml");
+		return valuesFile.exists() ? ValuesLoader.load(valuesFile) : new HashMap<>();
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/DependencyUpdateActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/DependencyUpdateActionTest.java
@@ -1,0 +1,129 @@
+package org.alexmond.jhelm.core.action;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.alexmond.jhelm.core.model.ChartLock;
+import org.alexmond.jhelm.core.model.ChartLock.LockDependency;
+import org.alexmond.jhelm.core.service.DependencyResolver;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DependencyUpdateActionTest {
+
+	@Mock
+	private RepoManager repoManager;
+
+	@Mock
+	private DependencyResolver resolver;
+
+	@TempDir
+	Path tempDir;
+
+	private DependencyUpdateAction action;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		this.action = new DependencyUpdateAction(this.repoManager, this.resolver);
+	}
+
+	private void writeChart(String dependenciesBlock) throws Exception {
+		Files.writeString(tempDir.resolve("Chart.yaml"), """
+				apiVersion: v2
+				name: parent
+				version: 1.0.0
+				""" + dependenciesBlock);
+	}
+
+	@Test
+	void throwsWhenChartPathIsNotADirectory() {
+		File missing = tempDir.resolve("nope").toFile();
+		assertThrows(IllegalArgumentException.class, () -> this.action.update(missing, List.of(), false));
+	}
+
+	@Test
+	void noDependenciesReturnsEmptyLockWithoutWritingChartLock() throws Exception {
+		writeChart("");
+
+		ChartLock lock = this.action.update(tempDir.toFile(), List.of(), false);
+
+		assertTrue(lock.getDependencies().isEmpty());
+		assertFalse(Files.exists(tempDir.resolve("Chart.lock")), "no Chart.lock is written when there are no deps");
+		verify(this.repoManager).updateAll();
+	}
+
+	@Test
+	void skipRefreshDoesNotUpdateRepositories() throws Exception {
+		writeChart("");
+
+		this.action.update(tempDir.toFile(), List.of(), true);
+
+		verify(this.repoManager, never()).updateAll();
+	}
+
+	@Test
+	void resolvesDownloadsAndWritesLockWhenDependenciesPresent() throws Exception {
+		writeChart("""
+				dependencies:
+				  - name: redis
+				    version: "17.0.0"
+				    repository: "https://charts.example.com"
+				""");
+		Files.writeString(tempDir.resolve("values.yaml"), "redis:\n  enabled: true\n");
+		ChartLock resolved = ChartLock.builder()
+			.dependencies(List.of(LockDependency.builder().name("redis").version("17.0.0").build()))
+			.digest("sha256:abc")
+			.build();
+		when(this.resolver.resolveDependencies(any(), any(), any())).thenReturn(resolved);
+
+		ChartLock lock = this.action.update(tempDir.toFile(), List.of(), false);
+
+		assertEquals(1, lock.getDependencies().size());
+		verify(this.resolver).downloadDependencies(eq(tempDir.toFile()), anyList());
+		assertTrue(Files.exists(tempDir.resolve("Chart.lock")), "Chart.lock is written when deps resolve");
+	}
+
+	@Test
+	void passesEnabledTagsThroughAndNullsEmptyTags() throws Exception {
+		writeChart("""
+				dependencies:
+				  - name: redis
+				    version: "17.0.0"
+				    repository: "https://charts.example.com"
+				""");
+		ChartLock resolved = ChartLock.builder()
+			.dependencies(List.of(LockDependency.builder().name("redis").version("17.0.0").build()))
+			.build();
+		when(this.resolver.resolveDependencies(any(), any(), any())).thenReturn(resolved);
+
+		ArgumentCaptor<List<String>> tags = ArgumentCaptor.forClass(List.class);
+
+		this.action.update(tempDir.toFile(), List.of("db"), false);
+		this.action.update(tempDir.toFile(), List.of(), false);
+
+		verify(this.resolver, org.mockito.Mockito.times(2)).resolveDependencies(any(), any(), tags.capture());
+		assertEquals(List.of("db"), tags.getAllValues().get(0));
+		assertNull(tags.getAllValues().get(1), "empty tags collapse to null");
+	}
+
+}


### PR DESCRIPTION
Adds Helm's `--dependency-update` — the last install/upgrade flag in #680.

## What
Before the operation, update a local chart's `charts/` from its `Chart.yaml` dependencies (resolve constraints, download subcharts, write `Chart.lock`).

- **Extract a reusable core `DependencyUpdateAction`** (resolve → download → write lock). Returns an empty-deps `ChartLock` (and writes no lock) when the chart declares no dependencies. Registered as a bean in `JhelmCoreAutoConfiguration`.
- **Refactor** `DependencyCommand.UpdateCommand` to delegate to the action (the CLI `dependency update` command and the flag now share one implementation).
- `InstallCommand`, `UpgradeCommand`, `TemplateCommand` gain `--dependency-update`; it runs **only for a local chart directory** (a no-op for repo refs / `.tgz`), before the chart is resolved/rendered.

## Tests
- `DependencyUpdateActionTest` — non-dir error; no-deps returns empty lock without writing `Chart.lock`; `--skip-refresh` skips the repo refresh.
- `InstallCommandTest` — the flag triggers the action on a local dir; absent flag does not.

## #680 — complete
With this, #680's install/upgrade flag set is done (`-g`, `--description`, `--labels`, `--set-literal`, `--dependency-update`). Install-from-repo (`--repo`/`--version`/creds) is tracked separately under #682.

Part of #680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)