### PR TITLE
feat(cli): list -a/--all and status filters (#681)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -30,6 +30,9 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
 * *`list` filtering & pagination* -- `list` gains `-l`/`--selector` (label selector, `key=value`
   / `key!=value`, comma-ANDed), `--filter` (regex on the release name), and `--offset`/`-m`/`--max`
   (paginate; default max 256). Results are sorted by name (#681).
+* *`list` status filters* -- `-a`/`--all` shows every status, and `--deployed`/`--failed`/`--pending`/
+  `--uninstalled`/`--uninstalling`/`--superseded` restrict to those states. The default view hides
+  uninstalled and superseded releases, matching Helm (#681).
 * *REST releases API now returns Helm-shaped JSON* -- the `/releases` list/status/history and
   install/upgrade responses now use Helm's `-o json` schema (snake_case, nested `info`) instead
   of jhelm's internal DTO, so REST consumers see the same shape as `helm ... -o json` and the

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -139,9 +139,9 @@ Most scripts work unchanged. Watch for these deliberate differences:
 Beyond the per-command tables above, these commonly-used Helm options are not yet wired
 (tracked for follow-up):
 
-* *`list`* — `-A`/`--all-namespaces`, `-a`/`--all`, the status filters
-  (`--deployed`/`--failed`/`--pending`/`--uninstalled`/`--superseded`).
-  (`-l`/`--selector`, `--filter`, and `--offset`/`--max` are supported.)
+* *`list`* — `-A`/`--all-namespaces`.
+  (`-l`/`--selector`, `--filter`, `--offset`/`--max`, `-a`/`--all`, and the status filters
+  `--deployed`/`--failed`/`--pending`/`--uninstalled`/`--uninstalling`/`--superseded` are supported.)
 * *`install`/`upgrade`* — install-from-repo (`--version`/`--repo`/`--username`/`--password`);
   `upgrade --cleanup-on-fail`.
   (`-g`/`--generate-name` is supported on `install`; `--description`/`--labels`/`--set-literal`/`--dependency-update` on both.)

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
@@ -4,14 +4,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.ListAction;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.output.OutputFormat;
 import org.alexmond.jhelm.core.util.ReleaseFilters;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 /**
@@ -49,6 +52,29 @@ public class ListCommand implements Callable<Integer> {
 			description = "maximum number of releases to fetch (0 = no limit)")
 	private int max;
 
+	@CommandLine.Option(names = { "-a", "--all" },
+			description = "show all releases regardless of status, including uninstalled and superseded")
+	private boolean all;
+
+	@CommandLine.Option(names = { "--deployed" }, description = "show deployed releases")
+	private boolean deployed;
+
+	@CommandLine.Option(names = { "--failed" }, description = "show failed releases")
+	private boolean failed;
+
+	@CommandLine.Option(names = { "--pending" }, description = "show pending releases")
+	private boolean pending;
+
+	@CommandLine.Option(names = { "--uninstalled" }, description = "show uninstalled releases")
+	private boolean uninstalled;
+
+	@CommandLine.Option(names = { "--uninstalling" },
+			description = "show releases that are currently being uninstalled")
+	private boolean uninstalling;
+
+	@CommandLine.Option(names = { "--superseded" }, description = "show superseded releases")
+	private boolean superseded;
+
 	/**
 	 * Creates the command.
 	 * @param listAction the action that lists releases
@@ -72,7 +98,8 @@ public class ListCommand implements Callable<Integer> {
 	@Override
 	public Integer call() {
 		try {
-			List<Release> releases = ReleaseFilters.apply(listAction.list(namespace), selector, filter, offset, max);
+			List<Release> byStatus = ReleaseFilters.retainStatuses(listAction.list(namespace), resolveStatuses());
+			List<Release> releases = ReleaseFilters.apply(byStatus, selector, filter, offset, max);
 			switch (output.toLowerCase(Locale.ROOT)) {
 				case "json" -> System.out.println(OutputFormat.json(toRows(releases)));
 				case "yaml" -> System.out.print(OutputFormat.yaml(toRows(releases)));
@@ -84,6 +111,43 @@ public class ListCommand implements Callable<Integer> {
 			CliOutput.errPrintln(CliOutput.error("Error listing releases: " + ex.getMessage()));
 			return CommandLine.ExitCode.SOFTWARE;
 		}
+	}
+
+	// Resolves the statuses to include: null = every status (--all); otherwise the
+	// flagged
+	// statuses, or a default mask (all except uninstalled/superseded) when no status flag
+	// is set.
+	private Set<ReleaseStatus> resolveStatuses() {
+		if (all) {
+			return null;
+		}
+		EnumSet<ReleaseStatus> set = EnumSet.noneOf(ReleaseStatus.class);
+		if (deployed) {
+			set.add(ReleaseStatus.DEPLOYED);
+		}
+		if (failed) {
+			set.add(ReleaseStatus.FAILED);
+		}
+		if (pending) {
+			set.add(ReleaseStatus.PENDING_INSTALL);
+			set.add(ReleaseStatus.PENDING_UPGRADE);
+			set.add(ReleaseStatus.PENDING_ROLLBACK);
+		}
+		if (uninstalled) {
+			set.add(ReleaseStatus.UNINSTALLED);
+		}
+		if (uninstalling) {
+			set.add(ReleaseStatus.UNINSTALLING);
+		}
+		if (superseded) {
+			set.add(ReleaseStatus.SUPERSEDED);
+		}
+		if (set.isEmpty()) {
+			set = EnumSet.allOf(ReleaseStatus.class);
+			set.remove(ReleaseStatus.UNINSTALLED);
+			set.remove(ReleaseStatus.SUPERSEDED);
+		}
+		return set;
 	}
 
 	private void printTable(List<Release> releases) {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ListCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ListCommandTest.java
@@ -128,6 +128,71 @@ class ListCommandTest {
 	}
 
 	@Test
+	void testListDefaultHidesUninstalled() throws Exception {
+		Release deployed = createMockRelease("web", 1);
+		Release gone = createMockRelease("old", 1).toBuilder()
+			.info(Release.ReleaseInfo.builder().status(ReleaseStatus.UNINSTALLED).build())
+			.build();
+		when(listAction.list(anyString())).thenReturn(Arrays.asList(deployed, gone));
+
+		new CommandLine(listCommand).execute("-o", "json");
+
+		String out = captured();
+		assertTrue(out.contains("\"name\":\"web\""), out);
+		assertFalse(out.contains("\"name\":\"old\""), out);
+	}
+
+	@Test
+	void testListUninstalledFlagShowsUninstalled() throws Exception {
+		Release deployed = createMockRelease("web", 1);
+		Release gone = createMockRelease("old", 1).toBuilder()
+			.info(Release.ReleaseInfo.builder().status(ReleaseStatus.UNINSTALLED).build())
+			.build();
+		when(listAction.list(anyString())).thenReturn(Arrays.asList(deployed, gone));
+
+		new CommandLine(listCommand).execute("-o", "json", "--uninstalled");
+
+		String out = captured();
+		assertTrue(out.contains("\"name\":\"old\""), out);
+		assertFalse(out.contains("\"name\":\"web\""), out);
+	}
+
+	@Test
+	void testExplicitStatusFlagsCombine() throws Exception {
+		Release d = statusRelease("d", ReleaseStatus.DEPLOYED);
+		Release f = statusRelease("f", ReleaseStatus.FAILED);
+		Release p = statusRelease("p", ReleaseStatus.PENDING_UPGRADE);
+		Release u = statusRelease("u", ReleaseStatus.UNINSTALLING);
+		Release s = statusRelease("s", ReleaseStatus.SUPERSEDED);
+		Release gone = statusRelease("gone", ReleaseStatus.UNINSTALLED);
+		when(listAction.list(anyString())).thenReturn(Arrays.asList(d, f, p, u, s, gone));
+
+		new CommandLine(listCommand).execute("-o", "json", "--deployed", "--failed", "--pending", "--uninstalling",
+				"--superseded");
+
+		String out = captured();
+		for (String name : new String[] { "d", "f", "p", "u", "s" }) {
+			assertTrue(out.contains("\"name\":\"" + name + "\""), name + " missing: " + out);
+		}
+		assertFalse(out.contains("\"name\":\"gone\""), out);
+	}
+
+	@Test
+	void testListAllShowsEveryStatus() throws Exception {
+		Release deployed = createMockRelease("web", 1);
+		Release gone = createMockRelease("old", 1).toBuilder()
+			.info(Release.ReleaseInfo.builder().status(ReleaseStatus.UNINSTALLED).build())
+			.build();
+		when(listAction.list(anyString())).thenReturn(Arrays.asList(deployed, gone));
+
+		new CommandLine(listCommand).execute("-o", "json", "-a");
+
+		String out = captured();
+		assertTrue(out.contains("\"name\":\"web\""), out);
+		assertTrue(out.contains("\"name\":\"old\""), out);
+	}
+
+	@Test
 	void testListCommandYamlOutput() throws Exception {
 		when(listAction.list(anyString())).thenReturn(Arrays.asList(createMockRelease("release1", 1)));
 
@@ -136,6 +201,12 @@ class ListCommandTest {
 		String out = captured();
 		assertTrue(out.contains("name: \"release1\""), out);
 		assertTrue(out.contains("status: \"deployed\""), out);
+	}
+
+	private Release statusRelease(String name, ReleaseStatus status) {
+		return createMockRelease(name, 1).toBuilder()
+			.info(Release.ReleaseInfo.builder().status(status).build())
+			.build();
 	}
 
 	private Release createMockRelease(String name, int version) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ReleaseFilters.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ReleaseFilters.java
@@ -4,9 +4,11 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 
 /**
  * Client-side filtering and pagination for {@code helm list}, mirroring Helm's
@@ -46,6 +48,23 @@ public final class ReleaseFilters {
 			return List.copyOf(result.subList(0, max));
 		}
 		return result;
+	}
+
+	/**
+	 * Keeps only releases whose status is in {@code included}, mirroring Helm's
+	 * {@code list} status filters ({@code --deployed}, {@code --failed}, …). A
+	 * {@code null} set means no status filtering (Helm's {@code --all}).
+	 * @param releases the releases to filter (not modified)
+	 * @param included the statuses to keep, or {@code null} to keep every status
+	 * @return a new list with the surviving releases
+	 */
+	public static List<Release> retainStatuses(List<Release> releases, Set<ReleaseStatus> included) {
+		if (included == null) {
+			return List.copyOf(releases);
+		}
+		return releases.stream()
+			.filter((r) -> r.getInfo() != null && included.contains(r.getInfo().getStatus()))
+			.toList();
 	}
 
 	private static Map<String, Matcher> parseSelector(String selector) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ReleaseFiltersTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ReleaseFiltersTest.java
@@ -1,9 +1,11 @@
 package org.alexmond.jhelm.core.util;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -86,6 +88,29 @@ class ReleaseFiltersTest {
 	@Test
 	void invalidSelectorTermThrows() {
 		assertThrows(IllegalArgumentException.class, () -> ReleaseFilters.apply(sample(), "bogusterm", null, 0, 0));
+	}
+
+	private static Release statusRelease(String name, ReleaseStatus status) {
+		return Release.builder().name(name).info(Release.ReleaseInfo.builder().status(status).build()).build();
+	}
+
+	@Test
+	void retainStatusesKeepsOnlyMatching() {
+		List<Release> releases = List.of(statusRelease("a", ReleaseStatus.DEPLOYED),
+				statusRelease("b", ReleaseStatus.FAILED), statusRelease("c", ReleaseStatus.UNINSTALLED));
+
+		List<Release> result = ReleaseFilters.retainStatuses(releases,
+				EnumSet.of(ReleaseStatus.DEPLOYED, ReleaseStatus.FAILED));
+
+		assertEquals(List.of("a", "b"), result.stream().map(Release::getName).toList());
+	}
+
+	@Test
+	void retainStatusesNullKeepsAll() {
+		List<Release> releases = List.of(statusRelease("a", ReleaseStatus.DEPLOYED),
+				statusRelease("c", ReleaseStatus.UNINSTALLED));
+
+		assertEquals(2, ReleaseFilters.retainStatuses(releases, null).size());
 	}
 
 }


### PR DESCRIPTION
Adds Helm's `list` status filtering — continuing #681.

## What
- **`-a`/`--all`** — show releases in every status.
- **`--deployed`/`--failed`/`--pending`/`--uninstalled`/`--uninstalling`/`--superseded`** — restrict to those states (`--pending` covers all three `pending-*` states).
- **Default view** (no status flag) hides uninstalled and superseded releases, matching Helm.

`ReleaseFilters` gains `retainStatuses(releases, Set<ReleaseStatus>)` (null = keep all); `ListCommand` resolves the status set from the flags and applies it before selector/name/pagination filtering.

## Tests
- `ReleaseFiltersTest` — `retainStatuses` keeps matching / null keeps all.
- `ListCommandTest` — default hides uninstalled, `--uninstalled` shows only it, `-a` shows all.

## #681 remaining
`-A`/`--all-namespaces` — needs a kube-layer all-namespaces list (list secrets across namespaces). Tracked as the final slice.

Part of #681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)