### PR TITLE
docs: prep 1.2.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 = jhelm
-:jhelm-version: 1.1.0
+:jhelm-version: 1.2.0
 :url-docs: https://www.alexmond.org/jhelm/current/
 :url-docs-mcp: https://www.alexmond.org/jhelm/current/mcp/
 :url-docs-rest: https://www.alexmond.org/jhelm/current/rest-api/

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -68,13 +68,12 @@ more `helm` scripts run unchanged against `jhelm`. See xref:cli-parity.adoc[CLI 
   (before or after the subcommand): `--kubeconfig`, `--kube-context`, `--kube-apiserver`,
   `--registry-config`, `--repository-config`, `--repository-cache`, and `--debug`. They are
   resolved before the application context is built (they configure startup beans) and take
-  precedence over the equivalent `jhelm.*` properties/env. `registry login` TLS flags remain a
-  documented gap (#708).
+  precedence over the equivalent `jhelm.*` properties/env (#708).
 * *Misc command flags* -- `package --version`/`--app-version` (rewrites the `Chart.yaml` inside the
   archive) and `-u`/`--dependency-update`; `show chart\|values\|readme\|crds\|all` `--version`/`--repo`/`--username`/`--password`
   + TLS (show a chart from a repository without a prior `pull`); `lint --quiet`/`--with-subcharts`/`--kube-version`;
-  and `version --template` (Go-templates the version output). `show --devel` and `registry login`
-  TLS flags remain documented gaps (#687).
+  and `version --template` (Go-templates the version output). `show --devel` remains a documented
+  gap (#687).
 * *REST releases API now returns Helm-shaped JSON* -- the `/releases` list/status/history and
   install/upgrade responses now use Helm's `-o json` schema (snake_case, nested `info`) instead
   of jhelm's internal DTO, so REST consumers see the same shape as `helm ... -o json` and the

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -74,7 +74,7 @@ no shelling out, no glue code. See xref:mcp.adoc[MCP Server].
 * Java 21
 * Spring Boot 4.0.7
 * Kubernetes Client 26.0.0
-* gotmpl4j 1.1.0 (Go template + Sprig engine)
+* gotmpl4j 1.2.0 (Go template + Sprig engine)
 * Picocli 4.7.7 (CLI framework)
 
 == Quick Links


### PR DESCRIPTION
Pre-release version-bound + doc-review fixes for **1.2.0** (the CLI/API Helm-parity cycle). Run of the `release-prep` checklist.

- **README.adoc** — bump `:jhelm-version:` `1.1.0` → `1.2.0` (the literal install-snippet attribute; `.adoc` is asciidoctor-substituted on GitHub, so it needs a per-release bump).
- **index.adoc** — fix the stale gotmpl4j dependency version `1.1.0` → `1.2.0` (matches `pom.xml`'s `gotmpl4j.version`). Spring Boot 4.0.7 / Kubernetes 26.0.0 / Picocli 4.7.7 / Java 21 all verified against the pom.
- **changelog.adoc** — drop the now-obsolete "registry login TLS flags remain a gap" notes from the global-flags and misc-flags entries, since #708 shipped both halves this cycle.

Doc review: the 1.2.0 changelog section and `cli-parity.adoc` were kept current across the parity slices; no stale REST/MCP reference prose (the breaking Helm-shaped release JSON is captured in the changelog migration note, and the API reference documents no release response body). `docs/antora.yml` uses `version: true`, so API links track the pinned tag automatically — no `api-*` change (no module added/removed/renamed this cycle).

Full `./mvnw clean install` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)