### PR TITLE
feat(cli): install/upgrade from a repo with --repo/--version + creds/TLS (#682)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -36,6 +36,11 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
 * *`list -A`/`--all-namespaces`* -- list releases across every namespace, backed by a new
   `KubeService.listAllReleases()` (lists release Secrets cluster-wide). Releases are keyed by
   namespace+name so same-named releases in different namespaces stay distinct (#681).
+* *`install`/`upgrade` from a repository* -- pass a chart name with `--version` and an ad-hoc
+  `--repo <url>` (plus `--username`/`--password` and TLS `--cert-file`/`--key-file`/`--ca-file`/
+  `--insecure-skip-tls-verify`/`--pass-credentials`) to fetch the chart directly, matching
+  `helm install/upgrade --repo`. A `repo/chart` or `oci://` reference is also resolved via the
+  registered repositories. Local chart paths still work unchanged (#682).
 * *REST releases API now returns Helm-shaped JSON* -- the `/releases` list/status/history and
   install/upgrade responses now use Helm's `-o json` schema (snake_case, nested `info`) instead
   of jhelm's internal DTO, so REST consumers see the same shape as `helm ... -o json` and the

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -29,7 +29,7 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | `--force` (upgrade) | ✅ | Delete-and-recreate strategy: existing resources are deleted before the new manifest is applied. May cause downtime or data loss for stateful resources — use with care.
 | `--wait-for-jobs` | ✅ | Accepted for Helm compatibility; implies `--wait`. jhelm's `--wait` already waits for Job completion.
 | `-o`, `--output` | ✅ | `table` (default human summary), `json`, `yaml`. JSON/YAML emit the Helm-shaped release object (nested `info`, snake_case keys).
-| `--version`, `--repo`, `--username`/`--password` (install from a repo) | ✗ | Install from an added repo/OCI ref; inline repo+auth flags aren't wired.
+| `--version`, `--repo`, `--username`/`--password` (install/upgrade from a repo) | ✅ | Fetch the chart by name with `--version` and an ad-hoc `--repo <url>` (`--username`/`--password` + TLS `--cert-file`/`--key-file`/`--ca-file`/`--insecure-skip-tls-verify`/`--pass-credentials`). A `repo/chart` or `oci://` ref resolves via the registered repositories; local chart paths are unchanged.
 | `-g`, `--generate-name` (install) | ✅ | Omit the NAME positional and pass `-g` to auto-generate `<chart>-<timestamp>` (like Helm). Errors if both a name and `-g` are given, or if neither is.
 | `--description` (install) | ✅ | Custom release description stored on the release (falls back to `Install complete`).
 | `--labels` (install) | ✅ | `key=value` labels (comma-separated or repeatable) added to the release Secret; the reserved `owner`/`name`/`status`/`version` labels are never overridden.

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ChartResolver.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ChartResolver.java
@@ -9,6 +9,7 @@ import java.util.Comparator;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.action.VerifyAction;
+import org.alexmond.jhelm.core.model.RepositoryConfig;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.util.ValuesProfiles;
@@ -104,6 +105,58 @@ public class ChartResolver {
 		}
 		finally {
 			deleteRecursively(workDir);
+		}
+	}
+
+	/**
+	 * Resolves a chart that may be a local path <em>or</em> a repository reference,
+	 * mirroring {@code helm install/upgrade [--repo URL] CHART --version V}. A local
+	 * directory or {@code .tgz} is loaded directly; otherwise the chart is pulled into a
+	 * temporary directory (from {@code repoUrl} when given, else from a registered
+	 * repository or an {@code oci://} URL) and the downloaded archive is loaded.
+	 * @param chartRef a local chart path, a {@code repo/chart} reference, or an
+	 * {@code oci://} URL
+	 * @param version the chart version (required for repository/{@code --repo} pulls)
+	 * @param repoUrl an ad-hoc repository URL (Helm's {@code --repo}), or {@code null}
+	 * @param auth the repository auth/TLS descriptor for a {@code --repo} pull, or
+	 * {@code null}
+	 * @param verify whether to verify the pulled archive's provenance
+	 * @param keyring path to the PGP public keyring, or {@code null} for the default
+	 * @param profiles the active value profiles
+	 * @return the loaded chart
+	 * @throws IOException if the chart cannot be pulled or loaded
+	 */
+	@SuppressWarnings("java:S5443")
+	public Chart resolveFromRepo(String chartRef, String version, String repoUrl, RepositoryConfig.Repository auth,
+			boolean verify, String keyring, ValuesProfiles profiles) throws IOException {
+		File local = new File(chartRef);
+		boolean fromRepo = (repoUrl != null && !repoUrl.isBlank());
+		if (!fromRepo && local.exists()) {
+			return resolve(chartRef, verify, keyring, profiles);
+		}
+		Path pullDir = Files.createTempDirectory("jhelm-pull-");
+		try {
+			if (fromRepo) {
+				repoManager.pullFromRepoUrl(repoUrl, chartRef, version, pullDir.toString(), auth);
+			}
+			else {
+				repoManager.pull(chartRef, version, pullDir.toString());
+			}
+			File archive = findArchive(pullDir, chartRef);
+			return resolve(archive.getPath(), verify, keyring, profiles);
+		}
+		finally {
+			deleteRecursively(pullDir);
+		}
+	}
+
+	// Locates the single .tgz the pull wrote into the temp directory.
+	private static File findArchive(Path pullDir, String chartRef) throws IOException {
+		try (var paths = Files.list(pullDir)) {
+			return paths.filter((p) -> p.getFileName().toString().endsWith(".tgz"))
+				.findFirst()
+				.map(Path::toFile)
+				.orElseThrow(() -> new IOException("No chart archive was pulled for '" + chartRef + "'"));
 		}
 	}
 

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -59,6 +59,9 @@ public class InstallCommand implements Callable<Integer> {
 	@CommandLine.Mixin
 	private final ConfigServerCliOptions configServerOptions = new ConfigServerCliOptions();
 
+	@CommandLine.Mixin
+	private final RepoChartOptions repoOptions = new RepoChartOptions();
+
 	@CommandLine.Parameters(arity = "1..2", paramLabel = "[NAME] CHART",
 			description = "release name (optional with -g/--generate-name) followed by the chart path")
 	private List<String> nameAndChart = new ArrayList<>();
@@ -196,7 +199,8 @@ public class InstallCommand implements Callable<Integer> {
 					dependencyUpdateAction.update(localChart, List.of(), false);
 				}
 			}
-			Chart chart = chartResolver.resolve(chartPath, verify, keyring, profiles);
+			Chart chart = chartResolver.resolveFromRepo(chartPath, repoOptions.getVersion(), repoOptions.getRepo(),
+					repoOptions.hasRepo() ? repoOptions.auth() : null, verify, keyring, profiles);
 			if (name == null) {
 				name = ReleaseNames.generateName(chart.getMetadata().getName());
 			}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoChartOptions.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoChartOptions.java
@@ -1,0 +1,72 @@
+package org.alexmond.jhelm.app.command;
+
+import lombok.Getter;
+import org.alexmond.jhelm.core.model.RepositoryConfig;
+import picocli.CommandLine.Option;
+
+/**
+ * Reusable Picocli mixin for resolving a chart from a repository on {@code install} and
+ * {@code upgrade}: the chart version, an ad-hoc {@code --repo} URL, and its
+ * authentication/TLS settings — mirroring Helm's {@code install}/{@code upgrade} repo
+ * flags (and matching {@code jhelm pull}).
+ */
+@Getter
+public class RepoChartOptions {
+
+	@Option(names = { "--version" },
+			description = "chart version to fetch when the chart is a repository reference or used with --repo")
+	private String version;
+
+	@Option(names = { "--repo" },
+			description = "chart repository URL to locate the named chart (Helm's --repo form; requires --version)")
+	private String repo;
+
+	@Option(names = { "--username" }, description = "chart repository username (with --repo)")
+	private String username;
+
+	@Option(names = { "--password" }, description = "chart repository password (with --repo)")
+	private String password;
+
+	@Option(names = { "--cert-file" }, description = "identity certificate (PEM) for client TLS auth")
+	private String certFile;
+
+	@Option(names = { "--key-file" }, description = "identity key (PEM) for client TLS auth")
+	private String keyFile;
+
+	@Option(names = { "--ca-file" }, description = "verify server certificate against this CA bundle (PEM)")
+	private String caFile;
+
+	@Option(names = { "--insecure-skip-tls-verify" },
+			description = "skip TLS certificate verification for the chart repository")
+	private boolean insecureSkipTlsVerify;
+
+	@Option(names = { "--pass-credentials" },
+			description = "send credentials to all domains, not just the repository host")
+	private boolean passCredentials;
+
+	/**
+	 * @return {@code true} if an ad-hoc {@code --repo} URL was supplied
+	 */
+	public boolean hasRepo() {
+		return this.repo != null && !this.repo.isBlank();
+	}
+
+	/**
+	 * Builds a repository descriptor carrying the auth and TLS settings for a
+	 * {@code --repo} pull.
+	 * @return the repository descriptor
+	 */
+	public RepositoryConfig.Repository auth() {
+		return RepositoryConfig.Repository.builder()
+			.url(this.repo)
+			.username(this.username)
+			.password(this.password)
+			.certFile(this.certFile)
+			.keyFile(this.keyFile)
+			.caFile(this.caFile)
+			.insecureSkipTlsVerify(this.insecureSkipTlsVerify)
+			.passCredentialsAll(this.passCredentials)
+			.build();
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -67,6 +67,9 @@ public class UpgradeCommand implements Callable<Integer> {
 	@CommandLine.Mixin
 	private final ConfigServerCliOptions configServerOptions = new ConfigServerCliOptions();
 
+	@CommandLine.Mixin
+	private final RepoChartOptions repoOptions = new RepoChartOptions();
+
 	@CommandLine.Parameters(index = "0", description = "release name")
 	private String name;
 
@@ -218,7 +221,8 @@ public class UpgradeCommand implements Callable<Integer> {
 			ConfigServerValuesLoader.Result configServer = configServerValuesLoader.load(name, profiles.active(),
 					configServerOptions.toOptions());
 			updateDependenciesIfRequested();
-			Chart chart = chartResolver.resolve(chartPath, verify, keyring, profiles);
+			Chart chart = chartResolver.resolveFromRepo(chartPath, repoOptions.getVersion(), repoOptions.getRepo(),
+					repoOptions.hasRepo() ? repoOptions.auth() : null, verify, keyring, profiles);
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, profiles, configServer.values(),
 					configServer.overrideNone(), configServer.overrideSystemProperties(), setValues, setStringValues,
 					setFileValues, setJsonValues, setLiteralValues);

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ChartResolverTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ChartResolverTest.java
@@ -11,12 +11,21 @@ import org.junit.jupiter.api.io.TempDir;
 import org.alexmond.jhelm.core.action.PackageAction;
 import org.alexmond.jhelm.core.action.VerifyAction;
 import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.RepositoryConfig;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.core.service.SignatureService;
+import org.alexmond.jhelm.core.util.ValuesProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 class ChartResolverTest {
 
@@ -75,6 +84,68 @@ class ChartResolverTest {
 	void missingPathIsRejected() {
 		assertThrows(IllegalArgumentException.class,
 				() -> resolver.resolve(tempDir.resolve("does-not-exist").toString(), false, null));
+	}
+
+	@Test
+	void resolveFromRepoWithRepoUrlPullsAndLoadsChart() throws Exception {
+		RepoManager repoManager = mock(RepoManager.class);
+		ChartResolver repoResolver = new ChartResolver(chartLoader, repoManager, new VerifyAction(signatureService));
+		// The --repo pull writes a .tgz into the destination directory (arg 3).
+		doAnswer((inv) -> {
+			Files.writeString(Path.of(inv.getArgument(3), "nginx-1.2.3.tgz"), "fake-archive");
+			return null;
+		}).when(repoManager)
+			.pullFromRepoUrl(eq("https://charts.example.com"), eq("nginx"), eq("1.2.3"), anyString(), any());
+		stubUntar(repoManager, "nginx");
+
+		Chart chart = repoResolver.resolveFromRepo("nginx", "1.2.3", "https://charts.example.com",
+				RepositoryConfig.Repository.builder().build(), false, null, ValuesProfiles.none());
+
+		assertEquals("nginx", chart.getMetadata().getName());
+		verify(repoManager).pullFromRepoUrl(eq("https://charts.example.com"), eq("nginx"), eq("1.2.3"), anyString(),
+				any());
+	}
+
+	@Test
+	void resolveFromRepoWithChartRefPullsFromRegisteredRepo() throws Exception {
+		RepoManager repoManager = mock(RepoManager.class);
+		ChartResolver repoResolver = new ChartResolver(chartLoader, repoManager, new VerifyAction(signatureService));
+		doAnswer((inv) -> {
+			Files.writeString(Path.of(inv.getArgument(2), "redis-17.0.0.tgz"), "fake-archive");
+			return null;
+		}).when(repoManager).pull(eq("bitnami/redis"), eq("17.0.0"), anyString());
+		stubUntar(repoManager, "redis");
+
+		Chart chart = repoResolver.resolveFromRepo("bitnami/redis", "17.0.0", null, null, false, null,
+				ValuesProfiles.none());
+
+		assertEquals("redis", chart.getMetadata().getName());
+		verify(repoManager).pull(eq("bitnami/redis"), eq("17.0.0"), anyString());
+	}
+
+	@Test
+	void resolveFromRepoFallsBackToLocalPathWithoutPulling() throws Exception {
+		RepoManager repoManager = mock(RepoManager.class);
+		ChartResolver localResolver = new ChartResolver(chartLoader, repoManager, new VerifyAction(signatureService));
+
+		Chart chart = localResolver.resolveFromRepo(chartDir.getAbsolutePath(), null, null, null, false, null,
+				ValuesProfiles.none());
+
+		assertEquals("test-chart", chart.getMetadata().getName());
+		verify(repoManager, never()).pull(anyString(), anyString(), anyString());
+	}
+
+	// Makes the mocked RepoManager.untar lay down a loadable chart directory under the
+	// work dir.
+	private void stubUntar(RepoManager repoManager, String chartName) throws Exception {
+		doAnswer((inv) -> {
+			File workDir = inv.getArgument(1);
+			File cd = new File(workDir, chartName);
+			cd.mkdirs();
+			Files.writeString(cd.toPath().resolve("Chart.yaml"),
+					"apiVersion: v2\nname: " + chartName + "\nversion: 1.0.0\n");
+			return null;
+		}).when(repoManager).untar(any(File.class), any(File.class));
 	}
 
 	private File packageChart() {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -9,6 +9,7 @@ import org.alexmond.jhelm.core.config.ConfigServerProperties;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.model.RepositoryConfig;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ReleaseStatus;
@@ -78,7 +79,8 @@ class InstallCommandTest {
 			.metadata(ChartMetadata.builder().name("test-chart").version("1.0.0").build())
 			.values(new HashMap<>())
 			.build();
-		when(chartResolver.resolve(anyString(), anyBoolean(), any())).thenReturn(defaultChart);
+		when(chartResolver.resolveFromRepo(anyString(), any(), any(), any(), anyBoolean(), any(), any()))
+			.thenReturn(defaultChart);
 		installCommand = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver, enabledPolicy(),
 				new JhelmCoreProperties(), new ConfigServerValuesLoader(new ConfigServerProperties(), null),
 				dependencyUpdateAction);
@@ -130,13 +132,36 @@ class InstallCommandTest {
 	}
 
 	@Test
+	void testRepoFlagsReachChartResolution() throws Exception {
+		ArgumentCaptor<String> versionCap = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> repoCap = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<RepositoryConfig.Repository> authCap = ArgumentCaptor
+			.forClass(RepositoryConfig.Repository.class);
+		when(installAction.install(any(InstallOptions.class))).thenReturn(createMockRelease("web", 1));
+
+		int exit = new CommandLine(installCommand).execute("web", "nginx", "--repo", "https://charts.example.com",
+				"--version", "1.2.3", "--username", "u", "--password", "p", "--insecure-skip-tls-verify");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		verify(chartResolver).resolveFromRepo(eq("nginx"), versionCap.capture(), repoCap.capture(), authCap.capture(),
+				anyBoolean(), any(), any());
+		assertEquals("1.2.3", versionCap.getValue());
+		assertEquals("https://charts.example.com", repoCap.getValue());
+		RepositoryConfig.Repository auth = authCap.getValue();
+		assertEquals("u", auth.getUsername());
+		assertEquals("p", auth.getPassword());
+		assertTrue(auth.isInsecureSkipTlsVerify());
+	}
+
+	@Test
 	void testGenerateNameProducesNameFromChart() throws Exception {
 		File chartDir = createMockChart();
 		Chart chart = Chart.builder()
 			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
 			.values(new HashMap<>())
 			.build();
-		when(chartResolver.resolve(anyString(), anyBoolean(), any(), any())).thenReturn(chart);
+		when(chartResolver.resolveFromRepo(anyString(), any(), any(), any(), anyBoolean(), any(), any()))
+			.thenReturn(chart);
 		ArgumentCaptor<InstallOptions> captor = ArgumentCaptor.forClass(InstallOptions.class);
 		when(installAction.install(captor.capture())).thenReturn(createMockRelease("mychart-1", 1));
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -87,7 +87,8 @@ class UpgradeCommandTest {
 			.metadata(ChartMetadata.builder().name("test-chart").version("1.0.0").build())
 			.values(new HashMap<>())
 			.build();
-		when(chartResolver.resolve(anyString(), anyBoolean(), any())).thenReturn(defaultChart);
+		when(chartResolver.resolveFromRepo(anyString(), any(), any(), any(), anyBoolean(), any(), any()))
+			.thenReturn(defaultChart);
 		upgradeCommand = new UpgradeCommand(kubeService, installAction, uninstallAction, upgradeAction, rollbackAction,
 				chartResolver, enabledPolicy(), new JhelmCoreProperties(),
 				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction);


### PR DESCRIPTION
Mirrors Helm's `install/upgrade [--repo URL] CHART --version V` — fetch a chart by name from a repository instead of only a local path.

## What
- **New `RepoChartOptions` Picocli `@Mixin`** carries `--version`/`--repo`/`--username`/`--password` and TLS `--cert-file`/`--key-file`/`--ca-file`/`--insecure-skip-tls-verify`/`--pass-credentials`, shared by `install` and `upgrade` (identical flag surface to `pull`).
- **`ChartResolver.resolveFromRepo()`** resolves a ref that may be local *or* remote: a local dir/`.tgz` loads directly; otherwise the chart is pulled into a temp dir (`RepoManager.pullFromRepoUrl` when `--repo` is given, else `RepoManager.pull` for a `repo/chart` or `oci://` ref), loaded, then cleaned up.
- **`Install`/`UpgradeCommand`** call `resolveFromRepo(...)` in place of `resolve(...)`; local chart paths behave exactly as before.

Reuses the existing `RepoManager` pull machinery (index fetch, auth, TLS) that already backs `jhelm pull --repo` — no new networking code.

## Tests
- `ChartResolverTest` — repo-URL pull, `repo/chart` pull, and local-path fallback (no pull), all via a mocked `RepoManager`.
- `InstallCommandTest` — `--repo`/`--version`/`--username`/`--password`/`--insecure-skip-tls-verify` reach `resolveFromRepo` with the right values.
- Existing Install/Upgrade stubs moved to `resolveFromRepo`.

Changelog + cli-parity doc updated (the `--repo`/`--version` row flips to ✅).

Closes #682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)