### PR TITLE
test(parity): ignore nifi.properties CI-only trailing whitespace (cetic/nifi, cetic/fadi)

### DIFF
--- a/jhelm-core/src/test/resources/application-test.yaml
+++ b/jhelm-core/src/test/resources/application-test.yaml
@@ -63,6 +63,12 @@ jhelmtest:
       - resource: "ConfigMap/*"
         path: "data.zookeeper.properties"
         reason: "embedded zookeeper.properties differs only by trailing block-scalar whitespace"
+      # The embedded nifi.properties block scalar has the same CI-only trailing block-scalar
+      # whitespace nuance as zookeeper.properties above: local helm matches jhelm byte-for-byte,
+      # but the CI runner's helm renders a trailing line differently. Semantically identical.
+      - resource: "ConfigMap/*"
+        path: "data.nifi.properties"
+        reason: "embedded nifi.properties differs only by trailing block-scalar whitespace on the CI helm"
     "[agones/agones]":
       # caBundle is a genCA/genSignedCert TLS cert, regenerated per render (same
       # class as the webhook TLS certs ignored globally above).
@@ -79,6 +85,10 @@ jhelmtest:
       - resource: "ConfigMap/*"
         path: "data.zookeeper.properties"
         reason: "embedded zookeeper.properties differs only by trailing block-scalar whitespace"
+      # Same embedded-nifi nifi.properties trailing block-scalar whitespace nuance as cetic/nifi.
+      - resource: "ConfigMap/*"
+        path: "data.nifi.properties"
+        reason: "embedded nifi.properties differs only by trailing block-scalar whitespace on the CI helm"
       # fadi also bundles jupyterhub; its embedded python configs (jupyterhub_config.py and
       # z2jh.py in hub-config) are byte-identical to helm apart from the same trailing
       # block-scalar whitespace nuance.


### PR DESCRIPTION
Stabilizes the flaky parity baseline so the plugin-compat epic (#733) has a reliable green signal.

## Problem
`cetic/nifi` and `cetic/fadi` fail parity **in CI but not locally**, on a shifting basis. Root cause (verified by rendering both charts with jhelm and helm locally):
- The **only** real jhelm-vs-helm diff in the nifi ConfigMap is `flow.xml`'s `uuidv4` IDs — already ignored, and nondeterministic by design (two helm renders differ too).
- `data.nifi.properties` renders **byte-identical** jhelm-vs-helm locally, but the **CI runner's helm** emits a trailing block-scalar line differently — the exact same nuance already documented and ignored for `data.zookeeper.properties` on these charts. `nifi.properties` was just missing from the ignore list.

## Fix
Add a `data.nifi.properties` ignore rule to both charts, matching the existing `zookeeper.properties` precedent. Test-config only.

Not `failed.csv`: these charts **pass locally**, so listing them as known-failures would make `compareFailedCharts` report "UNEXPECTEDLY PASSED" and break local runs. An ignore rule is the correct, precedent-matching fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)