### PR TITLE
feat(cli): validating registry login + TLS flags (closes #708)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -58,6 +58,12 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
   are persisted into `repositories.yaml` and honored (host-gated) on every index refresh and chart
   pull; `--force-update` replaces an existing repo (a duplicate name otherwise fails) and
   `--no-update` skips the immediate index fetch. Mirrored on REST `POST /repos` (#685).
+* *Validating `registry login`* -- `registry login` now follows Helm's flow: it validates the
+  credentials against the registry (a `/v2/` ping and, on a Bearer challenge, a token exchange)
+  before storing them, and honors the login-time transport flags `--insecure`, `--plain-http`,
+  `--ca-file`, `--cert-file`, and `--key-file`. As in Helm, those transport options apply only to
+  the handshake and are not persisted -- only the credentials are stored. A wrong password, TLS
+  failure, or unreachable registry now fails the login instead of silently saving. Completes #708.
 * *Global persistent flags* -- Helm's cluster/config flags are now accepted on every command
   (before or after the subcommand): `--kubeconfig`, `--kube-context`, `--kube-apiserver`,
   `--registry-config`, `--repository-config`, `--repository-cache`, and `--debug`. They are

--- a/docs/modules/ROOT/pages/cli-parity.adoc
+++ b/docs/modules/ROOT/pages/cli-parity.adoc
@@ -122,7 +122,8 @@ template produced each manifest.
 | `repo update [name...]` | ✅ | Refreshes all repos, or the named ones.
 | `repo add` auth/TLS (`--username`, `--password`, `--cert-file`, `--key-file`, `--ca-file`, `--insecure-skip-tls-verify`, `--pass-credentials`) | ✅ | Persisted into `repositories.yaml`; the stored credentials are host-gated and honored on every index refresh and chart pull.
 | `repo add` (`--force-update`, `--no-update`) | ✅ | `--force-update` replaces an existing repo (adding a duplicate name otherwise fails); `--no-update` skips the immediate index fetch.
-| `registry login` (`-u`, `-p`, `--password-stdin`) / `logout` | ✅ | `registry login` stores credentials only (no TLS handshake), so `--insecure`/`--plain-http`/`--ca-file`/`--cert-file`/`--key-file` are not yet wired.
+| `registry login` (`-u`, `-p`, `--password-stdin`) / `logout` | ✅ | Like Helm, `registry login` validates the credentials against the registry (a `/v2/` ping and, on a Bearer challenge, a token exchange) before storing them; a bad password, TLS failure, or unreachable registry fails the login.
+| `registry login` TLS (`--insecure`, `--plain-http`, `--ca-file`, `--cert-file`, `--key-file`) | ✅ | Configure the login-time validation handshake (skip TLS verify, plain HTTP, custom CA, and client mTLS). Matching Helm, they are used only for the handshake and are not persisted.
 | `pull` (`--version`, `-d/--dest`) | ✅ |
 | `pull --repo URL` + auth/TLS (`--username`, `--password`, `--cert-file`, `--key-file`, `--ca-file`, `--insecure-skip-tls-verify`, `--pass-credentials`) | ✅ | Pull a chart directly from a repository URL with inline credentials, without a prior `repo add`.
 | `pull` (`--untar`, `--untardir`) | ✅ | Unpacks the fetched chart into `--untardir` (default `.`) and removes the `.tgz`.
@@ -192,9 +193,8 @@ Beyond the per-command tables above, these commonly-used Helm options are not ye
   `-g`/`--generate-name` on `install`; `--description`/`--labels`/`--set-literal`/`--dependency-update` on both.)
 * *`pull`/`show`* — `--devel` (prerelease/latest-version resolution). `pull` `--untar`/`--untardir`
   and `--verify`/`--prov`/`--keyring`, and `show` `--version`/`--repo`/auth, are supported.
-* *`registry login`* — `--insecure`/`--plain-http`/`--ca-file`/`--cert-file`/`--key-file`.
-  jhelm's `registry login` stores credentials locally without a TLS handshake, so these
-  transport options have nothing to act on yet (tracked in #708).
+  (`registry login` now validates credentials against the registry and honors its TLS/transport
+  flags, matching Helm.)
 
 For sharing repositories, registry credentials, and releases with the `helm` binary itself, see
 xref:interoperability.adoc[Interoperability with Helm].

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RegistryCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/RegistryCommand.java
@@ -2,7 +2,9 @@ package org.alexmond.jhelm.app.command;
 
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.service.RegistryLoginOptions;
 import org.alexmond.jhelm.core.service.RegistryManager;
+import org.alexmond.jhelm.core.service.RepoManager;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
@@ -42,7 +44,7 @@ public class RegistryCommand implements Callable<Integer> {
 	@Slf4j
 	public static class LoginCommand implements Callable<Integer> {
 
-		private final RegistryManager registryManager;
+		private final RepoManager repoManager;
 
 		@CommandLine.Parameters(index = "0", description = "registry server")
 		private String server;
@@ -56,18 +58,37 @@ public class RegistryCommand implements Callable<Integer> {
 		@CommandLine.Option(names = "--password-stdin", description = "take the password from stdin")
 		private boolean passwordStdin;
 
+		@CommandLine.Option(names = "--insecure", description = "allow connections to TLS registry without certs")
+		private boolean insecure;
+
+		@CommandLine.Option(names = "--plain-http", description = "use insecure HTTP connections for the registry")
+		private boolean plainHttp;
+
+		@CommandLine.Option(names = "--ca-file",
+				description = "verify certificates of HTTPS-enabled servers using this CA bundle")
+		private String caFile;
+
+		@CommandLine.Option(names = "--cert-file",
+				description = "identify registry client using this SSL certificate file")
+		private String certFile;
+
+		@CommandLine.Option(names = "--key-file", description = "identify registry client using this SSL key file")
+		private String keyFile;
+
 		/**
 		 * Creates the command.
-		 * @param registryManager the manager that performs the registry login
+		 * @param repoManager performs the validating registry login (handshake then
+		 * store)
 		 */
-		public LoginCommand(RegistryManager registryManager) {
-			this.registryManager = registryManager;
+		public LoginCommand(RepoManager repoManager) {
+			this.repoManager = repoManager;
 		}
 
 		@Override
 		public Integer call() {
 			try {
-				registryManager.login(server, username, resolvePassword());
+				RegistryLoginOptions options = new RegistryLoginOptions(caFile, certFile, keyFile, insecure, plainHttp);
+				repoManager.registryLogin(server, username, resolvePassword(), options);
 				CliOutput.println(CliOutput.success("Login Succeeded"));
 				return CommandLine.ExitCode.OK;
 			}
@@ -75,7 +96,9 @@ public class RegistryCommand implements Callable<Integer> {
 				CliOutput.errPrintln(CliOutput.error(ex.getMessage()));
 				return CommandLine.ExitCode.SOFTWARE;
 			}
-			catch (IOException ex) {
+			catch (IOException | SecurityException ex) {
+				// IOException: registry unreachable / TLS failure / credentials rejected.
+				// SecurityException: the SSRF guard refused the registry host.
 				CliOutput.errPrintln(CliOutput.error("Error logging in: " + ex.getMessage()));
 				return CommandLine.ExitCode.SOFTWARE;
 			}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RegistryCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/RegistryCommandTest.java
@@ -1,8 +1,11 @@
 package org.alexmond.jhelm.app.command;
 
+import org.alexmond.jhelm.core.service.RegistryLoginOptions;
 import org.alexmond.jhelm.core.service.RegistryManager;
+import org.alexmond.jhelm.core.service.RepoManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import picocli.CommandLine;
@@ -12,6 +15,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -20,6 +27,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 class RegistryCommandTest {
+
+	@Mock
+	private RepoManager repoManager;
 
 	@Mock
 	private RegistryManager registryManager;
@@ -31,29 +41,46 @@ class RegistryCommandTest {
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		loginCommand = new RegistryCommand.LoginCommand(registryManager);
+		loginCommand = new RegistryCommand.LoginCommand(repoManager);
 		logoutCommand = new RegistryCommand.LogoutCommand(registryManager);
 	}
 
 	@Test
 	void testLoginCommandSuccess() throws IOException {
-		doNothing().when(registryManager).login(anyString(), anyString(), anyString());
+		doNothing().when(repoManager).registryLogin(anyString(), anyString(), anyString(), any());
 
 		CommandLine cmd = new CommandLine(loginCommand);
 		cmd.execute("registry.example.com", "-u", "user", "-p", "pass");
+
+		verify(repoManager).registryLogin(eq("registry.example.com"), eq("user"), eq("pass"), any());
 	}
 
 	@Test
 	void testLoginCommandWithError() throws IOException {
-		doThrow(new IOException("Test error")).when(registryManager).login(anyString(), anyString(), anyString());
+		doThrow(new IOException("Test error")).when(repoManager)
+			.registryLogin(anyString(), anyString(), anyString(), any());
 
 		CommandLine cmd = new CommandLine(loginCommand);
 		cmd.execute("registry.example.com", "-u", "user", "-p", "pass");
 	}
 
 	@Test
+	void testLoginHandlesSsrfRejectionCleanly() throws IOException {
+		// the SSRF guard throws SecurityException for a disallowed host — it must surface
+		// as
+		// a clean error, not an uncaught exception
+		doThrow(new SecurityException("blocked host")).when(repoManager)
+			.registryLogin(anyString(), anyString(), anyString(), any());
+
+		CommandLine cmd = new CommandLine(loginCommand);
+		int code = cmd.execute("registry.example.com", "-u", "user", "-p", "pass");
+
+		assertEquals(CommandLine.ExitCode.SOFTWARE, code);
+	}
+
+	@Test
 	void testLoginReadsPasswordFromStdin() throws IOException {
-		doNothing().when(registryManager).login(anyString(), anyString(), anyString());
+		doNothing().when(repoManager).registryLogin(anyString(), anyString(), anyString(), any());
 		InputStream original = System.in;
 		try {
 			System.setIn(new ByteArrayInputStream("s3cret\n".getBytes(StandardCharsets.UTF_8)));
@@ -64,14 +91,46 @@ class RegistryCommandTest {
 			System.setIn(original);
 		}
 		// trailing newline is stripped; the secret never appears on the command line
-		verify(registryManager).login(eq("registry.example.com"), eq("user"), eq("s3cret"));
+		verify(repoManager).registryLogin(eq("registry.example.com"), eq("user"), eq("s3cret"), any());
+	}
+
+	@Test
+	void testLoginPassesTlsOptionsWithoutPersisting() throws IOException {
+		doNothing().when(repoManager).registryLogin(anyString(), anyString(), anyString(), any());
+
+		CommandLine cmd = new CommandLine(loginCommand);
+		cmd.execute("registry.example.com", "-u", "user", "-p", "pass", "--insecure", "--plain-http", "--ca-file",
+				"/tmp/ca.pem", "--cert-file", "/tmp/client.crt", "--key-file", "/tmp/client.key");
+
+		ArgumentCaptor<RegistryLoginOptions> captor = ArgumentCaptor.forClass(RegistryLoginOptions.class);
+		verify(repoManager).registryLogin(eq("registry.example.com"), eq("user"), eq("pass"), captor.capture());
+		RegistryLoginOptions opts = captor.getValue();
+		assertTrue(opts.insecureSkipTlsVerify());
+		assertTrue(opts.plainHttp());
+		assertEquals("/tmp/ca.pem", opts.caFile());
+		assertEquals("/tmp/client.crt", opts.certFile());
+		assertEquals("/tmp/client.key", opts.keyFile());
+	}
+
+	@Test
+	void testLoginDefaultsHaveNoTlsOverrides() throws IOException {
+		doNothing().when(repoManager).registryLogin(anyString(), anyString(), anyString(), any());
+
+		CommandLine cmd = new CommandLine(loginCommand);
+		cmd.execute("registry.example.com", "-u", "user", "-p", "pass");
+
+		ArgumentCaptor<RegistryLoginOptions> captor = ArgumentCaptor.forClass(RegistryLoginOptions.class);
+		verify(repoManager).registryLogin(anyString(), anyString(), anyString(), captor.capture());
+		RegistryLoginOptions opts = captor.getValue();
+		assertFalse(opts.insecureSkipTlsVerify());
+		assertFalse(opts.plainHttp());
 	}
 
 	@Test
 	void testLoginRejectsPasswordAndStdinTogether() throws IOException {
 		CommandLine cmd = new CommandLine(loginCommand);
 		cmd.execute("registry.example.com", "-u", "user", "-p", "pass", "--password-stdin");
-		verify(registryManager, never()).login(anyString(), anyString(), anyString());
+		verify(repoManager, never()).registryLogin(anyString(), anyString(), anyString(), any());
 	}
 
 	@Test
@@ -79,7 +138,7 @@ class RegistryCommandTest {
 		// no -p, no --password-stdin, and no console under test → clean failure, no login
 		CommandLine cmd = new CommandLine(loginCommand);
 		cmd.execute("registry.example.com", "-u", "user");
-		verify(registryManager, never()).login(anyString(), anyString(), anyString());
+		verify(repoManager, never()).registryLogin(anyString(), anyString(), anyString(), any());
 	}
 
 	@Test

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/OciRegistryClient.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/OciRegistryClient.java
@@ -6,6 +6,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -128,6 +135,120 @@ class OciRegistryClient {
 			}
 			return null;
 		}
+	}
+
+	// Matches a single key="value" parameter inside a WWW-Authenticate challenge.
+	private static final Pattern CHALLENGE_PARAM = Pattern.compile("(\\w+)=\"([^\"]*)\"");
+
+	/**
+	 * Validates registry credentials by performing Helm's registry-login handshake: a
+	 * {@code GET /v2/} ping, and — if the registry answers with a {@code Bearer} auth
+	 * challenge — a token exchange against the advertised realm using the supplied Basic
+	 * credentials. Mirrors Helm's {@code registry login} ping: on success it returns
+	 * quietly; on rejected credentials, a TLS failure, or an unreachable registry it
+	 * throws. The transport (TLS material, plain-HTTP scheme) comes from the
+	 * caller-provided HTTP client and {@code plainHttp} flag and is <em>not</em>
+	 * persisted.
+	 * @param registry the registry hostname
+	 * @param auth Base64-encoded {@code user:pass} Basic credentials, or {@code null} for
+	 * an anonymous ping
+	 * @param plainHttp contact the registry over {@code http://} instead of
+	 * {@code https://}
+	 * @throws IOException if the registry is unreachable or the credentials are rejected
+	 */
+	void verifyLogin(String registry, String auth, boolean plainHttp) throws IOException {
+		String scheme = plainHttp ? "http://" : "https://";
+		String pingUrl = scheme + registry + "/v2/";
+		validateOciUrl(pingUrl);
+		HttpGet ping = new HttpGet(pingUrl);
+		if (auth != null) {
+			ping.setHeader("Authorization", "Basic " + auth);
+		}
+		String challenge = httpClient.execute(ping, (response) -> {
+			int code = response.getCode();
+			if (code == 200) {
+				// Authenticated (or the registry allows anonymous access, like Helm's
+				// ping).
+				return "";
+			}
+			if (code == 401) {
+				Header wwwAuth = response.getFirstHeader("WWW-Authenticate");
+				if (wwwAuth == null || wwwAuth.getValue() == null || wwwAuth.getValue().isBlank()) {
+					throw new IOException("registry requires authentication but sent no challenge");
+				}
+				return wwwAuth.getValue();
+			}
+			throw new IOException("unexpected response from registry: HTTP " + code);
+		});
+		if (challenge.isEmpty()) {
+			return;
+		}
+		// A Bearer challenge means the registry wants a token — exchange the Basic
+		// credentials for one at the advertised realm. Any other challenge (e.g. Basic)
+		// coming back after we already sent Basic auth means the credentials were
+		// rejected.
+		if (challenge.toLowerCase(Locale.ROOT).startsWith("bearer")) {
+			exchangeTokenOrThrow(challenge, auth);
+		}
+		else {
+			throw new IOException("authentication failed: credentials rejected");
+		}
+	}
+
+	private void exchangeTokenOrThrow(String challenge, String auth) throws IOException {
+		Map<String, String> params = parseChallengeParams(challenge);
+		String realm = params.get("realm");
+		if (realm == null || realm.isBlank()) {
+			throw new IOException("registry auth challenge missing realm");
+		}
+		StringBuilder tokenUrl = new StringBuilder(realm);
+		char sep = (realm.indexOf('?') >= 0) ? '&' : '?';
+		String service = params.get("service");
+		if (service != null && !service.isBlank()) {
+			tokenUrl.append(sep).append("service=").append(urlEncode(service));
+			sep = '&';
+		}
+		String scope = params.get("scope");
+		if (scope != null && !scope.isBlank()) {
+			tokenUrl.append(sep).append("scope=").append(urlEncode(scope));
+		}
+		String url = tokenUrl.toString();
+		validateOciUrl(url);
+		HttpGet httpGet = new HttpGet(url);
+		if (auth != null) {
+			httpGet.setHeader("Authorization", "Basic " + auth);
+		}
+		boolean granted = Boolean.TRUE.equals(httpClient.execute(httpGet, (response) -> {
+			if (response.getCode() != 200) {
+				return false;
+			}
+			HttpEntity entity = response.getEntity();
+			if (entity == null) {
+				return false;
+			}
+			try (InputStream in = entity.getContent()) {
+				JsonNode node = jsonMapper.readTree(in);
+				return node.has("token") || node.has("access_token");
+			}
+		}));
+		if (!granted) {
+			throw new IOException("authentication failed: credentials rejected");
+		}
+	}
+
+	private static Map<String, String> parseChallengeParams(String challenge) {
+		Map<String, String> params = new HashMap<>();
+		int space = challenge.indexOf(' ');
+		String rest = (space >= 0) ? challenge.substring(space + 1) : challenge;
+		Matcher matcher = CHALLENGE_PARAM.matcher(rest);
+		while (matcher.find()) {
+			params.put(matcher.group(1).toLowerCase(Locale.ROOT), matcher.group(2));
+		}
+		return params;
+	}
+
+	private static String urlEncode(String value) {
+		return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
 	}
 
 	/**

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RegistryLoginOptions.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RegistryLoginOptions.java
@@ -1,0 +1,33 @@
+package org.alexmond.jhelm.core.service;
+
+/**
+ * Transport options for a registry-login handshake, mirroring Helm's
+ * {@code registry login} flags. These configure only the login-time validation request
+ * (the TLS material and scheme used to authenticate against the registry) and are
+ * deliberately <em>not</em> persisted — like Helm, jhelm stores only the credentials, and
+ * later OCI operations take their own transport flags.
+ *
+ * @param caFile path to a CA bundle used to verify the registry's server certificate
+ * ({@code --ca-file}), or {@code null}
+ * @param certFile path to a client certificate for mutual TLS ({@code --cert-file}), or
+ * {@code null}
+ * @param keyFile path to the client certificate's private key ({@code --key-file}), or
+ * {@code null}
+ * @param insecureSkipTlsVerify skip verification of the registry's TLS certificate
+ * ({@code --insecure})
+ * @param plainHttp contact the registry over plain HTTP instead of HTTPS
+ * ({@code --plain-http})
+ */
+public record RegistryLoginOptions(String caFile, String certFile, String keyFile, boolean insecureSkipTlsVerify,
+		boolean plainHttp) {
+
+	/**
+	 * Returns options with no TLS material, secure HTTPS transport, and verification on —
+	 * the plain default when no login flags are given.
+	 * @return the default (no-op) login options
+	 */
+	public static RegistryLoginOptions none() {
+		return new RegistryLoginOptions(null, null, null, false, false);
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoHttpClientFactory.java
@@ -123,6 +123,37 @@ final class RepoHttpClientFactory {
 		return defaultClient.execute(request, handler);
 	}
 
+	/**
+	 * Builds a fresh, self-contained HTTP client for a one-shot registry-login handshake
+	 * from the caller's TLS options
+	 * ({@code --ca-file}/{@code --cert-file}/{@code --key-file}/{@code --insecure}). The
+	 * returned client is always newly created (never the shared default) and
+	 * SSRF-guarded, so the caller owns it and must close it (use try-with-resources).
+	 * @param caFile CA bundle path, or {@code null}
+	 * @param certFile client certificate path, or {@code null}
+	 * @param keyFile client key path, or {@code null}
+	 * @param insecureSkipTls whether to skip TLS verification
+	 * @return a new HTTP client honoring the given TLS options
+	 * @throws IOException if the TLS material cannot be loaded
+	 */
+	CloseableHttpClient buildLoginClient(String caFile, String certFile, String keyFile, boolean insecureSkipTls)
+			throws IOException {
+		RepositoryConfig.Repository repo = new RepositoryConfig.Repository();
+		repo.setCaFile(caFile);
+		repo.setCertFile(certFile);
+		repo.setKeyFile(keyFile);
+		repo.setInsecureSkipTlsVerify(insecureSkipTls);
+		if (needsCustomTls(repo)) {
+			return buildTlsClient(repo);
+		}
+		// No custom TLS: a plain client with the same SSRF-guarded DNS resolver as the
+		// default, built fresh so the caller can always close it.
+		HttpClientConnectionManager connManager = PoolingHttpClientConnectionManagerBuilder.create()
+			.setDnsResolver(new SsrfGuardingDnsResolver(blockPrivateNetworks))
+			.build();
+		return HttpClients.custom().setConnectionManager(connManager).build();
+	}
+
 	private boolean needsCustomTls(RepositoryConfig.Repository repo) {
 		if (repo == null) {
 			return false;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -31,6 +31,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -176,6 +177,50 @@ public class RepoManager {
 		this.httpClient = client;
 		this.httpClientFactory = new RepoHttpClientFactory(client, insecureSkipTlsVerify, blockPrivateNetworks);
 		this.ociClient = new OciRegistryClient(client, blockPrivateNetworks);
+	}
+
+	/**
+	 * Logs in to an OCI registry following Helm's flow: validate the credentials against
+	 * the registry with a login handshake using the supplied transport options, then —
+	 * only on success — store the credentials. The transport options ({@code --insecure},
+	 * {@code --plain-http}, and the CA/cert/key files) apply to the handshake only and
+	 * are not persisted, matching {@code helm registry login}.
+	 * @param registry the registry hostname
+	 * @param username the username
+	 * @param password the password
+	 * @param options the login-time transport options (never {@code null}; use
+	 * {@link RegistryLoginOptions#none()})
+	 * @throws IOException if the registry is unreachable, the TLS material is invalid,
+	 * the credentials are rejected, or the credentials cannot be stored
+	 */
+	public void registryLogin(String registry, String username, String password, RegistryLoginOptions options)
+			throws IOException {
+		if (registryManager == null) {
+			throw new IOException("no registry credential store is configured");
+		}
+		RegistryLoginOptions opts = (options != null) ? options : RegistryLoginOptions.none();
+		String auth = Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+		if (hasLoginTls(opts)) {
+			// Custom transport: a fresh, self-contained client honoring the login TLS
+			// flags.
+			try (CloseableHttpClient loginClient = httpClientFactory.buildLoginClient(opts.caFile(), opts.certFile(),
+					opts.keyFile(), opts.insecureSkipTlsVerify())) {
+				new OciRegistryClient(loginClient, blockPrivateNetworks).verifyLogin(registry, auth, opts.plainHttp());
+			}
+		}
+		else {
+			// No custom TLS: reuse the shared OCI client (default trust, SSRF-guarded).
+			ociClient.verifyLogin(registry, auth, opts.plainHttp());
+		}
+		registryManager.login(registry, username, password);
+	}
+
+	private static boolean hasLoginTls(RegistryLoginOptions opts) {
+		return opts.insecureSkipTlsVerify() || isSet(opts.caFile()) || isSet(opts.certFile()) || isSet(opts.keyFile());
+	}
+
+	private static boolean isSet(String value) {
+		return value != null && !value.isBlank();
 	}
 
 	private static String resolveDefaultConfigPath() {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/OciRegistryClientTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/OciRegistryClientTest.java
@@ -15,7 +15,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -265,6 +267,77 @@ class OciRegistryClientTest {
 		IOException ex = assertThrows(IOException.class,
 				() -> c.downloadBlob("https://registry.example.com/v2/blob", "tok", tempDir.resolve("b").toFile()));
 		assertTrue(ex.getMessage().contains("Too many redirects"));
+	}
+
+	@Test
+	void testVerifyLoginRejectsInternalMetadataHost() {
+		// SSRF guard fires on the /v2/ ping URL before any request is sent
+		assertThrows(SecurityException.class, () -> client.verifyLogin("169.254.169.254", "dXNlcjpwYXNz", false));
+	}
+
+	@Test
+	void testVerifyLoginSucceedsWhenPingReturns200() throws Exception {
+		OciRegistryClient c = clientReturning(jsonResponse(200, null));
+		assertDoesNotThrow(() -> c.verifyLogin("registry.example.com", "dXNlcjpwYXNz", false));
+	}
+
+	@Test
+	void testVerifyLoginExchangesTokenOnBearerChallenge() throws Exception {
+		ClassicHttpResponse ping = challengeResponse(401,
+				"Bearer realm=\"https://registry.example.com/token\",service=\"registry.example.com\"");
+		ClassicHttpResponse token = jsonResponse(200, "{\"token\":\"abc\"}");
+		OciRegistryClient c = clientReturningSequence(ping, token);
+		assertDoesNotThrow(() -> c.verifyLogin("registry.example.com", "dXNlcjpwYXNz", false));
+	}
+
+	@Test
+	void testVerifyLoginRejectsBadCredentialsOnTokenExchange() throws Exception {
+		ClassicHttpResponse ping = challengeResponse(401,
+				"Bearer realm=\"https://registry.example.com/token\",service=\"registry.example.com\"");
+		ClassicHttpResponse token = jsonResponse(401, null);
+		OciRegistryClient c = clientReturningSequence(ping, token);
+		IOException ex = assertThrows(IOException.class,
+				() -> c.verifyLogin("registry.example.com", "dXNlcjpwYXNz", false));
+		assertTrue(ex.getMessage().contains("credentials rejected"));
+	}
+
+	@Test
+	void testVerifyLoginRejectsBasicChallenge() throws Exception {
+		OciRegistryClient c = clientReturning(challengeResponse(401, "Basic realm=\"registry\""));
+		assertThrows(IOException.class, () -> c.verifyLogin("registry.example.com", "dXNlcjpwYXNz", false));
+	}
+
+	@Test
+	void testVerifyLoginThrowsOnServerError() throws Exception {
+		OciRegistryClient c = clientReturning(jsonResponse(500, null));
+		assertThrows(IOException.class, () -> c.verifyLogin("registry.example.com", "dXNlcjpwYXNz", false));
+	}
+
+	/**
+	 * Builds a mocked 401 response advertising the given {@code WWW-Authenticate}
+	 * challenge.
+	 */
+	private ClassicHttpResponse challengeResponse(int code, String wwwAuthenticate) {
+		ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+		when(response.getCode()).thenReturn(code);
+		when(response.getFirstHeader("WWW-Authenticate"))
+			.thenReturn(new BasicHeader("WWW-Authenticate", wwwAuthenticate));
+		return response;
+	}
+
+	/**
+	 * Builds a client whose successive HTTP executes run the handler against each
+	 * response in order.
+	 */
+	@SuppressWarnings("unchecked")
+	private OciRegistryClient clientReturningSequence(ClassicHttpResponse... responses) throws Exception {
+		CloseableHttpClient http = mock(CloseableHttpClient.class);
+		AtomicInteger idx = new AtomicInteger();
+		when(http.execute(any(HttpUriRequest.class), any(HttpClientResponseHandler.class))).thenAnswer((inv) -> {
+			ClassicHttpResponse response = responses[Math.min(idx.getAndIncrement(), responses.length - 1)];
+			return inv.getArgument(1, HttpClientResponseHandler.class).handleResponse(response);
+		});
+		return new OciRegistryClient(http);
 	}
 
 	/** Builds a mocked response with the given status and optional JSON body. */

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
@@ -729,6 +729,50 @@ class RepoManagerTest {
 		};
 	}
 
+	private static Answer<Object> challengeAnswer(int code, String wwwAuthenticate) {
+		return (inv) -> {
+			HttpClientResponseHandler<Object> handler = inv.getArgument(1);
+			ClassicHttpResponse resp = mock(ClassicHttpResponse.class);
+			when(resp.getCode()).thenReturn(code);
+			Header header = mock(Header.class);
+			when(header.getValue()).thenReturn(wwwAuthenticate);
+			when(resp.getFirstHeader("WWW-Authenticate")).thenReturn(header);
+			return handler.handleResponse(resp);
+		};
+	}
+
+	@Test
+	void testRegistryLoginValidatesThenStores() throws IOException {
+		RegistryManager registryManager = new RegistryManager(tempDir.resolve("registry-config.json").toString());
+		RepoManager rm = new RepoManager(registryManager, false);
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		rm.setHttpClientForTest(mockClient);
+		// /v2/ ping returns 200 -> the registry accepts the credentials
+		when(mockClient.execute(isA(HttpGet.class), any(HttpClientResponseHandler.class)))
+			.thenAnswer(httpAnswer(200, null));
+
+		rm.registryLogin("registry.example.com", "user", "pass", RegistryLoginOptions.none());
+
+		String expected = Base64.getEncoder().encodeToString("user:pass".getBytes(StandardCharsets.UTF_8));
+		assertEquals(expected, registryManager.getAuth("registry.example.com"));
+	}
+
+	@Test
+	void testRegistryLoginRejectsBadCredentialsWithoutStoring() throws IOException {
+		RegistryManager registryManager = new RegistryManager(tempDir.resolve("registry-config.json").toString());
+		RepoManager rm = new RepoManager(registryManager, false);
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		rm.setHttpClientForTest(mockClient);
+		// /v2/ ping returns 401 with a Basic challenge -> credentials rejected
+		when(mockClient.execute(isA(HttpGet.class), any(HttpClientResponseHandler.class)))
+			.thenAnswer(challengeAnswer(401, "Basic realm=\"registry\""));
+
+		assertThrows(IOException.class,
+				() -> rm.registryLogin("registry.example.com", "user", "wrong", RegistryLoginOptions.none()));
+		// nothing was persisted because validation failed first
+		assertNull(registryManager.getAuth("registry.example.com"));
+	}
+
 	@ParameterizedTest
 	@CsvSource({ "oci://ghcr.io/helm/charts/nginx:1.0.0, nginx-1.0.0.tgz",
 			"oci://registry.example.com/charts/myapp:2.3.4, myapp-2.3.4.tgz",


### PR DESCRIPTION
Makes `registry login` follow Helm's **exact** flow — the remaining half of #708. `registry login` now validates credentials against the registry before storing them, honors the login-time transport flags, and persists **only** the credentials.

## The problem
Previously `registry login` was a pure local credential store: it base64'd `user:pass` into `config.json` and never contacted the registry, so Helm's `--insecure`/`--plain-http`/`--ca-file`/`--cert-file`/`--key-file` had nothing to act on.

## Helm's flow, implemented
`helm registry login` does an ORAS `Ping` over a transport built from the flags, then stores only the credentials. Mirrored here:

- **`OciRegistryClient.verifyLogin`** — the OCI login handshake: `GET /v2/`, and on a `Bearer` challenge parse the `WWW-Authenticate` realm/service and exchange the Basic credentials for a token. `200` ⇒ valid; a `Basic` challenge or a rejected token exchange ⇒ `IOException`; any other status / unreachable ⇒ `IOException`.
- **`RepoHttpClientFactory.buildLoginClient`** — a fresh, SSRF-guarded one-off client from the login TLS options, reusing the existing mTLS/CA/trust-all plumbing, for the `--insecure`/`--ca-file`/`--cert-file`/`--key-file` cases; the plain (and `--plain-http`) case reuses the shared OCI client.
- **`RepoManager.registryLogin`** — validate via `verifyLogin`, then **only on success** delegate to `RegistryManager.login` to store. Transport options are used for the handshake only and are **not persisted**, exactly like Helm.
- **CLI** — `registry login` gains `--insecure`/`--plain-http`/`--ca-file`/`--cert-file`/`--key-file`, routes through `RepoManager` (validate-then-store), and reports a clean error on rejection / unreachable / TLS failure / SSRF-blocked host (no stack trace, no false "Login Succeeded").

## Verified on the assembled CLI
Flags show in `registry login --help`; a login to an unreachable/blocked registry now fails cleanly (`Error logging in: Refusing to fetch URL …`) instead of silently saving.

## Tests
- `OciRegistryClientTest.verifyLogin` — 200 ok, Bearer→token ok, bad-creds reject, Basic-challenge reject, server-error, SSRF host.
- `RepoManagerTest` — validate-then-store, and reject-without-store.
- `RegistryCommandTest` — flag→options mapping, non-persistence of transport flags, and clean SSRF-rejection handling.
- Changelog + `cli-parity.adoc` updated (registry-login gap removed; the parity board is now clear).

Closes #708.

🤖 Generated with [Claude Code](https://claude.com/claude-code)