### PR TITLE
feat(repo): repo add auth/TLS + --force-update/--no-update (#685)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -54,6 +54,10 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
   provenance before use (reusing the `verify` layer). REST `POST /repos/pull` gains a `verify` flag.
   `--devel` (prerelease resolution) remains the one open pull gap — it needs semver latest-version
   resolution jhelm does not have yet (#684).
+* *`repo add` auth, TLS & update control* -- `--username`/`--password`/`--cert-file`/`--key-file`/`--ca-file`/`--insecure-skip-tls-verify`/`--pass-credentials`
+  are persisted into `repositories.yaml` and honored (host-gated) on every index refresh and chart
+  pull; `--force-update` replaces an existing repo (a duplicate name otherwise fails) and
+  `--no-update` skips the immediate index fetch. Mirrored on REST `POST /repos` (#685).
 * *REST releases API now returns Helm-shaped JSON* -- the `/releases` list/status/history and
   install/upgrade responses now use Helm's `-o json` schema (snake_case, nested `info`) instead
   of jhelm's internal DTO, so REST consumers see the same shape as `helm ... -o json` and the

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -120,7 +120,8 @@ template produced each manifest.
 | `repo list -o table\|json\|yaml` | ✅ | Machine-readable repo listing (`name`, `url`).
 | `search hub -o table\|json\|yaml` | ✅ | Machine-readable Artifact Hub results.
 | `repo update [name...]` | ✅ | Refreshes all repos, or the named ones.
-| `repo add` auth (`--username`, `--password`, `--ca-file`) | ✗ |
+| `repo add` auth/TLS (`--username`, `--password`, `--cert-file`, `--key-file`, `--ca-file`, `--insecure-skip-tls-verify`, `--pass-credentials`) | ✅ | Persisted into `repositories.yaml`; the stored credentials are host-gated and honored on every index refresh and chart pull.
+| `repo add` (`--force-update`, `--no-update`) | ✅ | `--force-update` replaces an existing repo (adding a duplicate name otherwise fails); `--no-update` skips the immediate index fetch.
 | `registry login` (`-u`, `-p`, `--password-stdin`) / `logout` | ✅ |
 | `pull` (`--version`, `-d/--dest`) | ✅ |
 | `pull --repo URL` + auth/TLS (`--username`, `--password`, `--cert-file`, `--key-file`, `--ca-file`, `--insecure-skip-tls-verify`, `--pass-credentials`) | ✅ | Pull a chart directly from a repository URL with inline credentials, without a prior `repo add`.

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RepoCommand.java
@@ -55,6 +55,37 @@ public class RepoCommand implements Callable<Integer> {
 		@CommandLine.Parameters(index = "1", description = "repository url")
 		private String url;
 
+		@CommandLine.Option(names = { "--username" }, description = "chart repository username")
+		private String username;
+
+		@CommandLine.Option(names = { "--password" }, description = "chart repository password")
+		private String password;
+
+		@CommandLine.Option(names = { "--cert-file" }, description = "identity certificate (PEM) for client TLS auth")
+		private String certFile;
+
+		@CommandLine.Option(names = { "--key-file" }, description = "identity key (PEM) for client TLS auth")
+		private String keyFile;
+
+		@CommandLine.Option(names = { "--ca-file" },
+				description = "verify server certificate against this CA bundle (PEM)")
+		private String caFile;
+
+		@CommandLine.Option(names = { "--insecure-skip-tls-verify" },
+				description = "skip TLS verification of the repository")
+		private boolean insecureSkipTlsVerify;
+
+		@CommandLine.Option(names = { "--pass-credentials" },
+				description = "send credentials to all domains, not just the repository host")
+		private boolean passCredentials;
+
+		@CommandLine.Option(names = { "--force-update" },
+				description = "replace the repository if it already exists (default: fail)")
+		private boolean forceUpdate;
+
+		@CommandLine.Option(names = { "--no-update" }, description = "do not fetch the repository index after adding")
+		private boolean noUpdate;
+
 		/**
 		 * Creates the command.
 		 * @param repoManager the repository manager that stores the repository
@@ -66,7 +97,18 @@ public class RepoCommand implements Callable<Integer> {
 		@Override
 		public Integer call() {
 			try {
-				repoManager.addRepo(name, url);
+				RepositoryConfig.Repository repo = RepositoryConfig.Repository.builder()
+					.name(name)
+					.url(url)
+					.username(username)
+					.password(password)
+					.certFile(certFile)
+					.keyFile(keyFile)
+					.caFile(caFile)
+					.insecureSkipTlsVerify(insecureSkipTlsVerify)
+					.passCredentialsAll(passCredentials)
+					.build();
+				repoManager.addRepo(repo, !noUpdate, forceUpdate);
 				CliOutput.println(CliOutput.success("\"" + name + "\" has been added to your repositories"));
 				return CommandLine.ExitCode.OK;
 			}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RepoCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RepoCommandTest.java
@@ -4,6 +4,7 @@ import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.core.model.RepositoryConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
@@ -15,7 +16,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.doThrow;
@@ -54,18 +58,41 @@ class RepoCommandTest {
 
 	@Test
 	void testAddCommandSuccess() throws IOException {
-		doNothing().when(repoManager).addRepo(anyString(), anyString());
+		int exit = new CommandLine(addCommand).execute("bitnami", "https://charts.bitnami.com/bitnami");
 
-		CommandLine cmd = new CommandLine(addCommand);
-		cmd.execute("bitnami", "https://charts.bitnami.com/bitnami");
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		ArgumentCaptor<RepositoryConfig.Repository> captor = ArgumentCaptor.forClass(RepositoryConfig.Repository.class);
+		verify(repoManager).addRepo(captor.capture(), eq(true), eq(false));
+		assertEquals("bitnami", captor.getValue().getName());
+		assertEquals("https://charts.bitnami.com/bitnami", captor.getValue().getUrl());
+	}
+
+	@Test
+	void testAddCommandWithAuthTlsAndFlags() throws IOException {
+		int exit = new CommandLine(addCommand).execute("private", "https://charts.example.com", "--username", "u",
+				"--password", "p", "--ca-file", "/ca.pem", "--insecure-skip-tls-verify", "--pass-credentials",
+				"--force-update", "--no-update");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		ArgumentCaptor<RepositoryConfig.Repository> captor = ArgumentCaptor.forClass(RepositoryConfig.Repository.class);
+		// --no-update -> update=false, --force-update -> forceUpdate=true
+		verify(repoManager).addRepo(captor.capture(), eq(false), eq(true));
+		RepositoryConfig.Repository repo = captor.getValue();
+		assertEquals("u", repo.getUsername());
+		assertEquals("p", repo.getPassword());
+		assertEquals("/ca.pem", repo.getCaFile());
+		assertTrue(repo.isInsecureSkipTlsVerify());
+		assertTrue(repo.isPassCredentialsAll());
 	}
 
 	@Test
 	void testAddCommandWithError() throws IOException {
-		doThrow(new IOException("Test error")).when(repoManager).addRepo(anyString(), anyString());
+		doThrow(new IOException("Test error")).when(repoManager)
+			.addRepo(any(RepositoryConfig.Repository.class), anyBoolean(), anyBoolean());
 
-		CommandLine cmd = new CommandLine(addCommand);
-		cmd.execute("bitnami", "https://charts.bitnami.com/bitnami");
+		int exit = new CommandLine(addCommand).execute("bitnami", "https://charts.bitnami.com/bitnami");
+
+		assertEquals(CommandLine.ExitCode.SOFTWARE, exit);
 	}
 
 	@Test

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -253,19 +253,41 @@ public class RepoManager {
 	}
 
 	public void addRepo(String name, String url) throws IOException {
-		validateRepoName(name);
+		addRepo(RepositoryConfig.Repository.builder().name(name).url(url).build(), true, true);
+	}
+
+	/**
+	 * Registers a chart repository, persisting its auth/TLS settings and optionally
+	 * refreshing its index, matching {@code helm repo add} semantics.
+	 * @param repo the repository to add (name, URL, and any credentials/TLS settings)
+	 * @param update {@code true} to fetch the repository index immediately (Helm's
+	 * default; {@code --no-update} passes {@code false})
+	 * @param forceUpdate {@code true} to replace an existing repository of the same name
+	 * ({@code --force-update}); when {@code false}, adding a name that already exists
+	 * fails
+	 * @throws IOException if the name is already registered and {@code forceUpdate} is
+	 * {@code false}, or the config cannot be written
+	 */
+	public void addRepo(RepositoryConfig.Repository repo, boolean update, boolean forceUpdate) throws IOException {
+		validateRepoName(repo.getName());
 		RepositoryConfig config = loadConfig();
-		config.getRepositories().removeIf((r) -> r.getName().equals(name));
-		RepositoryConfig.Repository repo = RepositoryConfig.Repository.builder().name(name).url(url).build();
+		boolean exists = config.getRepositories().stream().anyMatch((r) -> r.getName().equals(repo.getName()));
+		if (exists && !forceUpdate) {
+			throw new IOException("repository name (" + repo.getName()
+					+ ") already exists, please specify a different name or use --force-update to replace it");
+		}
+		config.getRepositories().removeIf((r) -> r.getName().equals(repo.getName()));
 		config.getRepositories().add(repo);
 		config.setGenerated(OffsetDateTime.now().toString());
 		saveConfig(config);
-		try {
-			updateRepo(name);
-		}
-		catch (IOException ex) {
-			if (log.isWarnEnabled()) {
-				log.warn("Failed to update repo '{}' immediately after add: {}", name, ex.getMessage());
+		if (update) {
+			try {
+				updateRepo(repo.getName());
+			}
+			catch (IOException ex) {
+				if (log.isWarnEnabled()) {
+					log.warn("Failed to update repo '{}' immediately after add: {}", repo.getName(), ex.getMessage());
+				}
 			}
 		}
 	}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
@@ -84,6 +84,57 @@ class RepoManagerTest {
 	}
 
 	@Test
+	void testAddRepoPersistsCredentialsAndTls() throws IOException {
+		RepoManager rm = new RepoManager(tempDir.resolve("repositories.yaml").toString());
+		RepositoryConfig.Repository repo = RepositoryConfig.Repository.builder()
+			.name("private")
+			.url("https://charts.example.com")
+			.username("u")
+			.password("p")
+			.caFile("/ca.pem")
+			.insecureSkipTlsVerify(true)
+			.passCredentialsAll(true)
+			.build();
+		rm.addRepo(repo, false, false);
+		RepositoryConfig.Repository saved = rm.loadConfig()
+			.getRepositories()
+			.stream()
+			.filter((r) -> "private".equals(r.getName()))
+			.findFirst()
+			.orElseThrow();
+		assertEquals("u", saved.getUsername());
+		assertEquals("p", saved.getPassword());
+		assertEquals("/ca.pem", saved.getCaFile());
+		assertTrue(saved.isInsecureSkipTlsVerify());
+		assertTrue(saved.isPassCredentialsAll());
+	}
+
+	@Test
+	void testAddRepoDuplicateWithoutForceUpdateFails() throws IOException {
+		RepoManager rm = new RepoManager(tempDir.resolve("repositories.yaml").toString());
+		rm.addRepo(RepositoryConfig.Repository.builder().name("dup").url("https://a.example.com").build(), false,
+				false);
+		assertThrows(IOException.class,
+				() -> rm.addRepo(RepositoryConfig.Repository.builder().name("dup").url("https://b.example.com").build(),
+						false, false));
+	}
+
+	@Test
+	void testAddRepoForceUpdateReplaces() throws IOException {
+		RepoManager rm = new RepoManager(tempDir.resolve("repositories.yaml").toString());
+		rm.addRepo(RepositoryConfig.Repository.builder().name("dup").url("https://a.example.com").build(), false,
+				false);
+		rm.addRepo(RepositoryConfig.Repository.builder().name("dup").url("https://b.example.com").build(), false, true);
+		List<RepositoryConfig.Repository> dups = rm.loadConfig()
+			.getRepositories()
+			.stream()
+			.filter((r) -> "dup".equals(r.getName()))
+			.toList();
+		assertEquals(1, dups.size());
+		assertEquals("https://b.example.com", dups.get(0).getUrl());
+	}
+
+	@Test
 	void testRepoNotFound() {
 		RepoManager repoManager = new RepoManager();
 		assertThrows(IOException.class, () -> repoManager.getChartVersions("non-existent", "nginx"));

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/RepoController.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/controller/RepoController.java
@@ -75,7 +75,18 @@ public class RepoController {
 	@PostMapping
 	@Operation(summary = "Add a repository")
 	public ResponseEntity<Void> addRepo(@Valid @RequestBody RepoAddRequest request) throws IOException {
-		this.repoManager.addRepo(request.getName(), request.getUrl());
+		RepositoryConfig.Repository repo = RepositoryConfig.Repository.builder()
+			.name(request.getName())
+			.url(request.getUrl())
+			.username(request.getUsername())
+			.password(request.getPassword())
+			.certFile(request.getCertFile())
+			.keyFile(request.getKeyFile())
+			.caFile(request.getCaFile())
+			.insecureSkipTlsVerify(request.isInsecureSkipTlsVerify())
+			.passCredentialsAll(request.isPassCredentials())
+			.build();
+		this.repoManager.addRepo(repo, !request.isNoUpdate(), request.isForceUpdate());
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RepoAddRequest.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/dto/RepoAddRequest.java
@@ -21,4 +21,31 @@ public class RepoAddRequest {
 	@NotBlank(message = "url is required")
 	private String url;
 
+	@Schema(description = "Chart repository username")
+	private String username;
+
+	@Schema(description = "Chart repository password")
+	private String password;
+
+	@Schema(description = "Identity certificate (PEM) for client TLS auth")
+	private String certFile;
+
+	@Schema(description = "Identity key (PEM) for client TLS auth")
+	private String keyFile;
+
+	@Schema(description = "Verify the server certificate against this CA bundle (PEM)")
+	private String caFile;
+
+	@Schema(description = "Skip TLS verification of the repository", defaultValue = "false")
+	private boolean insecureSkipTlsVerify;
+
+	@Schema(description = "Send credentials to all domains, not just the repository host", defaultValue = "false")
+	private boolean passCredentials;
+
+	@Schema(description = "Replace the repository if it already exists (default: fail)", defaultValue = "false")
+	private boolean forceUpdate;
+
+	@Schema(description = "Do not fetch the repository index after adding", defaultValue = "false")
+	private boolean noUpdate;
+
 }

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/RepoControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/RepoControllerTest.java
@@ -10,6 +10,7 @@ import org.alexmond.jhelm.core.service.RepoManager;
 import org.alexmond.jhelm.rest.JhelmRestExceptionHandler;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -19,6 +20,8 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -56,7 +59,32 @@ class RepoControllerTest {
 						{"name": "bitnami", "url": "https://charts.bitnami.com/bitnami"}
 						"""))
 			.andExpect(status().isCreated());
-		verify(this.repoManager).addRepo("bitnami", "https://charts.bitnami.com/bitnami");
+		ArgumentCaptor<RepositoryConfig.Repository> captor = ArgumentCaptor.forClass(RepositoryConfig.Repository.class);
+		verify(this.repoManager).addRepo(captor.capture(), eq(true), eq(false));
+		assertEquals("bitnami", captor.getValue().getName());
+		assertEquals("https://charts.bitnami.com/bitnami", captor.getValue().getUrl());
+	}
+
+	@Test
+	void addRepoPersistsCredentialsAndFlags() throws Exception {
+		this.mockMvc
+			.perform(post("/api/v1/repos").contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content("""
+						{"name": "private", "url": "https://charts.example.com", "username": "u", "password": "p",
+						 "caFile": "/ca.pem", "insecureSkipTlsVerify": true, "passCredentials": true,
+						 "forceUpdate": true, "noUpdate": true}
+						"""))
+			.andExpect(status().isCreated());
+		ArgumentCaptor<RepositoryConfig.Repository> captor = ArgumentCaptor.forClass(RepositoryConfig.Repository.class);
+		// noUpdate -> update=false, forceUpdate -> true
+		verify(this.repoManager).addRepo(captor.capture(), eq(false), eq(true));
+		RepositoryConfig.Repository repo = captor.getValue();
+		assertEquals("u", repo.getUsername());
+		assertEquals("p", repo.getPassword());
+		assertEquals("/ca.pem", repo.getCaFile());
+		assertTrue(repo.isInsecureSkipTlsVerify());
+		assertTrue(repo.isPassCredentialsAll());
 	}
 
 	@Test


### PR DESCRIPTION
Exposes the auth/TLS settings on `repo add` (the `RepositoryConfig.Repository` model already carries them — the pull path uses them; this surfaces them on add) plus Helm's add-time update controls, on CLI + REST. Closes #685.

## CLI `jhelm repo add`
`--username`, `--password`, `--cert-file`, `--key-file`, `--ca-file`, `--insecure-skip-tls-verify`, `--pass-credentials`, plus `--force-update` (replace an existing repo — a duplicate name otherwise fails) and `--no-update` (skip the immediate index fetch).

## REST `POST /repos`
`RepoAddRequest` gains the same fields; the controller builds a `Repository` and calls the new overload.

## Core `RepoManager`
- New `addRepo(Repository, update, forceUpdate)` overload persists the full repo (creds + TLS) and, unless `update=false`, refreshes its index; a duplicate name fails unless `forceUpdate=true`.
- The 2-arg `addRepo(name, url)` delegates with `update+forceUpdate=true` — unchanged behavior for existing callers.
- `updateRepo` already passes the stored repo to `executeGet`, so persisted credentials are host-gated and honored on **every** index refresh and chart pull — no extra plumbing.

## Tests
- `RepoManagerTest` — creds persisted round-trip; duplicate without `--force-update` fails; `--force-update` replaces.
- `RepoCommandTest` — flags map to the captured `Repository` + the `update`/`forceUpdate` booleans; error path returns non-zero.
- `RepoControllerTest` — add verifies the 3-arg overload; creds/flags persisted.
- Changelog + `cli-parity.adoc` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)