### PR TITLE
feat(cli): Helm-plugin foundation — discovery, plugin.yaml, HELM_* env, exec gate (#734)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/DiscoveredHelmPlugin.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/DiscoveredHelmPlugin.java
@@ -1,0 +1,148 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A Helm plugin found on disk: its name, its installed directory, and its parsed
+ * {@link HelmPluginManifest}. Also resolves the manifest's {@code command} /
+ * {@code platformCommand} into a concrete argument vector for the current platform,
+ * expanding environment references such as {@code $HELM_PLUGIN_DIR}.
+ *
+ * @param name the plugin name (the {@code helm <name>} command)
+ * @param directory the plugin's installed directory
+ * @param manifest the parsed {@code plugin.yaml}
+ */
+public record DiscoveredHelmPlugin(String name, Path directory, HelmPluginManifest manifest) {
+
+	/**
+	 * Resolves the command to execute for the current OS/architecture, expanding
+	 * environment references against {@code env} and splitting into an argument vector.
+	 * The most specific {@code platformCommand} entry wins (exact
+	 * {@code os}+{@code arch}, then {@code os} with an unspecified {@code arch});
+	 * otherwise the top-level {@code command} is used.
+	 * @param os the Go {@code GOOS} value to match (see {@link HelmPlatform#currentOs()})
+	 * @param arch the Go {@code GOARCH} value to match
+	 * ({@link HelmPlatform#currentArch()})
+	 * @param env the environment used to expand {@code $VAR}/{@code ${VAR}} references
+	 * @return the argument vector, or an empty list if the manifest declares no command
+	 */
+	public List<String> resolveCommand(String os, String arch, Map<String, String> env) {
+		String raw = selectCommand(os, arch);
+		if (raw == null || raw.isBlank()) {
+			return List.of();
+		}
+		return tokenize(expand(raw, env));
+	}
+
+	private String selectCommand(String os, String arch) {
+		String osOnly = null;
+		for (HelmPluginManifest.PlatformCommand platform : this.manifest.getPlatformCommand()) {
+			if (!matchesOs(platform.getOs(), os)) {
+				continue;
+			}
+			if (matchesArch(platform.getArch(), arch)) {
+				return platform.getCommand();
+			}
+			if (isBlank(platform.getArch()) && osOnly == null) {
+				osOnly = platform.getCommand();
+			}
+		}
+		return (osOnly != null) ? osOnly : this.manifest.getCommand();
+	}
+
+	private static boolean matchesOs(String declared, String os) {
+		return isBlank(declared) || declared.equalsIgnoreCase(os);
+	}
+
+	private static boolean matchesArch(String declared, String arch) {
+		return !isBlank(declared) && declared.equalsIgnoreCase(arch);
+	}
+
+	private static boolean isBlank(String value) {
+		return value == null || value.isBlank();
+	}
+
+	/** Expands {@code $NAME} and {@code ${NAME}} references against the environment. */
+	static String expand(String input, Map<String, String> env) {
+		StringBuilder out = new StringBuilder(input.length());
+		int i = 0;
+		while (i < input.length()) {
+			char c = input.charAt(i);
+			if (c != '$') {
+				out.append(c);
+				i++;
+				continue;
+			}
+			int start = i + 1;
+			if (start < input.length() && input.charAt(start) == '{') {
+				int end = input.indexOf('}', start + 1);
+				if (end > 0) {
+					out.append(lookup(input.substring(start + 1, end), env));
+					i = end + 1;
+					continue;
+				}
+			}
+			int end = start;
+			while (end < input.length() && (Character.isLetterOrDigit(input.charAt(end)) || input.charAt(end) == '_')) {
+				end++;
+			}
+			if (end > start) {
+				out.append(lookup(input.substring(start, end), env));
+				i = end;
+			}
+			else {
+				out.append(c);
+				i++;
+			}
+		}
+		return out.toString();
+	}
+
+	private static String lookup(String name, Map<String, String> env) {
+		String value = env.get(name);
+		return (value != null) ? value : "";
+	}
+
+	/** Splits a command line into arguments on whitespace, honoring simple quoting. */
+	static List<String> tokenize(String command) {
+		List<String> args = new ArrayList<>();
+		StringBuilder current = new StringBuilder();
+		boolean inArg = false;
+		char quote = 0;
+		for (int i = 0; i < command.length(); i++) {
+			char c = command.charAt(i);
+			if (quote != 0) {
+				if (c == quote) {
+					quote = 0;
+				}
+				else {
+					current.append(c);
+				}
+				continue;
+			}
+			if (c == '"' || c == '\'') {
+				quote = c;
+				inArg = true;
+			}
+			else if (Character.isWhitespace(c)) {
+				if (inArg) {
+					args.add(current.toString());
+					current.setLength(0);
+					inArg = false;
+				}
+			}
+			else {
+				current.append(c);
+				inArg = true;
+			}
+		}
+		if (inArg) {
+			args.add(current.toString());
+		}
+		return args;
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPlatform.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPlatform.java
@@ -1,0 +1,54 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.util.Locale;
+
+/**
+ * Maps the JVM's {@code os.name}/{@code os.arch} to the Go {@code GOOS}/{@code GOARCH}
+ * spellings that Helm's {@code platformCommand} entries are keyed on, so a plugin's
+ * per-platform command can be matched the same way {@code helm} matches it.
+ */
+public final class HelmPlatform {
+
+	private HelmPlatform() {
+	}
+
+	/**
+	 * The current {@code GOOS} value ({@code linux}, {@code darwin}, {@code windows}, …).
+	 * @return the Go OS name for the running JVM
+	 */
+	public static String currentOs() {
+		return goOs(System.getProperty("os.name", ""));
+	}
+
+	/**
+	 * The current {@code GOARCH} value ({@code amd64}, {@code arm64}, {@code 386}, …).
+	 * @return the Go architecture name for the running JVM
+	 */
+	public static String currentArch() {
+		return goArch(System.getProperty("os.arch", ""));
+	}
+
+	static String goOs(String osName) {
+		String os = osName.toLowerCase(Locale.ROOT);
+		if (os.contains("win")) {
+			return "windows";
+		}
+		if (os.contains("mac") || os.contains("darwin")) {
+			return "darwin";
+		}
+		if (os.contains("nux") || os.contains("nix")) {
+			return "linux";
+		}
+		return os;
+	}
+
+	static String goArch(String osArch) {
+		return switch (osArch.toLowerCase(Locale.ROOT)) {
+			case "x86_64", "amd64" -> "amd64";
+			case "aarch64", "arm64" -> "arm64";
+			case "x86", "i386", "i486", "i586", "i686" -> "386";
+			default -> osArch.toLowerCase(Locale.ROOT);
+		};
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginDiscovery.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginDiscovery.java
@@ -1,0 +1,95 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import lombok.extern.slf4j.Slf4j;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+/**
+ * Discovers Helm plugins installed under the Helm plugins directory. Each immediate
+ * subdirectory that contains a {@code plugin.yaml} (or {@code plugin.yml}) is parsed into
+ * a {@link DiscoveredHelmPlugin}; directories without a manifest, or with an unparseable
+ * one, are skipped with a warning so a single bad plugin does not break discovery.
+ *
+ * @see HelmPluginPaths#pluginsDir()
+ */
+@Slf4j
+public class HelmPluginDiscovery {
+
+	private static final YAMLMapper YAML = YAMLMapper.builder().build();
+
+	private final HelmPluginPaths paths;
+
+	/**
+	 * Creates a discovery over the given path resolver.
+	 * @param paths the Helm path resolver whose {@link HelmPluginPaths#pluginsDir()} is
+	 * scanned
+	 */
+	public HelmPluginDiscovery(HelmPluginPaths paths) {
+		this.paths = paths;
+	}
+
+	/**
+	 * Scans the plugins directory and returns every parseable Helm plugin, sorted by
+	 * name.
+	 * @return the discovered plugins (empty if the directory is absent or empty)
+	 */
+	public List<DiscoveredHelmPlugin> discover() {
+		Path dir = this.paths.pluginsDir();
+		if (!Files.isDirectory(dir)) {
+			return List.of();
+		}
+		List<DiscoveredHelmPlugin> found = new ArrayList<>();
+		try (Stream<Path> entries = Files.list(dir)) {
+			entries.filter(Files::isDirectory).sorted().forEach((pluginDir) -> load(pluginDir).ifPresent(found::add));
+		}
+		catch (IOException ex) {
+			throw new UncheckedIOException("failed to list Helm plugins directory " + dir, ex);
+		}
+		return found;
+	}
+
+	/**
+	 * Finds a single installed plugin by name.
+	 * @param name the plugin name to look up
+	 * @return the matching plugin, or empty if none is installed under that name
+	 */
+	public Optional<DiscoveredHelmPlugin> find(String name) {
+		return discover().stream().filter((plugin) -> plugin.name().equals(name)).findFirst();
+	}
+
+	private Optional<DiscoveredHelmPlugin> load(Path pluginDir) {
+		Path manifestFile = manifestFile(pluginDir);
+		if (manifestFile == null) {
+			return Optional.empty();
+		}
+		try {
+			HelmPluginManifest manifest = YAML.readValue(manifestFile.toFile(), HelmPluginManifest.class);
+			String name = (manifest.getName() != null && !manifest.getName().isBlank()) ? manifest.getName()
+					: pluginDir.getFileName().toString();
+			manifest.setName(name);
+			return Optional.of(new DiscoveredHelmPlugin(name, pluginDir, manifest));
+		}
+		catch (RuntimeException ex) {
+			log.warn("skipping unparseable Helm plugin at {}: {}", pluginDir, ex.getMessage());
+			return Optional.empty();
+		}
+	}
+
+	private static Path manifestFile(Path pluginDir) {
+		Path yaml = pluginDir.resolve("plugin.yaml");
+		if (Files.isRegularFile(yaml)) {
+			return yaml;
+		}
+		Path yml = pluginDir.resolve("plugin.yml");
+		return Files.isRegularFile(yml) ? yml : null;
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginEnvironment.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginEnvironment.java
@@ -1,0 +1,91 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import lombok.Builder;
+
+/**
+ * Builds the {@code HELM_*} environment that Helm exports to a plugin subprocess, so a
+ * native Helm plugin (helm-diff, helm-s3, …) sees the same configuration it would under
+ * {@code helm}. Directory values come from {@link HelmPluginPaths}; the remaining values
+ * (namespace, kube context/config, registry/repository config and cache) are supplied by
+ * the caller from jhelm's already-resolved runtime configuration.
+ *
+ * <p>
+ * {@link #base()} yields the invocation-wide variables;
+ * {@link #forPlugin(DiscoveredHelmPlugin)} additionally adds the per-plugin
+ * {@code HELM_PLUGIN_NAME} and {@code HELM_PLUGIN_DIR}. Blank values are omitted rather
+ * than exported as empty strings.
+ */
+@Builder
+public class HelmPluginEnvironment {
+
+	private final HelmPluginPaths paths;
+
+	@Builder.Default
+	private final String helmBin = "jhelm";
+
+	@Builder.Default
+	private final String namespace = "default";
+
+	private final String kubeContext;
+
+	private final String kubeConfig;
+
+	private final String kubeApiServer;
+
+	private final String registryConfig;
+
+	private final String repositoryConfig;
+
+	private final String repositoryCache;
+
+	private final boolean debug;
+
+	/**
+	 * The invocation-wide {@code HELM_*} variables shared by every plugin call.
+	 * @return an ordered, mutable map of environment variables (blank values omitted)
+	 */
+	public Map<String, String> base() {
+		Map<String, String> env = new LinkedHashMap<>();
+		put(env, "HELM_BIN", this.helmBin);
+		put(env, "HELM_PLUGINS", str(this.paths.pluginsDir()));
+		put(env, "HELM_DATA_HOME", str(this.paths.dataHome()));
+		put(env, "HELM_CONFIG_HOME", str(this.paths.configHome()));
+		put(env, "HELM_CACHE_HOME", str(this.paths.cacheHome()));
+		put(env, "HELM_NAMESPACE", this.namespace);
+		put(env, "HELM_KUBECONTEXT", this.kubeContext);
+		put(env, "KUBECONFIG", this.kubeConfig);
+		put(env, "HELM_KUBEAPISERVER", this.kubeApiServer);
+		put(env, "HELM_REGISTRY_CONFIG", this.registryConfig);
+		put(env, "HELM_REPOSITORY_CONFIG", this.repositoryConfig);
+		put(env, "HELM_REPOSITORY_CACHE", this.repositoryCache);
+		put(env, "HELM_DEBUG", Boolean.toString(this.debug));
+		return env;
+	}
+
+	/**
+	 * The full environment for invoking a specific plugin: {@link #base()} plus
+	 * {@code HELM_PLUGIN_NAME} and {@code HELM_PLUGIN_DIR}.
+	 * @param plugin the plugin about to be invoked
+	 * @return an ordered map of environment variables for the plugin process
+	 */
+	public Map<String, String> forPlugin(DiscoveredHelmPlugin plugin) {
+		Map<String, String> env = base();
+		put(env, "HELM_PLUGIN_NAME", plugin.name());
+		put(env, "HELM_PLUGIN_DIR", str(plugin.directory()));
+		return env;
+	}
+
+	private static void put(Map<String, String> env, String key, String value) {
+		if (value != null && !value.isBlank()) {
+			env.put(key, value);
+		}
+	}
+
+	private static String str(Object value) {
+		return (value != null) ? value.toString() : null;
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginExecGuard.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginExecGuard.java
@@ -1,0 +1,42 @@
+package org.alexmond.jhelm.app.plugin;
+
+import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+
+/**
+ * Deny-by-default gate for running native Helm plugins. A Helm plugin is an arbitrary
+ * executable, so jhelm runs one only when the unified {@link JhelmSecurityPolicy} is in
+ * {@link JhelmAccessMode#FULL FULL} mode — the same posture the cluster-mutating commands
+ * require. In the {@link JhelmAccessMode#READ_ONLY READ_ONLY} posture the invocation is
+ * refused with a message pointing at the mode setting.
+ *
+ * <p>
+ * This mirrors the {@code MutatingGuard} used by the mutating commands: {@code FULL}
+ * alone unlocks the CLI (the local kubeconfig is already the trust boundary, as with
+ * {@code helm}); no API key is required for a local CLI.
+ */
+public final class HelmPluginExecGuard {
+
+	static final String DISABLED_MESSAGE = "running native Helm plugins is disabled in READ_ONLY mode — set "
+			+ "jhelm.security.mode=FULL to enable (e.g. -Djhelm.security.mode=FULL or JHELM_SECURITY_MODE=FULL)";
+
+	private HelmPluginExecGuard() {
+	}
+
+	/**
+	 * Reports whether running a native Helm plugin must be refused under the current
+	 * policy, printing the deny message to stderr when it must.
+	 * @param policy the unified security policy
+	 * @return {@code true} if plugin execution is blocked, {@code false} if it may
+	 * proceed
+	 */
+	public static boolean blocked(JhelmSecurityPolicy policy) {
+		if (policy.mode() == JhelmAccessMode.FULL) {
+			return false;
+		}
+		CliOutput.errPrintln(CliOutput.error(DISABLED_MESSAGE));
+		return true;
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginManifest.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginManifest.java
@@ -1,0 +1,104 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+/**
+ * The Helm {@code plugin.yaml} manifest, as published by real Helm plugins (helm-diff,
+ * helm-secrets, helm-s3, …). This is deliberately distinct from the WASM-centric
+ * {@code org.alexmond.jhelm.plugin.model.PluginManifest}: it models Helm's native/exec
+ * plugin contract (a {@code command} run as a subprocess) rather than a WASM module.
+ *
+ * <p>
+ * Unknown properties are ignored so newer Helm fields (for example {@code platformHooks})
+ * do not break parsing of an otherwise-usable plugin.
+ *
+ * @see <a href="https://helm.sh/docs/topics/plugins/">Helm plugin guide</a>
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HelmPluginManifest {
+
+	/** Plugin name; also the top-level command it is invoked as ({@code helm <name>}). */
+	private String name;
+
+	/** Plugin version (SemVer, informational). */
+	private String version;
+
+	/** One-line usage string shown in listings. */
+	private String usage;
+
+	/** Longer description. */
+	private String description;
+
+	/**
+	 * The command to run, as a single string that is whitespace-split into argv and
+	 * environment-expanded (notably {@code $HELM_PLUGIN_DIR}). Used when no
+	 * {@link #platformCommand} entry matches the current OS/architecture.
+	 */
+	private String command;
+
+	/** Per-OS/architecture command overrides, matched before {@link #command}. */
+	private List<PlatformCommand> platformCommand = new ArrayList<>();
+
+	/** Lifecycle hooks run on install/update/delete. */
+	private Hooks hooks;
+
+	/** Downloader declarations: which URL protocols this plugin can fetch. */
+	private List<Downloader> downloaders = new ArrayList<>();
+
+	/**
+	 * When {@code true}, Helm passes the plugin only the positional args and strips
+	 * flags; when {@code false} (default) all trailing args are forwarded verbatim.
+	 */
+	private boolean ignoreFlags;
+
+	/** A per-platform {@code command} override. */
+	@Data
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class PlatformCommand {
+
+		/** {@code GOOS} value to match (for example {@code linux}, {@code darwin}). */
+		private String os;
+
+		/** {@code GOARCH} value to match (for example {@code amd64}, {@code arm64}). */
+		private String arch;
+
+		/** The command string for this platform (same syntax as {@link #command}). */
+		private String command;
+
+	}
+
+	/** Lifecycle hook commands, each a single command string. */
+	@Data
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Hooks {
+
+		/** Run after the plugin is installed. */
+		private String install;
+
+		/** Run after the plugin is updated. */
+		private String update;
+
+		/** Run before the plugin is uninstalled. */
+		private String delete;
+
+	}
+
+	/** A downloader declaration binding a command to one or more URL protocols. */
+	@Data
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Downloader {
+
+		/** The command that fetches a chart for the declared {@link #protocols}. */
+		private String command;
+
+		/** URL schemes this downloader handles (for example {@code s3}, {@code gs}). */
+		private List<String> protocols = new ArrayList<>();
+
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginPaths.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginPaths.java
@@ -1,0 +1,96 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.nio.file.Path;
+import java.util.function.UnaryOperator;
+
+/**
+ * Resolves the Helm home directories the way the {@code helm} CLI does, so jhelm
+ * discovers plugins from the same locations. Resolution order for each directory is: the
+ * dedicated {@code HELM_*} environment variable, then the matching XDG base dir with a
+ * {@code helm} suffix, then the platform default under the user's home.
+ *
+ * <p>
+ * The environment lookup and home directory are injected so the resolver is unit-testable
+ * without touching the real process environment; {@link #fromEnvironment()} wires the
+ * production sources ({@link System#getenv(String)} and {@code user.home}).
+ *
+ * @see <a href="https://helm.sh/docs/helm/helm/">helm environment variables</a>
+ */
+public final class HelmPluginPaths {
+
+	private final UnaryOperator<String> env;
+
+	private final Path home;
+
+	HelmPluginPaths(UnaryOperator<String> env, Path home) {
+		this.env = env;
+		this.home = home;
+	}
+
+	/**
+	 * Builds a resolver backed by the real process environment and {@code user.home}.
+	 * @return an environment-backed resolver
+	 */
+	public static HelmPluginPaths fromEnvironment() {
+		return new HelmPluginPaths(System::getenv, Path.of(System.getProperty("user.home", ".")));
+	}
+
+	/**
+	 * The Helm data home ({@code $HELM_DATA_HOME}, else {@code $XDG_DATA_HOME/helm}, else
+	 * {@code ~/.local/share/helm}).
+	 * @return the data home directory
+	 */
+	public Path dataHome() {
+		return resolve("HELM_DATA_HOME", "XDG_DATA_HOME", ".local", "share");
+	}
+
+	/**
+	 * The Helm config home ({@code $HELM_CONFIG_HOME}, else
+	 * {@code $XDG_CONFIG_HOME/helm}, else {@code ~/.config/helm}).
+	 * @return the config home directory
+	 */
+	public Path configHome() {
+		return resolve("HELM_CONFIG_HOME", "XDG_CONFIG_HOME", ".config");
+	}
+
+	/**
+	 * The Helm cache home ({@code $HELM_CACHE_HOME}, else {@code $XDG_CACHE_HOME/helm},
+	 * else {@code ~/.cache/helm}).
+	 * @return the cache home directory
+	 */
+	public Path cacheHome() {
+		return resolve("HELM_CACHE_HOME", "XDG_CACHE_HOME", ".cache");
+	}
+
+	/**
+	 * The plugin directory Helm installs into and discovers from: {@code $HELM_PLUGINS}
+	 * if set, otherwise {@code <dataHome>/plugins}.
+	 * @return the plugins directory
+	 */
+	public Path pluginsDir() {
+		String override = value("HELM_PLUGINS");
+		return (override != null) ? Path.of(override) : dataHome().resolve("plugins");
+	}
+
+	private Path resolve(String helmVar, String xdgVar, String... homeSegments) {
+		String helm = value(helmVar);
+		if (helm != null) {
+			return Path.of(helm);
+		}
+		String xdg = value(xdgVar);
+		if (xdg != null) {
+			return Path.of(xdg).resolve("helm");
+		}
+		Path base = this.home;
+		for (String segment : homeSegments) {
+			base = base.resolve(segment);
+		}
+		return base.resolve("helm");
+	}
+
+	private String value(String name) {
+		String raw = this.env.apply(name);
+		return (raw == null || raw.isBlank()) ? null : raw;
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/DiscoveredHelmPluginTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/DiscoveredHelmPluginTest.java
@@ -1,0 +1,74 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DiscoveredHelmPluginTest {
+
+	private static DiscoveredHelmPlugin plugin(HelmPluginManifest manifest) {
+		return new DiscoveredHelmPlugin("diff", Path.of("/plugins/diff"), manifest);
+	}
+
+	private static HelmPluginManifest manifest(String command) {
+		HelmPluginManifest manifest = new HelmPluginManifest();
+		manifest.setName("diff");
+		manifest.setCommand(command);
+		return manifest;
+	}
+
+	private static HelmPluginManifest.PlatformCommand platform(String os, String arch, String command) {
+		HelmPluginManifest.PlatformCommand pc = new HelmPluginManifest.PlatformCommand();
+		pc.setOs(os);
+		pc.setArch(arch);
+		pc.setCommand(command);
+		return pc;
+	}
+
+	@Test
+	void expandsPluginDirAndSplitsArgv() {
+		Map<String, String> env = Map.of("HELM_PLUGIN_DIR", "/plugins/diff");
+		List<String> argv = plugin(manifest("$HELM_PLUGIN_DIR/bin/diff --detailed")).resolveCommand("linux", "amd64",
+				env);
+		assertEquals(List.of("/plugins/diff/bin/diff", "--detailed"), argv);
+	}
+
+	@Test
+	void selectsExactPlatformCommandFirst() {
+		HelmPluginManifest manifest = manifest("fallback");
+		manifest.setPlatformCommand(List.of(platform("linux", null, "linux-generic"),
+				platform("linux", "amd64", "linux-amd64"), platform("darwin", "arm64", "darwin-arm64")));
+		assertEquals(List.of("linux-amd64"), plugin(manifest).resolveCommand("linux", "amd64", Map.of()));
+	}
+
+	@Test
+	void fallsBackToOsOnlyThenTopLevelCommand() {
+		HelmPluginManifest manifest = manifest("fallback");
+		manifest.setPlatformCommand(List.of(platform("linux", null, "linux-generic")));
+		assertEquals(List.of("linux-generic"), plugin(manifest).resolveCommand("linux", "arm64", Map.of()));
+		assertEquals(List.of("fallback"), plugin(manifest).resolveCommand("windows", "amd64", Map.of()));
+	}
+
+	@Test
+	void honorsBracedVarsAndQuotedArgs() {
+		Map<String, String> env = Map.of("HELM_PLUGIN_DIR", "/p");
+		List<String> argv = plugin(manifest("${HELM_PLUGIN_DIR}/run \"one two\" three")).resolveCommand("linux",
+				"amd64", env);
+		assertEquals(List.of("/p/run", "one two", "three"), argv);
+	}
+
+	@Test
+	void unsetVariableExpandsToEmpty() {
+		assertEquals(List.of("/bin/x"), plugin(manifest("$MISSING/bin/x")).resolveCommand("linux", "amd64", Map.of()));
+	}
+
+	@Test
+	void emptyCommandYieldsEmptyList() {
+		assertEquals(List.of(), plugin(manifest(null)).resolveCommand("linux", "amd64", Map.of()));
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginDiscoveryTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginDiscoveryTest.java
@@ -1,0 +1,71 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HelmPluginDiscoveryTest {
+
+	@TempDir
+	Path pluginsDir;
+
+	private HelmPluginDiscovery discovery() {
+		HelmPluginPaths paths = new HelmPluginPaths(Map.of("HELM_PLUGINS", this.pluginsDir.toString())::get,
+				Path.of("/nohome"));
+		return new HelmPluginDiscovery(paths);
+	}
+
+	private void writePlugin(String dir, String yaml) throws Exception {
+		Path pluginDir = Files.createDirectories(this.pluginsDir.resolve(dir));
+		Files.writeString(pluginDir.resolve("plugin.yaml"), yaml);
+	}
+
+	@Test
+	void discoversPluginsSortedByName() throws Exception {
+		writePlugin("s3", "name: s3\nversion: 0.16.0\ncommand: run-s3\n");
+		writePlugin("diff", "name: diff\nversion: 3.9.0\ncommand: run-diff\n");
+		List<DiscoveredHelmPlugin> found = discovery().discover();
+		assertEquals(2, found.size());
+		assertEquals("diff", found.get(0).name());
+		assertEquals("s3", found.get(1).name());
+		assertTrue(found.get(0).directory().endsWith("diff"));
+	}
+
+	@Test
+	void skipsDirectoriesWithoutManifest() throws Exception {
+		writePlugin("diff", "name: diff\ncommand: run\n");
+		Files.createDirectories(this.pluginsDir.resolve("not-a-plugin"));
+		List<DiscoveredHelmPlugin> found = discovery().discover();
+		assertEquals(1, found.size());
+		assertEquals("diff", found.get(0).name());
+	}
+
+	@Test
+	void fallsBackToDirectoryNameWhenManifestNameMissing() throws Exception {
+		writePlugin("myplugin", "version: 1.0.0\ncommand: run\n");
+		DiscoveredHelmPlugin plugin = discovery().find("myplugin").orElseThrow();
+		assertEquals("myplugin", plugin.name());
+	}
+
+	@Test
+	void returnsEmptyWhenPluginsDirAbsent() {
+		HelmPluginPaths paths = new HelmPluginPaths(Map.of("HELM_PLUGINS", "/does/not/exist")::get, Path.of("/nohome"));
+		assertTrue(new HelmPluginDiscovery(paths).discover().isEmpty());
+	}
+
+	@Test
+	void findReturnsRequestedPlugin() throws Exception {
+		writePlugin("diff", "name: diff\ncommand: run\n");
+		writePlugin("s3", "name: s3\ncommand: run\n");
+		assertEquals("s3", discovery().find("s3").orElseThrow().name());
+		assertTrue(discovery().find("absent").isEmpty());
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginEnvironmentTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginEnvironmentTest.java
@@ -1,0 +1,55 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class HelmPluginEnvironmentTest {
+
+	private HelmPluginEnvironment environment() {
+		HelmPluginPaths paths = new HelmPluginPaths(Map.of("HELM_PLUGINS", "/plugins")::get, Path.of("/home/tester"));
+		return HelmPluginEnvironment.builder()
+			.paths(paths)
+			.namespace("apps")
+			.kubeContext("prod")
+			.kubeConfig("/home/tester/.kube/config")
+			.repositoryCache("/home/tester/.cache/helm/repository")
+			.debug(true)
+			.build();
+	}
+
+	@Test
+	void baseEnvironmentExportsHelmDirectoriesAndContext() {
+		Map<String, String> env = environment().base();
+		assertEquals("jhelm", env.get("HELM_BIN"));
+		assertEquals("/plugins", env.get("HELM_PLUGINS"));
+		assertEquals("/home/tester/.local/share/helm", env.get("HELM_DATA_HOME"));
+		assertEquals("apps", env.get("HELM_NAMESPACE"));
+		assertEquals("prod", env.get("HELM_KUBECONTEXT"));
+		assertEquals("/home/tester/.kube/config", env.get("KUBECONFIG"));
+		assertEquals("true", env.get("HELM_DEBUG"));
+	}
+
+	@Test
+	void blankOptionalValuesAreOmitted() {
+		Map<String, String> env = environment().base();
+		assertFalse(env.containsKey("HELM_KUBEAPISERVER"));
+		assertFalse(env.containsKey("HELM_REGISTRY_CONFIG"));
+	}
+
+	@Test
+	void forPluginAddsPluginNameAndDir() {
+		HelmPluginManifest manifest = new HelmPluginManifest();
+		manifest.setName("diff");
+		DiscoveredHelmPlugin plugin = new DiscoveredHelmPlugin("diff", Path.of("/plugins/diff"), manifest);
+		Map<String, String> env = environment().forPlugin(plugin);
+		assertEquals("diff", env.get("HELM_PLUGIN_NAME"));
+		assertEquals("/plugins/diff", env.get("HELM_PLUGIN_DIR"));
+		assertEquals("/plugins", env.get("HELM_PLUGINS"));
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginExecGuardTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginExecGuardTest.java
@@ -1,0 +1,29 @@
+package org.alexmond.jhelm.app.plugin;
+
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HelmPluginExecGuardTest {
+
+	private static JhelmSecurityPolicy policy(JhelmAccessMode mode) {
+		JhelmSecurityProperties properties = new JhelmSecurityProperties();
+		properties.setMode(mode);
+		return new JhelmSecurityPolicy(properties);
+	}
+
+	@Test
+	void fullModeAllowsPluginExecution() {
+		assertFalse(HelmPluginExecGuard.blocked(policy(JhelmAccessMode.FULL)));
+	}
+
+	@Test
+	void readOnlyModeBlocksPluginExecution() {
+		assertTrue(HelmPluginExecGuard.blocked(policy(JhelmAccessMode.READ_ONLY)));
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginManifestTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginManifestTest.java
@@ -1,0 +1,63 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HelmPluginManifestTest {
+
+	private final YAMLMapper yaml = YAMLMapper.builder().build();
+
+	private HelmPluginManifest parse(String resource) throws Exception {
+		try (InputStream in = getClass().getResourceAsStream(resource)) {
+			assertNotNull(in, "missing fixture " + resource);
+			return this.yaml.readValue(in, HelmPluginManifest.class);
+		}
+	}
+
+	@Test
+	void parsesSubcommandPluginManifest() throws Exception {
+		HelmPluginManifest manifest = parse("/helm-plugins/diff/plugin.yaml");
+		assertEquals("diff", manifest.getName());
+		assertEquals("3.9.0", manifest.getVersion());
+		assertEquals("Preview helm upgrade changes as a diff", manifest.getUsage());
+		assertEquals("$HELM_PLUGIN_DIR/bin/diff", manifest.getCommand());
+		assertFalse(manifest.isIgnoreFlags());
+		assertEquals(3, manifest.getPlatformCommand().size());
+		assertEquals("linux", manifest.getPlatformCommand().get(0).getOs());
+		assertEquals("amd64", manifest.getPlatformCommand().get(0).getArch());
+		assertNotNull(manifest.getHooks());
+		assertEquals("$HELM_PLUGIN_DIR/install-binary.sh", manifest.getHooks().getInstall());
+	}
+
+	@Test
+	void parsesDownloaderPluginManifest() throws Exception {
+		HelmPluginManifest manifest = parse("/helm-plugins/s3/plugin.yaml");
+		assertEquals("s3", manifest.getName());
+		assertEquals(1, manifest.getDownloaders().size());
+		assertTrue(manifest.getDownloaders().get(0).getProtocols().contains("s3"));
+		assertEquals("$HELM_PLUGIN_DIR/bin/helms3", manifest.getDownloaders().get(0).getCommand());
+	}
+
+	@Test
+	void ignoresUnknownFields() throws Exception {
+		HelmPluginManifest manifest = this.yaml.readValue("""
+				name: future
+				version: 1.0.0
+				command: run
+				somethingHelmAddsLater: true
+				platformHooks:
+				  install:
+				    - command: ["echo"]
+				""", HelmPluginManifest.class);
+		assertEquals("future", manifest.getName());
+		assertEquals("run", manifest.getCommand());
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginPathsTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginPathsTest.java
@@ -1,0 +1,53 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HelmPluginPathsTest {
+
+	private static final Path HOME = Path.of("/home/tester");
+
+	private HelmPluginPaths paths(Map<String, String> env) {
+		return new HelmPluginPaths(env::get, HOME);
+	}
+
+	@Test
+	void defaultsToXdgLinuxLayoutUnderHome() {
+		HelmPluginPaths paths = paths(Map.of());
+		assertEquals(Path.of("/home/tester/.local/share/helm"), paths.dataHome());
+		assertEquals(Path.of("/home/tester/.config/helm"), paths.configHome());
+		assertEquals(Path.of("/home/tester/.cache/helm"), paths.cacheHome());
+		assertEquals(Path.of("/home/tester/.local/share/helm/plugins"), paths.pluginsDir());
+	}
+
+	@Test
+	void honorsXdgDataHome() {
+		HelmPluginPaths paths = paths(Map.of("XDG_DATA_HOME", "/xdg/data"));
+		assertEquals(Path.of("/xdg/data/helm"), paths.dataHome());
+		assertEquals(Path.of("/xdg/data/helm/plugins"), paths.pluginsDir());
+	}
+
+	@Test
+	void helmDataHomeWinsOverXdg() {
+		HelmPluginPaths paths = paths(Map.of("XDG_DATA_HOME", "/xdg/data", "HELM_DATA_HOME", "/opt/helm"));
+		assertEquals(Path.of("/opt/helm"), paths.dataHome());
+		assertEquals(Path.of("/opt/helm/plugins"), paths.pluginsDir());
+	}
+
+	@Test
+	void helmPluginsOverridesDirectly() {
+		HelmPluginPaths paths = paths(Map.of("HELM_DATA_HOME", "/opt/helm", "HELM_PLUGINS", "/custom/plugins"));
+		assertEquals(Path.of("/custom/plugins"), paths.pluginsDir());
+	}
+
+	@Test
+	void blankValuesAreIgnored() {
+		HelmPluginPaths paths = paths(Map.of("HELM_DATA_HOME", "   "));
+		assertEquals(Path.of("/home/tester/.local/share/helm"), paths.dataHome());
+	}
+
+}

--- a/jhelm-cli/src/test/resources/helm-plugins/diff/plugin.yaml
+++ b/jhelm-cli/src/test/resources/helm-plugins/diff/plugin.yaml
@@ -1,0 +1,19 @@
+name: "diff"
+version: "3.9.0"
+usage: "Preview helm upgrade changes as a diff"
+description: |-
+  A Helm plugin that shows a diff explaining what a helm upgrade would change.
+command: "$HELM_PLUGIN_DIR/bin/diff"
+platformCommand:
+  - os: linux
+    arch: amd64
+    command: "$HELM_PLUGIN_DIR/bin/diff-linux-amd64"
+  - os: linux
+    command: "$HELM_PLUGIN_DIR/bin/diff-linux"
+  - os: darwin
+    arch: arm64
+    command: "$HELM_PLUGIN_DIR/bin/diff-darwin-arm64"
+ignoreFlags: false
+hooks:
+  install: "$HELM_PLUGIN_DIR/install-binary.sh"
+  update: "$HELM_PLUGIN_DIR/install-binary.sh -u"

--- a/jhelm-cli/src/test/resources/helm-plugins/s3/plugin.yaml
+++ b/jhelm-cli/src/test/resources/helm-plugins/s3/plugin.yaml
@@ -1,0 +1,9 @@
+name: "s3"
+version: "0.16.0"
+usage: "s3 protocol support for Helm charts"
+description: "This plugin provides s3 protocol support for downloading and uploading Helm charts."
+command: "$HELM_PLUGIN_DIR/bin/helms3"
+downloaders:
+  - command: "$HELM_PLUGIN_DIR/bin/helms3"
+    protocols:
+      - "s3"


### PR DESCRIPTION
First slice of the Helm-plugin compatibility epic (#733). Adds the CLI-side foundation for consuming **real Helm plugins**, parallel to the existing WASM/`.jhp` system.

## What's here
- **`HelmPluginManifest`** — Helm's `plugin.yaml` schema (`command`, `platformCommand`, `hooks`, `downloaders`, `ignoreFlags`); Jackson-YAML, unknown fields ignored so newer Helm fields don't break parsing.
- **`HelmPluginPaths`** — resolves `HELM_DATA/CONFIG/CACHE_HOME` + plugins dir exactly as helm does (`HELM_*` → XDG → `~/.local/share/helm`); env injectable for tests.
- **`DiscoveredHelmPlugin`** — `platformCommand` OS/arch selection + `$VAR`/`${VAR}` expansion (incl. `$HELM_PLUGIN_DIR`) + argv tokenization with quoting.
- **`HelmPluginDiscovery`** — scans `$HELM_PLUGINS`, skips missing/bad manifests, falls back to dir name.
- **`HelmPluginEnvironment`** — builds the `HELM_*` env exported to a plugin subprocess (base + per-plugin `HELM_PLUGIN_NAME`/`DIR`).
- **`HelmPluginExecGuard`** — native-exec deny-by-default gate on `FULL` mode, mirroring `MutatingGuard`.

## Scope note
No behavior change yet — nothing calls these. Subcommand dispatch (#735), install (#736), downloader (#738), post-renderer (#739) build on this. Native exec is gated per the epic's decision (FULL mode).

## Tests
24 unit tests (manifest parsing incl. real helm-diff/helm-s3 fixtures, path resolution, command/platform/env-expansion, discovery, env building, guard). Full `clean install` green locally.

Part of #733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)