### PR TITLE
feat(cli): list -A/--all-namespaces (#681)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -33,6 +33,9 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
 * *`list` status filters* -- `-a`/`--all` shows every status, and `--deployed`/`--failed`/`--pending`/
   `--uninstalled`/`--uninstalling`/`--superseded` restrict to those states. The default view hides
   uninstalled and superseded releases, matching Helm (#681).
+* *`list -A`/`--all-namespaces`* -- list releases across every namespace, backed by a new
+  `KubeService.listAllReleases()` (lists release Secrets cluster-wide). Releases are keyed by
+  namespace+name so same-named releases in different namespaces stay distinct (#681).
 * *REST releases API now returns Helm-shaped JSON* -- the `/releases` list/status/history and
   install/upgrade responses now use Helm's `-o json` schema (snake_case, nested `info`) instead
   of jhelm's internal DTO, so REST consumers see the same shape as `helm ... -o json` and the

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -139,9 +139,6 @@ Most scripts work unchanged. Watch for these deliberate differences:
 Beyond the per-command tables above, these commonly-used Helm options are not yet wired
 (tracked for follow-up):
 
-* *`list`* — `-A`/`--all-namespaces`.
-  (`-l`/`--selector`, `--filter`, `--offset`/`--max`, `-a`/`--all`, and the status filters
-  `--deployed`/`--failed`/`--pending`/`--uninstalled`/`--uninstalling`/`--superseded` are supported.)
 * *`install`/`upgrade`* — install-from-repo (`--version`/`--repo`/`--username`/`--password`);
   `upgrade --cleanup-on-fail`.
   (`-g`/`--generate-name` is supported on `install`; `--description`/`--labels`/`--set-literal`/`--dependency-update` on both.)

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ListCommand.java
@@ -32,6 +32,9 @@ public class ListCommand implements Callable<Integer> {
 	@CommandLine.Option(names = { "-n", "--namespace" }, defaultValue = "default", description = "namespace")
 	private String namespace;
 
+	@CommandLine.Option(names = { "-A", "--all-namespaces" }, description = "list releases across all namespaces")
+	private boolean allNamespaces;
+
 	@CommandLine.Option(names = { "-o", "--output" }, defaultValue = "table",
 			description = "output format: table, json, or yaml")
 	private String output;
@@ -98,7 +101,8 @@ public class ListCommand implements Callable<Integer> {
 	@Override
 	public Integer call() {
 		try {
-			List<Release> byStatus = ReleaseFilters.retainStatuses(listAction.list(namespace), resolveStatuses());
+			List<Release> fetched = allNamespaces ? listAction.listAll() : listAction.list(namespace);
+			List<Release> byStatus = ReleaseFilters.retainStatuses(fetched, resolveStatuses());
 			List<Release> releases = ReleaseFilters.apply(byStatus, selector, filter, offset, max);
 			switch (output.toLowerCase(Locale.ROOT)) {
 				case "json" -> System.out.println(OutputFormat.json(toRows(releases)));

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ListCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ListCommandTest.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ListCommandTest {
@@ -190,6 +192,18 @@ class ListCommandTest {
 		String out = captured();
 		assertTrue(out.contains("\"name\":\"web\""), out);
 		assertTrue(out.contains("\"name\":\"old\""), out);
+	}
+
+	@Test
+	void testAllNamespacesUsesListAll() throws Exception {
+		when(listAction.listAll()).thenReturn(Arrays.asList(createMockRelease("web", 1)));
+
+		new CommandLine(listCommand).execute("-o", "json", "-A");
+
+		String out = captured();
+		assertTrue(out.contains("\"name\":\"web\""), out);
+		verify(listAction).listAll();
+		verify(listAction, never()).list(anyString());
 	}
 
 	@Test

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/ListAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/ListAction.java
@@ -15,4 +15,13 @@ public class ListAction {
 		return kubeService.listReleases(namespace);
 	}
 
+	/**
+	 * Lists the latest revision of every release across all namespaces (Helm
+	 * {@code list --all-namespaces}).
+	 * @return the releases found across all namespaces
+	 */
+	public List<Release> listAll() {
+		return kubeService.listAllReleases();
+	}
+
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
@@ -45,6 +45,14 @@ public interface KubeService {
 	List<Release> listReleases(String namespace);
 
 	/**
+	 * Returns the latest revision of every release across all namespaces (Helm
+	 * {@code list --all-namespaces}).
+	 * @return the releases found, or an empty list if there are none
+	 * @throws KubernetesOperationException if the Kubernetes API cannot be reached
+	 */
+	List<Release> listAllReleases();
+
+	/**
 	 * Returns all stored revisions of a release, newest first.
 	 * @param name the release name
 	 * @param namespace the namespace to look in

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/ListActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/ListActionTest.java
@@ -51,4 +51,16 @@ class ListActionTest {
 		assertTrue(result.isEmpty());
 	}
 
+	@Test
+	void testListAllDelegatesToAllNamespaces() {
+		Release a = Release.builder().name("a").build();
+		Release b = Release.builder().name("b").build();
+		when(kubeService.listAllReleases()).thenReturn(Arrays.asList(a, b));
+
+		List<Release> result = listAction.listAll();
+
+		assertEquals(2, result.size());
+		assertEquals("a", result.get(0).getName());
+	}
+
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/EngineTest.java
@@ -603,6 +603,11 @@ class EngineTest {
 			}
 
 			@Override
+			public List<Release> listAllReleases() {
+				return List.of();
+			}
+
+			@Override
 			public List<Release> getReleaseHistory(String name, String namespace) {
 				return List.of();
 			}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
@@ -186,14 +186,24 @@ public class HelmKubeService implements KubeService {
 	@Override
 	public List<Release> listReleases(String namespace) {
 		CoreV1Api api = new CoreV1Api(apiClient);
-		String labelSelector = "owner=helm";
+		V1SecretList list = listSecrets(api, namespace, "owner=helm", "list releases in " + namespace);
+		return toLatestReleases(list);
+	}
 
-		V1SecretList list = listSecrets(api, namespace, labelSelector, "list releases in " + namespace);
+	@Override
+	public List<Release> listAllReleases() {
+		CoreV1Api api = new CoreV1Api(apiClient);
+		V1SecretList list = listAllSecrets(api, "owner=helm", "list releases across all namespaces");
+		return toLatestReleases(list);
+	}
 
-		// Group by name and pick the highest version for each
+	// Groups release Secrets by namespace+name (a release name is unique only within a
+	// namespace) and keeps the highest revision of each, decoding it to a Release.
+	private List<Release> toLatestReleases(V1SecretList list) {
 		Map<String, List<V1Secret>> grouped = list.getItems()
 			.stream()
-			.collect(Collectors.groupingBy((s) -> s.getMetadata().getLabels().get("name")));
+			.collect(Collectors
+				.groupingBy((s) -> s.getMetadata().getNamespace() + "/" + s.getMetadata().getLabels().get("name")));
 
 		List<V1Secret> latestPerName = grouped.values()
 			.stream()
@@ -303,6 +313,19 @@ public class HelmKubeService implements KubeService {
 	private V1SecretList listSecrets(CoreV1Api api, String namespace, String labelSelector, String operation) {
 		try {
 			return api.listNamespacedSecret(namespace).labelSelector(labelSelector).execute();
+		}
+		catch (ApiException ex) {
+			throw new KubernetesOperationException("Failed to " + operation, ex, ex.getCode());
+		}
+	}
+
+	/**
+	 * Lists release Secrets across all namespaces for a label selector, translating the
+	 * kubernetes-client {@link ApiException} into a {@link KubernetesOperationException}.
+	 */
+	private V1SecretList listAllSecrets(CoreV1Api api, String labelSelector, String operation) {
+		try {
+			return api.listSecretForAllNamespaces().labelSelector(labelSelector).execute();
 		}
 		catch (ApiException ex) {
 			throw new KubernetesOperationException("Failed to " + operation, ex, ex.getCode());

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeService.java
@@ -73,6 +73,11 @@ public class ObservableKubeService implements KubeService {
 	}
 
 	@Override
+	public List<Release> listAllReleases() {
+		return time(listTimer, delegate::listAllReleases);
+	}
+
+	@Override
 	public List<Release> getReleaseHistory(String name, String namespace) {
 		return time(historyTimer, () -> delegate.getReleaseHistory(name, namespace));
 	}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeService.java
@@ -62,6 +62,11 @@ public class RetryableKubeService implements KubeService {
 	}
 
 	@Override
+	public List<Release> listAllReleases() {
+		return executeWithRetry("listAllReleases", delegate::listAllReleases);
+	}
+
+	@Override
 	public List<Release> getReleaseHistory(String name, String namespace) {
 		return executeWithRetry("getReleaseHistory", () -> delegate.getReleaseHistory(name, namespace));
 	}

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
@@ -155,6 +155,13 @@ class HelmKubeServiceTest {
 		when(mock.listNamespacedSecret(anyString())).thenReturn(listReq);
 	}
 
+	private void setupListAllRequest(CoreV1Api mock, V1SecretList list) throws Exception {
+		var listReq = mock(CoreV1Api.APIlistSecretForAllNamespacesRequest.class);
+		when(listReq.labelSelector(anyString())).thenReturn(listReq);
+		when(listReq.execute()).thenReturn(list);
+		when(mock.listSecretForAllNamespaces()).thenReturn(listReq);
+	}
+
 	private void setupSsaMock() {
 		dynamicApiConstruction = mockConstruction(DynamicKubernetesApi.class, (mock, ctx) -> {
 			mockDynamicApi = mock;
@@ -370,6 +377,23 @@ class HelmKubeServiceTest {
 		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> setupListRequest(mock, list));
 
 		assertTrue(kubeService.listReleases("staging").isEmpty());
+	}
+
+	// --- listAllReleases ---
+
+	@Test
+	void testListAllReleasesSpansNamespacesAndKeepsSameNameDistinct() throws Exception {
+		// Two releases named "app" in different namespaces must NOT be collapsed into
+		// one.
+		Release teamA = createTestRelease("app", "team-a", 1, "deployed");
+		Release teamB = createTestRelease("app", "team-b", 1, "deployed");
+		V1SecretList list = new V1SecretList()
+			.items(List.of(createSecretForRelease(teamA), createSecretForRelease(teamB)));
+
+		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> setupListAllRequest(mock, list));
+
+		List<Release> releases = kubeService.listAllReleases();
+		assertEquals(2, releases.size());
 	}
 
 	// --- getReleaseHistory ---

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeServiceTest.java
@@ -70,6 +70,13 @@ class ObservableKubeServiceTest {
 	}
 
 	@Test
+	void testListAllReleasesForwardsToDelegate() {
+		when(delegate.listAllReleases()).thenReturn(List.of(mock(Release.class)));
+		assertEquals(1, service.listAllReleases().size());
+		verify(delegate).listAllReleases();
+	}
+
+	@Test
 	void testApplyDryRunForwardsToDelegate() throws Exception {
 		service.applyDryRun("default", "apiVersion: v1");
 		verify(delegate).applyDryRun("default", "apiVersion: v1");

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeServiceTest.java
@@ -59,6 +59,14 @@ class RetryableKubeServiceTest {
 	}
 
 	@Test
+	void testListAllReleasesDelegates() {
+		when(delegate.listAllReleases()).thenReturn(List.of(mock(Release.class), mock(Release.class)));
+
+		assertEquals(2, retryableService.listAllReleases().size());
+		verify(delegate).listAllReleases();
+	}
+
+	@Test
 	void testRetriesOnTransientException() throws Exception {
 		when(delegate.listReleases("default")).thenThrow(new RuntimeException(new ApiException(500, "Server Error")))
 			.thenThrow(new RuntimeException(new ApiException(503, "Unavailable")))


### PR DESCRIPTION
Adds Helm's cross-namespace listing — the final flag for #681.

## What
- **New `KubeService.listAllReleases()`** lists Helm release Secrets across all namespaces (`CoreV1Api.listSecretForAllNamespaces`), implemented in `HelmKubeService` and forwarded through the `Observable`/`Retryable` decorators (`AsyncHelmKubeService` inherits it).
- **Grouping now keys on namespace+name** (a release name is unique only *within* a namespace), so same-named releases in different namespaces stay distinct. Extracted shared `toLatestReleases()`/`listAllSecrets()` helpers.
- **`ListAction.listAll()` + `ListCommand -A`/`--all-namespaces`** select the cross-namespace path; all existing status/selector/name/pagination filters still apply on top.

## Tests
- `HelmKubeServiceTest` — all-namespaces keeps same-named releases in different namespaces distinct.
- `Observable`/`RetryableKubeServiceTest` — forwarding.
- `ListActionTest` — `listAll` delegates; `ListCommandTest` — `-A` uses `listAll`, not `list`.

Closes #681 (all list scope & filtering flags now supported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)