### PR TITLE
perf(core): box render values once per render, not twice (#718)

### DIFF
--- a/jhelm-benchmarks/src/main/resources/charts/bench-app/templates/configmap.yaml
+++ b/jhelm-benchmarks/src/main/resources/charts/bench-app/templates/configmap.yaml
@@ -6,3 +6,9 @@ metadata:
     {{- include "bench-app.labels" . | nindent 4 }}
 data:
   {{- toYaml .Values.config | nindent 2 }}
+  metrics.yaml: |
+    {{- toYaml .Values.metrics | nindent 4 }}
+  pools.yaml: |
+    {{- toYaml .Values.pools | nindent 4 }}
+  shards.yaml: |
+    {{- toYaml .Values.shards | nindent 4 }}

--- a/jhelm-benchmarks/src/main/resources/charts/bench-app/values.yaml
+++ b/jhelm-benchmarks/src/main/resources/charts/bench-app/values.yaml
@@ -57,3 +57,28 @@ tolerations:
     operator: Equal
     value: bench
     effect: NoSchedule
+# Large nested block to make values-prep (deep copy + Integer->Double boxing) measurable.
+metrics:
+  scrape:
+    interval: 30
+    timeout: 10
+    limits:
+      samples: 50000
+      series: 1000000
+  thresholds:
+    cpu: 80
+    memory: 75
+    disk: 90
+    latencyMs: 250
+pools:
+  a: { size: 8, weight: 100, port: 9001, maxIdle: 16, minIdle: 2 }
+  b: { size: 16, weight: 200, port: 9002, maxIdle: 32, minIdle: 4 }
+  c: { size: 32, weight: 400, port: 9003, maxIdle: 64, minIdle: 8 }
+  d: { size: 64, weight: 800, port: 9004, maxIdle: 128, minIdle: 16 }
+shards:
+  - { id: 0, replicas: 3, weight: 10, port: 7000, capacity: 100000 }
+  - { id: 1, replicas: 3, weight: 20, port: 7001, capacity: 200000 }
+  - { id: 2, replicas: 5, weight: 30, port: 7002, capacity: 300000 }
+  - { id: 3, replicas: 5, weight: 40, port: 7003, capacity: 400000 }
+  - { id: 4, replicas: 7, weight: 50, port: 7004, capacity: 500000 }
+  - { id: 5, replicas: 7, weight: 60, port: 7005, capacity: 600000 }

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -804,16 +804,26 @@ public class Engine {
 		// * Null map entries are pruned for a subchart (depth > 0) but kept for the
 		// top-level release chart, mirroring Helm's coalesce ("a null key removes it",
 		// applied while coalescing subcharts).
-		// Pruned view for THIS chart's own rendering: Helm removes null keys while
-		// coalescing a subchart (depth > 0); the top-level release chart keeps them.
-		Map<String, Object> renderValues = prepareRenderValues(mergedValues, chartValues, depth > 0);
 		// Unpruned view (null tombstones retained) for slicing down to subcharts. A
 		// parent's null override must survive to DELETE the subchart's same-named default
 		// (Helm's coalesce nil-deletion). Pruning before slicing drops the tombstone and
 		// lets the subchart re-introduce its default — e.g. signoz nulls
 		// clickhouse.zookeeper.image.registry to drop bitnami zookeeper's docker.io. The
-		// subchart prunes the null itself when it renders.
-		Map<String, Object> subchartSliceValues = prepareRenderValues(mergedValues, null, false);
+		// subchart prunes the null itself when it renders. This is the ONE pass that
+		// boxes
+		// numbers to Double.
+		Map<String, Object> subchartSliceValues = prepareRenderValues(mergedValues, null, false, true);
+		// Pruned view for THIS chart's own rendering: Helm removes null keys while
+		// coalescing a subchart (depth > 0); the top-level release chart keeps them.
+		// Derived
+		// from the boxed slice view above (not a second walk of mergedValues) — it clones
+		// the
+		// container maps/lists (kept independent because subchartSliceValues is mutated
+		// below
+		// with each subchart's merged global) but REUSES the already-boxed immutable
+		// leaves,
+		// so numbers are boxed once per render instead of twice.
+		Map<String, Object> renderValues = prepareRenderValues(subchartSliceValues, chartValues, depth > 0, false);
 
 		// Validate merged values against the chart's JSON Schema (if present)
 		if (chart.getValuesSchema() != null) {
@@ -1317,12 +1327,12 @@ public class Engine {
 	 */
 	@SuppressWarnings("unchecked")
 	private Map<String, Object> prepareRenderValues(Map<String, Object> values, Map<String, Object> chartDefaults,
-			boolean pruneNulls) {
-		return (Map<String, Object>) prepareValueNode(values, chartDefaults, pruneNulls);
+			boolean pruneNulls, boolean boxNumbers) {
+		return (Map<String, Object>) prepareValueNode(values, chartDefaults, pruneNulls, boxNumbers);
 	}
 
 	@SuppressWarnings("unchecked")
-	private Object prepareValueNode(Object node, Object defaultNode, boolean pruneNulls) {
+	private Object prepareValueNode(Object node, Object defaultNode, boolean pruneNulls, boolean boxNumbers) {
 		if (node instanceof Map) {
 			Map<String, Object> src = (Map<String, Object>) node;
 			Map<String, Object> defMap = (defaultNode instanceof Map) ? (Map<String, Object>) defaultNode : null;
@@ -1341,7 +1351,7 @@ public class Engine {
 					continue;
 				}
 				Object dv = (defMap != null) ? defMap.get(entry.getKey()) : null;
-				out.put(entry.getKey(), prepareValueNode(value, dv, pruneNulls));
+				out.put(entry.getKey(), prepareValueNode(value, dv, pruneNulls, boxNumbers));
 			}
 			return out;
 		}
@@ -1349,16 +1359,20 @@ public class Engine {
 			List<Object> src = (List<Object>) node;
 			List<Object> out = new ArrayList<>(src.size());
 			for (Object item : src) {
-				out.add(prepareValueNode(item, null, pruneNulls));
+				out.add(prepareValueNode(item, null, pruneNulls, boxNumbers));
 			}
 			return out;
 		}
 		// Helm's values numbers are all float64; integer types become Double so a direct
 		// interpolation matches Go's float formatting. Double/Float and BigDecimal are
 		// left
-		// as-is (already floating), and booleans/strings are untouched.
-		if (node instanceof Integer || node instanceof Long || node instanceof Short || node instanceof Byte
-				|| node instanceof BigInteger) {
+		// as-is (already floating), and booleans/strings are untouched. When boxNumbers
+		// is
+		// false the leaf is already a prepared (boxed) value from an earlier pass — reuse
+		// it
+		// as-is (leaves are immutable, so sharing them across the two views is safe).
+		if (boxNumbers && (node instanceof Integer || node instanceof Long || node instanceof Short
+				|| node instanceof Byte || node instanceof BigInteger)) {
 			return ((Number) node).doubleValue();
 		}
 		return node;


### PR DESCRIPTION
Closes #718.

## What
Each render built **two** normalised copies of the merged values tree — `renderValues` (this chart's pruned view) and `subchartSliceValues` (unpruned, for slicing to subcharts) — and **both** independently boxed every `Integer`/`Long` → `Double`. Now the boxing happens **once**: `subchartSliceValues` is built first (the boxing pass), and `renderValues` is derived from it, cloning the container maps/lists (they must stay independent — `subchartSliceValues` is mutated with each subchart's merged `global`) but **reusing the already-boxed immutable leaves**.

Output is **byte-identical**: `subchartSliceValues` is unpruned, so it has the same keys as the merged tree, and deriving with the same `chartDefaults`/prune reproduces the exact `renderValues` structure and values.

## Honest grounding
I profiled this with jvmlens on an **enlarged** bench values tree (this PR also grows the #722 `bench-app` values so value-prep is measurable — a worthwhile harness upgrade on its own). Findings:

- `prepareValueNode` is ~**8%** of render allocation — but that's almost entirely the **container** maps/lists for the two independent trees, which are **structurally required and not safe to share** (one is mutated). The only safely-removable part is the second *boxing* pass.
- So the measured whole-render win is **small (~0.2% B/op)** and scales with how many numbers a chart's values carry.
- The real allocation leaders are elsewhere — `toYaml` ~20%, `include` ~17%, rendering ~16% (the first two are gotmpl4j; already partly addressed by #720).

This is the safe extent of #718: the change is correct and a strict improvement, but value-prep is not the lever the ticket assumed. The bench enlargement is arguably the more valuable part — it makes the harness representative.

## Gate
jhelm-core suite green (847). **Parity guards byte-identical output** — the real check for a value-coalescing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)