### PR TITLE
deps(core): bump gotmpl4j 1.2.2 → 1.3.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -94,7 +94,7 @@ as a dependency.
 | Java | 21
 | Spring Boot | 4.0.7
 | Kubernetes Client | 26.0.0
-| Template engine | gotmpl4j 1.2.2
+| Template engine | gotmpl4j 1.3.0
 | CLI framework | Picocli 4.7.7
 |===
 

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -4,9 +4,11 @@
 
 === Dependencies
 
-* *Template engine moved to `gotmpl4j 1.2.2`* (from 1.2.0). Picks up a Go-parity correctness
+* *Template engine moved to `gotmpl4j 1.3.0`* (from 1.2.0). Picks up a Go-parity correctness
   fix -- variadic method calls on values now resolve instead of silently returning nil -- plus
-  custom action delimiters and a thread-safe template cache. No jhelm API or rendering change.
+  custom action delimiters, a thread-safe template cache, and the 1.3.0 engine perf batch
+  (shareable function registry, cached method/field dispatch, cheaper scope handling). Additive
+  and non-breaking; no jhelm API or rendering change (chart-parity suite unchanged).
 
 === Fixes
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -74,7 +74,7 @@ no shelling out, no glue code. See xref:mcp.adoc[MCP Server].
 * Java 21
 * Spring Boot 4.0.7
 * Kubernetes Client 26.0.0
-* gotmpl4j 1.2.2 (Go template + Sprig engine)
+* gotmpl4j 1.3.0 (Go template + Sprig engine)
 * Picocli 4.7.7 (CLI framework)
 
 == Quick Links

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
              The chart-parity suite renders + diffs every chart (large manifests through
              SnakeYAML), so the parity CI job overrides this (-Djhelm.test.maxHeap=4g). -->
         <jhelm.test.maxHeap>512m</jhelm.test.maxHeap>
-        <gotmpl4j.version>1.2.2</gotmpl4j.version>
+        <gotmpl4j.version>1.3.0</gotmpl4j.version>
         <kubernetes-client.version>26.0.0</kubernetes-client.version>
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>


### PR DESCRIPTION
Bumps the template engine from **gotmpl4j 1.2.2 → 1.3.0** (on Maven Central), superseding the interim #723.

## Why 1.3.0 (minor)
The release adds public API — `GoTemplateRegistry`, `GoTemplate.builder().registry(...)`, the `FunctionProvider.isTemplateIndependent()` SPI default, and `DispatchCache` — so it's a semver **minor**, not a patch. It also carries the engine **perf batch**: shareable function registry (−69% construction alloc), cached method/field dispatch (−50% alloc), scope-by-reference on `include` (−54% alloc / ~2× throughput), and lazy scope frames (−74% alloc). A delegating compat overload keeps the pre-1.3 `Executor` constructor non-breaking.

## Pre-release grounding
Before this bump I reviewed the `1.2.2..1.3.0` diff adversarially across three axes — executor scope lifecycle, `DispatchCache`, and `GoTemplateRegistry`/SPI — and ran gotmpl4j's own suite: **1259 tests green** (full conformance + `SharedTemplateConcurrencyTest`), **no blockers**. Key correctness properties confirmed: cross-template `include` isolation under a shared registry, variadic-overload preservation in the cached dispatch, and executor thread-confinement.

## Gate here
`./mvnw clean install` green — full reactor + unit suite (**2836 tests, 0 failures**; parity `comparison` group excluded as usual). gotmpl4j-core 1.3.0 resolves from Central. README, docs index, and changelog updated to 1.3.0.

## Follow-ups (already filed)
Non-blocking hardening on gotmpl4j from the review: alexmond/gotmpl4j#135 (registry test-coverage gaps) and alexmond/gotmpl4j#136 (docs + `DispatchCache` list tidy). Unblocks jhelm #717 (render-reuse via `GoTemplateRegistry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)