### PR TITLE
deps(core): bump gotmpl4j 1.2.0 → 1.2.2

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -94,7 +94,7 @@ as a dependency.
 | Java | 21
 | Spring Boot | 4.0.7
 | Kubernetes Client | 26.0.0
-| Template engine | gotmpl4j 1.2.0
+| Template engine | gotmpl4j 1.2.2
 | CLI framework | Picocli 4.7.7
 |===
 

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -2,6 +2,12 @@
 
 == 1.2.1
 
+=== Dependencies
+
+* *Template engine moved to `gotmpl4j 1.2.2`* (from 1.2.0). Picks up a Go-parity correctness
+  fix -- variadic method calls on values now resolve instead of silently returning nil -- plus
+  custom action delimiters and a thread-safe template cache. No jhelm API or rendering change.
+
 === Fixes
 
 * *`install`/`upgrade` no longer choke on `---` inside a YAML comment* -- a rendered manifest

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -74,7 +74,7 @@ no shelling out, no glue code. See xref:mcp.adoc[MCP Server].
 * Java 21
 * Spring Boot 4.0.7
 * Kubernetes Client 26.0.0
-* gotmpl4j 1.2.0 (Go template + Sprig engine)
+* gotmpl4j 1.2.2 (Go template + Sprig engine)
 * Picocli 4.7.7 (CLI framework)
 
 == Quick Links

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
              The chart-parity suite renders + diffs every chart (large manifests through
              SnakeYAML), so the parity CI job overrides this (-Djhelm.test.maxHeap=4g). -->
         <jhelm.test.maxHeap>512m</jhelm.test.maxHeap>
-        <gotmpl4j.version>1.2.0</gotmpl4j.version>
+        <gotmpl4j.version>1.2.2</gotmpl4j.version>
         <kubernetes-client.version>26.0.0</kubernetes-client.version>
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>


### PR DESCRIPTION
Bumps the template engine dependency from **gotmpl4j 1.2.0 → 1.2.2** (both on Maven Central).

## Why
jhelm was two gotmpl4j releases behind. 1.2.1/1.2.2 bring:

- **Correctness (Go parity):** variadic method calls on values now resolve instead of silently returning nil (gotmpl4j #111). A chart calling a variadic method on a value was previously broken.
- Custom action delimiters (`delims(left,right)`, gotmpl4j #121) — additive.
- Thread-safe `TemplateCache` field (gotmpl4j #103) — relevant to future render-cache work.

All changes are additive/patch — **no jhelm API or rendering change.**

## Gate
`./mvnw clean install` green (full reactor + unit suite; parity `comparison` group excluded as usual). gotmpl4j-core 1.2.2 resolves from Central. Updated the stated engine version in `README.adoc`, docs `index.adoc`, and added a `1.2.1` changelog entry.

## Not included
The gotmpl4j render-reuse **perf batch** (`GoTemplateRegistry` / gotmpl4j #119 + the executor allocation cuts) is on gotmpl4j `main` (1.2.3-SNAPSHOT) but **not yet released**, so it's out of scope here. The jhelm render-reuse ticket (#717) stays blocked until gotmpl4j cuts 1.2.3 to Central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)