### PR TITLE
feat(uninstall,rollback): wait/cascade + force/cleanup/recreate-pods semantics (#683)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -41,6 +41,14 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
   `--insecure-skip-tls-verify`/`--pass-credentials`) to fetch the chart directly, matching
   `helm install/upgrade --repo`. A `repo/chart` or `oci://` reference is also resolved via the
   registered repositories. Local chart paths still work unchanged (#682).
+* *`uninstall` wait/cascade semantics* -- `--dry-run` (report without deleting), `--wait`/`--timeout`
+  (block until the resources are gone, backed by a new `KubeService.waitForDeleted`), `--cascade`
+  `background\|foreground\|orphan` (Kubernetes deletion propagation), and `--description` (stored on
+  the release when `--keep-history` is set). Mirrored on REST (`DELETE` query params) and MCP (#683).
+* *`rollback` force/cleanup semantics* -- `--dry-run`, `--force` (delete-and-recreate),
+  `--cleanup-on-fail` (delete resources created during a failed rollback), `--recreate-pods` (rolling
+  restart of the release's workloads via a restart annotation), and `--wait`/`--wait-for-jobs`/`--timeout`.
+  The rollback readiness wait now lives in the action so REST and MCP honor it too (#683).
 * *REST releases API now returns Helm-shaped JSON* -- the `/releases` list/status/history and
   install/upgrade responses now use Helm's `-o json` schema (snake_case, nested `info`) instead
   of jhelm's internal DTO, so REST consumers see the same shape as `helm ... -o json` and the

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -48,7 +48,10 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 | `-n`, `--namespace` | ✅ |
 | `--no-hooks` | ✅ |
 | `--keep-history` | ✅ |
-| `--wait`, `--timeout`, `--cascade` | ✗ |
+| `--dry-run` | ✅ | Reports what would be uninstalled without deleting resources or touching history.
+| `--wait`, `--timeout` | ✅ | Blocks until the release's resources are gone from the cluster (polls each resource).
+| `--cascade` | ✅ | `background` (default), `foreground`, or `orphan` — the Kubernetes deletion propagation policy.
+| `--description` | ✅ | Custom description stored on the release when `--keep-history` is set.
 |===
 
 == list
@@ -69,12 +72,17 @@ Status legend: ✅ same flag · ✎ supported but differs (see note) · ✗ not 
 |===
 | Command | Helm flag | jhelm
 
-| rollback | `-n`, `--no-hooks`, `--wait`, `--timeout` | ✅
-| rollback | `--force`, `--cleanup-on-fail`, `--recreate-pods`, `--wait-for-jobs` | ✗
+| rollback | `-n`, `--no-hooks`, `--wait`, `--timeout`, `--dry-run` | ✅
+| rollback | `--force`, `--cleanup-on-fail`, `--recreate-pods`, `--wait-for-jobs` | ✅
 | status | `-n`, `--show-resources`, `-o/--output` | ✅
 | status | `--revision` | ✗
 | history | `-n`, `-o/--output`, `--max` | ✅
 |===
+
+On `rollback`: `--force` delete-and-recreates the target revision's resources, `--cleanup-on-fail`
+deletes any resources created during a failed rollback, and `--recreate-pods` triggers a rolling
+restart of the release's workloads (Deployments/StatefulSets/DaemonSets) via a restart annotation.
+`--wait-for-jobs` extends `--wait` to also block on Job completion.
 
 `status -o json|yaml` emits the Helm-shaped release object (nested `info`, plus a `resources`
 array when `--show-resources` is set); `history -o json|yaml` emits the Helm history array.
@@ -127,8 +135,6 @@ Most scripts work unchanged. Watch for these deliberate differences:
   kube-context namespace or `$HELM_NAMESPACE`).
 * *`--timeout`* — jhelm expects **seconds** (`--timeout 300`), not a Go duration (`5m0s`).
 * *`--dry-run`* — use the bare flag; the `=client|server` value form is not parsed.
-* *`list -A`* — not supported; iterate namespaces, or pass `-n`.
-* *`--force` / `--wait-for-jobs`* — not yet supported on install/upgrade/rollback.
 * *Output* — `-o table|json|yaml` is supported on `list`, `get values`, `get metadata`,
   `status`, `history`, `install`, `upgrade`, `repo list`, and `search hub`, producing
   Helm-shaped output for scripts and agents. Commands where Helm has no `-o` (`template`,
@@ -139,11 +145,9 @@ Most scripts work unchanged. Watch for these deliberate differences:
 Beyond the per-command tables above, these commonly-used Helm options are not yet wired
 (tracked for follow-up):
 
-* *`install`/`upgrade`* — install-from-repo (`--version`/`--repo`/`--username`/`--password`);
-  `upgrade --cleanup-on-fail`.
-  (`-g`/`--generate-name` is supported on `install`; `--description`/`--labels`/`--set-literal`/`--dependency-update` on both.)
-* *`uninstall`/`rollback`* — `--wait`/`--timeout`/`--cascade` (uninstall);
-  `--force`/`--cleanup-on-fail`/`--recreate-pods`/`--wait-for-jobs` (rollback).
+* *`install`/`upgrade`* — `upgrade --cleanup-on-fail`.
+  (install-from-repo `--version`/`--repo`/`--username`/`--password` + TLS is supported;
+  `-g`/`--generate-name` on `install`; `--description`/`--labels`/`--set-literal`/`--dependency-update` on both.)
 * *`pull`* — `--untar`/`--untardir`, `--verify`/`--prov`/`--keyring`, `--devel`.
 * *Global flags* — Helm's persistent flags (`--kube-context`, `--kubeconfig`,
   `--kube-apiserver`, `--registry-config`, `--repository-config`, `--repository-cache`,

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RollbackCommand.java
@@ -7,8 +7,6 @@ import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.RollbackAction;
 import org.alexmond.jhelm.core.action.RollbackOptions;
 import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
-import org.alexmond.jhelm.core.model.Release;
-import org.alexmond.jhelm.core.service.KubeService;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
@@ -23,8 +21,6 @@ import picocli.CommandLine;
 public class RollbackCommand implements Callable<Integer> {
 
 	private final RollbackAction rollbackAction;
-
-	private final KubeService kubeService;
 
 	private final JhelmSecurityPolicy securityPolicy;
 
@@ -47,20 +43,38 @@ public class RollbackCommand implements Callable<Integer> {
 	@CommandLine.Option(names = { "--wait" }, description = "wait until all resources are ready")
 	private boolean wait;
 
+	@CommandLine.Option(names = { "--wait-for-jobs" },
+			description = "with --wait, also wait for Jobs to complete before marking the rollback done")
+	private boolean waitForJobs;
+
 	@CommandLine.Option(names = { "--timeout" }, defaultValue = "300",
 			description = "timeout in seconds for --wait (default 300)")
 	private int timeout;
 
+	@CommandLine.Option(names = { "--dry-run" },
+			description = "simulate the rollback without applying manifests or storing a revision")
+	private boolean dryRun;
+
+	@CommandLine.Option(names = { "--force" },
+			description = "delete and recreate the target revision's resources instead of patching in place")
+	private boolean force;
+
+	@CommandLine.Option(names = { "--cleanup-on-fail" },
+			description = "delete resources created during the rollback if it fails")
+	private boolean cleanupOnFail;
+
+	@CommandLine.Option(names = { "--recreate-pods" },
+			description = "perform a rolling restart of the release's workloads after the rollback (deprecated in Helm)")
+	private boolean recreatePods;
+
 	/**
 	 * Creates the command.
 	 * @param rollbackAction the action that performs the rollback
-	 * @param kubeService the Kubernetes service used to wait for resource readiness
 	 * @param securityPolicy the unified access-mode policy; the operation is refused
 	 * unless mutating operations are enabled
 	 */
-	public RollbackCommand(RollbackAction rollbackAction, KubeService kubeService, JhelmSecurityPolicy securityPolicy) {
+	public RollbackCommand(RollbackAction rollbackAction, JhelmSecurityPolicy securityPolicy) {
 		this.rollbackAction = rollbackAction;
-		this.kubeService = kubeService;
 		this.securityPolicy = securityPolicy;
 	}
 
@@ -70,17 +84,22 @@ public class RollbackCommand implements Callable<Integer> {
 			return CommandLine.ExitCode.SOFTWARE;
 		}
 		try {
-			Release release = rollbackAction.rollback(RollbackOptions.builder()
+			rollbackAction.rollback(RollbackOptions.builder()
 				.releaseName(name)
 				.namespace(namespace)
 				.revision(revision)
 				.noHooks(noHooks)
 				.maxHistory(historyMax)
+				.dryRun(dryRun)
+				.force(force)
+				.cleanupOnFail(cleanupOnFail)
+				.recreatePods(recreatePods)
+				.wait(wait)
+				.waitForJobs(waitForJobs)
+				.timeout(timeout)
 				.build());
-			CliOutput.println(CliOutput.success("Rollback was a success! Happy Helming!"));
-			if (wait) {
-				kubeService.waitForReady(namespace, release.getManifest(), timeout);
-			}
+			CliOutput.println(CliOutput
+				.success(dryRun ? "Rollback dry run complete. No changes were applied." : "Rollback was a success!"));
 			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UninstallCommand.java
@@ -7,6 +7,7 @@ import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
@@ -36,6 +37,26 @@ public class UninstallCommand implements Callable<Integer> {
 			description = "remove all associated resources and mark the release as deleted, but retain the release history")
 	private boolean keepHistory;
 
+	@CommandLine.Option(names = { "--dry-run" },
+			description = "simulate the uninstall without deleting resources or history")
+	private boolean dryRun;
+
+	@CommandLine.Option(names = { "--wait" },
+			description = "wait until the release's resources are removed from the cluster")
+	private boolean wait;
+
+	@CommandLine.Option(names = { "--timeout" }, defaultValue = "300",
+			description = "timeout in seconds for --wait (default 300)")
+	private int timeout;
+
+	@CommandLine.Option(names = { "--cascade" }, defaultValue = "background",
+			description = "resource deletion propagation: background, foreground, or orphan")
+	private String cascade;
+
+	@CommandLine.Option(names = { "--description" },
+			description = "custom description stored on the release when --keep-history is set")
+	private String description;
+
 	/**
 	 * Creates the command.
 	 * @param uninstallAction the action that uninstalls the release
@@ -58,8 +79,14 @@ public class UninstallCommand implements Callable<Integer> {
 				.namespace(namespace)
 				.noHooks(noHooks)
 				.keepHistory(keepHistory)
+				.dryRun(dryRun)
+				.wait(wait)
+				.timeout(timeout)
+				.cascade(CascadePolicy.fromString(cascade))
+				.description(description)
 				.build());
-			CliOutput.println(CliOutput.success("release \"" + name + "\" uninstalled"));
+			String verb = dryRun ? "\" would be uninstalled (dry run)" : "\" uninstalled";
+			CliOutput.println(CliOutput.success("release \"" + name + verb));
 			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RollbackCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RollbackCommandTest.java
@@ -6,14 +6,16 @@ import org.alexmond.jhelm.core.config.JhelmAccessMode;
 import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
 import org.alexmond.jhelm.core.model.Release;
-import org.alexmond.jhelm.core.service.KubeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -25,15 +27,12 @@ class RollbackCommandTest {
 	@Mock
 	private RollbackAction rollbackAction;
 
-	@Mock
-	private KubeService kubeService;
-
 	private RollbackCommand rollbackCommand;
 
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		rollbackCommand = new RollbackCommand(rollbackAction, kubeService, enabledPolicy());
+		rollbackCommand = new RollbackCommand(rollbackAction, enabledPolicy());
 	}
 
 	@Test
@@ -63,8 +62,39 @@ class RollbackCommandTest {
 	}
 
 	@Test
+	void testRollbackFlagsReachOptions() throws Exception {
+		Release release = Release.builder().name("my-release").namespace("default").manifest("---\n").build();
+		ArgumentCaptor<RollbackOptions> captor = ArgumentCaptor.forClass(RollbackOptions.class);
+		when(rollbackAction.rollback(captor.capture())).thenReturn(release);
+
+		int exit = new CommandLine(rollbackCommand).execute("my-release", "1", "--force", "--cleanup-on-fail",
+				"--recreate-pods", "--wait", "--wait-for-jobs", "--timeout", "120");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		RollbackOptions opts = captor.getValue();
+		assertTrue(opts.isForce());
+		assertTrue(opts.isCleanupOnFail());
+		assertTrue(opts.isRecreatePods());
+		assertTrue(opts.isWait());
+		assertTrue(opts.isWaitForJobs());
+		assertEquals(120, opts.getTimeout());
+	}
+
+	@Test
+	void testRollbackDryRunPassesFlag() throws Exception {
+		Release release = Release.builder().name("my-release").namespace("default").manifest("---\n").build();
+		ArgumentCaptor<RollbackOptions> captor = ArgumentCaptor.forClass(RollbackOptions.class);
+		when(rollbackAction.rollback(captor.capture())).thenReturn(release);
+
+		int exit = new CommandLine(rollbackCommand).execute("my-release", "1", "--dry-run");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		assertTrue(captor.getValue().isDryRun());
+	}
+
+	@Test
 	void testRollbackBlockedInReadOnlyMode() throws Exception {
-		RollbackCommand readOnlyCommand = new RollbackCommand(rollbackAction, kubeService, readOnlyPolicy());
+		RollbackCommand readOnlyCommand = new RollbackCommand(rollbackAction, readOnlyPolicy());
 
 		CommandLine cmd = new CommandLine(readOnlyCommand);
 		int exitCode = cmd.execute("my-release", "1", "-n", "default");

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UninstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UninstallCommandTest.java
@@ -5,13 +5,17 @@ import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.alexmond.jhelm.core.config.JhelmAccessMode;
 import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -64,6 +68,34 @@ class UninstallCommandTest {
 
 		CommandLine cmd = new CommandLine(uninstallCommand);
 		cmd.execute("my-release");
+	}
+
+	@Test
+	void testUninstallFlagsReachOptions() throws Exception {
+		ArgumentCaptor<UninstallOptions> captor = ArgumentCaptor.forClass(UninstallOptions.class);
+		doNothing().when(uninstallAction).uninstall(captor.capture());
+
+		int exit = new CommandLine(uninstallCommand).execute("my-release", "--wait", "--timeout", "90", "--cascade",
+				"foreground", "--keep-history", "--description", "cleanup");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		UninstallOptions opts = captor.getValue();
+		assertTrue(opts.isWait());
+		assertEquals(90, opts.getTimeout());
+		assertEquals(CascadePolicy.FOREGROUND, opts.getCascade());
+		assertTrue(opts.isKeepHistory());
+		assertEquals("cleanup", opts.getDescription());
+	}
+
+	@Test
+	void testUninstallDryRunReportsWithoutError() throws Exception {
+		ArgumentCaptor<UninstallOptions> captor = ArgumentCaptor.forClass(UninstallOptions.class);
+		doNothing().when(uninstallAction).uninstall(captor.capture());
+
+		int exit = new CommandLine(uninstallCommand).execute("my-release", "--dry-run");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		assertTrue(captor.getValue().isDryRun());
 	}
 
 	@Test

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackAction.java
@@ -45,7 +45,6 @@ public class RollbackAction {
 		String namespace = options.getNamespace();
 		int revision = options.getRevision();
 		boolean noHooks = options.isNoHooks();
-		int maxHistory = options.getMaxHistory();
 		List<Release> history = kubeService.getReleaseHistory(name, namespace);
 		Optional<Release> targetReleaseOpt = history.stream().filter((r) -> r.getVersion() == revision).findFirst();
 
@@ -75,18 +74,67 @@ public class RollbackAction {
 
 		String manifest = newRelease.getManifest();
 		String regularManifest = HookParser.stripHooks(manifest);
+		// --dry-run: report the target revision without applying or storing anything.
+		if (options.isDryRun()) {
+			log.info("--dry-run: would roll back release {} to revision {}", name, revision);
+			return newRelease;
+		}
 		List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(manifest);
 		HookExecutor hookExecutor = noHooks ? null : new HookExecutor(kubeService);
 		if (!noHooks) {
 			runHooks(hookExecutor, namespace, hooks, "pre-rollback");
 		}
-		kubeService.apply(namespace, regularManifest);
-		kubeService.storeRelease(newRelease);
-		kubeService.pruneReleaseHistory(name, namespace, maxHistory);
+		applyRollback(options, newRelease, regularManifest);
 		if (!noHooks) {
 			runHooks(hookExecutor, namespace, hooks, "post-rollback");
 		}
+		if (options.isWait()) {
+			kubeService.waitForReady(namespace, regularManifest, options.getTimeout(), options.isWaitForJobs());
+		}
 		return newRelease;
+	}
+
+	/**
+	 * Applies the rolled-back manifest and stores the new revision, honoring the
+	 * {@code --force}, {@code --cleanup-on-fail} and {@code --recreate-pods} options.
+	 * @param options the rollback options
+	 * @param newRelease the new revision to store after a successful apply
+	 * @param regularManifest the hooks-stripped manifest to apply
+	 */
+	private void applyRollback(RollbackOptions options, Release newRelease, String regularManifest) {
+		String name = newRelease.getName();
+		String namespace = newRelease.getNamespace();
+		if (options.isForce()) {
+			log.info("--force: deleting existing resources of release {} before rollback", name);
+			kubeService.delete(namespace, regularManifest);
+		}
+		try {
+			kubeService.apply(namespace, regularManifest);
+		}
+		catch (RuntimeException ex) {
+			if (options.isCleanupOnFail()) {
+				cleanupFailedRollback(namespace, regularManifest, name);
+			}
+			throw ex;
+		}
+		kubeService.storeRelease(newRelease);
+		kubeService.pruneReleaseHistory(name, namespace, options.getMaxHistory());
+		if (options.isRecreatePods()) {
+			log.info("--recreate-pods: restarting workloads of release {}", name);
+			kubeService.restartWorkloads(namespace, regularManifest);
+		}
+	}
+
+	// --cleanup-on-fail: best-effort deletion of resources created during a failed
+	// rollback; a failed cleanup is logged and the original apply failure is rethrown.
+	private void cleanupFailedRollback(String namespace, String regularManifest, String name) {
+		log.warn("--cleanup-on-fail: deleting resources created during the failed rollback of {}", name);
+		try {
+			kubeService.delete(namespace, regularManifest);
+		}
+		catch (RuntimeException cleanupEx) {
+			log.error("cleanup-on-fail delete failed for release {}: {}", name, cleanupEx.getMessage(), cleanupEx);
+		}
 	}
 
 	private void runHooks(HookExecutor hookExecutor, String namespace, List<HelmHook> hooks, String phase) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/RollbackOptions.java
@@ -36,4 +36,46 @@ public final class RollbackOptions {
 	@Builder.Default
 	private final int maxHistory = 10;
 
+	/**
+	 * When {@code true}, simulate the rollback without applying manifests or storing the
+	 * new revision (Helm {@code --dry-run}). Defaults to {@code false}.
+	 */
+	private final boolean dryRun;
+
+	/**
+	 * When {@code true}, delete the target revision's resources and recreate them instead
+	 * of patching in place (Helm {@code --force}). Defaults to {@code false}.
+	 */
+	private final boolean force;
+
+	/**
+	 * When {@code true}, delete any resources created during a failed rollback (Helm
+	 * {@code --cleanup-on-fail}). Defaults to {@code false}.
+	 */
+	private final boolean cleanupOnFail;
+
+	/**
+	 * When {@code true}, trigger a rolling restart of the release's workloads after the
+	 * rollback (Helm's deprecated {@code --recreate-pods}). Defaults to {@code false}.
+	 */
+	private final boolean recreatePods;
+
+	/**
+	 * When {@code true}, wait until the rolled-back resources are ready before returning
+	 * (Helm {@code --wait}). Defaults to {@code false}.
+	 */
+	private final boolean wait;
+
+	/**
+	 * When {@code true}, additionally wait for Jobs to complete when {@link #wait} is set
+	 * (Helm {@code --wait-for-jobs}). Defaults to {@code false}.
+	 */
+	private final boolean waitForJobs;
+
+	/**
+	 * Seconds to wait when {@link #wait} is set. Defaults to {@code 300}.
+	 */
+	@Builder.Default
+	private final int timeout = 300;
+
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallAction.java
@@ -53,25 +53,34 @@ public class UninstallAction {
 
 		Release release = releaseOpt.get();
 		String regularManifest = HookParser.stripHooks(release.getManifest());
+		String deletableManifest = HookParser.stripKeptResources(regularManifest);
+		// --dry-run: report what would happen without deleting resources or touching
+		// history.
+		if (options.isDryRun()) {
+			log.info("--dry-run: would uninstall release {} in namespace {}", releaseName, namespace);
+			return;
+		}
 		List<HelmHook> hooks = noHooks ? List.of() : HookParser.parseHooks(release.getManifest());
 		HookExecutor hookExecutor = noHooks ? null : new HookExecutor(kubeService);
 		if (!noHooks) {
 			runHooks(hookExecutor, namespace, hooks, "pre-delete");
 		}
-		String deletableManifest = HookParser.stripKeptResources(regularManifest);
-		kubeService.delete(namespace, deletableManifest);
+		kubeService.delete(namespace, deletableManifest, options.getCascade());
+		if (options.isWait()) {
+			kubeService.waitForDeleted(namespace, deletableManifest, options.getTimeout());
+		}
 		if (!noHooks) {
 			runHooks(hookExecutor, namespace, hooks, "post-delete");
 		}
 		if (options.isKeepHistory()) {
-			kubeService.storeRelease(markUninstalled(release));
+			kubeService.storeRelease(markUninstalled(release, options.getDescription()));
 		}
 		else {
 			kubeService.deleteReleaseHistory(releaseName, namespace);
 		}
 	}
 
-	private Release markUninstalled(Release release) {
+	private Release markUninstalled(Release release, String description) {
 		Release.ReleaseInfo previousInfo = release.getInfo();
 		OffsetDateTime firstDeployed = (previousInfo != null) ? previousInfo.getFirstDeployed() : null;
 		return Release.builder()
@@ -84,7 +93,7 @@ public class UninstallAction {
 				.firstDeployed(firstDeployed)
 				.lastDeployed(OffsetDateTime.now())
 				.status(ReleaseStatus.UNINSTALLED)
-				.description("Uninstallation complete")
+				.description((description != null && !description.isBlank()) ? description : "Uninstallation complete")
 				.build())
 			.build();
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UninstallOptions.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.core.action;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 
 /**
  * Immutable options for {@link UninstallAction#uninstall(UninstallOptions)}.
@@ -31,5 +32,36 @@ public final class UninstallOptions {
 	 * instead of deleting its history. Defaults to {@code false}.
 	 */
 	private final boolean keepHistory;
+
+	/**
+	 * When {@code true}, simulate the uninstall without deleting anything or touching the
+	 * release history (Helm {@code --dry-run}). Defaults to {@code false}.
+	 */
+	private final boolean dryRun;
+
+	/**
+	 * When {@code true}, wait until the release's resources are removed from the cluster
+	 * before returning (Helm {@code --wait}). Defaults to {@code false}.
+	 */
+	private final boolean wait;
+
+	/**
+	 * Seconds to wait when {@link #wait} is set. Defaults to {@code 300}.
+	 */
+	@Builder.Default
+	private final int timeout = 300;
+
+	/**
+	 * The deletion propagation policy (Helm {@code --cascade}). Defaults to
+	 * {@link CascadePolicy#BACKGROUND}.
+	 */
+	@Builder.Default
+	private final CascadePolicy cascade = CascadePolicy.BACKGROUND;
+
+	/**
+	 * Custom description stored on the uninstalled release when history is kept; falls
+	 * back to {@code "Uninstallation complete"} when blank.
+	 */
+	private final String description;
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/CascadePolicy.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/CascadePolicy.java
@@ -1,0 +1,63 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.Locale;
+
+/**
+ * Deletion propagation policy for removing a release's resources, mirroring Helm's
+ * {@code --cascade} option and Kubernetes' {@code DeleteOptions.propagationPolicy}.
+ */
+public enum CascadePolicy {
+
+	/**
+	 * Delete the owner immediately and garbage-collect its dependents in the background
+	 * (Kubernetes {@code Background}). This is Helm's and Kubernetes' default.
+	 */
+	BACKGROUND("Background"),
+
+	/**
+	 * Block until the owner and all its dependents are deleted (Kubernetes
+	 * {@code Foreground}).
+	 */
+	FOREGROUND("Foreground"),
+
+	/**
+	 * Delete only the owner and leave its dependents orphaned (Kubernetes
+	 * {@code Orphan}).
+	 */
+	ORPHAN("Orphan");
+
+	private final String propagationPolicy;
+
+	CascadePolicy(String propagationPolicy) {
+		this.propagationPolicy = propagationPolicy;
+	}
+
+	/**
+	 * @return the Kubernetes {@code DeleteOptions.propagationPolicy} value for this
+	 * policy
+	 */
+	public String propagationPolicy() {
+		return this.propagationPolicy;
+	}
+
+	/**
+	 * Parses Helm's {@code --cascade} argument ({@code background}, {@code foreground},
+	 * or {@code orphan}, case-insensitive) into a policy.
+	 * @param value the argument value; {@code null} or blank yields {@link #BACKGROUND}
+	 * @return the matching policy
+	 * @throws IllegalArgumentException if the value is not a recognised cascade mode
+	 */
+	public static CascadePolicy fromString(String value) {
+		if (value == null || value.isBlank()) {
+			return BACKGROUND;
+		}
+		return switch (value.trim().toLowerCase(Locale.ROOT)) {
+			case "background" -> BACKGROUND;
+			case "foreground" -> FOREGROUND;
+			case "orphan" -> ORPHAN;
+			default -> throw new IllegalArgumentException(
+					"invalid cascade '" + value + "' (expected background, foreground, or orphan)");
+		};
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
@@ -127,6 +127,47 @@ public interface KubeService {
 	void delete(String namespace, String yamlContent);
 
 	/**
+	 * Deletes the resources described in a rendered manifest using the given deletion
+	 * propagation policy (Helm {@code --cascade}). The default implementation ignores the
+	 * policy and delegates to {@link #delete(String, String)} (background propagation),
+	 * so only implementations that support propagation control need to override it.
+	 * @param namespace the target namespace
+	 * @param yamlContent rendered YAML manifest (may contain multiple documents)
+	 * @param cascade the deletion propagation policy
+	 * @throws KubernetesOperationException if a resource cannot be deleted
+	 */
+	default void delete(String namespace, String yamlContent, CascadePolicy cascade) {
+		delete(namespace, yamlContent);
+	}
+
+	/**
+	 * Blocks until all resources described in the manifest are deleted from the cluster,
+	 * or until the timeout elapses (Helm {@code uninstall --wait}). The default
+	 * implementation is a no-op, so a test double or an implementation that cannot poll
+	 * the cluster returns immediately; real implementations override it.
+	 * @param namespace the namespace to query
+	 * @param manifest rendered YAML manifest
+	 * @param timeoutSeconds maximum seconds to wait
+	 * @throws WaitTimeoutException if the timeout elapses before all resources are gone
+	 * @throws KubernetesOperationException if the wait is interrupted or the Kubernetes
+	 * API cannot be reached
+	 */
+	default void waitForDeleted(String namespace, String manifest, int timeoutSeconds) {
+	}
+
+	/**
+	 * Triggers a rolling restart of the workloads (Deployments, StatefulSets, DaemonSets)
+	 * described in the manifest by stamping a restart annotation, mirroring Helm's
+	 * (deprecated) {@code rollback --recreate-pods}. The default implementation is a
+	 * no-op so test doubles need not implement it; real implementations override it.
+	 * @param namespace the namespace of the workloads
+	 * @param manifest rendered YAML manifest
+	 * @throws KubernetesOperationException if a workload cannot be patched
+	 */
+	default void restartWorkloads(String namespace, String manifest) {
+	}
+
+	/**
 	 * Returns the readiness status of each Kubernetes resource described in the rendered
 	 * manifest.
 	 * @param namespace the namespace to query
@@ -148,6 +189,24 @@ public interface KubeService {
 	 * API cannot be reached
 	 */
 	void waitForReady(String namespace, String manifest, int timeoutSeconds);
+
+	/**
+	 * Blocks until all resources described in the manifest are ready, additionally
+	 * waiting for any Jobs to run to completion when {@code waitForJobs} is set (Helm
+	 * {@code --wait-for-jobs}). The default implementation ignores {@code waitForJobs}
+	 * and delegates to {@link #waitForReady(String, String, int)}; implementations that
+	 * can distinguish Job completion override it.
+	 * @param namespace the namespace to query
+	 * @param manifest rendered YAML manifest
+	 * @param timeoutSeconds maximum seconds to wait
+	 * @param waitForJobs whether to also wait for Jobs to complete
+	 * @throws WaitTimeoutException if the timeout elapses before everything is ready
+	 * @throws KubernetesOperationException if the wait is interrupted or the Kubernetes
+	 * API cannot be reached
+	 */
+	default void waitForReady(String namespace, String manifest, int timeoutSeconds, boolean waitForJobs) {
+		waitForReady(namespace, manifest, timeoutSeconds);
+	}
 
 	/**
 	 * Returns the {@code .Capabilities} to expose to templates for this cluster — chiefly

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/RollbackActionTest.java
@@ -21,9 +21,11 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.ArgumentMatchers.eq;
 import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
@@ -315,6 +317,114 @@ class RollbackActionTest {
 			.rollback(RollbackOptions.builder().releaseName("myapp").namespace("default").revision(99).build()));
 
 		assertTrue(exception.getMessage().contains("Revision 99 not found"));
+	}
+
+	// --- #683 rollback semantics ---
+
+	private List<Release> twoRevisionHistory() {
+		Chart chart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
+			.build();
+		Release v1 = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.manifest("---\nv1 manifest")
+			.info(Release.ReleaseInfo.builder()
+				.firstDeployed(OffsetDateTime.now().minusDays(2))
+				.lastDeployed(OffsetDateTime.now().minusDays(2))
+				.status(ReleaseStatus.DEPLOYED)
+				.build())
+			.build();
+		Release v2 = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(2)
+			.chart(chart)
+			.manifest("---\nv2 manifest")
+			.info(Release.ReleaseInfo.builder()
+				.firstDeployed(OffsetDateTime.now().minusDays(2))
+				.lastDeployed(OffsetDateTime.now().minusDays(1))
+				.status(ReleaseStatus.DEPLOYED)
+				.build())
+			.build();
+		return Arrays.asList(v2, v1);
+	}
+
+	@Test
+	void testDryRunDoesNotApplyOrStore() {
+		when(kubeService.getReleaseHistory(anyString(), anyString())).thenReturn(twoRevisionHistory());
+
+		rollbackAction.rollback(
+				RollbackOptions.builder().releaseName("myapp").namespace("default").revision(1).dryRun(true).build());
+
+		verify(kubeService, never()).apply(anyString(), anyString());
+		verify(kubeService, never()).storeRelease(any(Release.class));
+	}
+
+	@Test
+	void testForceDeletesBeforeApply() {
+		when(kubeService.getReleaseHistory(anyString(), anyString())).thenReturn(twoRevisionHistory());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+
+		rollbackAction.rollback(
+				RollbackOptions.builder().releaseName("myapp").namespace("default").revision(1).force(true).build());
+
+		String manifest = HookParser.stripHooks("---\nv1 manifest");
+		InOrder ord = inOrder(kubeService);
+		ord.verify(kubeService).delete("default", manifest);
+		ord.verify(kubeService).apply("default", manifest);
+	}
+
+	@Test
+	void testCleanupOnFailDeletesAndRethrows() {
+		when(kubeService.getReleaseHistory(anyString(), anyString())).thenReturn(twoRevisionHistory());
+		doThrow(new RuntimeException("apply failed")).when(kubeService).apply(anyString(), anyString());
+
+		RuntimeException ex = assertThrows(RuntimeException.class,
+				() -> rollbackAction.rollback(RollbackOptions.builder()
+					.releaseName("myapp")
+					.namespace("default")
+					.revision(1)
+					.cleanupOnFail(true)
+					.build()));
+
+		assertTrue(ex.getMessage().contains("apply failed"));
+		verify(kubeService).delete("default", HookParser.stripHooks("---\nv1 manifest"));
+		verify(kubeService, never()).storeRelease(any(Release.class));
+	}
+
+	@Test
+	void testRecreatePodsRestartsWorkloads() {
+		when(kubeService.getReleaseHistory(anyString(), anyString())).thenReturn(twoRevisionHistory());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+
+		rollbackAction.rollback(RollbackOptions.builder()
+			.releaseName("myapp")
+			.namespace("default")
+			.revision(1)
+			.recreatePods(true)
+			.build());
+
+		verify(kubeService).restartWorkloads("default", HookParser.stripHooks("---\nv1 manifest"));
+	}
+
+	@Test
+	void testWaitCallsWaitForReadyWithJobsFlag() {
+		when(kubeService.getReleaseHistory(anyString(), anyString())).thenReturn(twoRevisionHistory());
+		doNothing().when(kubeService).apply(anyString(), anyString());
+
+		rollbackAction.rollback(RollbackOptions.builder()
+			.releaseName("myapp")
+			.namespace("default")
+			.revision(1)
+			.wait(true)
+			.waitForJobs(true)
+			.timeout(77)
+			.build());
+
+		verify(kubeService).waitForReady(eq("default"), anyString(), eq(77), eq(true));
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UninstallActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UninstallActionTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
@@ -24,6 +25,7 @@ import org.alexmond.jhelm.core.exception.ReleaseNotFoundException;
 import org.alexmond.jhelm.core.model.HelmHook;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ReleaseStatus;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.util.HookParser;
 
@@ -45,12 +47,12 @@ class UninstallActionTest {
 		Release release = Release.builder().name("myapp").namespace("default").manifest("---\nkind: Service\n").build();
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
-		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).delete(anyString(), anyString(), any());
 		doNothing().when(kubeService).deleteReleaseHistory(anyString(), anyString());
 
 		uninstallAction.uninstall(UninstallOptions.builder().releaseName("myapp").namespace("default").build());
 
-		verify(kubeService).delete("default", "---\nkind: Service\n");
+		verify(kubeService).delete("default", "---\nkind: Service\n", CascadePolicy.BACKGROUND);
 		verify(kubeService).deleteReleaseHistory("myapp", "default");
 	}
 
@@ -76,7 +78,7 @@ class UninstallActionTest {
 		Release release = Release.builder().name("myapp").namespace("default").manifest(fullManifest).build();
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
-		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).delete(anyString(), anyString(), any());
 		doNothing().when(kubeService).apply(anyString(), anyString());
 		doNothing().when(kubeService).waitForReady(anyString(), anyString(), anyInt());
 		doNothing().when(kubeService).deleteReleaseHistory(anyString(), anyString());
@@ -89,7 +91,7 @@ class UninstallActionTest {
 		// Pre-delete hook: delete (before-hook-creation) + apply + waitForReady
 		verify(kubeService).apply("default", hooks.get(0).getYaml());
 		// Regular resource deletion uses stripped manifest
-		verify(kubeService).delete("default", strippedManifest);
+		verify(kubeService).delete("default", strippedManifest, CascadePolicy.BACKGROUND);
 		verify(kubeService).deleteReleaseHistory("myapp", "default");
 	}
 
@@ -115,7 +117,7 @@ class UninstallActionTest {
 		Release release = Release.builder().name("myapp").namespace("default").manifest(fullManifest).build();
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
-		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).delete(anyString(), anyString(), any());
 		doNothing().when(kubeService).deleteReleaseHistory(anyString(), anyString());
 
 		uninstallAction
@@ -127,7 +129,7 @@ class UninstallActionTest {
 		// Hook resource is NOT applied when noHooks is true
 		verify(kubeService, never()).apply("default", hooks.get(0).getYaml());
 		// Regular resources are still deleted and history removed
-		verify(kubeService).delete("default", deletableManifest);
+		verify(kubeService).delete("default", deletableManifest, CascadePolicy.BACKGROUND);
 		verify(kubeService).deleteReleaseHistory("myapp", "default");
 	}
 
@@ -149,14 +151,14 @@ class UninstallActionTest {
 		Release release = Release.builder().name("myapp").namespace("default").manifest(fullManifest).build();
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
-		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).delete(anyString(), anyString(), any());
 		doNothing().when(kubeService).deleteReleaseHistory(anyString(), anyString());
 
 		uninstallAction.uninstall(UninstallOptions.builder().releaseName("myapp").namespace("default").build());
 
 		// Only ConfigMap should be deleted — PVC with resource-policy: keep is preserved
 		String deletedManifest = HookParser.stripKeptResources(HookParser.stripHooks(fullManifest));
-		verify(kubeService).delete("default", deletedManifest);
+		verify(kubeService).delete("default", deletedManifest, CascadePolicy.BACKGROUND);
 	}
 
 	@Test
@@ -175,7 +177,7 @@ class UninstallActionTest {
 			.build();
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
-		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).delete(anyString(), anyString(), any());
 		doNothing().when(kubeService).storeRelease(any(Release.class));
 
 		uninstallAction
@@ -204,13 +206,79 @@ class UninstallActionTest {
 			.build();
 
 		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
-		doNothing().when(kubeService).delete(anyString(), anyString());
+		doNothing().when(kubeService).delete(anyString(), anyString(), any());
 		doNothing().when(kubeService).deleteReleaseHistory(anyString(), anyString());
 
 		uninstallAction.uninstall(UninstallOptions.builder().releaseName("myapp").namespace("default").build());
 
 		verify(kubeService).deleteReleaseHistory("myapp", "default");
 		verify(kubeService, never()).storeRelease(any(Release.class));
+	}
+
+	@Test
+	void testDryRunDeletesNothingAndLeavesHistory() {
+		Release release = Release.builder().name("myapp").namespace("default").manifest("---\nkind: Service\n").build();
+		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
+
+		uninstallAction
+			.uninstall(UninstallOptions.builder().releaseName("myapp").namespace("default").dryRun(true).build());
+
+		verify(kubeService, never()).delete(anyString(), anyString(), any());
+		verify(kubeService, never()).deleteReleaseHistory(anyString(), anyString());
+		verify(kubeService, never()).storeRelease(any(Release.class));
+	}
+
+	@Test
+	void testWaitCallsWaitForDeleted() {
+		Release release = Release.builder().name("myapp").namespace("default").manifest("---\nkind: Service\n").build();
+		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
+
+		uninstallAction.uninstall(
+				UninstallOptions.builder().releaseName("myapp").namespace("default").wait(true).timeout(42).build());
+
+		verify(kubeService).waitForDeleted(eq("default"), anyString(), eq(42));
+	}
+
+	@Test
+	void testCascadePolicyIsPassedToDelete() {
+		Release release = Release.builder().name("myapp").namespace("default").manifest("---\nkind: Service\n").build();
+		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
+
+		uninstallAction.uninstall(UninstallOptions.builder()
+			.releaseName("myapp")
+			.namespace("default")
+			.cascade(CascadePolicy.FOREGROUND)
+			.build());
+
+		verify(kubeService).delete(eq("default"), anyString(), eq(CascadePolicy.FOREGROUND));
+	}
+
+	@Test
+	void testCustomDescriptionStoredWhenKeepingHistory() {
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status(ReleaseStatus.DEPLOYED)
+			.build();
+		Release release = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.manifest("---\nkind: Service\n")
+			.info(info)
+			.build();
+		when(kubeService.getRelease(anyString(), anyString())).thenReturn(Optional.of(release));
+
+		uninstallAction.uninstall(UninstallOptions.builder()
+			.releaseName("myapp")
+			.namespace("default")
+			.keepHistory(true)
+			.description("scaling down")
+			.build());
+
+		ArgumentCaptor<Release> releaseCaptor = ArgumentCaptor.forClass(Release.class);
+		verify(kubeService).storeRelease(releaseCaptor.capture());
+		assertEquals("scaling down", releaseCaptor.getValue().getInfo().getDescription());
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/CascadePolicyTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/CascadePolicyTest.java
@@ -1,0 +1,35 @@
+package org.alexmond.jhelm.core.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CascadePolicyTest {
+
+	@Test
+	void parsesKnownModesCaseInsensitively() {
+		assertEquals(CascadePolicy.BACKGROUND, CascadePolicy.fromString("background"));
+		assertEquals(CascadePolicy.FOREGROUND, CascadePolicy.fromString("Foreground"));
+		assertEquals(CascadePolicy.ORPHAN, CascadePolicy.fromString("ORPHAN"));
+	}
+
+	@Test
+	void nullOrBlankDefaultsToBackground() {
+		assertEquals(CascadePolicy.BACKGROUND, CascadePolicy.fromString(null));
+		assertEquals(CascadePolicy.BACKGROUND, CascadePolicy.fromString("   "));
+	}
+
+	@Test
+	void unknownModeIsRejected() {
+		assertThrows(IllegalArgumentException.class, () -> CascadePolicy.fromString("sideways"));
+	}
+
+	@Test
+	void propagationPolicyMapsToKubernetesValues() {
+		assertEquals("Background", CascadePolicy.BACKGROUND.propagationPolicy());
+		assertEquals("Foreground", CascadePolicy.FOREGROUND.propagationPolicy());
+		assertEquals("Orphan", CascadePolicy.ORPHAN.propagationPolicy());
+	}
+
+}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
@@ -25,6 +25,7 @@ import io.kubernetes.client.util.Yaml;
 import io.kubernetes.client.util.generic.KubernetesApiResponse;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
+import io.kubernetes.client.util.generic.options.DeleteOptions;
 import io.kubernetes.client.util.generic.options.PatchOptions;
 import lombok.extern.slf4j.Slf4j;
 import org.yaml.snakeyaml.DumperOptions;
@@ -33,6 +34,7 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.exception.ReleaseStorageException;
 import org.alexmond.jhelm.core.exception.WaitTimeoutException;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.HelmReleaseCodec;
@@ -52,6 +54,7 @@ import java.util.Comparator;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
 
 /**
  * Default {@link KubeService} implementation backed by the official Kubernetes Java
@@ -71,6 +74,9 @@ public class HelmKubeService implements KubeService {
 	// Storage labels Helm's own tooling queries on; custom --labels must not override
 	// these.
 	private static final Set<String> RESERVED_RELEASE_LABELS = Set.of("owner", "name", "status", "version");
+
+	// Workload kinds whose pods a rolling restart (--recreate-pods) can trigger.
+	private static final Set<String> RESTARTABLE_KINDS = Set.of("Deployment", "StatefulSet", "DaemonSet");
 
 	/** Configured Kubernetes API client used for all cluster operations. */
 	private final ApiClient apiClient;
@@ -476,12 +482,21 @@ public class HelmKubeService implements KubeService {
 	 */
 	@Override
 	public void delete(String namespace, String yamlContent) {
+		delete(namespace, yamlContent, CascadePolicy.BACKGROUND);
+	}
+
+	/**
+	 * Deletes the manifest's resources using the given deletion propagation policy (Helm
+	 * {@code --cascade}).
+	 */
+	@Override
+	public void delete(String namespace, String yamlContent, CascadePolicy cascade) {
 		try {
 			for (Object doc : loadUnstructured(yamlContent)) {
 				if (doc instanceof Map<?, ?> map) {
 					@SuppressWarnings("unchecked")
 					Map<String, Object> resource = (Map<String, Object>) map;
-					deleteResource(namespace, resource);
+					deleteResource(namespace, resource, cascade);
 				}
 			}
 		}
@@ -493,7 +508,8 @@ public class HelmKubeService implements KubeService {
 		}
 	}
 
-	private void deleteResource(String namespace, Map<String, Object> resource) throws ApiException {
+	private void deleteResource(String namespace, Map<String, Object> resource, CascadePolicy cascade)
+			throws ApiException {
 		String[] id = identify(resource);
 		String apiVersion = id[0];
 		String kind = id[1];
@@ -507,12 +523,134 @@ public class HelmKubeService implements KubeService {
 			log.info("Deleting {} {}{}", kind, name, namespaced ? " in namespace " + namespace : " (cluster-scoped)");
 		}
 
+		DeleteOptions deleteOptions = new DeleteOptions();
+		deleteOptions.setPropagationPolicy(cascade.propagationPolicy());
 		// Same core-group vs named-group routing and kind-based scoping as applyResource.
 		DynamicKubernetesApi api = new DynamicKubernetesApi(group, version, plural, apiClient);
-		KubernetesApiResponse<DynamicKubernetesObject> response = namespaced ? api.delete(namespace, name)
-				: api.delete(name);
+		KubernetesApiResponse<DynamicKubernetesObject> response = namespaced
+				? api.delete(namespace, name, deleteOptions) : api.delete(name, deleteOptions);
 		if (!response.isSuccess() && response.getHttpStatusCode() != 404) {
 			response.throwsApiException();
+		}
+	}
+
+	/**
+	 * Polls until every resource in the manifest is gone from the cluster or the timeout
+	 * elapses (Helm {@code uninstall --wait}).
+	 */
+	@Override
+	public void waitForDeleted(String namespace, String manifest, int timeoutSeconds) {
+		long deadline = System.currentTimeMillis() + (long) timeoutSeconds * 1000;
+		int pollIntervalMs = 2000;
+		List<Map<String, Object>> resources = new ArrayList<>();
+		for (Object doc : loadUnstructured(manifest)) {
+			if (doc instanceof Map<?, ?> map) {
+				@SuppressWarnings("unchecked")
+				Map<String, Object> resource = (Map<String, Object>) map;
+				resources.add(resource);
+			}
+		}
+		while (true) {
+			List<String> remaining = stillPresent(namespace, resources);
+			if (remaining.isEmpty()) {
+				return;
+			}
+			long left = deadline - System.currentTimeMillis();
+			if (left <= 0) {
+				throw new WaitTimeoutException(
+						"Timeout waiting for resources to be deleted: " + String.join(", ", remaining), List.of());
+			}
+			remaining.forEach((r) -> log.info("Waiting for {} to be deleted", r));
+			try {
+				Thread.sleep(Math.min(pollIntervalMs, left));
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				throw new KubernetesOperationException("Interrupted while waiting for resources to be deleted", ex);
+			}
+		}
+	}
+
+	// Returns "kind/name" for each manifest resource still present in the cluster.
+	private List<String> stillPresent(String namespace, List<Map<String, Object>> resources) {
+		List<String> remaining = new ArrayList<>();
+		try {
+			for (Map<String, Object> resource : resources) {
+				if (resourceExists(namespace, resource)) {
+					String[] id = identify(resource);
+					remaining.add(id[1] + "/" + id[2]);
+				}
+			}
+		}
+		catch (ApiException ex) {
+			throw new KubernetesOperationException("Failed while waiting for resources to be deleted", ex,
+					ex.getCode());
+		}
+		return remaining;
+	}
+
+	private boolean resourceExists(String namespace, Map<String, Object> resource) throws ApiException {
+		String[] id = identify(resource);
+		String apiVersion = id[0];
+		String kind = id[1];
+		String name = id[2];
+		String group = apiVersion.contains("/") ? apiVersion.split("/")[0] : "";
+		String version = apiVersion.contains("/") ? apiVersion.split("/")[1] : apiVersion;
+		String plural = inferPlural(kind);
+		boolean namespaced = inferNamespaced(kind);
+		DynamicKubernetesApi api = new DynamicKubernetesApi(group, version, plural, apiClient);
+		KubernetesApiResponse<DynamicKubernetesObject> resp = namespaced ? api.get(namespace, name) : api.get(name);
+		return resp.isSuccess();
+	}
+
+	/**
+	 * Triggers a rolling restart of the manifest's workloads by stamping a
+	 * {@code kubectl.kubernetes.io/restartedAt} annotation on their pod template (Helm's
+	 * deprecated {@code rollback --recreate-pods}).
+	 */
+	@Override
+	public void restartWorkloads(String namespace, String manifest) {
+		String restartedAt = OffsetDateTime.now().toString();
+		try {
+			for (Object doc : loadUnstructured(manifest)) {
+				if (doc instanceof Map<?, ?> map) {
+					String kind = (String) map.get("kind");
+					if (RESTARTABLE_KINDS.contains(kind)) {
+						@SuppressWarnings("unchecked")
+						Map<String, Object> resource = (Map<String, Object>) map;
+						restartWorkload(namespace, resource, restartedAt);
+					}
+				}
+			}
+		}
+		catch (ApiException ex) {
+			throw new KubernetesOperationException("Failed to restart workloads", ex, ex.getCode());
+		}
+		catch (Exception ex) {
+			throw new KubernetesOperationException("Failed to restart workloads", ex);
+		}
+	}
+
+	private void restartWorkload(String namespace, Map<String, Object> resource, String restartedAt)
+			throws ApiException {
+		String[] id = identify(resource);
+		String apiVersion = id[0];
+		String kind = id[1];
+		String name = id[2];
+		String group = apiVersion.contains("/") ? apiVersion.split("/")[0] : "";
+		String version = apiVersion.contains("/") ? apiVersion.split("/")[1] : apiVersion;
+		String plural = inferPlural(kind);
+		DynamicKubernetesApi api = new DynamicKubernetesApi(group, version, plural, apiClient);
+		String patchJson = "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":"
+				+ "{\"kubectl.kubernetes.io/restartedAt\":\"" + restartedAt + "\"}}}}}";
+		V1Patch patch = new V1Patch(patchJson);
+		PatchOptions options = new PatchOptions();
+		options.setFieldManager("helm");
+		KubernetesApiResponse<DynamicKubernetesObject> response = api.patch(namespace, name,
+				V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, patch, options);
+		response.throwsApiException();
+		if (log.isInfoEnabled()) {
+			log.info("Restarted workload {}/{}", kind, name);
 		}
 	}
 

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeService.java
@@ -10,6 +10,7 @@ import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 import org.alexmond.jhelm.core.service.KubeService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -113,6 +114,21 @@ public class ObservableKubeService implements KubeService {
 	}
 
 	@Override
+	public void delete(String namespace, String yamlContent, CascadePolicy cascade) {
+		timeVoid(deleteTimer, () -> delegate.delete(namespace, yamlContent, cascade));
+	}
+
+	@Override
+	public void waitForDeleted(String namespace, String manifest, int timeoutSeconds) {
+		delegate.waitForDeleted(namespace, manifest, timeoutSeconds);
+	}
+
+	@Override
+	public void restartWorkloads(String namespace, String manifest) {
+		timeVoid(applyTimer, () -> delegate.restartWorkloads(namespace, manifest));
+	}
+
+	@Override
 	public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) {
 		return time(getTimer, () -> delegate.getResourceStatuses(namespace, manifest));
 	}
@@ -120,6 +136,11 @@ public class ObservableKubeService implements KubeService {
 	@Override
 	public void waitForReady(String namespace, String manifest, int timeoutSeconds) {
 		delegate.waitForReady(namespace, manifest, timeoutSeconds);
+	}
+
+	@Override
+	public void waitForReady(String namespace, String manifest, int timeoutSeconds, boolean waitForJobs) {
+		delegate.waitForReady(namespace, manifest, timeoutSeconds, waitForJobs);
 	}
 
 	@Override

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeService.java
@@ -9,6 +9,7 @@ import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryTemplate;
@@ -120,6 +121,28 @@ public class RetryableKubeService implements KubeService {
 	}
 
 	@Override
+	public void delete(String namespace, String yamlContent, CascadePolicy cascade) {
+		executeWithRetry("delete", () -> {
+			delegate.delete(namespace, yamlContent, cascade);
+			return null;
+		});
+	}
+
+	@Override
+	public void waitForDeleted(String namespace, String manifest, int timeoutSeconds) {
+		// waitForDeleted already polls internally; do not retry the entire operation
+		delegate.waitForDeleted(namespace, manifest, timeoutSeconds);
+	}
+
+	@Override
+	public void restartWorkloads(String namespace, String manifest) {
+		executeWithRetry("restartWorkloads", () -> {
+			delegate.restartWorkloads(namespace, manifest);
+			return null;
+		});
+	}
+
+	@Override
 	public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) {
 		return executeWithRetry("getResourceStatuses", () -> delegate.getResourceStatuses(namespace, manifest));
 	}
@@ -128,6 +151,12 @@ public class RetryableKubeService implements KubeService {
 	public void waitForReady(String namespace, String manifest, int timeoutSeconds) {
 		// waitForReady already polls internally; do not retry the entire operation
 		delegate.waitForReady(namespace, manifest, timeoutSeconds);
+	}
+
+	@Override
+	public void waitForReady(String namespace, String manifest, int timeoutSeconds, boolean waitForJobs) {
+		// waitForReady already polls internally; do not retry the entire operation
+		delegate.waitForReady(namespace, manifest, timeoutSeconds, waitForJobs);
 	}
 
 	@Override

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
@@ -27,6 +27,8 @@ import io.kubernetes.client.openapi.models.V1SecretList;
 import io.kubernetes.client.util.generic.KubernetesApiResponse;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
+import io.kubernetes.client.util.generic.options.DeleteOptions;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 import io.kubernetes.client.util.generic.options.PatchOptions;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.exception.ReleaseStorageException;
@@ -175,6 +177,10 @@ class HelmKubeServiceTest {
 			when(mock.patch(anyString(), anyString(), any(V1Patch.class), any(PatchOptions.class))).thenReturn(resp);
 			when(mock.delete(anyString(), anyString())).thenReturn(resp);
 			when(mock.delete(anyString())).thenReturn(resp);
+			when(mock.delete(anyString(), anyString(), any(DeleteOptions.class))).thenReturn(resp);
+			when(mock.delete(anyString(), any(DeleteOptions.class))).thenReturn(resp);
+			when(mock.get(anyString(), anyString())).thenReturn(resp);
+			when(mock.get(anyString())).thenReturn(resp);
 		});
 	}
 
@@ -579,6 +585,80 @@ class HelmKubeServiceTest {
 	}
 
 	@Test
+	void testDeleteWithCascadePassesPropagationPolicy() throws Exception {
+		String yaml = """
+				apiVersion: apps/v1
+				kind: Deployment
+				metadata:
+				  name: my-deploy
+				  namespace: default
+				""";
+
+		setupSsaMock();
+		kubeService.delete("default", yaml, CascadePolicy.FOREGROUND);
+
+		ArgumentCaptor<DeleteOptions> captor = ArgumentCaptor.forClass(DeleteOptions.class);
+		verify(mockDynamicApi).delete(eq("default"), eq("my-deploy"), captor.capture());
+		assertEquals("Foreground", captor.getValue().getPropagationPolicy());
+	}
+
+	@Test
+	void testRestartWorkloadsStrategicMergePatchesWorkload() throws Exception {
+		String yaml = """
+				apiVersion: apps/v1
+				kind: Deployment
+				metadata:
+				  name: my-deploy
+				  namespace: default
+				""";
+
+		setupSsaMock();
+		kubeService.restartWorkloads("default", yaml);
+
+		verify(mockDynamicApi).patch(eq("default"), eq("my-deploy"), eq(V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH),
+				any(V1Patch.class), any(PatchOptions.class));
+	}
+
+	@Test
+	void testRestartWorkloadsIgnoresNonWorkloadKinds() throws Exception {
+		String yaml = """
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: my-cfg
+				  namespace: default
+				""";
+
+		setupSsaMock();
+		kubeService.restartWorkloads("default", yaml);
+
+		// A ConfigMap is not a workload, so no DynamicKubernetesApi is constructed to
+		// patch.
+		assertTrue(dynamicApiConstruction.constructed().isEmpty());
+	}
+
+	@Test
+	void testWaitForDeletedReturnsWhenResourceAbsent() throws Exception {
+		String yaml = """
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: my-cfg
+				  namespace: default
+				""";
+
+		dynamicApiConstruction = mockConstruction(DynamicKubernetesApi.class, (mock, ctx) -> {
+			@SuppressWarnings("unchecked")
+			KubernetesApiResponse<DynamicKubernetesObject> resp = mock(KubernetesApiResponse.class);
+			// isSuccess() == false models a 404 — the resource is already gone.
+			when(resp.isSuccess()).thenReturn(false);
+			when(mock.get(anyString(), anyString())).thenReturn(resp);
+		});
+
+		assertDoesNotThrow(() -> kubeService.waitForDeleted("default", yaml, 5));
+	}
+
+	@Test
 	void testApplyClusterScopedResourceUsesClusterPath() throws Exception {
 		// Regression for #650: a ClusterRole must be applied via the cluster-scoped path
 		// (no namespace segment), not scoped into the release namespace.
@@ -622,8 +702,8 @@ class HelmKubeServiceTest {
 		setupSsaMock();
 		kubeService.delete("demo", yaml);
 
-		verify(mockDynamicApi).delete(eq("demo-discovery"));
-		verify(mockDynamicApi, never()).delete(anyString(), anyString());
+		verify(mockDynamicApi).delete(eq("demo-discovery"), any(DeleteOptions.class));
+		verify(mockDynamicApi, never()).delete(anyString(), anyString(), any(DeleteOptions.class));
 	}
 
 	@Test
@@ -709,7 +789,7 @@ class HelmKubeServiceTest {
 		assertEquals("apps", lastDynamicApiCtorArgs.get(0));
 		assertEquals("v1", lastDynamicApiCtorArgs.get(1));
 		assertEquals("deployments", lastDynamicApiCtorArgs.get(2));
-		verify(mockDynamicApi).delete("default", "my-deploy");
+		verify(mockDynamicApi).delete(eq("default"), eq("my-deploy"), any(DeleteOptions.class));
 	}
 
 	@Test
@@ -728,7 +808,7 @@ class HelmKubeServiceTest {
 			KubernetesApiResponse<DynamicKubernetesObject> resp = mock(KubernetesApiResponse.class);
 			when(resp.isSuccess()).thenReturn(false);
 			when(resp.getHttpStatusCode()).thenReturn(404);
-			when(mock.delete(anyString(), anyString())).thenReturn(resp);
+			when(mock.delete(anyString(), anyString(), any(DeleteOptions.class))).thenReturn(resp);
 		});
 
 		// Should not throw on 404
@@ -823,7 +903,7 @@ class HelmKubeServiceTest {
 		assertEquals("", lastDynamicApiCtorArgs.get(0));
 		assertEquals("v1", lastDynamicApiCtorArgs.get(1));
 		assertEquals("namespaces", lastDynamicApiCtorArgs.get(2));
-		verify(mockDynamicApi).delete("test-ns");
+		verify(mockDynamicApi).delete(eq("test-ns"), any(DeleteOptions.class));
 	}
 
 	// --- ensureNamespace ---

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeServiceTest.java
@@ -10,6 +10,7 @@ import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,6 +75,30 @@ class ObservableKubeServiceTest {
 		when(delegate.listAllReleases()).thenReturn(List.of(mock(Release.class)));
 		assertEquals(1, service.listAllReleases().size());
 		verify(delegate).listAllReleases();
+	}
+
+	@Test
+	void testCascadeDeleteForwardsToDelegate() {
+		service.delete("default", "yaml", CascadePolicy.ORPHAN);
+		verify(delegate).delete("default", "yaml", CascadePolicy.ORPHAN);
+	}
+
+	@Test
+	void testWaitForDeletedForwardsToDelegate() {
+		service.waitForDeleted("default", "yaml", 30);
+		verify(delegate).waitForDeleted("default", "yaml", 30);
+	}
+
+	@Test
+	void testRestartWorkloadsForwardsToDelegate() {
+		service.restartWorkloads("default", "yaml");
+		verify(delegate).restartWorkloads("default", "yaml");
+	}
+
+	@Test
+	void testWaitForReadyWithJobsForwardsToDelegate() {
+		service.waitForReady("default", "yaml", 30, true);
+		verify(delegate).waitForReady("default", "yaml", 30, true);
 	}
 
 	@Test

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeServiceTest.java
@@ -9,6 +9,7 @@ import io.kubernetes.client.openapi.ApiException;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 import org.alexmond.jhelm.core.service.KubeService;
 import java.time.Duration;
 
@@ -64,6 +65,30 @@ class RetryableKubeServiceTest {
 
 		assertEquals(2, retryableService.listAllReleases().size());
 		verify(delegate).listAllReleases();
+	}
+
+	@Test
+	void testCascadeDeleteDelegates() {
+		retryableService.delete("default", "yaml", CascadePolicy.FOREGROUND);
+		verify(delegate).delete("default", "yaml", CascadePolicy.FOREGROUND);
+	}
+
+	@Test
+	void testWaitForDeletedDelegates() {
+		retryableService.waitForDeleted("default", "yaml", 30);
+		verify(delegate).waitForDeleted("default", "yaml", 30);
+	}
+
+	@Test
+	void testRestartWorkloadsDelegates() {
+		retryableService.restartWorkloads("default", "yaml");
+		verify(delegate).restartWorkloads("default", "yaml");
+	}
+
+	@Test
+	void testWaitForReadyWithJobsDelegates() {
+		retryableService.waitForReady("default", "yaml", 30, true);
+		verify(delegate).waitForReady("default", "yaml", 30, true);
 	}
 
 	@Test

--- a/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingTools.java
+++ b/jhelm-mcp/src/main/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingTools.java
@@ -13,6 +13,7 @@ import org.alexmond.jhelm.core.action.RollbackOptions;
 import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UninstallOptions;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.action.UpgradeOptions;
 import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
@@ -131,9 +132,26 @@ public class ReleaseMutatingTools {
 			description = "Uninstall a Helm release (like 'helm uninstall'). MUTATES the cluster: deletes the "
 					+ "release's resources and removes its history.")
 	public String uninstall(@McpToolParam(description = "Release name to uninstall") String name,
-			@McpToolParam(description = "Kubernetes namespace") String namespace) {
-		this.uninstallAction.uninstall(UninstallOptions.builder().releaseName(name).namespace(namespace).build());
-		return "Uninstalled release '" + name + "' from namespace '" + namespace + '\'';
+			@McpToolParam(description = "Kubernetes namespace") String namespace,
+			@McpToolParam(required = false, description = "Simulate without deleting anything") boolean dryRun,
+			@McpToolParam(required = false,
+					description = "Wait until the resources are removed from the cluster") boolean wait,
+			@McpToolParam(required = false, description = "Timeout in seconds for wait (default 300)") Integer timeout,
+			@McpToolParam(required = false,
+					description = "Deletion propagation: background, foreground, or orphan") String cascade,
+			@McpToolParam(required = false,
+					description = "Retain history and mark the release uninstalled") boolean keepHistory) {
+		this.uninstallAction.uninstall(UninstallOptions.builder()
+			.releaseName(name)
+			.namespace(namespace)
+			.dryRun(dryRun)
+			.wait(wait)
+			.timeout((timeout != null) ? timeout : 300)
+			.cascade(CascadePolicy.fromString(cascade))
+			.keepHistory(keepHistory)
+			.build());
+		String verb = dryRun ? "Would uninstall" : "Uninstalled";
+		return verb + " release '" + name + "' from namespace '" + namespace + '\'';
 	}
 
 	/**
@@ -149,10 +167,35 @@ public class ReleaseMutatingTools {
 					+ "cluster: re-applies the target revision's resources as a new revision.")
 	public String rollback(@McpToolParam(description = "Release name") String name,
 			@McpToolParam(description = "Kubernetes namespace") String namespace,
-			@McpToolParam(description = "Target revision number to roll back to") int revision) {
-		this.rollbackAction
-			.rollback(RollbackOptions.builder().releaseName(name).namespace(namespace).revision(revision).build());
-		return "Rolled back release '" + name + "' in namespace '" + namespace + "' to revision " + revision;
+			@McpToolParam(description = "Target revision number to roll back to") int revision,
+			@McpToolParam(required = false,
+					description = "Simulate without applying or storing a revision") boolean dryRun,
+			@McpToolParam(required = false,
+					description = "Delete and recreate resources instead of patching in place") boolean force,
+			@McpToolParam(required = false,
+					description = "Delete resources created during the rollback if it fails") boolean cleanupOnFail,
+			@McpToolParam(required = false,
+					description = "Rolling-restart the release's workloads after the rollback") boolean recreatePods,
+			@McpToolParam(required = false,
+					description = "Wait until the rolled-back resources are ready") boolean wait,
+			@McpToolParam(required = false,
+					description = "With wait, also wait for Jobs to complete") boolean waitForJobs,
+			@McpToolParam(required = false,
+					description = "Timeout in seconds for wait (default 300)") Integer timeout) {
+		this.rollbackAction.rollback(RollbackOptions.builder()
+			.releaseName(name)
+			.namespace(namespace)
+			.revision(revision)
+			.dryRun(dryRun)
+			.force(force)
+			.cleanupOnFail(cleanupOnFail)
+			.recreatePods(recreatePods)
+			.wait(wait)
+			.waitForJobs(waitForJobs)
+			.timeout((timeout != null) ? timeout : 300)
+			.build());
+		String verb = dryRun ? "Would roll back" : "Rolled back";
+		return verb + " release '" + name + "' in namespace '" + namespace + "' to revision " + revision;
 	}
 
 	/**

--- a/jhelm-mcp/src/test/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingToolsTest.java
+++ b/jhelm-mcp/src/test/java/org/alexmond/jhelm/mcp/tools/ReleaseMutatingToolsTest.java
@@ -8,9 +8,12 @@ import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.InstallAction;
 import org.alexmond.jhelm.core.action.InstallOptions;
 import org.alexmond.jhelm.core.action.RollbackAction;
+import org.alexmond.jhelm.core.action.RollbackOptions;
 import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
+import org.alexmond.jhelm.core.action.UninstallOptions;
 import org.alexmond.jhelm.core.action.UpgradeAction;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
@@ -23,7 +26,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ReleaseMutatingToolsTest {
@@ -101,6 +106,50 @@ class ReleaseMutatingToolsTest {
 		this.tools.install("/charts/nginx", "my-release", "default", false, null, null);
 
 		assertEquals(Map.of(), captor.getValue().getLabels());
+	}
+
+	@Test
+	void uninstallThreadsWaitCascadeAndDryRun() {
+		ArgumentCaptor<UninstallOptions> captor = ArgumentCaptor.forClass(UninstallOptions.class);
+
+		this.tools.uninstall("my-release", "default", true, true, 90, "foreground", true);
+
+		verify(this.uninstallAction).uninstall(captor.capture());
+		UninstallOptions opts = captor.getValue();
+		assertTrue(opts.isDryRun());
+		assertTrue(opts.isWait());
+		assertEquals(90, opts.getTimeout());
+		assertEquals(CascadePolicy.FOREGROUND, opts.getCascade());
+		assertTrue(opts.isKeepHistory());
+	}
+
+	@Test
+	void uninstallDefaultsTimeoutWhenNull() {
+		ArgumentCaptor<UninstallOptions> captor = ArgumentCaptor.forClass(UninstallOptions.class);
+
+		this.tools.uninstall("my-release", "default", false, false, null, null, false);
+
+		verify(this.uninstallAction).uninstall(captor.capture());
+		assertEquals(300, captor.getValue().getTimeout());
+		assertEquals(CascadePolicy.BACKGROUND, captor.getValue().getCascade());
+	}
+
+	@Test
+	void rollbackThreadsForceCleanupAndWaitFlags() {
+		Release release = Release.builder().name("my-release").namespace("default").version(2).build();
+		ArgumentCaptor<RollbackOptions> captor = ArgumentCaptor.forClass(RollbackOptions.class);
+		when(this.rollbackAction.rollback(captor.capture())).thenReturn(release);
+
+		this.tools.rollback("my-release", "default", 1, false, true, true, true, true, true, 120);
+
+		RollbackOptions opts = captor.getValue();
+		assertEquals(1, opts.getRevision());
+		assertTrue(opts.isForce());
+		assertTrue(opts.isCleanupOnFail());
+		assertTrue(opts.isRecreatePods());
+		assertTrue(opts.isWait());
+		assertTrue(opts.isWaitForJobs());
+		assertEquals(120, opts.getTimeout());
 	}
 
 }

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/ReleaseController.java
@@ -23,6 +23,7 @@ import org.alexmond.jhelm.core.action.StatusAction;
 import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UninstallOptions;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.action.UpgradeOptions;
 import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
@@ -305,8 +306,31 @@ public class ReleaseController {
 	@MutatingOperation
 	@Operation(summary = "Uninstall a release")
 	public ResponseEntity<Void> uninstall(@Parameter(description = "Release name") @PathVariable String name,
-			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace) {
-		this.uninstallAction.uninstall(UninstallOptions.builder().releaseName(name).namespace(namespace).build());
+			@Parameter(description = "Kubernetes namespace") @RequestParam(defaultValue = "default") String namespace,
+			@Parameter(description = "Skip pre/post-delete hooks") @RequestParam(
+					defaultValue = "false") boolean noHooks,
+			@Parameter(description = "Retain release history, marking it uninstalled") @RequestParam(
+					defaultValue = "false") boolean keepHistory,
+			@Parameter(description = "Simulate without deleting anything") @RequestParam(
+					defaultValue = "false") boolean dryRun,
+			@Parameter(description = "Wait until resources are removed") @RequestParam(
+					defaultValue = "false") boolean wait,
+			@Parameter(description = "Timeout in seconds for wait") @RequestParam(defaultValue = "300") int timeout,
+			@Parameter(description = "Deletion propagation: background, foreground, or orphan") @RequestParam(
+					defaultValue = "background") String cascade,
+			@Parameter(description = "Custom description when keeping history") @RequestParam(
+					required = false) String description) {
+		this.uninstallAction.uninstall(UninstallOptions.builder()
+			.releaseName(name)
+			.namespace(namespace)
+			.noHooks(noHooks)
+			.keepHistory(keepHistory)
+			.dryRun(dryRun)
+			.wait(wait)
+			.timeout(timeout)
+			.cascade(CascadePolicy.fromString(cascade))
+			.description(description)
+			.build());
 		return ResponseEntity.noContent().build();
 	}
 
@@ -341,6 +365,15 @@ public class ReleaseController {
 			.releaseName(name)
 			.namespace(namespace)
 			.revision(request.getRevision())
+			.noHooks(request.isNoHooks())
+			.maxHistory(request.getMaxHistory())
+			.dryRun(request.isDryRun())
+			.force(request.isForce())
+			.cleanupOnFail(request.isCleanupOnFail())
+			.recreatePods(request.isRecreatePods())
+			.wait(request.isWait())
+			.waitForJobs(request.isWaitForJobs())
+			.timeout(request.getTimeout())
 			.build());
 		return ResponseEntity.noContent().build();
 	}

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RollbackRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RollbackRequest.java
@@ -13,4 +13,33 @@ public class RollbackRequest {
 	@Schema(description = "Revision number to rollback to", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 	private int revision;
 
+	@Schema(description = "Skip pre/post-rollback hooks", defaultValue = "false")
+	private boolean noHooks;
+
+	@Schema(description = "Maximum revisions to keep (0 = no limit)", defaultValue = "10")
+	private int maxHistory = 10;
+
+	@Schema(description = "Simulate without applying manifests or storing a revision", defaultValue = "false")
+	private boolean dryRun;
+
+	@Schema(description = "Delete and recreate the target resources instead of patching in place",
+			defaultValue = "false")
+	private boolean force;
+
+	@Schema(description = "Delete resources created during the rollback if it fails", defaultValue = "false")
+	private boolean cleanupOnFail;
+
+	@Schema(description = "Rolling-restart the release's workloads after the rollback (deprecated in Helm)",
+			defaultValue = "false")
+	private boolean recreatePods;
+
+	@Schema(description = "Wait until the rolled-back resources are ready", defaultValue = "false")
+	private boolean wait;
+
+	@Schema(description = "With wait, also wait for Jobs to complete", defaultValue = "false")
+	private boolean waitForJobs;
+
+	@Schema(description = "Timeout in seconds for wait", defaultValue = "300")
+	private int timeout = 300;
+
 }

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ReleaseControllerTest.java
@@ -18,6 +18,7 @@ import org.alexmond.jhelm.core.action.StatusAction;
 import org.alexmond.jhelm.core.action.TestAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UninstallOptions;
+import org.alexmond.jhelm.core.service.CascadePolicy;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.action.UpgradeOptions;
 import org.alexmond.jhelm.core.action.UpgradeValueStrategy;
@@ -329,6 +330,19 @@ class ReleaseControllerTest {
 	}
 
 	@Test
+	void uninstallWithWaitCascadeAndDryRunParams() throws Exception {
+		this.mockMvc
+			.perform(delete("/api/v1/releases/my-release").param("wait", "true")
+				.param("timeout", "90")
+				.param("cascade", "foreground")
+				.param("dryRun", "true"))
+			.andExpect(status().isNoContent());
+		verify(this.uninstallAction)
+			.uninstall(argThat((UninstallOptions options) -> options.isWait() && options.getTimeout() == 90
+					&& options.getCascade() == CascadePolicy.FOREGROUND && options.isDryRun()));
+	}
+
+	@Test
 	void history() throws Exception {
 		when(this.historyAction.history("my-release", "default")).thenReturn(List.of(sampleRelease()));
 		this.mockMvc.perform(get("/api/v1/releases/my-release/history").accept(MediaType.APPLICATION_JSON))
@@ -349,6 +363,21 @@ class ReleaseControllerTest {
 		verify(this.rollbackAction)
 			.rollback(argThat((RollbackOptions options) -> "my-release".equals(options.getReleaseName())
 					&& "default".equals(options.getNamespace()) && options.getRevision() == 1));
+	}
+
+	@Test
+	void rollbackWithForceCleanupAndWaitFlags() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/releases/my-release/rollback").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"revision": 2, "force": true, "cleanupOnFail": true, "recreatePods": true,
+						 "wait": true, "waitForJobs": true, "timeout": 120}
+						"""))
+			.andExpect(status().isNoContent());
+		verify(this.rollbackAction).rollback(argThat((RollbackOptions options) -> options.getRevision() == 2
+				&& options.isForce() && options.isCleanupOnFail() && options.isRecreatePods() && options.isWait()
+				&& options.isWaitForJobs() && options.getTimeout() == 120));
 	}
 
 	@Test


### PR DESCRIPTION
Brings destructive-path parity to Helm across **CLI + REST + MCP** — the wait/force/cascade semantics for `uninstall` and `rollback`.

## Core / kube
- **New `CascadePolicy` enum** (background|foreground|orphan) + three new `KubeService` primitives, added as **interface `default`s** so test doubles/anonymous impls inherit safe fallbacks and only real impls override:
  - `delete(ns, yaml, CascadePolicy)` — deletion propagation (`HelmKubeService` maps it to `DeleteOptions.propagationPolicy`; the 2-arg `delete` now routes through it with `BACKGROUND`).
  - `waitForDeleted(ns, manifest, timeout)` — polls each resource with GET until it 404s (`uninstall --wait`).
  - `restartWorkloads(ns, manifest)` — strategic-merge patches `kubectl.kubernetes.io/restartedAt` onto Deployments/StatefulSets/DaemonSets (`rollback --recreate-pods`).
  - `waitForReady(..., waitForJobs)` overload (`--wait-for-jobs`).

  The **Observable/Retryable decorators forward all four** to the delegate — required, since the runtime bean is decorated and a default no-op would silently skip the wait.

- **`UninstallAction`** honors `dryRun` (report, delete nothing), `cascade`, `wait`, and a custom `description` on the kept-history release.
- **`RollbackAction`** honors `dryRun`, `force` (delete-and-recreate), `cleanup-on-fail` (delete on apply failure, then rethrow), `recreate-pods`, and `wait`/`wait-for-jobs`/`timeout`. The readiness wait moved from `RollbackCommand` into the action so REST + MCP honor it too.

## Surfaces
- **CLI**: `uninstall` gains `--dry-run`/`--wait`/`--timeout`/`--cascade`/`--description`; `rollback` gains `--dry-run`/`--force`/`--cleanup-on-fail`/`--recreate-pods`/`--wait-for-jobs`.
- **REST**: `DELETE` query params + `RollbackRequest` fields.
- **MCP**: `helm_uninstall` + `helm_rollback` gain the same optional params.

## Tests
`CascadePolicyTest`; Uninstall/RollbackActionTest (dry-run, cascade, wait, force, cleanup-on-fail, recreate-pods); `HelmKubeServiceTest` (cascade propagation, restart patch, `waitForDeleted`); Observable/RetryableKubeServiceTest (new forwards); command/controller/MCP tests (flags reach options). Existing delete-verify sites updated to the 3-arg overload.

Full `clean install` green (all jacoco coverage gates + PMD + checkstyle). A live kind-cluster smoke of the destructive paths follows before merge.

Closes #683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)