### PR TITLE
feat(cli): list -l/--selector, --filter, --offset/--max (#681)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -27,6 +27,9 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
   `charts/` from its `Chart.yaml` dependencies (like `helm dependency update`) before the
   operation. The update flow is now a reusable `DependencyUpdateAction` shared with the
   `dependency update` command (#680).
+* *`list` filtering & pagination* -- `list` gains `-l`/`--selector` (label selector, `key=value`
+  / `key!=value`, comma-ANDed), `--filter` (regex on the release name), and `--offset`/`-m`/`--max`
+  (paginate; default max 256). Results are sorted by name (#681).
 * *REST releases API now returns Helm-shaped JSON* -- the `/releases` list/status/history and
   install/upgrade responses now use Helm's `-o json` schema (snake_case, nested `info`) instead
   of jhelm's internal DTO, so REST consumers see the same shape as `helm ... -o json` and the

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -139,8 +139,9 @@ Most scripts work unchanged. Watch for these deliberate differences:
 Beyond the per-command tables above, these commonly-used Helm options are not yet wired
 (tracked for follow-up):
 
-* *`list`* — `-A`/`--all-namespaces`, `-l`/`--selector`, `-a`/`--all`, the status filters,
-  `--max`/`--offset`/`--filter`.
+* *`list`* — `-A`/`--all-namespaces`, `-a`/`--all`, the status filters
+  (`--deployed`/`--failed`/`--pending`/`--uninstalled`/`--superseded`).
+  (`-l`/`--selector`, `--filter`, and `--offset`/`--max` are supported.)
 * *`install`/`upgrade`* — install-from-repo (`--version`/`--repo`/`--username`/`--password`);
   `upgrade --cleanup-on-fail`.
   (`-g`/`--generate-name` is supported on `install`; `--description`/`--labels`/`--set-literal`/`--dependency-update` on both.)

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
@@ -5,6 +5,7 @@ import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.ListAction;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.output.OutputFormat;
+import org.alexmond.jhelm.core.util.ReleaseFilters;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
@@ -32,6 +33,22 @@ public class ListCommand implements Callable<Integer> {
 			description = "output format: table, json, or yaml")
 	private String output;
 
+	@CommandLine.Option(names = { "-l", "--selector" },
+			description = "filter by a label selector (key=value or key!=value, comma-separated, all ANDed)")
+	private String selector;
+
+	@CommandLine.Option(names = { "--filter" },
+			description = "filter releases by a regular expression matched against the name")
+	private String filter;
+
+	@CommandLine.Option(names = { "--offset" }, defaultValue = "0",
+			description = "next release index in the list to start from")
+	private int offset;
+
+	@CommandLine.Option(names = { "-m", "--max" }, defaultValue = "256",
+			description = "maximum number of releases to fetch (0 = no limit)")
+	private int max;
+
 	/**
 	 * Creates the command.
 	 * @param listAction the action that lists releases
@@ -55,7 +72,7 @@ public class ListCommand implements Callable<Integer> {
 	@Override
 	public Integer call() {
 		try {
-			List<Release> releases = listAction.list(namespace);
+			List<Release> releases = ReleaseFilters.apply(listAction.list(namespace), selector, filter, offset, max);
 			switch (output.toLowerCase(Locale.ROOT)) {
 				case "json" -> System.out.println(OutputFormat.json(toRows(releases)));
 				case "yaml" -> System.out.print(OutputFormat.yaml(toRows(releases)));

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ListCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ListCommandTest.java
@@ -17,6 +17,8 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -86,6 +88,43 @@ class ListCommandTest {
 		assertTrue(out.contains("\"status\":\"deployed\""), out);
 		assertTrue(out.contains("\"chart\":\"test-chart-1.0.0\""), out);
 		assertTrue(out.contains("\"app_version\""), out);
+	}
+
+	@Test
+	void testListFilterByNameRegex() throws Exception {
+		when(listAction.list(anyString()))
+			.thenReturn(Arrays.asList(createMockRelease("web", 1), createMockRelease("db", 1)));
+
+		new CommandLine(listCommand).execute("-o", "json", "--filter", "^web$");
+
+		String out = captured();
+		assertTrue(out.contains("\"name\":\"web\""), out);
+		assertFalse(out.contains("\"name\":\"db\""), out);
+	}
+
+	@Test
+	void testListSelectorByLabel() throws Exception {
+		Release payments = createMockRelease("web", 1).toBuilder().labels(Map.of("team", "payments")).build();
+		Release search = createMockRelease("db", 1).toBuilder().labels(Map.of("team", "search")).build();
+		when(listAction.list(anyString())).thenReturn(Arrays.asList(payments, search));
+
+		new CommandLine(listCommand).execute("-o", "json", "-l", "team=payments");
+
+		String out = captured();
+		assertTrue(out.contains("\"name\":\"web\""), out);
+		assertFalse(out.contains("\"name\":\"db\""), out);
+	}
+
+	@Test
+	void testListMaxLimitsCount() throws Exception {
+		when(listAction.list(anyString()))
+			.thenReturn(Arrays.asList(createMockRelease("a", 1), createMockRelease("b", 1), createMockRelease("c", 1)));
+
+		new CommandLine(listCommand).execute("-o", "json", "--max", "1");
+
+		String out = captured();
+		assertTrue(out.contains("\"name\":\"a\""), out);
+		assertFalse(out.contains("\"name\":\"b\""), out);
 	}
 
 	@Test

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ReleaseFilters.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ReleaseFilters.java
@@ -1,0 +1,102 @@
+package org.alexmond.jhelm.core.util;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.alexmond.jhelm.core.model.Release;
+
+/**
+ * Client-side filtering and pagination for {@code helm list}, mirroring Helm's
+ * {@code -l}/{@code --selector}, {@code --filter}, {@code --offset} and {@code --max}
+ * flags. Applied to the releases already fetched from the cluster.
+ */
+public final class ReleaseFilters {
+
+	private ReleaseFilters() {
+	}
+
+	/**
+	 * Applies the label selector, name filter and pagination to a release list, in Helm's
+	 * order: filter by selector, then by the name regex, sort by name, then apply
+	 * {@code offset}/{@code max}.
+	 * @param releases the releases to filter (not modified)
+	 * @param selector a label selector ({@code k=v}, {@code k==v} or {@code k!=v} terms
+	 * joined by commas, all ANDed); {@code null}/blank means no selector
+	 * @param filter a regular expression matched against the release name (unanchored);
+	 * {@code null}/blank means no name filter
+	 * @param offset the number of leading releases to skip (negative treated as 0)
+	 * @param max the maximum number of releases to return ({@code <= 0} means no limit)
+	 * @return a new list with the surviving releases, sorted by name
+	 */
+	public static List<Release> apply(List<Release> releases, String selector, String filter, int offset, int max) {
+		Map<String, Matcher> selectors = parseSelector(selector);
+		Pattern namePattern = (filter != null && !filter.isBlank()) ? Pattern.compile(filter) : null;
+
+		List<Release> result = releases.stream()
+			.filter((r) -> matchesSelector(r, selectors))
+			.filter((r) -> namePattern == null || (r.getName() != null && namePattern.matcher(r.getName()).find()))
+			.sorted(Comparator.comparing(Release::getName, Comparator.nullsFirst(Comparator.naturalOrder())))
+			.skip(Math.max(0, offset))
+			.toList();
+
+		if (max > 0 && result.size() > max) {
+			return List.copyOf(result.subList(0, max));
+		}
+		return result;
+	}
+
+	private static Map<String, Matcher> parseSelector(String selector) {
+		if (selector == null || selector.isBlank()) {
+			return Map.of();
+		}
+		Map<String, Matcher> matchers = new LinkedHashMap<>();
+		for (String term : selector.split(",")) {
+			String t = term.trim();
+			if (t.isEmpty()) {
+				continue;
+			}
+			int neq = t.indexOf("!=");
+			if (neq >= 0) {
+				matchers.put(t.substring(0, neq).trim(), new Matcher(t.substring(neq + 2).trim(), false));
+				continue;
+			}
+			int eq = t.indexOf('=');
+			if (eq < 0) {
+				throw new IllegalArgumentException(
+						"Invalid selector term '" + t + "' (expected key=value or key!=value)");
+			}
+			// tolerate both key=value and key==value
+			String value = t.substring(eq + 1);
+			if (value.startsWith("=")) {
+				value = value.substring(1);
+			}
+			matchers.put(t.substring(0, eq).trim(), new Matcher(value.trim(), true));
+		}
+		return matchers;
+	}
+
+	private static boolean matchesSelector(Release release, Map<String, Matcher> selectors) {
+		if (selectors.isEmpty()) {
+			return true;
+		}
+		Map<String, String> labels = release.getLabels();
+		for (Map.Entry<String, Matcher> entry : selectors.entrySet()) {
+			String actual = (labels != null) ? labels.get(entry.getKey()) : null;
+			Matcher matcher = entry.getValue();
+			boolean equal = matcher.value.equals(actual);
+			if (matcher.wantEqual != equal) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	// A single selector term: the expected value and whether equality (=) or inequality
+	// (!=).
+	private record Matcher(String value, boolean wantEqual) {
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ReleaseFiltersTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ReleaseFiltersTest.java
@@ -1,0 +1,91 @@
+package org.alexmond.jhelm.core.util;
+
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.jhelm.core.model.Release;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ReleaseFiltersTest {
+
+	private static Release release(String name, Map<String, String> labels) {
+		return Release.builder().name(name).labels(labels).build();
+	}
+
+	private static List<Release> sample() {
+		return List.of(release("alpha", Map.of("team", "payments", "env", "prod")),
+				release("beta", Map.of("team", "search")), release("gamma", Map.of("team", "payments", "env", "dev")),
+				release("delta", null));
+	}
+
+	@Test
+	void noCriteriaReturnsAllSortedByName() {
+		List<Release> result = ReleaseFilters.apply(sample(), null, null, 0, 0);
+		assertEquals(List.of("alpha", "beta", "delta", "gamma"), result.stream().map(Release::getName).toList());
+	}
+
+	@Test
+	void selectorEqualityFiltersByLabel() {
+		List<Release> result = ReleaseFilters.apply(sample(), "team=payments", null, 0, 0);
+		assertEquals(List.of("alpha", "gamma"), result.stream().map(Release::getName).toList());
+	}
+
+	@Test
+	void selectorAndsMultipleTerms() {
+		List<Release> result = ReleaseFilters.apply(sample(), "team=payments,env=prod", null, 0, 0);
+		assertEquals(List.of("alpha"), result.stream().map(Release::getName).toList());
+	}
+
+	@Test
+	void selectorInequalityExcludesMatchingAndMissingLabels() {
+		// env!=prod keeps releases whose env is not "prod" (including those with no env
+		// label)
+		List<Release> result = ReleaseFilters.apply(sample(), "env!=prod", null, 0, 0);
+		assertEquals(List.of("beta", "delta", "gamma"), result.stream().map(Release::getName).toList());
+	}
+
+	@Test
+	void doubleEqualsIsTreatedAsEquality() {
+		List<Release> result = ReleaseFilters.apply(sample(), "team==search", null, 0, 0);
+		assertEquals(List.of("beta"), result.stream().map(Release::getName).toList());
+	}
+
+	@Test
+	void filterMatchesNameRegexUnanchored() {
+		List<Release> result = ReleaseFilters.apply(sample(), null, "a$", 0, 0);
+		assertEquals(List.of("alpha", "beta", "delta", "gamma"), result.stream().map(Release::getName).toList());
+	}
+
+	@Test
+	void filterRegexNarrows() {
+		List<Release> result = ReleaseFilters.apply(sample(), null, "^(alpha|beta)$", 0, 0);
+		assertEquals(List.of("alpha", "beta"), result.stream().map(Release::getName).toList());
+	}
+
+	@Test
+	void offsetAndMaxPaginateAfterSorting() {
+		List<Release> result = ReleaseFilters.apply(sample(), null, null, 1, 2);
+		assertEquals(List.of("beta", "delta"), result.stream().map(Release::getName).toList());
+	}
+
+	@Test
+	void maxZeroMeansNoLimit() {
+		List<Release> result = ReleaseFilters.apply(sample(), null, null, 0, 0);
+		assertEquals(4, result.size());
+	}
+
+	@Test
+	void negativeOffsetTreatedAsZero() {
+		List<Release> result = ReleaseFilters.apply(sample(), null, null, -5, 0);
+		assertEquals(4, result.size());
+	}
+
+	@Test
+	void invalidSelectorTermThrows() {
+		assertThrows(IllegalArgumentException.class, () -> ReleaseFilters.apply(sample(), "bogusterm", null, 0, 0));
+	}
+
+}


### PR DESCRIPTION
Adds client-side filtering & pagination to `list`, matching Helm — the first slice of #681.

## What
- **`-l`/`--selector`** — label selector over the release's stored labels: `key=value`, `key==value`, `key!=value` terms, comma-separated and ANDed.
- **`--filter`** — regular expression matched (unanchored) against the release name.
- **`--offset` / `-m`/`--max`** — paginate after sorting by name (default max 256; 0 = no limit).

Logic lives in a reusable core `ReleaseFilters` util (so a REST/MCP list can adopt it later); `ListCommand` applies it over the fetched releases.

## Tests
- `ReleaseFiltersTest` — selector equality/inequality/AND, `==`, name regex, offset/max, invalid-term error.
- `ListCommandTest` — end-to-end filter / selector / max over JSON output.

## #681 remaining
`-A`/`--all-namespaces` (needs a kube-layer all-namespaces list), `-a`/`--all`, and the status filters (`--deployed`/`--failed`/`--pending`/…). Tracked as follow-on slices.

Part of #681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)