### PR TITLE
feat(cli): global persistent flags (part of #708)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -58,6 +58,12 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
   are persisted into `repositories.yaml` and honored (host-gated) on every index refresh and chart
   pull; `--force-update` replaces an existing repo (a duplicate name otherwise fails) and
   `--no-update` skips the immediate index fetch. Mirrored on REST `POST /repos` (#685).
+* *Global persistent flags* -- Helm's cluster/config flags are now accepted on every command
+  (before or after the subcommand): `--kubeconfig`, `--kube-context`, `--kube-apiserver`,
+  `--registry-config`, `--repository-config`, `--repository-cache`, and `--debug`. They are
+  resolved before the application context is built (they configure startup beans) and take
+  precedence over the equivalent `jhelm.*` properties/env. `registry login` TLS flags remain a
+  documented gap (#708).
 * *Misc command flags* -- `package --version`/`--app-version` (rewrites the `Chart.yaml` inside the
   archive) and `-u`/`--dependency-update`; `show chart\|values\|readme\|crds\|all` `--version`/`--repo`/`--username`/`--password`
   + TLS (show a chart from a repository without a prior `pull`); `lint --quiet`/`--with-subcharts`/`--kube-version`;

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -144,6 +144,31 @@ template produced each manifest.
 | `version` (`--template`) | ✅ | Go-templates the version output against `.Version`, `.GitCommit`, `.GitTreeState`, `.GoVersion` (jhelm has no git metadata, so `GitCommit`/`GitTreeState` are empty and `GoVersion` is the running Java version).
 |===
 
+== Global flags
+
+Helm's persistent flags are accepted on **every** command (before or after the subcommand),
+matching `helm`. They configure beans that are built at startup, so jhelm resolves them from
+the command line before the application context is created.
+
+[cols="2,1,3"]
+|===
+| Flag | jhelm | Notes
+
+| `--kubeconfig <path>` | ✅ | Path to the kubeconfig file.
+| `--kube-context <name>` | ✅ | Select a context from the kubeconfig (loaded from `--kubeconfig`, `$KUBECONFIG`, or `~/.kube/config`).
+| `--kube-apiserver <url>` | ✅ | Override the Kubernetes API server address resolved from the kubeconfig.
+| `--registry-config <path>` | ✅ | Path to the OCI registry auth file (`config.json`).
+| `--repository-config <path>` | ✅ | Path to `repositories.yaml`.
+| `--repository-cache <path>` | ✅ | Path to the repository index cache directory.
+| `--debug` | ✅ | Enable verbose (debug) logging.
+|===
+
+These flags are equivalent to the corresponding `jhelm.*` Spring properties / environment
+variables (e.g. `--kubeconfig` ⇔ `jhelm.kubernetes.kubeconfig-path`); the inline flag takes
+precedence. Because they configure startup beans, an invalid value (e.g. a `--kubeconfig`
+pointing at a missing file, or an unknown `--kube-context`) fails at startup rather than when
+the cluster is first used.
+
 == Porting a Helm script to jhelm
 
 Most scripts work unchanged. Watch for these deliberate differences:
@@ -170,10 +195,6 @@ Beyond the per-command tables above, these commonly-used Helm options are not ye
 * *`registry login`* — `--insecure`/`--plain-http`/`--ca-file`/`--cert-file`/`--key-file`.
   jhelm's `registry login` stores credentials locally without a TLS handshake, so these
   transport options have nothing to act on yet (tracked in #708).
-* *Global flags* — Helm's persistent flags (`--kube-context`, `--kubeconfig`,
-  `--kube-apiserver`, `--registry-config`, `--repository-config`, `--repository-cache`,
-  `--debug`) aren't accepted inline; jhelm resolves these via Spring properties / environment
-  variables instead (tracked in #708).
 
 For sharing repositories, registry credentials, and releases with the `helm` binary itself, see
 xref:interoperability.adoc[Interoperability with Helm].

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/GlobalOptionsPreParser.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/GlobalOptionsPreParser.java
@@ -1,0 +1,105 @@
+package org.alexmond.jhelm.app;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Pre-scans the raw command line for Helm's global persistent flags and maps them to
+ * jhelm Spring properties.
+ * <p>
+ * These flags ({@code --kubeconfig}, {@code --kube-context}, {@code --kube-apiserver},
+ * {@code --registry-config}, {@code --repository-config}, {@code --repository-cache},
+ * {@code --debug}) configure beans that are built eagerly at startup — the Kubernetes
+ * client, the repository manager, the registry manager — so they must be resolved
+ * <em>before</em> the Spring context is created, not during Picocli execution. This
+ * parser runs in {@code main()}: the mapped values are set as JVM system properties
+ * (authoritative over environment and defaults), and the flags are stripped from the
+ * argument vector handed to Spring so the bare {@code --debug} does not trigger Spring
+ * Boot's own autoconfiguration report. Picocli still receives the original arguments (the
+ * flags are declared as inherited options on the root command), so they appear in
+ * {@code --help} and are accepted anywhere.
+ */
+public final class GlobalOptionsPreParser {
+
+	/** Select the kube context from the kubeconfig. */
+	public static final String KUBE_CONTEXT = "--kube-context";
+
+	/** Path to the kubeconfig file. */
+	public static final String KUBECONFIG = "--kubeconfig";
+
+	/** Override the Kubernetes API server address. */
+	public static final String KUBE_APISERVER = "--kube-apiserver";
+
+	/** Path to the OCI registry config ({@code config.json}). */
+	public static final String REGISTRY_CONFIG = "--registry-config";
+
+	/** Path to the repository config ({@code repositories.yaml}). */
+	public static final String REPOSITORY_CONFIG = "--repository-config";
+
+	/** Path to the repository cache directory. */
+	public static final String REPOSITORY_CACHE = "--repository-cache";
+
+	/** Enable verbose (debug) logging. */
+	public static final String DEBUG = "--debug";
+
+	// Value-taking global flags mapped to their jhelm Spring property.
+	private static final Map<String, String> VALUE_FLAGS = Map.of(KUBE_CONTEXT, "jhelm.kubernetes.context", KUBECONFIG,
+			"jhelm.kubernetes.kubeconfig-path", KUBE_APISERVER, "jhelm.kubernetes.api-server", REGISTRY_CONFIG,
+			"jhelm.registry-config-path", REPOSITORY_CONFIG, "jhelm.config-path", REPOSITORY_CACHE,
+			"jhelm.repository-cache-path");
+
+	private GlobalOptionsPreParser() {
+	}
+
+	/**
+	 * Scans the raw arguments for the global flags.
+	 * @param args the raw command-line arguments
+	 * @return the derived system properties and the Spring argument vector
+	 */
+	public static Result parse(String[] args) {
+		Map<String, String> props = new LinkedHashMap<>();
+		List<String> springArgs = new ArrayList<>();
+		for (int i = 0; i < args.length; i++) {
+			String arg = args[i];
+			String name = arg;
+			String inlineValue = null;
+			int eq = arg.indexOf('=');
+			if (arg.startsWith("--") && eq > 0) {
+				name = arg.substring(0, eq);
+				inlineValue = arg.substring(eq + 1);
+			}
+			if (DEBUG.equals(name)) {
+				props.put("logging.level.org.alexmond.jhelm", "DEBUG");
+				continue;
+			}
+			String property = VALUE_FLAGS.get(name);
+			if (property != null) {
+				String value = inlineValue;
+				if (value == null && i + 1 < args.length) {
+					value = args[++i];
+				}
+				if (value != null && !value.isBlank()) {
+					props.put(property, value);
+				}
+				continue;
+			}
+			springArgs.add(arg);
+		}
+		return new Result(props, springArgs.toArray(new String[0]));
+	}
+
+	/**
+	 * The result of pre-parsing: the system properties to set before the Spring context
+	 * is built, and the argument vector to hand to Spring (with the global flags
+	 * removed).
+	 *
+	 * @param systemProperties jhelm Spring properties derived from the global flags
+	 * @param springArgs the original arguments with the global flags (and their values)
+	 * stripped
+	 */
+	public record Result(Map<String, String> systemProperties, String[] springArgs) {
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/HelmJavaApplication.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/HelmJavaApplication.java
@@ -25,6 +25,11 @@ import picocli.CommandLine.IFactory;
 @SpringBootApplication
 public class HelmJavaApplication implements CommandLineRunner, ExitCodeGenerator {
 
+	// The unmodified argument vector, captured in main(). Picocli parses this (so the
+	// global flags are accepted anywhere), while Spring receives the vector with those
+	// flags stripped.
+	private static String[] originalArgs = {};
+
 	private final IFactory factory;
 
 	private final JHelmCommand jHelmCommand;
@@ -47,7 +52,12 @@ public class HelmJavaApplication implements CommandLineRunner, ExitCodeGenerator
 	 * @param args the command-line arguments
 	 */
 	public static void main(String[] args) {
-		System.exit(SpringApplication.exit(SpringApplication.run(HelmJavaApplication.class, args)));
+		originalArgs = args.clone();
+		// Resolve Helm's global persistent flags before the context is built (they
+		// configure eagerly-created beans), and hide them from Spring's own arg parsing.
+		GlobalOptionsPreParser.Result parsed = GlobalOptionsPreParser.parse(args);
+		parsed.systemProperties().forEach(System::setProperty);
+		System.exit(SpringApplication.exit(SpringApplication.run(HelmJavaApplication.class, parsed.springArgs())));
 	}
 
 	/**
@@ -59,7 +69,10 @@ public class HelmJavaApplication implements CommandLineRunner, ExitCodeGenerator
 		CommandLine cmd = new CommandLine(jHelmCommand, factory);
 		cmd.setUsageHelpWidth(120);
 		cmd.setColorScheme(CommandLine.Help.defaultColorScheme(Ansi.AUTO));
-		exitCode = cmd.execute(args);
+		// Picocli parses the original vector so the global flags (stripped from the
+		// Spring
+		// args) are still accepted and shown in --help.
+		exitCode = cmd.execute(originalArgs);
 	}
 
 	/**

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
@@ -82,6 +82,41 @@ public class JHelmCommand implements Callable<Integer> {
 		}
 	}
 
+	// Helm's global persistent flags. Their effect is applied before the Spring context
+	// is
+	// built (see GlobalOptionsPreParser and HelmJavaApplication#main); these declarations
+	// make Picocli accept them on every command and list them in --help.
+
+	@CommandLine.Option(names = GlobalOptionsPreParser.KUBECONFIG, paramLabel = "<path>",
+			description = "path to the kubeconfig file", scope = CommandLine.ScopeType.INHERIT)
+	String kubeconfig;
+
+	@CommandLine.Option(names = GlobalOptionsPreParser.KUBE_CONTEXT, paramLabel = "<context>",
+			description = "name of the kubeconfig context to use", scope = CommandLine.ScopeType.INHERIT)
+	String kubeContext;
+
+	@CommandLine.Option(names = GlobalOptionsPreParser.KUBE_APISERVER, paramLabel = "<url>",
+			description = "the address and port of the Kubernetes API server", scope = CommandLine.ScopeType.INHERIT)
+	String kubeApiServer;
+
+	@CommandLine.Option(names = GlobalOptionsPreParser.REGISTRY_CONFIG, paramLabel = "<path>",
+			description = "path to the registry config file", scope = CommandLine.ScopeType.INHERIT)
+	String registryConfig;
+
+	@CommandLine.Option(names = GlobalOptionsPreParser.REPOSITORY_CONFIG, paramLabel = "<path>",
+			description = "path to the file containing repository names and URLs",
+			scope = CommandLine.ScopeType.INHERIT)
+	String repositoryConfig;
+
+	@CommandLine.Option(names = GlobalOptionsPreParser.REPOSITORY_CACHE, paramLabel = "<path>",
+			description = "path to the directory containing cached repository indexes",
+			scope = CommandLine.ScopeType.INHERIT)
+	String repositoryCache;
+
+	@CommandLine.Option(names = GlobalOptionsPreParser.DEBUG, description = "enable verbose (debug) output",
+			scope = CommandLine.ScopeType.INHERIT)
+	boolean debug;
+
 	/**
 	 * Prints the jhelm banner (to stderr, so piped stdout stays clean) followed by the
 	 * usage help when {@code jhelm} is invoked without a subcommand.

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/GlobalOptionsPreParserTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/GlobalOptionsPreParserTest.java
@@ -1,0 +1,65 @@
+package org.alexmond.jhelm.app;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GlobalOptionsPreParserTest {
+
+	@Test
+	void mapsSpaceSeparatedValueFlagsAndStripsThem() {
+		GlobalOptionsPreParser.Result r = GlobalOptionsPreParser
+			.parse(new String[] { "install", "foo", "--kubeconfig", "/k", "--repository-config", "/r" });
+
+		assertEquals("/k", r.systemProperties().get("jhelm.kubernetes.kubeconfig-path"));
+		assertEquals("/r", r.systemProperties().get("jhelm.config-path"));
+		assertArrayEquals(new String[] { "install", "foo" }, r.springArgs());
+	}
+
+	@Test
+	void mapsInlineValueFlags() {
+		GlobalOptionsPreParser.Result r = GlobalOptionsPreParser.parse(new String[] { "--kube-context=prod", "list" });
+
+		assertEquals("prod", r.systemProperties().get("jhelm.kubernetes.context"));
+		assertArrayEquals(new String[] { "list" }, r.springArgs());
+	}
+
+	@Test
+	void debugMapsToLogLevelAndIsStripped() {
+		GlobalOptionsPreParser.Result r = GlobalOptionsPreParser.parse(new String[] { "--debug", "status", "rel" });
+
+		assertEquals("DEBUG", r.systemProperties().get("logging.level.org.alexmond.jhelm"));
+		assertArrayEquals(new String[] { "status", "rel" }, r.springArgs());
+	}
+
+	@Test
+	void nonGlobalArgsArePreservedUntouched() {
+		String[] args = { "template", "./chart", "--set", "a=b" };
+		GlobalOptionsPreParser.Result r = GlobalOptionsPreParser.parse(args);
+
+		assertTrue(r.systemProperties().isEmpty());
+		assertArrayEquals(args, r.springArgs());
+	}
+
+	@Test
+	void mapsEveryGlobalFlag() {
+		GlobalOptionsPreParser.Result r = GlobalOptionsPreParser.parse(new String[] { "--kubeconfig", "/k",
+				"--kube-context", "c", "--kube-apiserver", "https://s:6443", "--registry-config", "/rc",
+				"--repository-config", "/rp", "--repository-cache", "/rch", "--debug", "version" });
+
+		Map<String, String> p = r.systemProperties();
+		assertEquals("/k", p.get("jhelm.kubernetes.kubeconfig-path"));
+		assertEquals("c", p.get("jhelm.kubernetes.context"));
+		assertEquals("https://s:6443", p.get("jhelm.kubernetes.api-server"));
+		assertEquals("/rc", p.get("jhelm.registry-config-path"));
+		assertEquals("/rp", p.get("jhelm.config-path"));
+		assertEquals("/rch", p.get("jhelm.repository-cache-path"));
+		assertEquals("DEBUG", p.get("logging.level.org.alexmond.jhelm"));
+		assertArrayEquals(new String[] { "version" }, r.springArgs());
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -114,6 +114,7 @@ public class JhelmCoreAutoConfiguration {
 				? new RepoManager(props.getConfigPath(), registryManager, props.isInsecureSkipTlsVerify(), blockPrivate)
 				: new RepoManager(registryManager, props.isInsecureSkipTlsVerify(), blockPrivate);
 		repoManager.setMetrics(metrics.getIfAvailable());
+		repoManager.setRepositoryCacheOverride(props.getRepositoryCachePath());
 		return repoManager;
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmCoreProperties.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmCoreProperties.java
@@ -31,6 +31,12 @@ public class JhelmCoreProperties {
 	private String registryConfigPath;
 
 	/**
+	 * Path to the repository index cache directory. Defaults to
+	 * {@code $HELM_REPOSITORY_CACHE} or the per-OS Helm cache location when not set.
+	 */
+	private String repositoryCachePath;
+
+	/**
 	 * Whether to skip TLS certificate verification for HTTP chart downloads. Defaults to
 	 * {@code false}.
 	 */

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -66,6 +66,11 @@ public class RepoManager {
 	// Null in library/direct-construction use (no instrumentation, no overhead).
 	private JhelmMetrics metrics;
 
+	// Optional repository-cache directory override (Helm's --repository-cache), set by
+	// the
+	// auto-configuration from jhelm.repository-cache-path. Null -> standard resolution.
+	private String repositoryCacheOverride;
+
 	// Parsed repo indexes (the full entries map of an index.yaml) keyed by repo name.
 	// A repo's index can be tens of MB (e.g. bitnami), so this is bounded by an LRU:
 	// resolving many charts across many repos (the parity suite, or a long-running
@@ -318,21 +323,37 @@ public class RepoManager {
 	}
 
 	/**
-	 * Returns the effective repository index cache directory
-	 * ({@code $HELM_REPOSITORY_CACHE} or the per-OS default), without creating it.
+	 * Overrides the repository index cache directory, taking precedence over
+	 * {@code $HELM_REPOSITORY_CACHE} and the per-OS default. Wired from
+	 * {@code jhelm.repository-cache-path} (Helm's {@code --repository-cache}); leave
+	 * unset to use the standard resolution.
+	 * @param path the cache directory path, or {@code null}/blank to clear the override
+	 */
+	public void setRepositoryCacheOverride(String path) {
+		this.repositoryCacheOverride = path;
+	}
+
+	/**
+	 * Returns the effective repository index cache directory (the configured override,
+	 * else {@code $HELM_REPOSITORY_CACHE} or the per-OS default), without creating it.
 	 * @return the repository cache directory path
 	 */
 	public String getRepositoryCachePath() {
-		return resolveCacheDir(System.getenv("HELM_REPOSITORY_CACHE"), System.getProperty("user.home"),
-				System.getProperty("os.name"))
-			.getPath();
+		return resolveCacheBaseDir().getPath();
 	}
 
 	private File getCacheDir() {
-		File base = resolveCacheDir(System.getenv("HELM_REPOSITORY_CACHE"), System.getProperty("user.home"),
-				System.getProperty("os.name"));
+		File base = resolveCacheBaseDir();
 		base.mkdirs();
 		return base;
+	}
+
+	private File resolveCacheBaseDir() {
+		if (repositoryCacheOverride != null && !repositoryCacheOverride.isBlank()) {
+			return Paths.get(repositoryCacheOverride).toFile();
+		}
+		return resolveCacheDir(System.getenv("HELM_REPOSITORY_CACHE"), System.getProperty("user.home"),
+				System.getProperty("os.name"));
 	}
 
 	/**

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
@@ -135,6 +135,22 @@ class RepoManagerTest {
 	}
 
 	@Test
+	void testRepositoryCacheOverrideTakesPrecedence() {
+		RepoManager rm = new RepoManager();
+		String custom = tempDir.resolve("mycache").toFile().getPath();
+		rm.setRepositoryCacheOverride(custom);
+		assertEquals(custom, rm.getRepositoryCachePath());
+	}
+
+	@Test
+	void testRepositoryCacheOverrideBlankFallsBackToDefault() {
+		RepoManager rm = new RepoManager();
+		String def = rm.getRepositoryCachePath();
+		rm.setRepositoryCacheOverride("");
+		assertEquals(def, rm.getRepositoryCachePath());
+	}
+
+	@Test
 	void testRepoNotFound() {
 		RepoManager repoManager = new RepoManager();
 		assertThrows(IOException.class, () -> repoManager.getChartVersions("non-existent", "nginx"));

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
@@ -1,7 +1,9 @@
 package org.alexmond.jhelm.kube;
 
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.util.Config;
@@ -99,10 +101,39 @@ public class JhelmKubeAutoConfiguration {
 	 * @throws IOException if the configured kubeconfig file cannot be read
 	 */
 	private ApiClient buildApiClient(JhelmKubernetesProperties props) throws IOException {
-		if (props.getKubeconfigPath() != null) {
-			return Config.fromConfig(KubeConfig.loadKubeConfig(new FileReader(props.getKubeconfigPath())));
+		ApiClient client;
+		String kubeconfigPath = props.getKubeconfigPath();
+		String context = props.getContext();
+		if (kubeconfigPath != null || (context != null && !context.isBlank())) {
+			// A configured kubeconfig path, or an explicit --kube-context, means load the
+			// kubeconfig ourselves so the requested context can be selected.
+			String path = (kubeconfigPath != null) ? kubeconfigPath : defaultKubeconfigPath();
+			try (FileReader reader = new FileReader(path, StandardCharsets.UTF_8)) {
+				KubeConfig kubeConfig = KubeConfig.loadKubeConfig(reader);
+				if (context != null && !context.isBlank() && !kubeConfig.setContext(context)) {
+					throw new IOException("kube context not found in kubeconfig: " + context);
+				}
+				client = Config.fromConfig(kubeConfig);
+			}
 		}
-		return Config.defaultClient();
+		else {
+			client = Config.defaultClient();
+		}
+		if (props.getApiServer() != null && !props.getApiServer().isBlank()) {
+			client.setBasePath(props.getApiServer());
+		}
+		return client;
+	}
+
+	// The kubeconfig the Kubernetes client would auto-detect: the first entry of
+	// $KUBECONFIG, else ~/.kube/config. Used only when a context is requested without an
+	// explicit --kubeconfig.
+	private static String defaultKubeconfigPath() {
+		String env = System.getenv("KUBECONFIG");
+		if (env != null && !env.isBlank()) {
+			return env.split(File.pathSeparator, 2)[0];
+		}
+		return System.getProperty("user.home") + "/.kube/config";
 	}
 
 	/**

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
@@ -26,6 +26,21 @@ public class JhelmKubernetesProperties {
 	private String kubeconfigPath;
 
 	/**
+	 * Name of the kubeconfig context to use (Helm's {@code --kube-context}). When set,
+	 * the kubeconfig is loaded (from {@link #kubeconfigPath}, {@code $KUBECONFIG}, or
+	 * {@code ~/.kube/config}) and this context is selected. When not set, the
+	 * kubeconfig's current context is used.
+	 */
+	private String context;
+
+	/**
+	 * Address of the Kubernetes API server to talk to (Helm's {@code --kube-apiserver}).
+	 * When set, it overrides the server resolved from the kubeconfig. When not set, the
+	 * kubeconfig's server is used.
+	 */
+	private String apiServer;
+
+	/**
 	 * Retry configuration for transient Kubernetes API failures.
 	 */
 	private Retry retry = new Retry();


### PR DESCRIPTION
Accepts Helm's global persistent flags on **every** command (before or after the subcommand) — the global-flags half of #708. The `registry login` TLS flags remain (still tracked in #708).

## Flags
`--kubeconfig`, `--kube-context`, `--kube-apiserver`, `--registry-config`, `--repository-config`, `--repository-cache`, `--debug`.

## How it works
These configure beans built **eagerly at startup** (the Kubernetes client, repo manager, registry manager), so they can't be resolved during Picocli execution. `GlobalOptionsPreParser` runs in `main()`:
- maps each flag to its `jhelm.*` Spring property and sets those as JVM **system properties** (authoritative over env/defaults) **before** the context is built;
- **strips** the flags from the arg vector handed to Spring, so a bare `--debug` doesn't trigger Spring Boot's own autoconfig report;
- Picocli parses the **original** vector — the flags are declared as `INHERIT` options on the root command, so they show in `--help` and are accepted anywhere.

## New plumbing (flags with no prior binding)
- `--repository-cache` → `jhelm.repository-cache-path`; `RepoManager.setRepositoryCacheOverride` takes precedence over `$HELM_REPOSITORY_CACHE` and the per-OS default.
- `--kube-context` / `--kube-apiserver` → `jhelm.kubernetes.context` / `.api-server`; `buildApiClient` loads the kubeconfig (configured path, `$KUBECONFIG`, or `~/.kube/config`) to select the context, and `setBasePath` for the apiserver. **Both null-guarded** — the default client path is byte-for-byte unchanged when unset.

## Verified on the assembled CLI
All seven flags listed in `--help`; accepted before and after the subcommand; `--repository-config`/`--registry-config`/`--repository-cache` reflected by `jhelm env`; `--debug` enables debug logging; `--kubeconfig`/`--kube-context` load and select correctly (invalid values fail at startup, as they would via the underlying properties). Kube smoke used a read-only `version` (client built, no API calls).

## Tests
- `GlobalOptionsPreParserTest` — flag→property mapping (inline `=` and space forms), `--debug`, arg stripping, non-global pass-through.
- `RepoManagerTest` — cache-override precedence + blank fallback.
- Changelog + `cli-parity.adoc` updated (new **Global flags** section).

Part of #708 (registry-login TLS flags remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)