### PR TITLE
feat(pull): --untar/--untardir + --verify/--prov/--keyring (#684)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -49,6 +49,11 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
   `--cleanup-on-fail` (delete resources created during a failed rollback), `--recreate-pods` (rolling
   restart of the release's workloads via a restart annotation), and `--wait`/`--wait-for-jobs`/`--timeout`.
   The rollback readiness wait now lives in the action so REST and MCP honor it too (#683).
+* *`pull` unpack & provenance* -- `--untar`/`--untardir` unpack the fetched chart (and drop the
+  `.tgz`), and `--verify`/`--prov`/`--keyring` fetch the chart's detached `.prov` and check its PGP
+  provenance before use (reusing the `verify` layer). REST `POST /repos/pull` gains a `verify` flag.
+  `--devel` (prerelease resolution) remains the one open pull gap — it needs semver latest-version
+  resolution jhelm does not have yet (#684).
 * *REST releases API now returns Helm-shaped JSON* -- the `/releases` list/status/history and
   install/upgrade responses now use Helm's `-o json` schema (snake_case, nested `info`) instead
   of jhelm's internal DTO, so REST consumers see the same shape as `helm ... -o json` and the

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -124,7 +124,9 @@ template produced each manifest.
 | `registry login` (`-u`, `-p`, `--password-stdin`) / `logout` | ✅ |
 | `pull` (`--version`, `-d/--dest`) | ✅ |
 | `pull --repo URL` + auth/TLS (`--username`, `--password`, `--cert-file`, `--key-file`, `--ca-file`, `--insecure-skip-tls-verify`, `--pass-credentials`) | ✅ | Pull a chart directly from a repository URL with inline credentials, without a prior `repo add`.
-| `pull` (`--untar`, `--verify`) | ✗ | Charts are unpacked into `--dest`; provenance verification not yet wired.
+| `pull` (`--untar`, `--untardir`) | ✅ | Unpacks the fetched chart into `--untardir` (default `.`) and removes the `.tgz`.
+| `pull` (`--verify`, `--prov`, `--keyring`) | ✅ | Fetches the chart's detached `.prov` and checks its PGP provenance before use (`--prov` keeps the file without verifying).
+| `pull` (`--devel`) | ✗ | Prerelease/latest-version resolution is not yet implemented (jhelm requires an explicit `--version`).
 |===
 
 == Porting a Helm script to jhelm
@@ -148,7 +150,8 @@ Beyond the per-command tables above, these commonly-used Helm options are not ye
 * *`install`/`upgrade`* — `upgrade --cleanup-on-fail`.
   (install-from-repo `--version`/`--repo`/`--username`/`--password` + TLS is supported;
   `-g`/`--generate-name` on `install`; `--description`/`--labels`/`--set-literal`/`--dependency-update` on both.)
-* *`pull`* — `--untar`/`--untardir`, `--verify`/`--prov`/`--keyring`, `--devel`.
+* *`pull`* — `--devel` (prerelease/latest-version resolution). `--untar`/`--untardir` and
+  `--verify`/`--prov`/`--keyring` are supported.
 * *Global flags* — Helm's persistent flags (`--kube-context`, `--kubeconfig`,
   `--kube-apiserver`, `--registry-config`, `--repository-config`, `--repository-cache`,
   `--debug`) aren't accepted inline; jhelm resolves these via Spring properties / environment

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PullCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PullCommand.java
@@ -1,9 +1,17 @@
 package org.alexmond.jhelm.app.command;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
 import java.util.concurrent.Callable;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.action.VerifyAction;
 import org.alexmond.jhelm.core.model.RepositoryConfig;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.springframework.stereotype.Component;
@@ -12,8 +20,9 @@ import picocli.CommandLine;
 /**
  * Implements {@code jhelm pull CHART}, downloading a chart from a repository or OCI
  * registry to a local directory. Supports Helm's {@code --repo} form for pulling directly
- * from a repository URL with inline credentials and TLS settings, without adding the repo
- * first.
+ * from a repository URL with inline credentials and TLS settings, plus {@code --untar}
+ * (unpack the fetched archive) and {@code --verify}/{@code --prov} (fetch and check the
+ * chart's PGP provenance).
  */
 @Component
 @CommandLine.Command(name = "pull", mixinStandardHelpOptions = true, description = "Download a chart from a repository")
@@ -21,6 +30,8 @@ import picocli.CommandLine;
 public class PullCommand implements Callable<Integer> {
 
 	private final RepoManager repoManager;
+
+	private final VerifyAction verifyAction;
 
 	@CommandLine.Parameters(index = "0", description = "chart to pull: repo/chart, repo/chart:version, or oci://...")
 	private String chart;
@@ -30,6 +41,23 @@ public class PullCommand implements Callable<Integer> {
 
 	@CommandLine.Option(names = { "--dest", "-d" }, defaultValue = ".", description = "destination directory")
 	private String dest;
+
+	@CommandLine.Option(names = { "--untar" },
+			description = "unpack the chart after downloading and remove the .tgz archive")
+	private boolean untar;
+
+	@CommandLine.Option(names = { "--untardir" }, defaultValue = ".",
+			description = "with --untar, the directory the chart is expanded into (default \".\")")
+	private String untardir;
+
+	@CommandLine.Option(names = { "--verify" }, description = "verify the chart's PGP provenance before using it")
+	private boolean verify;
+
+	@CommandLine.Option(names = { "--prov" }, description = "fetch the chart's provenance (.prov) file too")
+	private boolean prov;
+
+	@CommandLine.Option(names = { "--keyring" }, description = "keyring containing the public keys used for --verify")
+	private String keyring;
 
 	@CommandLine.Option(names = { "--repo" },
 			description = "chart repository URL to pull the named chart from directly (no prior repo add)")
@@ -61,26 +89,108 @@ public class PullCommand implements Callable<Integer> {
 	/**
 	 * Creates the command.
 	 * @param repoManager the repository manager that downloads the chart
+	 * @param verifyAction verifies a packaged chart's PGP provenance
 	 */
-	public PullCommand(RepoManager repoManager) {
+	public PullCommand(RepoManager repoManager, VerifyAction verifyAction) {
 		this.repoManager = repoManager;
+		this.verifyAction = verifyAction;
 	}
 
+	// S5443: the work directory is created via NIO createTempDirectory with owner-only
+	// permissions and holds only the downloaded chart archive, so the shared temp
+	// directory is used safely here.
+	@SuppressWarnings("java:S5443")
 	@Override
 	public Integer call() {
+		boolean withProv = this.prov || this.verify;
 		try {
-			if (this.repo != null && !this.repo.isBlank()) {
-				repoManager.pullFromRepoUrl(this.repo, this.chart, this.version, this.dest, buildRepoAuth());
+			Path workDir = Files.createTempDirectory("jhelm-pull-");
+			try {
+				pullInto(workDir.toString(), withProv);
+				File tgz = findArchive(workDir);
+				if (this.verify) {
+					this.verifyAction.verify(tgz.getPath(),
+							(this.keyring != null) ? this.keyring : defaultKeyringPath());
+				}
+				deliver(tgz);
+				return CommandLine.ExitCode.OK;
 			}
-			else {
-				repoManager.pull(this.chart, this.version, this.dest);
+			finally {
+				deleteRecursively(workDir);
 			}
-			CliOutput.println(CliOutput.success("Chart pulled to " + this.dest));
-			return CommandLine.ExitCode.OK;
 		}
 		catch (Exception ex) {
 			CliOutput.errPrintln(CliOutput.error("Error pulling chart: " + ex.getMessage()));
 			return CommandLine.ExitCode.SOFTWARE;
+		}
+	}
+
+	private void pullInto(String destDir, boolean withProv) throws IOException {
+		if (this.repo != null && !this.repo.isBlank()) {
+			this.repoManager.pullFromRepoUrl(this.repo, this.chart, this.version, destDir, buildRepoAuth(), withProv);
+		}
+		else {
+			this.repoManager.pull(this.chart, this.version, destDir, withProv);
+		}
+	}
+
+	// Unpacks (--untar) or moves the downloaded .tgz (and its .prov when requested) to
+	// the
+	// destination.
+	private void deliver(File tgz) throws IOException {
+		File provFile = new File(tgz.getParentFile(), tgz.getName() + ".prov");
+		if (this.untar) {
+			File target = new File((this.untardir != null && !this.untardir.isBlank()) ? this.untardir : ".");
+			Files.createDirectories(target.toPath());
+			this.repoManager.untar(tgz, target);
+			if (this.prov && provFile.exists()) {
+				moveInto(provFile, new File(this.dest));
+			}
+			CliOutput.println(CliOutput.success("Chart unpacked into " + target.getPath()));
+		}
+		else {
+			File destDir = new File(this.dest);
+			moveInto(tgz, destDir);
+			if (this.prov && provFile.exists()) {
+				moveInto(provFile, destDir);
+			}
+			CliOutput.println(CliOutput.success("Chart pulled to " + this.dest));
+		}
+	}
+
+	private static void moveInto(File source, File targetDir) throws IOException {
+		Files.createDirectories(targetDir.toPath());
+		Files.move(source.toPath(), targetDir.toPath().resolve(source.getName()), StandardCopyOption.REPLACE_EXISTING);
+	}
+
+	private static File findArchive(Path workDir) throws IOException {
+		try (var paths = Files.list(workDir)) {
+			return paths.filter((p) -> p.getFileName().toString().endsWith(".tgz"))
+				.findFirst()
+				.map(Path::toFile)
+				.orElseThrow(() -> new IOException("No chart archive was downloaded"));
+		}
+	}
+
+	private static String defaultKeyringPath() {
+		return System.getProperty("user.home") + "/.gnupg/pubring.gpg";
+	}
+
+	private static void deleteRecursively(Path dir) {
+		try (var paths = Files.walk(dir)) {
+			paths.sorted(Comparator.reverseOrder()).forEach((p) -> {
+				try {
+					Files.deleteIfExists(p);
+				}
+				catch (IOException ex) {
+					throw new UncheckedIOException(ex);
+				}
+			});
+		}
+		catch (IOException | UncheckedIOException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("Failed to clean up temp pull dir {}: {}", dir, ex.getMessage());
+			}
 		}
 	}
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/PullCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/PullCommandTest.java
@@ -1,23 +1,32 @@
 package org.alexmond.jhelm.app.command;
 
+import org.alexmond.jhelm.core.action.VerifyAction;
 import org.alexmond.jhelm.core.model.RepositoryConfig;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 class PullCommandTest {
@@ -25,66 +34,95 @@ class PullCommandTest {
 	@Mock
 	private RepoManager repoManager;
 
+	@Mock
+	private VerifyAction verifyAction;
+
 	private PullCommand pullCommand;
+
+	@TempDir
+	Path dest;
 
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		pullCommand = new PullCommand(repoManager);
+		pullCommand = new PullCommand(repoManager, verifyAction);
+	}
+
+	// Makes the mocked pull(chart, version, destDir, withProv) write a .tgz (and,
+	// when withProv, a .prov) into the work directory (arg index 2) so the command's
+	// findArchive/deliver steps have something to operate on.
+	private void stubPullWritesArchive(String tgzName, boolean withProv) throws IOException {
+		doAnswer((inv) -> {
+			String workDir = inv.getArgument(2);
+			Files.writeString(Path.of(workDir, tgzName), "tgz");
+			if (withProv) {
+				Files.writeString(Path.of(workDir, tgzName + ".prov"), "prov");
+			}
+			return null;
+		}).when(repoManager).pull(anyString(), any(), anyString(), anyBoolean());
 	}
 
 	@Test
 	void testPullOciChart() throws IOException {
-		doNothing().when(repoManager).pull(anyString(), isNull(), anyString());
+		stubPullWritesArchive("nginx-1.0.0.tgz", false);
 
-		CommandLine cmd = new CommandLine(pullCommand);
-		cmd.execute("oci://ghcr.io/helm/charts/nginx:1.0.0");
+		int exit = new CommandLine(pullCommand).execute("oci://ghcr.io/helm/charts/nginx:1.0.0", "--dest",
+				dest.toString());
 
-		verify(repoManager).pull("oci://ghcr.io/helm/charts/nginx:1.0.0", null, ".");
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		assertTrue(dest.resolve("nginx-1.0.0.tgz").toFile().exists());
+		verify(repoManager).pull(eq("oci://ghcr.io/helm/charts/nginx:1.0.0"), isNull(), anyString(), eq(false));
 	}
 
 	@Test
 	void testPullRepoChartWithVersion() throws IOException {
-		doNothing().when(repoManager).pull(anyString(), anyString(), anyString());
+		stubPullWritesArchive("nginx-19.0.0.tgz", false);
 
-		CommandLine cmd = new CommandLine(pullCommand);
-		cmd.execute("bitnami/nginx", "--version", "19.0.0");
+		int exit = new CommandLine(pullCommand).execute("bitnami/nginx", "--version", "19.0.0", "--dest",
+				dest.toString());
 
-		verify(repoManager).pull("bitnami/nginx", "19.0.0", ".");
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		assertTrue(dest.resolve("nginx-19.0.0.tgz").toFile().exists());
+		verify(repoManager).pull(eq("bitnami/nginx"), eq("19.0.0"), anyString(), eq(false));
 	}
 
 	@Test
 	void testPullRepoChartMissingVersion() throws IOException {
 		doThrow(new IOException("version is required for repository chart pulls")).when(repoManager)
-			.pull(eq("bitnami/nginx"), isNull(), eq("."));
+			.pull(eq("bitnami/nginx"), isNull(), anyString(), anyBoolean());
 
-		CommandLine cmd = new CommandLine(pullCommand);
-		cmd.execute("bitnami/nginx");
-		// Should log error, no crash
+		int exit = new CommandLine(pullCommand).execute("bitnami/nginx", "--dest", dest.toString());
+
+		assertNotEquals(CommandLine.ExitCode.OK, exit);
 	}
 
 	@Test
 	void testPullWithError() throws IOException {
-		doThrow(new IOException("connection refused")).when(repoManager).pull(anyString(), isNull(), anyString());
+		doThrow(new IOException("connection refused")).when(repoManager)
+			.pull(anyString(), any(), anyString(), anyBoolean());
 
-		CommandLine cmd = new CommandLine(pullCommand);
-		cmd.execute("oci://ghcr.io/helm/charts/nginx:1.0.0");
-		// Should log error without throwing
+		int exit = new CommandLine(pullCommand).execute("oci://ghcr.io/helm/charts/nginx:1.0.0", "--dest",
+				dest.toString());
+
+		assertNotEquals(CommandLine.ExitCode.OK, exit);
 	}
 
 	@Test
 	void testPullWithRepoUrlAndAuth() throws IOException {
-		doNothing().when(repoManager)
-			.pullFromRepoUrl(anyString(), anyString(), anyString(), anyString(),
-					any(RepositoryConfig.Repository.class));
+		doAnswer((inv) -> {
+			Files.writeString(Path.of(inv.getArgument(3), "mychart-1.0.0.tgz"), "tgz");
+			return null;
+		}).when(repoManager)
+			.pullFromRepoUrl(anyString(), anyString(), anyString(), anyString(), any(RepositoryConfig.Repository.class),
+					anyBoolean());
 
-		CommandLine cmd = new CommandLine(pullCommand);
-		cmd.execute("mychart", "--repo", "https://charts.example.com", "--version", "1.0.0", "--username", "u",
-				"--password", "p", "--insecure-skip-tls-verify");
+		int exit = new CommandLine(pullCommand).execute("mychart", "--repo", "https://charts.example.com", "--version",
+				"1.0.0", "--username", "u", "--password", "p", "--insecure-skip-tls-verify", "--dest", dest.toString());
 
+		assertEquals(CommandLine.ExitCode.OK, exit);
 		ArgumentCaptor<RepositoryConfig.Repository> auth = ArgumentCaptor.forClass(RepositoryConfig.Repository.class);
-		verify(repoManager).pullFromRepoUrl(eq("https://charts.example.com"), eq("mychart"), eq("1.0.0"), eq("."),
-				auth.capture());
+		verify(repoManager).pullFromRepoUrl(eq("https://charts.example.com"), eq("mychart"), eq("1.0.0"), anyString(),
+				auth.capture(), eq(false));
 		RepositoryConfig.Repository built = auth.getValue();
 		assertEquals("u", built.getUsername());
 		assertEquals("p", built.getPassword());
@@ -92,13 +130,57 @@ class PullCommandTest {
 	}
 
 	@Test
+	void testPullUntarUnpacksAndRemovesArchive() throws IOException {
+		stubPullWritesArchive("nginx-1.0.0.tgz", false);
+		File untarDir = dest.resolve("unpacked").toFile();
+
+		int exit = new CommandLine(pullCommand).execute("bitnami/nginx", "--version", "1.0.0", "--untar", "--untardir",
+				untarDir.getPath(), "--dest", dest.toString());
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		// The archive is unpacked into --untardir, not left as a .tgz in --dest.
+		verify(repoManager).untar(any(File.class), eq(untarDir));
+		assertTrue(untarDir.exists());
+		assertTrue(!dest.resolve("nginx-1.0.0.tgz").toFile().exists());
+	}
+
+	@Test
+	void testPullVerifyChecksProvenance() throws IOException {
+		stubPullWritesArchive("nginx-1.0.0.tgz", true);
+
+		int exit = new CommandLine(pullCommand).execute("bitnami/nginx", "--version", "1.0.0", "--verify", "--dest",
+				dest.toString());
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		// --verify fetches the .prov (withProv=true) and runs VerifyAction before
+		// delivery.
+		verify(repoManager).pull(eq("bitnami/nginx"), eq("1.0.0"), anyString(), eq(true));
+		verify(verifyAction).verify(anyString(), anyString());
+	}
+
+	@Test
+	void testPullProvKeepsProvenanceFile() throws IOException {
+		stubPullWritesArchive("nginx-1.0.0.tgz", true);
+
+		int exit = new CommandLine(pullCommand).execute("bitnami/nginx", "--version", "1.0.0", "--prov", "--dest",
+				dest.toString());
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		verify(repoManager).pull(eq("bitnami/nginx"), eq("1.0.0"), anyString(), eq(true));
+		verify(verifyAction, never()).verify(anyString(), anyString());
+		assertTrue(dest.resolve("nginx-1.0.0.tgz").toFile().exists());
+		assertTrue(dest.resolve("nginx-1.0.0.tgz.prov").toFile().exists());
+	}
+
+	@Test
 	void testPullWithDestOption() throws IOException {
-		doNothing().when(repoManager).pull(anyString(), isNull(), anyString());
+		stubPullWritesArchive("nginx-1.0.0.tgz", false);
 
-		CommandLine cmd = new CommandLine(pullCommand);
-		cmd.execute("oci://ghcr.io/helm/charts/nginx:1.0.0", "--dest", "/tmp/charts");
+		int exit = new CommandLine(pullCommand).execute("oci://ghcr.io/helm/charts/nginx:1.0.0", "--dest",
+				dest.toString());
 
-		verify(repoManager).pull("oci://ghcr.io/helm/charts/nginx:1.0.0", null, "/tmp/charts");
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		assertTrue(dest.resolve("nginx-1.0.0.tgz").toFile().exists());
 	}
 
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -659,6 +659,21 @@ public class RepoManager {
 	 * @param destDir destination directory
 	 */
 	public void pull(String chart, String version, String destDir) throws IOException {
+		pull(chart, version, destDir, false);
+	}
+
+	/**
+	 * Downloads a chart, optionally also fetching its {@code .prov} provenance file (Helm
+	 * {@code pull --prov}/{@code --verify}). Provenance fetching is not supported for
+	 * {@code oci://} references in this path.
+	 * @param chart {@code repo/chartName}, {@code repo/chartName:version}, or
+	 * {@code oci://...}
+	 * @param version optional version (for repo charts)
+	 * @param destDir destination directory
+	 * @param withProv when {@code true}, also download the chart's {@code .prov} file
+	 * @throws IOException if the chart (or requested provenance) cannot be downloaded
+	 */
+	public void pull(String chart, String version, String destDir, boolean withProv) throws IOException {
 		if (chart.startsWith("oci://")) {
 			String fileName = deriveOciFileName(chart);
 			pullOci(chart, destDir, fileName);
@@ -673,7 +688,7 @@ public class RepoManager {
 			if (resolvedVersion == null || resolvedVersion.isBlank()) {
 				throw new IOException("version is required for repository chart pulls");
 			}
-			pull(chart, null, resolvedVersion, destDir);
+			pull(chart, null, resolvedVersion, destDir, withProv);
 		}
 	}
 
@@ -687,6 +702,21 @@ public class RepoManager {
 	}
 
 	public void pull(String chartFullName, String repoName, String version, String destDir) throws IOException {
+		pull(chartFullName, repoName, version, destDir, false);
+	}
+
+	/**
+	 * Downloads a chart from a registered repository, optionally also fetching its
+	 * {@code .prov} provenance file (Helm {@code pull --prov}/{@code --verify}).
+	 * @param chartFullName the chart name, optionally prefixed with {@code repo/}
+	 * @param repoName the repository name (or {@code null} to take it from the prefix)
+	 * @param version the chart version
+	 * @param destDir the destination directory
+	 * @param withProv when {@code true}, also download the chart's {@code .prov} file
+	 * @throws IOException if the chart (or requested provenance) cannot be downloaded
+	 */
+	public void pull(String chartFullName, String repoName, String version, String destDir, boolean withProv)
+			throws IOException {
 		String finalChartName = chartFullName;
 		String finalRepoName = repoName;
 
@@ -712,6 +742,7 @@ public class RepoManager {
 		String chartUrl = resolveChartUrl((indexEntry != null) ? indexEntry[0] : null, repo.getUrl(), finalChartName,
 				version);
 		String chartDigest = (indexEntry != null) ? indexEntry[1] : null;
+		String tgzFileName = finalChartName + "-" + version + ".tgz";
 
 		if (chartDigest != null) {
 			File cached = getChartCacheFile(chartDigest);
@@ -719,15 +750,20 @@ public class RepoManager {
 				if (log.isInfoEnabled()) {
 					log.info("Using cached chart (digest: {})", chartDigest);
 				}
-				File destFile = new File(destDir, finalChartName + "-" + version + ".tgz");
+				File destFile = new File(destDir, tgzFileName);
 				Files.copy(cached.toPath(), destFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
 				untar(destFile, new File(destDir));
+				if (withProv) {
+					fetchProvenance(chartUrl, destDir, tgzFileName, repo);
+				}
 				return;
 			}
 		}
 
-		String tgzFileName = finalChartName + "-" + version + ".tgz";
 		pullFromUrl(chartUrl, destDir, tgzFileName, repo);
+		if (withProv) {
+			fetchProvenance(chartUrl, destDir, tgzFileName, repo);
+		}
 
 		File downloaded = new File(destDir, tgzFileName);
 		if (downloaded.exists()) {
@@ -737,6 +773,29 @@ public class RepoManager {
 				Files.copy(downloaded.toPath(), cacheTarget.toPath());
 			}
 		}
+	}
+
+	// Downloads the chart's detached PGP provenance (.prov) next to the .tgz — the file
+	// Helm's --verify checks and --prov keeps. Unlike pullFromUrl this is a raw fetch (a
+	// .prov is not a gzip archive, so it must not be untarred).
+	private void fetchProvenance(String chartUrl, String destDir, String tgzFileName, RepositoryConfig.Repository repo)
+			throws IOException {
+		String provUrl = chartUrl + ".prov";
+		File provFile = new File(destDir, tgzFileName + ".prov");
+		HttpGet httpGet = new HttpGet(provUrl);
+		httpGet.setHeader("User-Agent", "jhelm");
+		httpClientFactory.executeGet(httpGet, repo, (response) -> {
+			if (response.getCode() != 200) {
+				throw new IOException("Failed to download provenance from " + provUrl + ": " + response.getCode());
+			}
+			HttpEntity entity = response.getEntity();
+			if (entity != null) {
+				try (InputStream in = entity.getContent(); FileOutputStream fos = new FileOutputStream(provFile)) {
+					in.transferTo(fos);
+				}
+			}
+			return null;
+		});
 	}
 
 	/**
@@ -760,6 +819,26 @@ public class RepoManager {
 	@SuppressWarnings("java:S5443")
 	public void pullFromRepoUrl(String repoUrl, String chartName, String version, String destDir,
 			RepositoryConfig.Repository auth) throws IOException {
+		pullFromRepoUrl(repoUrl, chartName, version, destDir, auth, false);
+	}
+
+	/**
+	 * As
+	 * {@link #pullFromRepoUrl(String, String, String, String, RepositoryConfig.Repository)},
+	 * optionally also fetching the chart's {@code .prov} provenance file (Helm
+	 * {@code pull --repo ... --prov}/{@code --verify}).
+	 * @param repoUrl the repository base URL
+	 * @param chartName the chart name to resolve in the index
+	 * @param version the chart version (required)
+	 * @param destDir the destination directory
+	 * @param auth a repository descriptor carrying auth and TLS settings, or {@code null}
+	 * @param withProv when {@code true}, also download the chart's {@code .prov} file
+	 * @throws IOException if the index, chart, or requested provenance cannot be
+	 * downloaded
+	 */
+	@SuppressWarnings("java:S5443")
+	public void pullFromRepoUrl(String repoUrl, String chartName, String version, String destDir,
+			RepositoryConfig.Repository auth, boolean withProv) throws IOException {
 		if (version == null || version.isBlank()) {
 			throw new IOException("version is required when pulling with --repo");
 		}
@@ -788,7 +867,11 @@ public class RepoManager {
 			});
 			String[] indexEntry = lookupChartInIndex(indexTmp, chartName, version);
 			String chartUrl = resolveChartUrl((indexEntry != null) ? indexEntry[0] : null, repoUrl, chartName, version);
-			pullFromUrl(chartUrl, destDir, chartName + "-" + version + ".tgz", repo);
+			String tgzFileName = chartName + "-" + version + ".tgz";
+			pullFromUrl(chartUrl, destDir, tgzFileName, repo);
+			if (withProv) {
+				fetchProvenance(chartUrl, destDir, tgzFileName, repo);
+			}
 		}
 		finally {
 			Files.deleteIfExists(indexTmp.toPath());

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
@@ -389,6 +389,30 @@ class RepoManagerTest {
 	}
 
 	@Test
+	void testPullFromRepoUrlWithProvFetchesProvenance() throws Exception {
+		RepoManager rm = new RepoManager();
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		rm.setHttpClientForTest(mockClient);
+		byte[] tgz = createMinimalTgz();
+		String index = """
+				entries:
+				  mychart:
+				    - version: "1.0.0"
+				      urls:
+				        - "https://charts.example.com/mychart-1.0.0.tgz"
+				""";
+		// Three sequential fetches: index.yaml, the .tgz, then the .prov.
+		when(mockClient.execute(isA(HttpGet.class), any(HttpClientResponseHandler.class)))
+			.thenAnswer(httpAnswer(200, index.getBytes(StandardCharsets.UTF_8)))
+			.thenAnswer(httpAnswer(200, tgz))
+			.thenAnswer(httpAnswer(200, "signed-prov".getBytes(StandardCharsets.UTF_8)));
+		rm.pullFromRepoUrl("https://charts.example.com", "mychart", "1.0.0", tempDir.toString(), null, true);
+		assertTrue(tempDir.resolve("mychart-1.0.0.tgz").toFile().exists());
+		assertTrue(tempDir.resolve("mychart-1.0.0.tgz.prov").toFile().exists(),
+				"the .prov file is fetched with --prov");
+	}
+
+	@Test
 	void testPullFromRepoUrlRequiresVersion() {
 		RepoManager rm = new RepoManager();
 		assertThrows(java.io.IOException.class,

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -3,6 +3,7 @@ package org.alexmond.jhelm.rest;
 import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
 import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.action.CreateAction;
+import org.alexmond.jhelm.core.action.VerifyAction;
 import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.SearchHubAction;
 import org.alexmond.jhelm.core.action.HistoryAction;
@@ -219,8 +220,9 @@ public class JhelmRestAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(RepoManager.class)
-	public RepoController repoController(RepoManager repoManager, JhelmRestProperties properties) {
-		return new RepoController(repoManager, properties);
+	public RepoController repoController(RepoManager repoManager, VerifyAction verifyAction,
+			JhelmRestProperties properties) {
+		return new RepoController(repoManager, verifyAction, properties);
 	}
 
 	/**

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/RepoController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/RepoController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.alexmond.jhelm.core.model.RepositoryConfig;
+import org.alexmond.jhelm.core.action.VerifyAction;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
 import org.alexmond.jhelm.rest.dto.ChartVersionDto;
@@ -50,15 +51,19 @@ public class RepoController {
 
 	private final RepoManager repoManager;
 
+	private final VerifyAction verifyAction;
+
 	private final JhelmRestProperties properties;
 
 	/**
 	 * Creates the controller with the repository manager it delegates to.
 	 * @param repoManager manages chart repositories
+	 * @param verifyAction verifies a packaged chart's PGP provenance
 	 * @param properties REST module configuration (temp directory, base path)
 	 */
-	public RepoController(RepoManager repoManager, JhelmRestProperties properties) {
+	public RepoController(RepoManager repoManager, VerifyAction verifyAction, JhelmRestProperties properties) {
 		this.repoManager = repoManager;
+		this.verifyAction = verifyAction;
 		this.properties = properties;
 	}
 
@@ -150,14 +155,20 @@ public class RepoController {
 			description = "Pull a chart from a repository or OCI registry and return it as a .tgz archive")
 	public ResponseEntity<byte[]> pull(@Valid @RequestBody PullRequest request) throws IOException {
 		try (TempDir tempDir = new TempDir(this.properties.getTempDir(), "jhelm-pull-")) {
-			this.repoManager.pull(request.getChart(), request.getVersion(), tempDir.path().toString());
+			this.repoManager.pull(request.getChart(), request.getVersion(), tempDir.path().toString(),
+					request.isVerify());
 			String fileName = resolveFileName(request.getChart(), request.getVersion());
 			File[] files = tempDir.path().toFile().listFiles();
-			if (files != null && files.length == 1 && files[0].getName().endsWith(".tgz")) {
-				byte[] tgz = Files.readAllBytes(files[0].toPath());
+			File tgzFile = firstTgz(files);
+			if (request.isVerify() && tgzFile != null) {
+				this.verifyAction.verify(tgzFile.getPath(),
+						(request.getKeyring() != null) ? request.getKeyring() : defaultKeyringPath());
+			}
+			if (tgzFile != null) {
+				byte[] tgz = Files.readAllBytes(tgzFile.toPath());
 				return ResponseEntity.ok()
 					.contentType(APPLICATION_GZIP)
-					.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + files[0].getName() + "\"")
+					.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + tgzFile.getName() + "\"")
 					.body(tgz);
 			}
 			Path chartDir = ChartLoader.findChartDir(tempDir.path());
@@ -201,6 +212,24 @@ public class RepoController {
 			this.repoManager.pushOci(tgzPath.toString(), remote);
 			return ResponseEntity.ok().build();
 		}
+	}
+
+	// The downloaded .tgz among the temp-dir contents (a --verify pull also writes a
+	// .prov, and a registered-repo pull may leave an unpacked directory).
+	private static File firstTgz(File[] files) {
+		if (files == null) {
+			return null;
+		}
+		for (File f : files) {
+			if (f.isFile() && f.getName().endsWith(".tgz")) {
+				return f;
+			}
+		}
+		return null;
+	}
+
+	private static String defaultKeyringPath() {
+		return System.getProperty("user.home") + "/.gnupg/pubring.gpg";
 	}
 
 	private static String resolveFileName(String chart, String version) {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/PullRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/PullRequest.java
@@ -20,4 +20,10 @@ public class PullRequest {
 	@Schema(description = "Chart version (required for repo charts, optional for OCI)", example = "18.3.1")
 	private String version;
 
+	@Schema(description = "Verify the chart's PGP provenance before returning it", defaultValue = "false")
+	private boolean verify;
+
+	@Schema(description = "Keyring with the public keys used for verification (defaults to ~/.gnupg/pubring.gpg)")
+	private String keyring;
+
 }

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/RepoControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/RepoControllerTest.java
@@ -4,6 +4,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import org.alexmond.jhelm.core.action.VerifyAction;
 import org.alexmond.jhelm.core.model.RepositoryConfig;
 import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.rest.JhelmRestExceptionHandler;
@@ -18,6 +19,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -41,6 +43,9 @@ class RepoControllerTest {
 
 	@MockitoBean
 	private RepoManager repoManager;
+
+	@MockitoBean
+	private VerifyAction verifyAction;
 
 	@Test
 	void addRepo() throws Exception {
@@ -125,7 +130,7 @@ class RepoControllerTest {
 			Files.createDirectories(chartDir);
 			Files.writeString(chartDir.resolve("Chart.yaml"), "name: nginx\nversion: 1.0.0");
 			return null;
-		}).when(this.repoManager).pull(eq("bitnami/nginx"), eq("1.0.0"), anyString());
+		}).when(this.repoManager).pull(eq("bitnami/nginx"), eq("1.0.0"), anyString(), anyBoolean());
 
 		this.mockMvc.perform(post("/api/v1/repos/pull").contentType(MediaType.APPLICATION_JSON).content("""
 				{"chart": "bitnami/nginx", "version": "1.0.0"}
@@ -136,6 +141,23 @@ class RepoControllerTest {
 	}
 
 	@Test
+	void pullWithVerifyChecksProvenance() throws Exception {
+		doAnswer((invocation) -> {
+			String destDir = invocation.getArgument(2);
+			Files.writeString(Path.of(destDir).resolve("nginx-1.0.0.tgz"), "tgz");
+			Files.writeString(Path.of(destDir).resolve("nginx-1.0.0.tgz.prov"), "prov");
+			return null;
+		}).when(this.repoManager).pull(eq("bitnami/nginx"), eq("1.0.0"), anyString(), eq(true));
+
+		this.mockMvc.perform(post("/api/v1/repos/pull").contentType(MediaType.APPLICATION_JSON).content("""
+				{"chart": "bitnami/nginx", "version": "1.0.0", "verify": true}
+				""")).andExpect(status().isOk());
+
+		verify(this.repoManager).pull(eq("bitnami/nginx"), eq("1.0.0"), anyString(), eq(true));
+		verify(this.verifyAction).verify(anyString(), anyString());
+	}
+
+	@Test
 	void pullOciChartReturnsArchiveDownload() throws Exception {
 		doAnswer((invocation) -> {
 			String destDir = invocation.getArgument(2);
@@ -143,7 +165,8 @@ class RepoControllerTest {
 			Files.createDirectories(chartDir);
 			Files.writeString(chartDir.resolve("Chart.yaml"), "name: nginx\nversion: 1.0.0");
 			return null;
-		}).when(this.repoManager).pull(eq("oci://registry.example.com/nginx:1.0.0"), eq(null), anyString());
+		}).when(this.repoManager)
+			.pull(eq("oci://registry.example.com/nginx:1.0.0"), eq(null), anyString(), anyBoolean());
 
 		this.mockMvc.perform(post("/api/v1/repos/pull").contentType(MediaType.APPLICATION_JSON).content("""
 				{"chart": "oci://registry.example.com/nginx:1.0.0"}


### PR DESCRIPTION
Adds Helm's chart-pull unpack and provenance flags to CLI + REST, closing most of #684.

## CLI `jhelm pull`
- `--untar` / `--untardir` (default `.`) — unpack the fetched chart into the target dir and drop the `.tgz`.
- `--verify` / `--prov` / `--keyring` — fetch the chart's detached `.prov` and (with `--verify`) check its PGP provenance via the existing `VerifyAction` before delivery.
- Pulls now land in an owner-only temp dir so the exact `.tgz`/`.prov` are located, then are verified / unpacked / moved to `--dest` (local-path pulls behave as before).

## REST `POST /repos/pull`
- `PullRequest` gains `verify` + `keyring`; the endpoint fetches the `.prov` and verifies before returning the archive. `RepoController` now takes `VerifyAction` (wired in `JhelmRestAutoConfiguration`).

## Core `RepoManager`
- `pull(...)` and `pullFromRepoUrl(...)` gain a `withProv` overload that also downloads the `.prov` via a **raw** fetch (not `pullFromUrl`, which untars — a `.prov` is not a gzip archive). Existing signatures delegate with `withProv=false`.

## Known gap
`--devel` (prerelease / latest-version resolution) is **not** implemented — it needs semver latest-version resolution jhelm doesn't have yet (`pull` requires an explicit `--version`). Documented in `cli-parity.adoc`.

## Tests
- `RepoManagerTest` — `withProv` fetches the `.prov` with the correct filename.
- `PullCommandTest` — rewritten for the temp-dir flow: untar, verify, prov, repo-url auth.
- `RepoControllerTest` — `verify:true` triggers `VerifyAction`.
- Changelog + `cli-parity.adoc` updated.

Closes #684 (except `--devel`, tracked as a known gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)