### PR TITLE
feat(cli): package/show/lint/version misc flags (#687)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -58,6 +58,11 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
   are persisted into `repositories.yaml` and honored (host-gated) on every index refresh and chart
   pull; `--force-update` replaces an existing repo (a duplicate name otherwise fails) and
   `--no-update` skips the immediate index fetch. Mirrored on REST `POST /repos` (#685).
+* *Misc command flags* -- `package --version`/`--app-version` (rewrites the `Chart.yaml` inside the
+  archive) and `-u`/`--dependency-update`; `show chart\|values\|readme\|crds\|all` `--version`/`--repo`/`--username`/`--password`
+  + TLS (show a chart from a repository without a prior `pull`); `lint --quiet`/`--with-subcharts`/`--kube-version`;
+  and `version --template` (Go-templates the version output). `show --devel` and `registry login`
+  TLS flags remain documented gaps (#687).
 * *REST releases API now returns Helm-shaped JSON* -- the `/releases` list/status/history and
   install/upgrade responses now use Helm's `-o json` schema (snake_case, nested `info`) instead
   of jhelm's internal DTO, so REST consumers see the same shape as `helm ... -o json` and the

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -122,12 +122,26 @@ template produced each manifest.
 | `repo update [name...]` | ✅ | Refreshes all repos, or the named ones.
 | `repo add` auth/TLS (`--username`, `--password`, `--cert-file`, `--key-file`, `--ca-file`, `--insecure-skip-tls-verify`, `--pass-credentials`) | ✅ | Persisted into `repositories.yaml`; the stored credentials are host-gated and honored on every index refresh and chart pull.
 | `repo add` (`--force-update`, `--no-update`) | ✅ | `--force-update` replaces an existing repo (adding a duplicate name otherwise fails); `--no-update` skips the immediate index fetch.
-| `registry login` (`-u`, `-p`, `--password-stdin`) / `logout` | ✅ |
+| `registry login` (`-u`, `-p`, `--password-stdin`) / `logout` | ✅ | `registry login` stores credentials only (no TLS handshake), so `--insecure`/`--plain-http`/`--ca-file`/`--cert-file`/`--key-file` are not yet wired.
 | `pull` (`--version`, `-d/--dest`) | ✅ |
 | `pull --repo URL` + auth/TLS (`--username`, `--password`, `--cert-file`, `--key-file`, `--ca-file`, `--insecure-skip-tls-verify`, `--pass-credentials`) | ✅ | Pull a chart directly from a repository URL with inline credentials, without a prior `repo add`.
 | `pull` (`--untar`, `--untardir`) | ✅ | Unpacks the fetched chart into `--untardir` (default `.`) and removes the `.tgz`.
 | `pull` (`--verify`, `--prov`, `--keyring`) | ✅ | Fetches the chart's detached `.prov` and checks its PGP provenance before use (`--prov` keeps the file without verifying).
 | `pull` (`--devel`) | ✗ | Prerelease/latest-version resolution is not yet implemented (jhelm requires an explicit `--version`).
+|===
+
+== package / show / lint / version
+
+[cols="2,1,3"]
+|===
+| Command | jhelm | Notes
+
+| `package` (`--version`, `--app-version`) | ✅ | Stamp the packaged chart's version/app-version — rewrites the `Chart.yaml` inside the archive (and names the archive for the overridden version), not just the filename.
+| `package` (`-u`/`--dependency-update`) | ✅ | Updates the chart's `charts/` from its `Chart.yaml` dependencies before packaging.
+| `show chart\|values\|readme\|crds\|all` (`--version`, `--repo`, `--username`/`--password` + TLS) | ✅ | Show a chart pulled from a repository (registered `repo/chart` ref or ad-hoc `--repo <url>` with credentials/TLS) without a prior `pull`; local paths are unchanged.
+| `show` (`--devel`) | ✗ | Prerelease/latest-version resolution is not yet implemented (needs an explicit `--version`).
+| `lint` (`--quiet`, `--with-subcharts`, `--kube-version`) | ✅ | `--quiet` suppresses the linting header; `--with-subcharts` also lints each subchart (findings prefixed with the subchart name); `--kube-version` sets `.Capabilities.KubeVersion` for template rendering.
+| `version` (`--template`) | ✅ | Go-templates the version output against `.Version`, `.GitCommit`, `.GitTreeState`, `.GoVersion` (jhelm has no git metadata, so `GitCommit`/`GitTreeState` are empty and `GoVersion` is the running Java version).
 |===
 
 == Porting a Helm script to jhelm
@@ -151,12 +165,15 @@ Beyond the per-command tables above, these commonly-used Helm options are not ye
 * *`install`/`upgrade`* — `upgrade --cleanup-on-fail`.
   (install-from-repo `--version`/`--repo`/`--username`/`--password` + TLS is supported;
   `-g`/`--generate-name` on `install`; `--description`/`--labels`/`--set-literal`/`--dependency-update` on both.)
-* *`pull`* — `--devel` (prerelease/latest-version resolution). `--untar`/`--untardir` and
-  `--verify`/`--prov`/`--keyring` are supported.
+* *`pull`/`show`* — `--devel` (prerelease/latest-version resolution). `pull` `--untar`/`--untardir`
+  and `--verify`/`--prov`/`--keyring`, and `show` `--version`/`--repo`/auth, are supported.
+* *`registry login`* — `--insecure`/`--plain-http`/`--ca-file`/`--cert-file`/`--key-file`.
+  jhelm's `registry login` stores credentials locally without a TLS handshake, so these
+  transport options have nothing to act on yet (tracked in #708).
 * *Global flags* — Helm's persistent flags (`--kube-context`, `--kubeconfig`,
   `--kube-apiserver`, `--registry-config`, `--repository-config`, `--repository-cache`,
   `--debug`) aren't accepted inline; jhelm resolves these via Spring properties / environment
-  variables instead.
+  variables instead (tracked in #708).
 
 For sharing repositories, registry credentials, and releases with the `helm` binary itself, see
 xref:interoperability.adoc[Interoperability with Helm].

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/LintCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/LintCommand.java
@@ -48,6 +48,17 @@ public class LintCommand implements Callable<Integer> {
 	@Option(names = { "--strict" }, defaultValue = "false", description = "fail on lint warnings")
 	private boolean strict;
 
+	@Option(names = { "--quiet" }, defaultValue = "false",
+			description = "print only warnings and errors (suppress the linting header)")
+	private boolean quiet;
+
+	@Option(names = { "--with-subcharts" }, defaultValue = "false", description = "lint dependent charts")
+	private boolean withSubcharts;
+
+	@Option(names = { "--kube-version" },
+			description = "Kubernetes version used for capabilities checks during template rendering")
+	private String kubeVersion;
+
 	/**
 	 * Creates the command.
 	 * @param lintAction the action that lints the chart
@@ -61,9 +72,11 @@ public class LintCommand implements Callable<Integer> {
 		try {
 			Map<String, Object> overrides = ValuesOverrides.parse(valuesFiles, setValues, setStringValues,
 					setFileValues, setJsonValues, setLiteralValues);
-			LintAction.LintResult result = lintAction.lint(chartPath, overrides, strict);
+			LintAction.LintResult result = lintAction.lint(chartPath, overrides, strict, withSubcharts, kubeVersion);
 
-			CliOutput.println("==> Linting " + result.getChartPath());
+			if (!quiet) {
+				CliOutput.println("==> Linting " + result.getChartPath());
+			}
 
 			for (String warning : result.getWarnings()) {
 				CliOutput.println("[WARNING] " + warning);

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PackageCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PackageCommand.java
@@ -6,9 +6,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 
+import java.util.List;
+
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.action.DependencyUpdateAction;
 import org.alexmond.jhelm.core.action.PackageAction;
+import org.alexmond.jhelm.core.service.SigningKey;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
@@ -24,8 +28,20 @@ public class PackageCommand implements Callable<Integer> {
 
 	private final PackageAction packageAction;
 
+	private final DependencyUpdateAction dependencyUpdateAction;
+
 	@CommandLine.Parameters(index = "0", description = "path to the chart directory")
 	private String chartPath;
+
+	@CommandLine.Option(names = { "--version" }, description = "set the version on the packaged chart")
+	private String version;
+
+	@CommandLine.Option(names = { "--app-version" }, description = "set the appVersion on the packaged chart")
+	private String appVersion;
+
+	@CommandLine.Option(names = { "-u", "--dependency-update" },
+			description = "update dependencies from Chart.yaml before packaging")
+	private boolean dependencyUpdate;
 
 	@CommandLine.Option(names = { "-d", "--destination" }, defaultValue = ".",
 			description = "destination directory for the packaged chart")
@@ -47,14 +63,19 @@ public class PackageCommand implements Callable<Integer> {
 	/**
 	 * Creates the command.
 	 * @param packageAction the action that packages and optionally signs the chart
+	 * @param dependencyUpdateAction updates the chart's dependencies for {@code -u}
 	 */
-	public PackageCommand(PackageAction packageAction) {
+	public PackageCommand(PackageAction packageAction, DependencyUpdateAction dependencyUpdateAction) {
 		this.packageAction = packageAction;
+		this.dependencyUpdateAction = dependencyUpdateAction;
 	}
 
 	@Override
 	public Integer call() {
 		try {
+			if (dependencyUpdate) {
+				dependencyUpdateAction.update(new File(chartPath), List.of(), false);
+			}
 			packageAction.setDestination(new File(destination));
 			File archive;
 
@@ -65,10 +86,11 @@ public class PackageCommand implements Callable<Integer> {
 				}
 				String resolvedKeyring = (keyring != null) ? keyring : defaultKeyringPath();
 				char[] passphrase = loadPassphrase();
-				archive = packageAction.packageChart(chartPath, resolvedKeyring, keyId, passphrase);
+				archive = packageAction.packageChart(chartPath, resolvedKeyring, keyId, passphrase, version,
+						appVersion);
 			}
 			else {
-				archive = packageAction.packageChart(chartPath);
+				archive = packageAction.packageChart(chartPath, (SigningKey) null, null, version, appVersion);
 			}
 
 			CliOutput.println(CliOutput.success("Successfully packaged chart: " + archive.getName()));

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ShowCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/ShowCommand.java
@@ -3,15 +3,20 @@ package org.alexmond.jhelm.app.command;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.action.ShowAction;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.util.ValuesProfiles;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
+import java.io.IOException;
 import java.util.concurrent.Callable;
 
 /**
  * Implements {@code jhelm show}, displaying information about a chart via the
  * {@code chart}, {@code values}, {@code readme}, {@code crds}, and {@code all}
- * subcommands.
+ * subcommands. Each subcommand accepts a local chart path or, via the shared repo options
+ * ({@code --version}, {@code --repo}, {@code --username}/{@code --password}, TLS flags),
+ * a chart pulled from a repository without a prior {@code pull}.
  */
 @Component
 @CommandLine.Command(name = "show", mixinStandardHelpOptions = true, description = "Show information about a chart",
@@ -20,18 +25,35 @@ import java.util.concurrent.Callable;
 @Slf4j
 public class ShowCommand implements Callable<Integer> {
 
+	@CommandLine.Spec
+	private CommandLine.Model.CommandSpec spec;
+
 	/** Creates the command. */
 	@SuppressWarnings("PMD.UnnecessaryConstructor")
 	public ShowCommand() {
 	}
 
 	/**
-	 * Prints the usage help when {@code show} is invoked without a subcommand.
+	 * Prints the usage help when {@code show} is invoked without a subcommand. Renders
+	 * via the already-built command line so the subcommands (which carry {@code @Mixin}
+	 * options and have no no-arg constructor) are not re-instantiated by the default
+	 * factory.
 	 */
 	@Override
 	public Integer call() {
-		CommandLine.usage(this, System.out);
+		if (spec != null) {
+			spec.commandLine().usage(System.out);
+		}
 		return CommandLine.ExitCode.OK;
+	}
+
+	// Resolves the chart from a local path, a registered repo/chart ref, or an ad-hoc
+	// --repo URL (with the mixin's credentials/TLS), reusing the install/upgrade
+	// resolver.
+	private static Chart resolve(ChartResolver chartResolver, String chartPath, RepoChartOptions repoOptions)
+			throws IOException {
+		return chartResolver.resolveFromRepo(chartPath, repoOptions.getVersion(), repoOptions.getRepo(),
+				repoOptions.hasRepo() ? repoOptions.auth() : null, false, null, ValuesProfiles.none());
 	}
 
 	/** Implements {@code show chart}: prints the chart's Chart.yaml. */
@@ -42,21 +64,28 @@ public class ShowCommand implements Callable<Integer> {
 
 		private final ShowAction showAction;
 
-		@CommandLine.Parameters(index = "0", description = "chart path")
+		private final ChartResolver chartResolver;
+
+		@CommandLine.Parameters(index = "0", description = "chart path or repo/chart reference")
 		String chartPath;
+
+		@CommandLine.Mixin
+		private final RepoChartOptions repoOptions = new RepoChartOptions();
 
 		/**
 		 * Creates the command.
 		 * @param showAction the action that reads chart contents
+		 * @param chartResolver resolves the chart source (local path or repository)
 		 */
-		public ChartCommand(ShowAction showAction) {
+		public ChartCommand(ShowAction showAction, ChartResolver chartResolver) {
 			this.showAction = showAction;
+			this.chartResolver = chartResolver;
 		}
 
 		@Override
 		public Integer call() {
 			try {
-				System.out.println(showAction.showChart(chartPath));
+				System.out.println(showAction.showChart(resolve(chartResolver, chartPath, repoOptions)));
 				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
@@ -75,21 +104,28 @@ public class ShowCommand implements Callable<Integer> {
 
 		private final ShowAction showAction;
 
-		@CommandLine.Parameters(index = "0", description = "chart path")
+		private final ChartResolver chartResolver;
+
+		@CommandLine.Parameters(index = "0", description = "chart path or repo/chart reference")
 		String chartPath;
+
+		@CommandLine.Mixin
+		private final RepoChartOptions repoOptions = new RepoChartOptions();
 
 		/**
 		 * Creates the command.
 		 * @param showAction the action that reads chart contents
+		 * @param chartResolver resolves the chart source (local path or repository)
 		 */
-		public ValuesCommand(ShowAction showAction) {
+		public ValuesCommand(ShowAction showAction, ChartResolver chartResolver) {
 			this.showAction = showAction;
+			this.chartResolver = chartResolver;
 		}
 
 		@Override
 		public Integer call() {
 			try {
-				System.out.println(showAction.showValues(chartPath));
+				System.out.println(showAction.showValues(resolve(chartResolver, chartPath, repoOptions)));
 				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
@@ -108,21 +144,28 @@ public class ShowCommand implements Callable<Integer> {
 
 		private final ShowAction showAction;
 
-		@CommandLine.Parameters(index = "0", description = "chart path")
+		private final ChartResolver chartResolver;
+
+		@CommandLine.Parameters(index = "0", description = "chart path or repo/chart reference")
 		String chartPath;
+
+		@CommandLine.Mixin
+		private final RepoChartOptions repoOptions = new RepoChartOptions();
 
 		/**
 		 * Creates the command.
 		 * @param showAction the action that reads chart contents
+		 * @param chartResolver resolves the chart source (local path or repository)
 		 */
-		public ReadmeCommand(ShowAction showAction) {
+		public ReadmeCommand(ShowAction showAction, ChartResolver chartResolver) {
 			this.showAction = showAction;
+			this.chartResolver = chartResolver;
 		}
 
 		@Override
 		public Integer call() {
 			try {
-				String readme = showAction.showReadme(chartPath);
+				String readme = showAction.showReadme(resolve(chartResolver, chartPath, repoOptions));
 				if (readme.isEmpty()) {
 					System.out.println("No README found in chart");
 					return CommandLine.ExitCode.OK;
@@ -147,21 +190,28 @@ public class ShowCommand implements Callable<Integer> {
 
 		private final ShowAction showAction;
 
-		@CommandLine.Parameters(index = "0", description = "chart path")
+		private final ChartResolver chartResolver;
+
+		@CommandLine.Parameters(index = "0", description = "chart path or repo/chart reference")
 		String chartPath;
+
+		@CommandLine.Mixin
+		private final RepoChartOptions repoOptions = new RepoChartOptions();
 
 		/**
 		 * Creates the command.
 		 * @param showAction the action that reads chart contents
+		 * @param chartResolver resolves the chart source (local path or repository)
 		 */
-		public CrdsCommand(ShowAction showAction) {
+		public CrdsCommand(ShowAction showAction, ChartResolver chartResolver) {
 			this.showAction = showAction;
+			this.chartResolver = chartResolver;
 		}
 
 		@Override
 		public Integer call() {
 			try {
-				String crds = showAction.showCrds(chartPath);
+				String crds = showAction.showCrds(resolve(chartResolver, chartPath, repoOptions));
 				if (crds.isEmpty()) {
 					System.out.println("No CRDs found in chart");
 					return CommandLine.ExitCode.OK;
@@ -189,21 +239,28 @@ public class ShowCommand implements Callable<Integer> {
 
 		private final ShowAction showAction;
 
-		@CommandLine.Parameters(index = "0", description = "chart path")
+		private final ChartResolver chartResolver;
+
+		@CommandLine.Parameters(index = "0", description = "chart path or repo/chart reference")
 		String chartPath;
+
+		@CommandLine.Mixin
+		private final RepoChartOptions repoOptions = new RepoChartOptions();
 
 		/**
 		 * Creates the command.
 		 * @param showAction the action that reads chart contents
+		 * @param chartResolver resolves the chart source (local path or repository)
 		 */
-		public AllCommand(ShowAction showAction) {
+		public AllCommand(ShowAction showAction, ChartResolver chartResolver) {
 			this.showAction = showAction;
+			this.chartResolver = chartResolver;
 		}
 
 		@Override
 		public Integer call() {
 			try {
-				System.out.println(showAction.showAll(chartPath));
+				System.out.println(showAction.showAll(resolve(chartResolver, chartPath, repoOptions)));
 				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/VersionCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/VersionCommand.java
@@ -1,8 +1,11 @@
 package org.alexmond.jhelm.app.command;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
+import org.alexmond.gotmpl4j.GoTemplate;
 import org.alexmond.jhelm.app.VersionInfo;
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.springframework.stereotype.Component;
@@ -20,6 +23,10 @@ public class VersionCommand implements Callable<Integer> {
 
 	@CommandLine.Option(names = { "--short" }, description = "print the version number only")
 	private boolean shortOutput;
+
+	@CommandLine.Option(names = { "--template" },
+			description = "template for the output (Go template against .Version, .GitCommit, .GitTreeState, .GoVersion)")
+	private String template;
 
 	private final VersionInfo versionInfo;
 
@@ -42,6 +49,9 @@ public class VersionCommand implements Callable<Integer> {
 
 	@Override
 	public Integer call() {
+		if (this.template != null) {
+			return renderTemplate();
+		}
 		if (this.shortOutput) {
 			CliOutput.println(versionString());
 		}
@@ -54,6 +64,27 @@ public class VersionCommand implements Callable<Integer> {
 			CliOutput.println("jhelm version " + versionString() + " (" + details + ")");
 		}
 		return CommandLine.ExitCode.OK;
+	}
+
+	// Renders --template as a Go template against the version info, matching
+	// `helm version --template`. jhelm has no git metadata, so GitCommit/GitTreeState are
+	// empty and GoVersion carries the running Java version.
+	private Integer renderTemplate() {
+		Map<String, Object> data = new LinkedHashMap<>();
+		data.put("Version", versionString());
+		data.put("GitCommit", "");
+		data.put("GitTreeState", "");
+		data.put("GoVersion", System.getProperty("java.version"));
+		try {
+			GoTemplate engine = new GoTemplate();
+			engine.parse("version", this.template);
+			CliOutput.printf("%s", engine.render("version", data));
+			return CommandLine.ExitCode.OK;
+		}
+		catch (RuntimeException ex) {
+			CliOutput.errPrintln(CliOutput.error("Error rendering version template: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
+		}
 	}
 
 }

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/LintCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/LintCommandTest.java
@@ -10,9 +10,12 @@ import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class LintCommandTest {
@@ -30,7 +33,7 @@ class LintCommandTest {
 
 	@Test
 	void testLintCommandSuccess() {
-		when(lintAction.lint(anyString(), anyMap(), anyBoolean()))
+		when(lintAction.lint(anyString(), anyMap(), anyBoolean(), anyBoolean(), any()))
 			.thenReturn(new LintAction.LintResult("./", List.of(), List.of()));
 		CommandLine cmd = new CommandLine(lintCommand);
 		int exitCode = cmd.execute(".");
@@ -39,7 +42,7 @@ class LintCommandTest {
 
 	@Test
 	void testLintCommandWithWarnings() {
-		when(lintAction.lint(anyString(), anyMap(), anyBoolean()))
+		when(lintAction.lint(anyString(), anyMap(), anyBoolean(), anyBoolean(), any()))
 			.thenReturn(new LintAction.LintResult("./", List.of(), List.of("missing description")));
 		CommandLine cmd = new CommandLine(lintCommand);
 		int exitCode = cmd.execute(".");
@@ -47,8 +50,18 @@ class LintCommandTest {
 	}
 
 	@Test
+	void testLintThreadsSubchartsQuietAndKubeVersion() {
+		when(lintAction.lint(anyString(), anyMap(), anyBoolean(), anyBoolean(), any()))
+			.thenReturn(new LintAction.LintResult("./chart", List.of(), List.of()));
+		CommandLine cmd = new CommandLine(lintCommand);
+		int exitCode = cmd.execute(".", "--with-subcharts", "--kube-version", "1.30.0", "--quiet");
+		assertEquals(0, exitCode);
+		verify(lintAction).lint(eq("."), anyMap(), eq(false), eq(true), eq("1.30.0"));
+	}
+
+	@Test
 	void testLintCommandWithErrors() {
-		when(lintAction.lint(anyString(), anyMap(), anyBoolean()))
+		when(lintAction.lint(anyString(), anyMap(), anyBoolean(), anyBoolean(), any()))
 			.thenReturn(new LintAction.LintResult("./", List.of("chart name is required"), List.of()));
 		CommandLine cmd = new CommandLine(lintCommand);
 		int exitCode = cmd.execute(".");

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/PackageCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/PackageCommandTest.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.alexmond.jhelm.core.action.DependencyUpdateAction;
 import org.alexmond.jhelm.core.action.PackageAction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +28,9 @@ class PackageCommandTest {
 
 	@Mock
 	private PackageAction packageAction;
+
+	@Mock
+	private DependencyUpdateAction dependencyUpdateAction;
 
 	private PackageCommand packageCommand;
 
@@ -43,7 +48,7 @@ class PackageCommandTest {
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		packageCommand = new PackageCommand(packageAction);
+		packageCommand = new PackageCommand(packageAction, dependencyUpdateAction);
 		System.setOut(new PrintStream(outStream));
 		System.setErr(new PrintStream(errStream));
 	}
@@ -57,26 +62,50 @@ class PackageCommandTest {
 	@Test
 	void testPackageChart() throws Exception {
 		File archive = new File("test-chart-1.0.0.tgz");
-		when(packageAction.packageChart("./my-chart")).thenReturn(archive);
+		when(packageAction.packageChart(eq("./my-chart"), any(), any(), any(), any())).thenReturn(archive);
 
 		CommandLine cmd = new CommandLine(packageCommand);
 		cmd.execute("./my-chart");
 
 		verify(packageAction).setDestination(any(File.class));
-		verify(packageAction).packageChart("./my-chart");
+		verify(packageAction).packageChart(eq("./my-chart"), isNull(), isNull(), isNull(), isNull());
 		assertTrue(outStream.toString().contains("Successfully packaged chart"));
 	}
 
 	@Test
 	void testPackageWithDestination() throws Exception {
 		File archive = new File("test-chart-1.0.0.tgz");
-		when(packageAction.packageChart("./my-chart")).thenReturn(archive);
+		when(packageAction.packageChart(eq("./my-chart"), any(), any(), any(), any())).thenReturn(archive);
 
 		CommandLine cmd = new CommandLine(packageCommand);
 		cmd.execute("./my-chart", "-d", "/tmp/output");
 
 		verify(packageAction).setDestination(new File("/tmp/output"));
-		verify(packageAction).packageChart("./my-chart");
+		verify(packageAction).packageChart(eq("./my-chart"), isNull(), isNull(), isNull(), isNull());
+	}
+
+	@Test
+	void testPackageWithVersionOverrides() throws Exception {
+		File archive = new File("test-chart-2.0.0.tgz");
+		when(packageAction.packageChart(eq("./my-chart"), any(), any(), any(), any())).thenReturn(archive);
+
+		CommandLine cmd = new CommandLine(packageCommand);
+		cmd.execute("./my-chart", "--version", "2.0.0", "--app-version", "9.9");
+
+		// version/app-version thread through to the packager (positions 4 and 5).
+		verify(packageAction).packageChart(eq("./my-chart"), isNull(), isNull(), eq("2.0.0"), eq("9.9"));
+	}
+
+	@Test
+	void testPackageWithDependencyUpdate() throws Exception {
+		File archive = new File("test-chart-1.0.0.tgz");
+		when(packageAction.packageChart(eq("./my-chart"), any(), any(), any(), any())).thenReturn(archive);
+
+		CommandLine cmd = new CommandLine(packageCommand);
+		cmd.execute("./my-chart", "-u");
+
+		verify(dependencyUpdateAction).update(eq(new File("./my-chart")), any(), eq(false));
+		verify(packageAction).packageChart(eq("./my-chart"), isNull(), isNull(), isNull(), isNull());
 	}
 
 	@Test
@@ -85,7 +114,8 @@ class PackageCommandTest {
 		Files.writeString(passphraseFile, "secret123");
 
 		File archive = new File("test-chart-1.0.0.tgz");
-		when(packageAction.packageChart(eq("./my-chart"), anyString(), eq("user@example.com"), any(char[].class)))
+		when(packageAction.packageChart(eq("./my-chart"), anyString(), eq("user@example.com"), any(char[].class), any(),
+				any()))
 			.thenReturn(archive);
 
 		CommandLine cmd = new CommandLine(packageCommand);
@@ -93,7 +123,7 @@ class PackageCommandTest {
 				"--passphrase-file", passphraseFile.toString());
 
 		verify(packageAction).packageChart(eq("./my-chart"), eq("/path/to/keyring.gpg"), eq("user@example.com"),
-				any(char[].class));
+				any(char[].class), isNull(), isNull());
 	}
 
 	@Test
@@ -106,7 +136,8 @@ class PackageCommandTest {
 
 	@Test
 	void testPackageWithError() throws Exception {
-		when(packageAction.packageChart("./my-chart")).thenThrow(new RuntimeException("chart not found"));
+		when(packageAction.packageChart(eq("./my-chart"), any(), any(), any(), any()))
+			.thenThrow(new RuntimeException("chart not found"));
 
 		CommandLine cmd = new CommandLine(packageCommand);
 		cmd.execute("./my-chart");
@@ -118,7 +149,8 @@ class PackageCommandTest {
 	void testPackageSignWithEnvPassphrase() throws Exception {
 		// When no passphrase file and no env var, should error
 		File archive = new File("test-chart-1.0.0.tgz");
-		when(packageAction.packageChart(eq("./my-chart"), anyString(), eq("user@example.com"), any(char[].class)))
+		when(packageAction.packageChart(eq("./my-chart"), anyString(), eq("user@example.com"), any(char[].class), any(),
+				any()))
 			.thenReturn(archive);
 
 		CommandLine cmd = new CommandLine(packageCommand);

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ShowCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/ShowCommandTest.java
@@ -1,7 +1,10 @@
 package org.alexmond.jhelm.app.command;
 
 import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.core.service.SignatureService;
 import org.alexmond.jhelm.core.action.ShowAction;
+import org.alexmond.jhelm.core.action.VerifyAction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -31,6 +34,8 @@ class ShowCommandTest {
 
 	private ShowAction showAction;
 
+	private ChartResolver chartResolver;
+
 	@BeforeEach
 	void setUp() throws Exception {
 		// Redirect System.out to capture command output
@@ -38,6 +43,10 @@ class ShowCommandTest {
 
 		ChartLoader chartLoader = new ChartLoader();
 		showAction = new ShowAction(chartLoader);
+		// Local chart paths resolve directly (no repo pull), so the
+		// RepoManager/VerifyAction
+		// wiring here is only to satisfy the resolver's constructor.
+		chartResolver = new ChartResolver(chartLoader, new RepoManager(), new VerifyAction(new SignatureService()));
 
 		// Create a test chart
 		chartDir = tempDir.resolve("test-chart");
@@ -127,7 +136,7 @@ class ShowCommandTest {
 
 	@Test
 	void testShowChart() {
-		ShowCommand.ChartCommand command = new ShowCommand.ChartCommand(showAction);
+		ShowCommand.ChartCommand command = new ShowCommand.ChartCommand(showAction, chartResolver);
 		command.chartPath = chartDir.toString();
 
 		command.call();
@@ -143,7 +152,7 @@ class ShowCommandTest {
 
 	@Test
 	void testShowValues() {
-		ShowCommand.ValuesCommand command = new ShowCommand.ValuesCommand(showAction);
+		ShowCommand.ValuesCommand command = new ShowCommand.ValuesCommand(showAction, chartResolver);
 		command.chartPath = chartDir.toString();
 
 		command.call();
@@ -157,7 +166,7 @@ class ShowCommandTest {
 
 	@Test
 	void testShowReadme() {
-		ShowCommand.ReadmeCommand command = new ShowCommand.ReadmeCommand(showAction);
+		ShowCommand.ReadmeCommand command = new ShowCommand.ReadmeCommand(showAction, chartResolver);
 		command.chartPath = chartDir.toString();
 
 		command.call();
@@ -171,7 +180,7 @@ class ShowCommandTest {
 
 	@Test
 	void testShowCrds() {
-		ShowCommand.CrdsCommand command = new ShowCommand.CrdsCommand(showAction);
+		ShowCommand.CrdsCommand command = new ShowCommand.CrdsCommand(showAction, chartResolver);
 		command.chartPath = chartDir.toString();
 
 		command.call();
@@ -187,7 +196,7 @@ class ShowCommandTest {
 
 	@Test
 	void testShowAll() {
-		ShowCommand.AllCommand command = new ShowCommand.AllCommand(showAction);
+		ShowCommand.AllCommand command = new ShowCommand.AllCommand(showAction, chartResolver);
 		command.chartPath = chartDir.toString();
 
 		command.call();
@@ -229,7 +238,7 @@ class ShowCommandTest {
 		Files.writeString(noReadmeDir.resolve("values.yaml"), "{}");
 		Files.createDirectories(noReadmeDir.resolve("templates"));
 
-		ShowCommand.ReadmeCommand command = new ShowCommand.ReadmeCommand(showAction);
+		ShowCommand.ReadmeCommand command = new ShowCommand.ReadmeCommand(showAction, chartResolver);
 		command.chartPath = noReadmeDir.toString();
 
 		command.call();
@@ -253,7 +262,7 @@ class ShowCommandTest {
 		Files.writeString(noCrdsDir.resolve("values.yaml"), "{}");
 		Files.createDirectories(noCrdsDir.resolve("templates"));
 
-		ShowCommand.CrdsCommand command = new ShowCommand.CrdsCommand(showAction);
+		ShowCommand.CrdsCommand command = new ShowCommand.CrdsCommand(showAction, chartResolver);
 		command.chartPath = noCrdsDir.toString();
 
 		command.call();
@@ -277,7 +286,7 @@ class ShowCommandTest {
 		Files.writeString(emptyValuesDir.resolve("values.yaml"), "{}");
 		Files.createDirectories(emptyValuesDir.resolve("templates"));
 
-		ShowCommand.ValuesCommand command = new ShowCommand.ValuesCommand(showAction);
+		ShowCommand.ValuesCommand command = new ShowCommand.ValuesCommand(showAction, chartResolver);
 		command.chartPath = emptyValuesDir.toString();
 
 		command.call();
@@ -288,7 +297,7 @@ class ShowCommandTest {
 
 	@Test
 	void testShowCommandWithInvalidPath() {
-		ShowCommand.ChartCommand command = new ShowCommand.ChartCommand(showAction);
+		ShowCommand.ChartCommand command = new ShowCommand.ChartCommand(showAction, chartResolver);
 		command.chartPath = "/nonexistent/path";
 
 		// Should not throw, but should log error
@@ -298,10 +307,37 @@ class ShowCommandTest {
 		// In a real scenario, this would be verified with a logging framework test
 	}
 
+	// Picocli must instantiate the subcommands to resolve their @Mixin options; the
+	// subcommands have no no-arg constructor, so supply a factory that builds them from
+	// the
+	// test collaborators (Spring does this in production).
+	private CommandLine.IFactory subcommandFactory() {
+		return new CommandLine.IFactory() {
+			@Override
+			public <K> K create(Class<K> cls) throws Exception {
+				if (cls == ShowCommand.ChartCommand.class) {
+					return cls.cast(new ShowCommand.ChartCommand(showAction, chartResolver));
+				}
+				if (cls == ShowCommand.ValuesCommand.class) {
+					return cls.cast(new ShowCommand.ValuesCommand(showAction, chartResolver));
+				}
+				if (cls == ShowCommand.ReadmeCommand.class) {
+					return cls.cast(new ShowCommand.ReadmeCommand(showAction, chartResolver));
+				}
+				if (cls == ShowCommand.CrdsCommand.class) {
+					return cls.cast(new ShowCommand.CrdsCommand(showAction, chartResolver));
+				}
+				if (cls == ShowCommand.AllCommand.class) {
+					return cls.cast(new ShowCommand.AllCommand(showAction, chartResolver));
+				}
+				return CommandLine.defaultFactory().create(cls);
+			}
+		};
+	}
+
 	@Test
 	void testShowCommandHelp() {
-		ShowCommand showCommand = new ShowCommand();
-		CommandLine cmd = new CommandLine(showCommand);
+		CommandLine cmd = new CommandLine(new ShowCommand(), subcommandFactory());
 
 		String help = cmd.getUsageMessage();
 
@@ -312,8 +348,9 @@ class ShowCommandTest {
 	@Test
 	void testShowCommandRunShowsUsage() {
 		outputStream.reset();
-		ShowCommand showCommand = new ShowCommand();
-		showCommand.call();
+		// Executing with no subcommand invokes ShowCommand.call(), which prints usage via
+		// the injected spec (the factory-built command line).
+		new CommandLine(new ShowCommand(), subcommandFactory()).execute();
 
 		String output = outputStream.toString();
 		assertTrue(output.contains("show") || output.contains("Usage"));
@@ -326,27 +363,27 @@ class ShowCommandTest {
 		// All subcommands should handle nonexistent paths gracefully
 		switch (commandName) {
 			case "chart" -> {
-				var cmd = new ShowCommand.ChartCommand(showAction);
+				var cmd = new ShowCommand.ChartCommand(showAction, chartResolver);
 				cmd.chartPath = invalidDir.toString();
 				cmd.call();
 			}
 			case "values" -> {
-				var cmd = new ShowCommand.ValuesCommand(showAction);
+				var cmd = new ShowCommand.ValuesCommand(showAction, chartResolver);
 				cmd.chartPath = invalidDir.toString();
 				cmd.call();
 			}
 			case "all" -> {
-				var cmd = new ShowCommand.AllCommand(showAction);
+				var cmd = new ShowCommand.AllCommand(showAction, chartResolver);
 				cmd.chartPath = invalidDir.toString();
 				cmd.call();
 			}
 			case "readme" -> {
-				var cmd = new ShowCommand.ReadmeCommand(showAction);
+				var cmd = new ShowCommand.ReadmeCommand(showAction, chartResolver);
 				cmd.chartPath = invalidDir.toString();
 				cmd.call();
 			}
 			case "crds" -> {
-				var cmd = new ShowCommand.CrdsCommand(showAction);
+				var cmd = new ShowCommand.CrdsCommand(showAction, chartResolver);
 				cmd.chartPath = invalidDir.toString();
 				cmd.call();
 			}
@@ -360,7 +397,7 @@ class ShowCommandTest {
 
 	@Test
 	void testShowChartCommandDirectExecution() {
-		ShowCommand.ChartCommand command = new ShowCommand.ChartCommand(showAction);
+		ShowCommand.ChartCommand command = new ShowCommand.ChartCommand(showAction, chartResolver);
 		command.chartPath = chartDir.toString();
 
 		command.call();

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/VersionCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/VersionCommandTest.java
@@ -53,4 +53,20 @@ class VersionCommandTest {
 		assertFalse(out.contains("jhelm version"));
 	}
 
+	@Test
+	void testTemplateRendersVersionField() {
+		String out = run("--template", "{{.Version}}");
+		// --template drives the whole output; only the rendered version, no "jhelm
+		// version".
+		assertTrue(out.startsWith("v9.9.9-test"), "Output: " + out);
+		assertFalse(out.contains("jhelm version"), "Output: " + out);
+	}
+
+	@Test
+	void testTemplateRendersGoVersionField() {
+		String out = run("--template", "go={{.GoVersion}}");
+		assertTrue(out.startsWith("go="), "Output: " + out);
+		assertTrue(out.contains(System.getProperty("java.version")), "Output: " + out);
+	}
+
 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/LintAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/LintAction.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.SchemaValidationException;
+import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.ReleaseContext;
@@ -28,6 +29,24 @@ public class LintAction {
 	private final SchemaValidator schemaValidator;
 
 	public LintResult lint(String chartPath, Map<String, Object> overrideValues, boolean strict) {
+		return lint(chartPath, overrideValues, strict, false, null);
+	}
+
+	/**
+	 * Lints a chart, optionally descending into its subcharts and rendering templates
+	 * against a specific Kubernetes version.
+	 * @param chartPath the chart directory to lint
+	 * @param overrideValues user value overrides applied before schema/template checks
+	 * @param strict whether warnings are treated as failures (evaluated by the caller)
+	 * @param withSubcharts also lint each of the chart's subcharts
+	 * ({@code --with-subcharts})
+	 * @param kubeVersion the Kubernetes version to expose as
+	 * {@code .Capabilities.KubeVersion} during template rendering, or {@code null} for
+	 * the engine default ({@code --kube-version})
+	 * @return the collected errors and warnings
+	 */
+	public LintResult lint(String chartPath, Map<String, Object> overrideValues, boolean strict, boolean withSubcharts,
+			String kubeVersion) {
 		List<String> errors = new ArrayList<>();
 		List<String> warnings = new ArrayList<>();
 
@@ -48,9 +67,36 @@ public class LintAction {
 
 		validateMetadata(chart.getMetadata(), errors, warnings);
 		validateValues(chart, overrideValues, errors);
-		validateTemplates(chart, overrideValues, errors);
+		validateTemplates(chart, overrideValues, errors, kubeVersion);
+
+		if (withSubcharts) {
+			for (Chart sub : chart.getDependencies()) {
+				lintSubchart(sub, errors, warnings, kubeVersion);
+			}
+		}
 
 		return new LintResult(chartPath, errors, warnings);
+	}
+
+	// Lints a loaded subchart, prefixing its findings with the subchart name so they are
+	// attributable in the parent chart's combined report.
+	private void lintSubchart(Chart sub, List<String> errors, List<String> warnings, String kubeVersion) {
+		String name = (sub.getMetadata() != null && sub.getMetadata().getName() != null) ? sub.getMetadata().getName()
+				: "subchart";
+		List<String> subErrors = new ArrayList<>();
+		List<String> subWarnings = new ArrayList<>();
+		validateMetadata(sub.getMetadata(), subErrors, subWarnings);
+		validateValues(sub, null, subErrors);
+		validateTemplates(sub, null, subErrors, kubeVersion);
+		for (String w : subWarnings) {
+			warnings.add("[" + name + "] " + w);
+		}
+		for (String e : subErrors) {
+			errors.add("[" + name + "] " + e);
+		}
+		for (Chart nested : sub.getDependencies()) {
+			lintSubchart(nested, errors, warnings, kubeVersion);
+		}
 	}
 
 	private void validateMetadata(ChartMetadata metadata, List<String> errors, List<String> warnings) {
@@ -93,7 +139,8 @@ public class LintAction {
 		}
 	}
 
-	private void validateTemplates(Chart chart, Map<String, Object> overrideValues, List<String> errors) {
+	private void validateTemplates(Chart chart, Map<String, Object> overrideValues, List<String> errors,
+			String kubeVersion) {
 		if ("library".equals(chart.getMetadata().getType())) {
 			return;
 		}
@@ -111,7 +158,12 @@ public class LintAction {
 			.build();
 
 		try {
-			engine.render(chart, values, releaseContext);
+			if (kubeVersion != null && !kubeVersion.isBlank()) {
+				engine.render(chart, values, releaseContext, new Capabilities(kubeVersion, List.of()));
+			}
+			else {
+				engine.render(chart, values, releaseContext);
+			}
 		}
 		catch (Exception ex) {
 			errors.add("template rendering failed: " + ex.getMessage());

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/PackageAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/PackageAction.java
@@ -13,12 +13,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Stream;
 
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
@@ -39,6 +42,8 @@ public class PackageAction {
 	private final ChartLoader chartLoader;
 
 	private final SignatureService signatureService;
+
+	private final YAMLMapper yamlMapper = YAMLMapper.builder().build();
 
 	@Setter
 	private File destination;
@@ -69,6 +74,25 @@ public class PackageAction {
 	}
 
 	/**
+	 * Packages a chart, applying version/app-version overrides and signing it using the
+	 * specified keyring and key ID.
+	 * @param chartPath path to the chart directory
+	 * @param keyringPath path to the PGP secret keyring file
+	 * @param keyId substring to match against key user IDs
+	 * @param passphrase the key passphrase
+	 * @param versionOverride chart version to stamp into the archive, or {@code null}
+	 * @param appVersionOverride app-version to stamp into the archive, or {@code null}
+	 * @return the created archive file
+	 * @throws JhelmException if the chart cannot be read or the archive cannot be written
+	 * @throws SignatureException if the signing key cannot be loaded or signing fails
+	 */
+	public File packageChart(String chartPath, String keyringPath, String keyId, char[] passphrase,
+			String versionOverride, String appVersionOverride) {
+		SigningKey signingKey = signatureService.loadSigningKey(keyringPath, keyId);
+		return packageChart(chartPath, signingKey, passphrase, versionOverride, appVersionOverride);
+	}
+
+	/**
 	 * Packages a chart directory into a {@code .tgz} archive and optionally signs it.
 	 * @param chartPath path to the chart directory
 	 * @param signingKey signing key, or {@code null} to skip signing
@@ -78,14 +102,43 @@ public class PackageAction {
 	 * @throws SignatureException if signing fails
 	 */
 	public File packageChart(String chartPath, SigningKey signingKey, char[] passphrase) {
+		return packageChart(chartPath, signingKey, passphrase, null, null);
+	}
+
+	/**
+	 * Packages a chart directory, optionally overriding its version and/or app-version
+	 * and signing it. When an override is given, the {@code Chart.yaml} written into the
+	 * archive carries the new value (matching
+	 * {@code helm package --version}/{@code --app-version}), and the archive is named for
+	 * the overridden version.
+	 * @param chartPath path to the chart directory
+	 * @param signingKey signing key, or {@code null} to skip signing
+	 * @param passphrase key passphrase, or {@code null} if not signing
+	 * @param versionOverride chart version to stamp into the archive, or {@code null} to
+	 * keep the {@code Chart.yaml} value
+	 * @param appVersionOverride app-version to stamp into the archive, or {@code null} to
+	 * keep the {@code Chart.yaml} value
+	 * @return the created archive file
+	 * @throws JhelmException if the chart cannot be read or the archive cannot be written
+	 * @throws SignatureException if signing fails
+	 */
+	public File packageChart(String chartPath, SigningKey signingKey, char[] passphrase, String versionOverride,
+			String appVersionOverride) {
 		Chart chart = chartLoader.load(new File(chartPath));
+		if (versionOverride != null && !versionOverride.isBlank()) {
+			chart.getMetadata().setVersion(versionOverride);
+		}
+		if (appVersionOverride != null && !appVersionOverride.isBlank()) {
+			chart.getMetadata().setAppVersion(appVersionOverride);
+		}
 		String archiveName = chart.getMetadata().getName() + "-" + chart.getMetadata().getVersion() + ".tgz";
 
 		File destDir = (destination != null) ? destination : new File(".");
 		File archiveFile = new File(destDir, archiveName);
 
 		try {
-			createTgz(new File(chartPath), chart.getMetadata().getName(), archiveFile);
+			createTgz(new File(chartPath), chart.getMetadata().getName(), archiveFile, versionOverride,
+					appVersionOverride);
 			if (log.isInfoEnabled()) {
 				log.info("Successfully packaged chart and saved it to: {}", archiveFile.getAbsolutePath());
 			}
@@ -106,19 +159,45 @@ public class PackageAction {
 		return archiveFile;
 	}
 
-	private void createTgz(File chartDir, String chartName, File outputFile) throws IOException {
+	private void createTgz(File chartDir, String chartName, File outputFile, String versionOverride,
+			String appVersionOverride) throws IOException {
 		List<PathMatcher> ignoreMatchers = loadHelmIgnore(chartDir);
+		byte[] chartYamlOverride = chartYamlOverrideBytes(chartDir, versionOverride, appVersionOverride);
 		try (OutputStream fos = Files.newOutputStream(outputFile.toPath());
 				BufferedOutputStream bos = new BufferedOutputStream(fos);
 				GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(bos);
 				TarArchiveOutputStream taos = new TarArchiveOutputStream(gzos)) {
 			taos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
-			addDirectory(taos, chartDir, chartName, ignoreMatchers);
+			addDirectory(taos, chartDir, chartName, ignoreMatchers, chartYamlOverride);
 		}
 	}
 
-	private void addDirectory(TarArchiveOutputStream taos, File dir, String entryBase, List<PathMatcher> ignoreMatchers)
+	// Re-serializes the top-level Chart.yaml with the version/app-version overrides
+	// applied,
+	// preserving the other keys, so `package --version`/`--app-version` change the
+	// archive
+	// contents (not just its filename). Returns null when there is nothing to override.
+	private byte[] chartYamlOverrideBytes(File chartDir, String versionOverride, String appVersionOverride)
 			throws IOException {
+		boolean hasVersion = versionOverride != null && !versionOverride.isBlank();
+		boolean hasAppVersion = appVersionOverride != null && !appVersionOverride.isBlank();
+		if (!hasVersion && !hasAppVersion) {
+			return null;
+		}
+		File chartYaml = new File(chartDir, "Chart.yaml");
+		LinkedHashMap<String, Object> map = yamlMapper.readValue(chartYaml, new TypeReference<>() {
+		});
+		if (hasVersion) {
+			map.put("version", versionOverride);
+		}
+		if (hasAppVersion) {
+			map.put("appVersion", appVersionOverride);
+		}
+		return yamlMapper.writeValueAsBytes(map);
+	}
+
+	private void addDirectory(TarArchiveOutputStream taos, File dir, String entryBase, List<PathMatcher> ignoreMatchers,
+			byte[] chartYamlOverride) throws IOException {
 		Path dirPath = dir.toPath();
 		try (Stream<Path> paths = Files.walk(dirPath)) {
 			paths.forEach((path) -> {
@@ -132,6 +211,10 @@ public class PackageAction {
 						return;
 					}
 					String entryName = entryBase + "/" + relativePath;
+					if (chartYamlOverride != null && "Chart.yaml".equals(relativePath.toString())) {
+						writeBytesEntry(taos, entryName, chartYamlOverride);
+						return;
+					}
 					TarArchiveEntry entry = new TarArchiveEntry(file, entryName);
 					taos.putArchiveEntry(entry);
 					Files.copy(path, taos);
@@ -145,6 +228,15 @@ public class PackageAction {
 		catch (UncheckedIOException ex) {
 			throw ex.getCause();
 		}
+	}
+
+	private static void writeBytesEntry(TarArchiveOutputStream taos, String entryName, byte[] content)
+			throws IOException {
+		TarArchiveEntry entry = new TarArchiveEntry(entryName);
+		entry.setSize(content.length);
+		taos.putArchiveEntry(entry);
+		taos.write(content);
+		taos.closeArchiveEntry();
 	}
 
 	static List<PathMatcher> loadHelmIgnore(File chartDir) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/ShowAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/ShowAction.java
@@ -17,12 +17,29 @@ public class ShowAction {
 	private final ChartLoader chartLoader;
 
 	public String showChart(String chartPath) {
-		Chart chart = chartLoader.load(new File(chartPath));
+		return showChart(chartLoader.load(new File(chartPath)));
+	}
+
+	/**
+	 * Renders the chart's {@code Chart.yaml} from an already-loaded chart (e.g. one
+	 * pulled from a repository).
+	 * @param chart the loaded chart
+	 * @return the chart metadata as YAML
+	 */
+	public String showChart(Chart chart) {
 		return toYaml(chart.getMetadata());
 	}
 
 	public String showValues(String chartPath) {
-		Chart chart = chartLoader.load(new File(chartPath));
+		return showValues(chartLoader.load(new File(chartPath)));
+	}
+
+	/**
+	 * Renders the chart's {@code values.yaml} from an already-loaded chart.
+	 * @param chart the loaded chart
+	 * @return the default values as YAML, or {@code {}} when there are none
+	 */
+	public String showValues(Chart chart) {
 		if (chart.getValues() == null || chart.getValues().isEmpty()) {
 			return "{}";
 		}
@@ -30,12 +47,28 @@ public class ShowAction {
 	}
 
 	public String showReadme(String chartPath) {
-		Chart chart = chartLoader.load(new File(chartPath));
+		return showReadme(chartLoader.load(new File(chartPath)));
+	}
+
+	/**
+	 * Returns the chart's README from an already-loaded chart.
+	 * @param chart the loaded chart
+	 * @return the README text, or an empty string when absent
+	 */
+	public String showReadme(Chart chart) {
 		return (chart.getReadme() != null) ? chart.getReadme() : "";
 	}
 
 	public String showCrds(String chartPath) {
-		Chart chart = chartLoader.load(new File(chartPath));
+		return showCrds(chartLoader.load(new File(chartPath)));
+	}
+
+	/**
+	 * Returns the chart's Custom Resource Definitions from an already-loaded chart.
+	 * @param chart the loaded chart
+	 * @return the concatenated CRD documents, or an empty string when absent
+	 */
+	public String showCrds(Chart chart) {
 		if (chart.getCrds() == null || chart.getCrds().isEmpty()) {
 			return "";
 		}
@@ -50,7 +83,16 @@ public class ShowAction {
 	}
 
 	public String showAll(String chartPath) {
-		Chart chart = chartLoader.load(new File(chartPath));
+		return showAll(chartLoader.load(new File(chartPath)));
+	}
+
+	/**
+	 * Renders the chart's combined {@code Chart.yaml}, values, README, and CRDs from an
+	 * already-loaded chart.
+	 * @param chart the loaded chart
+	 * @return the combined document
+	 */
+	public String showAll(Chart chart) {
 		StringBuilder sb = new StringBuilder();
 
 		sb.append("# Chart.yaml\n");

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/LintActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/LintActionTest.java
@@ -117,6 +117,42 @@ class LintActionTest {
 		assertTrue(result.isOk(), "valid override values should pass: " + result.getErrors());
 	}
 
+	@Test
+	void testLintWithSubchartsSurfacesSubchartFindings() throws Exception {
+		Path parent = createChart("parent-chart", "1.0.0", "v2", "Parent chart");
+		Path subDir = parent.resolve("charts/badsub");
+		Files.createDirectories(subDir);
+		// Subchart missing a description -> a lint warning.
+		Files.writeString(subDir.resolve("Chart.yaml"), "apiVersion: v2\nname: badsub\nversion: 0.1.0\n");
+		Files.writeString(subDir.resolve("values.yaml"), "{}\n");
+
+		// Without --with-subcharts the subchart is not inspected.
+		LintAction.LintResult without = lintAction.lint(parent.toString(), null, false, false, null);
+		assertFalse(without.getWarnings().stream().anyMatch((w) -> w.contains("[badsub]")),
+				without.getWarnings().toString());
+
+		// With --with-subcharts the subchart's warning surfaces, prefixed by its name.
+		LintAction.LintResult with = lintAction.lint(parent.toString(), null, false, true, null);
+		assertTrue(with.getWarnings().stream().anyMatch((w) -> w.contains("[badsub]")), with.getWarnings().toString());
+	}
+
+	@Test
+	void testLintWithKubeVersionRendersTemplates() throws Exception {
+		Path chartDir = createMinimalChart("kubever-chart", "1.0.0", "v2");
+		Files.createDirectories(chartDir.resolve("templates"));
+		// A template that reads .Capabilities.KubeVersion must render without error.
+		Files.writeString(chartDir.resolve("templates/cm.yaml"), """
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: cm
+				data:
+				  kube: "{{ .Capabilities.KubeVersion.Version }}"
+				""");
+		LintAction.LintResult result = lintAction.lint(chartDir.toString(), null, false, false, "v1.30.0");
+		assertTrue(result.isOk(), "rendering with an explicit kube-version should pass: " + result.getErrors());
+	}
+
 	private Path createMinimalChart(String name, String version, String apiVersion) throws Exception {
 		return createChart(name, version, apiVersion, "A test chart");
 	}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/PackageActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/PackageActionTest.java
@@ -1,6 +1,7 @@
 package org.alexmond.jhelm.core.action;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -12,6 +13,7 @@ import java.util.Date;
 import java.util.List;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.SignatureService;
+import org.alexmond.jhelm.core.service.SigningKey;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.bcpg.HashAlgorithmTags;
 import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
@@ -38,6 +40,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -141,6 +144,37 @@ class PackageActionTest {
 		assertTrue(entries.stream().anyMatch((e) -> e.contains("Chart.yaml")), "Chart.yaml should be included");
 		assertFalse(entries.stream().anyMatch((e) -> e.contains(".git")), ".git should be excluded");
 		assertFalse(entries.stream().anyMatch((e) -> e.contains("notes.txt")), "notes.txt should be excluded");
+	}
+
+	@Test
+	void testPackageChartWithVersionOverridesRewritesChartYaml() throws Exception {
+		Path chartDir = createMinimalChart("override-chart", "1.0.0");
+		packageAction.setDestination(tempDir.toFile());
+
+		File archive = packageAction.packageChart(chartDir.toString(), (SigningKey) null, null, "2.5.0", "9.9");
+
+		// The archive is named for the overridden version...
+		assertEquals("override-chart-2.5.0.tgz", archive.getName());
+		// ...and the Chart.yaml inside carries the overrides (not just the filename).
+		String chartYaml = readTgzEntry(archive, "Chart.yaml");
+		assertTrue(chartYaml.contains("override-chart"), chartYaml);
+		assertTrue(chartYaml.contains("2.5.0"), chartYaml);
+		assertTrue(chartYaml.contains("9.9"), chartYaml);
+		assertFalse(chartYaml.contains("1.0.0"), chartYaml);
+	}
+
+	private String readTgzEntry(File tgzFile, String suffix) throws Exception {
+		try (var fis = Files.newInputStream(tgzFile.toPath());
+				var gis = new GzipCompressorInputStream(fis);
+				var tis = new TarArchiveInputStream(gis)) {
+			TarArchiveEntry entry;
+			while ((entry = tis.getNextEntry()) != null) {
+				if (entry.getName().endsWith(suffix)) {
+					return new String(tis.readAllBytes(), StandardCharsets.UTF_8);
+				}
+			}
+		}
+		return "";
 	}
 
 	private Set<String> listTgzEntries(File tgzFile) throws Exception {


### PR DESCRIPTION
Wires the per-command flag long-tail from #687 across CLI + core. The two sub-items that need more than a flag wire-up — `registry login` TLS and the global persistent flags — are split into #708 and documented as known gaps.

## `package`
- `--version` / `--app-version` — stamp the packaged chart. The `Chart.yaml` written **into** the archive carries the overrides (re-serialized, other keys preserved), and the archive is named for the overridden version — not just the filename.
- `-u` / `--dependency-update` — update `charts/` from `Chart.yaml` deps before packaging.

## `show chart|values|readme|crds|all`
- `--version` / `--repo` / `--username` / `--password` (+ TLS via the shared `RepoChartOptions` mixin) — show a chart pulled from a repository (registered `repo/chart` ref or ad-hoc `--repo <url>`) without a prior `pull`; local paths unchanged.
- `ShowAction` gains `Chart`-based overloads (path variants delegate). Parent `show` now renders usage via `@Spec` — the subcommands carry `@Mixin` and have no no-arg constructor, so the default factory can't build them (a latent break the tests caught).

## `lint`
- `--quiet` (suppress the linting header), `--with-subcharts` (lint each subchart; findings prefixed with the subchart name), `--kube-version` (sets `.Capabilities.KubeVersion` for template rendering).

## `version`
- `--template` — Go-templates the output against `.Version` / `.GitCommit` / `.GitTreeState` / `.GoVersion` (no git metadata → `GitCommit`/`GitTreeState` empty, `GoVersion` is the running Java version).

## Deferred → #708 (documented gaps)
`show --devel` (needs prerelease/latest-version resolution jhelm lacks), `registry login` TLS flags (login is a local credential store, no handshake), global persistent flags.

## Tests
- `PackageActionTest` — override rewrites the archive `Chart.yaml` (read back from the `.tgz`).
- `LintActionTest` — subchart recursion surfaces prefixed findings; `--kube-version` renders a `.Capabilities.KubeVersion` template.
- `PackageCommandTest` / `LintCommandTest` / `ShowCommandTest` / `VersionCommandTest` — flag wiring.
- Changelog + `cli-parity.adoc` updated (new package/show/lint/version table).

Closes #687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)