### PR TITLE
fix(core): line-anchor the manifest document splitter (closes #713)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -1,5 +1,18 @@
 = Changelog
 
+== 1.2.1
+
+=== Fixes
+
+* *`install`/`upgrade` no longer choke on `---` inside a YAML comment* -- a rendered manifest
+  with a decorative comment such as `# ---------------- Postgres ----------------` failed to
+  apply with a SnakeYAML parse error, because the manifest document splitter matched the `---`
+  inside the comment as a document separator and produced an invalid fragment (`jhelm template`
+  was unaffected; the bug was only in the apply/diff/get path that re-splits the manifest). The
+  splitter is now line-anchored — only a line that is exactly `---` (optionally with trailing
+  whitespace or a comment) starts a new document — via a shared `ManifestDocuments.split`
+  reused by hook stripping, manifest diffing, and `get`. #713.
+
 == 1.2.0
 
 Closing CLI flag-parity gaps with Helm across the `template`, `install`, and query commands, so

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/GetAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/GetAction.java
@@ -19,6 +19,7 @@ import org.alexmond.jhelm.core.model.ChartMetadata;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ReleaseStatus;
 import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.core.util.ManifestDocuments;
 import org.alexmond.jhelm.core.util.ValuesLoader;
 
 /**
@@ -109,7 +110,7 @@ public class GetAction {
 		if (release.getManifest() == null || release.getManifest().isEmpty()) {
 			return "";
 		}
-		String[] docs = release.getManifest().split("---");
+		String[] docs = ManifestDocuments.split(release.getManifest());
 		StringBuilder hooks = new StringBuilder();
 		for (String doc : docs) {
 			if (doc.isBlank()) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/HookParser.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/HookParser.java
@@ -31,7 +31,7 @@ public final class HookParser {
 		}
 
 		List<HelmHook> hooks = new ArrayList<>();
-		String[] docs = manifest.split("---");
+		String[] docs = ManifestDocuments.split(manifest);
 
 		for (String doc : docs) {
 			if (doc.isBlank() || !doc.contains("helm.sh/hook")) {
@@ -107,7 +107,7 @@ public final class HookParser {
 			return manifest;
 		}
 
-		String[] docs = manifest.split("---");
+		String[] docs = ManifestDocuments.split(manifest);
 		StringBuilder result = new StringBuilder();
 
 		for (String doc : docs) {
@@ -134,7 +134,7 @@ public final class HookParser {
 			return manifest;
 		}
 
-		String[] docs = manifest.split("---");
+		String[] docs = ManifestDocuments.split(manifest);
 		StringBuilder result = new StringBuilder();
 
 		for (String doc : docs) {

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ManifestDiff.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ManifestDiff.java
@@ -62,7 +62,7 @@ public final class ManifestDiff {
 			return resources;
 		}
 
-		String[] docs = manifest.split("---");
+		String[] docs = ManifestDocuments.split(manifest);
 		for (String doc : docs) {
 			if (doc.isBlank()) {
 				continue;

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ManifestDocuments.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ManifestDocuments.java
@@ -1,0 +1,32 @@
+package org.alexmond.jhelm.core.util;
+
+import java.util.regex.Pattern;
+
+/**
+ * Splits a rendered multi-document YAML manifest into its individual documents.
+ */
+public final class ManifestDocuments {
+
+	// A YAML document separator is a line that is exactly `---` (optionally with trailing
+	// whitespace or a trailing comment). Splitting on the bare string `---` would also
+	// match
+	// it inside content or a comment — e.g. a decorative `# ---- section ----` — and
+	// mangle
+	// the manifest into invalid fragments (issue #713). Anchor to a whole line.
+	private static final Pattern DOC_SEPARATOR = Pattern.compile("(?m)^---[ \\t]*(#.*)?$");
+
+	private ManifestDocuments() {
+	}
+
+	/**
+	 * Splits a manifest into its YAML documents on document-separator lines (a line that
+	 * is exactly {@code ---}, optionally with trailing whitespace or a comment). A
+	 * {@code ---} appearing inside document content or a comment is left intact.
+	 * @param manifest the rendered manifest (must be non-null)
+	 * @return the document chunks in order; some may be blank (callers skip those)
+	 */
+	public static String[] split(String manifest) {
+		return DOC_SEPARATOR.split(manifest);
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/HookParserTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/HookParserTest.java
@@ -1,7 +1,9 @@
 package org.alexmond.jhelm.core.util;
 
 import java.util.List;
+import java.util.Map;
 
+import tools.jackson.dataformat.yaml.YAMLMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,6 +56,39 @@ class HookParserTest {
 		String manifest = "---\n" + REGULAR_DOC;
 		List<HelmHook> hooks = HookParser.parseHooks(manifest);
 		assertTrue(hooks.isEmpty());
+	}
+
+	@Test
+	void testStripHooksKeepsManifestWithDashesInCommentParseable() {
+		// issue #713: a decorative comment containing --- must not be treated as a
+		// document
+		// separator; the stripped manifest fed to the apply path must stay valid YAML.
+		String manifest = """
+				# ---------------- Postgres ----------------
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: repro-dash
+				data:
+				  k: "1"
+				""";
+
+		String stripped = HookParser.stripHooks(manifest);
+
+		assertTrue(stripped.contains("kind: ConfigMap"));
+		// re-parse every document the way the apply path does — a mangled fragment throws
+		YAMLMapper mapper = YAMLMapper.builder().build();
+		int configMaps = 0;
+		for (String doc : ManifestDocuments.split(stripped)) {
+			if (doc.isBlank()) {
+				continue;
+			}
+			Map<String, Object> parsed = mapper.readValue(doc, Map.class);
+			if ("ConfigMap".equals(parsed.get("kind"))) {
+				configMaps++;
+			}
+		}
+		assertEquals(1, configMaps);
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ManifestDocumentsTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ManifestDocumentsTest.java
@@ -1,0 +1,67 @@
+package org.alexmond.jhelm.core.util;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ManifestDocumentsTest {
+
+	private static long nonBlank(String[] docs) {
+		return Arrays.stream(docs).filter((d) -> !d.isBlank()).count();
+	}
+
+	@Test
+	void splitsOnSeparatorLines() {
+		String manifest = """
+				apiVersion: v1
+				kind: ConfigMap
+				---
+				apiVersion: v1
+				kind: Secret
+				""";
+		assertEquals(2, nonBlank(ManifestDocuments.split(manifest)));
+	}
+
+	@Test
+	void doesNotSplitOnDashesInsideAComment() {
+		// issue #713: a decorative comment containing --- must not start a new document
+		String manifest = """
+				# ---------------- Postgres ----------------
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: repro-dash
+				""";
+		String[] docs = ManifestDocuments.split(manifest);
+		assertEquals(1, nonBlank(docs), "a comment containing --- must not split the document");
+		assertTrue(Arrays.stream(docs).anyMatch((d) -> d.contains("kind: ConfigMap")));
+	}
+
+	@Test
+	void doesNotSplitOnDashesInsideContent() {
+		String manifest = """
+				apiVersion: v1
+				kind: ConfigMap
+				data:
+				  note: "a value with --- inside"
+				""";
+		assertEquals(1, nonBlank(ManifestDocuments.split(manifest)));
+	}
+
+	@Test
+	void splitsOnSeparatorWithTrailingSpacesOrComment() {
+		// a separator line may carry trailing whitespace or a trailing comment
+		String manifest = "kind: A\n---  \nkind: B\n--- # next doc\nkind: C\n";
+		assertEquals(3, nonBlank(ManifestDocuments.split(manifest)));
+	}
+
+	@Test
+	void handlesCrlfSeparators() {
+		String manifest = "kind: A\r\n---\r\nkind: B\r\n";
+		assertEquals(2, nonBlank(ManifestDocuments.split(manifest)));
+	}
+
+}


### PR DESCRIPTION
Fixes #713 — `install`/`upgrade` failing to apply a manifest that contains a YAML comment with `---` inside it (e.g. a decorative `# ---------------- Postgres ----------------`), with a SnakeYAML `expected the node content, but found '?'` error. The manifest is valid YAML that `jhelm template`, `kubectl`, and `helm` all accept.

## Root cause
The apply path's own parser is correct (SnakeYAML `loadAll`). But `HookParser.stripHooks` — run before apply by install/upgrade/rollback — split the manifest on the **bare string `"---"`**, matching the dashes *inside the comment* and shattering the document into invalid fragments, which it rejoined and handed to the parser. The same naive `split("---")` was also in `ManifestDiff` (diff) and `GetAction.getHooks` (`get hooks`) — the identical latent bug.

## Fix
A shared `ManifestDocuments.split` that splits only on a **document-separator line** — `(?m)^---[ \t]*(#.*)?$` (a line that is exactly `---`, optionally trailing whitespace or a comment), per the YAML spec. `---` inside content or a comment is left intact. `HookParser`, `ManifestDiff`, and `GetAction` all route through it. `RenderedManifest` already used a line-anchored `\r?\n---\r?\n` and is unchanged.

## Tests
- `ManifestDocumentsTest` — comment/content dashes don't split; real separators (incl. trailing space, trailing comment, and CRLF) do.
- `HookParserTest` regression — strips the reporter's exact repro manifest and re-parses every document the way the apply path does (a mangled fragment would throw).
- Changelog `1.2.1` entry.

Closes #713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)