### PR TITLE
feat(cli): dispatch unmatched subcommands to installed Helm plugins (#735)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/HelmJavaApplication.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/HelmJavaApplication.java
@@ -2,6 +2,8 @@ package org.alexmond.jhelm.app;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.alexmond.jhelm.app.plugin.HelmPluginDispatcher;
+import org.alexmond.jhelm.app.plugin.HelmPluginParameterExceptionHandler;
 import org.alexmond.jhelm.core.config.JhelmAccessMode;
 import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.springframework.boot.ApplicationRunner;
@@ -34,16 +36,20 @@ public class HelmJavaApplication implements CommandLineRunner, ExitCodeGenerator
 
 	private final JHelmCommand jHelmCommand;
 
+	private final HelmPluginDispatcher pluginDispatcher;
+
 	private int exitCode;
 
 	/**
 	 * Creates the application runner.
 	 * @param factory the Picocli factory used to instantiate Spring-managed commands
 	 * @param jHelmCommand the root {@code jhelm} command
+	 * @param pluginDispatcher dispatches unmatched subcommands to installed Helm plugins
 	 */
-	public HelmJavaApplication(IFactory factory, JHelmCommand jHelmCommand) {
+	public HelmJavaApplication(IFactory factory, JHelmCommand jHelmCommand, HelmPluginDispatcher pluginDispatcher) {
 		this.factory = factory;
 		this.jHelmCommand = jHelmCommand;
+		this.pluginDispatcher = pluginDispatcher;
 	}
 
 	/**
@@ -69,6 +75,10 @@ public class HelmJavaApplication implements CommandLineRunner, ExitCodeGenerator
 		CommandLine cmd = new CommandLine(jHelmCommand, factory);
 		cmd.setUsageHelpWidth(120);
 		cmd.setColorScheme(CommandLine.Help.defaultColorScheme(Ansi.AUTO));
+		// Route an unmatched top-level subcommand to an installed Helm plugin (helm-diff,
+		// helm-secrets, …) before falling back to the default "Unmatched argument" error.
+		cmd.setParameterExceptionHandler(
+				new HelmPluginParameterExceptionHandler(cmd.getParameterExceptionHandler(), pluginDispatcher));
 		// Picocli parses the original vector so the global flags (stripped from the
 		// Spring
 		// args) are still accepted and shown in --help.

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginDispatcher.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginDispatcher.java
@@ -1,0 +1,153 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.service.RegistryManager;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine.ExitCode;
+
+/**
+ * Resolves and runs installed Helm subcommand plugins (helm-diff, helm-secrets, …). When
+ * {@code jhelm <name>} names an installed Helm plugin rather than a built-in command, the
+ * dispatcher executes the plugin's {@code command} for the current platform as a child
+ * process, forwarding the remaining arguments and the {@code HELM_*} environment, so
+ * existing Helm plugin workflows run unchanged against jhelm.
+ *
+ * <p>
+ * Running a native plugin is gated on {@link HelmPluginExecGuard}: it proceeds only in
+ * the CLI's {@code FULL} security posture (the plugin is arbitrary local code, the same
+ * trust boundary as {@code helm}).
+ */
+@Slf4j
+@Component
+public class HelmPluginDispatcher {
+
+	private final HelmPluginDiscovery discovery;
+
+	private final Supplier<HelmPluginEnvironment> environment;
+
+	private final JhelmSecurityPolicy policy;
+
+	private final HelmPluginRunner runner;
+
+	/**
+	 * Spring constructor: builds the discovery and {@code HELM_*} environment from
+	 * jhelm's already-resolved runtime configuration.
+	 * @param repoManager supplies the repository config and cache paths
+	 * @param registryManager supplies the registry config path
+	 * @param kubeProperties supplies the configured kubeconfig override, if any
+	 * @param policy the security policy that gates native plugin execution
+	 * @param runner runs the resolved plugin command as a child process
+	 */
+	@Autowired
+	public HelmPluginDispatcher(RepoManager repoManager, RegistryManager registryManager,
+			JhelmKubernetesProperties kubeProperties, JhelmSecurityPolicy policy, HelmPluginRunner runner) {
+		this(new HelmPluginDiscovery(HelmPluginPaths.fromEnvironment()),
+				() -> springEnvironment(repoManager, registryManager, kubeProperties), policy, runner);
+	}
+
+	HelmPluginDispatcher(HelmPluginDiscovery discovery, Supplier<HelmPluginEnvironment> environment,
+			JhelmSecurityPolicy policy, HelmPluginRunner runner) {
+		this.discovery = discovery;
+		this.environment = environment;
+		this.policy = policy;
+		this.runner = runner;
+	}
+
+	/**
+	 * Looks up an installed Helm plugin by the command name.
+	 * @param name the candidate command name ({@code jhelm <name>})
+	 * @return the matching installed plugin, or empty if none is installed under that
+	 * name
+	 */
+	public Optional<DiscoveredHelmPlugin> find(String name) {
+		return this.discovery.find(name);
+	}
+
+	/**
+	 * Runs a plugin with the given arguments, forwarding the {@code HELM_*} environment
+	 * and returning the plugin's exit code. Refuses (and returns a non-zero code) when
+	 * the security posture disallows native execution or the plugin declares no command
+	 * for the current platform.
+	 * @param plugin the plugin to run
+	 * @param args the arguments to pass after the plugin command
+	 * @return the plugin's exit code, or a non-zero jhelm exit code on refusal/error
+	 */
+	public int dispatch(DiscoveredHelmPlugin plugin, List<String> args) {
+		if (HelmPluginExecGuard.blocked(this.policy)) {
+			return ExitCode.SOFTWARE;
+		}
+		Map<String, String> env = this.environment.get().forPlugin(plugin);
+		List<String> command = plugin.resolveCommand(HelmPlatform.currentOs(), HelmPlatform.currentArch(), env);
+		if (command.isEmpty()) {
+			CliOutput
+				.errPrintln(CliOutput.error("plugin '" + plugin.name() + "' declares no command for this platform ("
+						+ HelmPlatform.currentOs() + "/" + HelmPlatform.currentArch() + ')'));
+			return ExitCode.SOFTWARE;
+		}
+		List<String> full = new ArrayList<>(command);
+		full.addAll(args);
+		try {
+			return this.runner.run(full, env, plugin.directory());
+		}
+		catch (IOException ex) {
+			CliOutput.errPrintln(CliOutput.error("failed to run plugin '" + plugin.name() + "': " + ex.getMessage()));
+			return ExitCode.SOFTWARE;
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			CliOutput.errPrintln(CliOutput.error("interrupted while running plugin '" + plugin.name() + '\''));
+			return ExitCode.SOFTWARE;
+		}
+	}
+
+	private static HelmPluginEnvironment springEnvironment(RepoManager repoManager, RegistryManager registryManager,
+			JhelmKubernetesProperties kubeProperties) {
+		return HelmPluginEnvironment.builder()
+			.paths(HelmPluginPaths.fromEnvironment())
+			.namespace(envOrDefault("HELM_NAMESPACE", "default"))
+			.kubeConfig(resolveKubeconfig(kubeProperties))
+			.registryConfig(registryManager.getConfigPath())
+			.repositoryConfig(repoManager.getConfigPath())
+			.repositoryCache(repoManager.getRepositoryCachePath())
+			.debug(Boolean.parseBoolean(envOrDefault("HELM_DEBUG", "false")))
+			.build();
+	}
+
+	private static String resolveKubeconfig(JhelmKubernetesProperties kubeProperties) {
+		String configured = kubeProperties.getKubeconfigPath();
+		if (configured != null && !configured.isBlank()) {
+			return configured;
+		}
+		return envOrDefault("KUBECONFIG",
+				Paths.get(System.getProperty("user.home", "."), ".kube", "config").toString());
+	}
+
+	private static String envOrDefault(String name, String fallback) {
+		String value = System.getenv(name);
+		return (value != null && !value.isBlank()) ? value : fallback;
+	}
+
+	// Retained for symmetry with test construction over an explicit plugins directory.
+	static HelmPluginDispatcher forTesting(Path pluginsDir, Supplier<HelmPluginEnvironment> environment,
+			JhelmSecurityPolicy policy, HelmPluginRunner runner) {
+		HelmPluginPaths paths = new HelmPluginPaths(Map.of("HELM_PLUGINS", pluginsDir.toString())::get,
+				Path.of(System.getProperty("user.home", ".")));
+		return new HelmPluginDispatcher(new HelmPluginDiscovery(paths), environment, policy, runner);
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginParameterExceptionHandler.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginParameterExceptionHandler.java
@@ -1,0 +1,48 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.util.List;
+import java.util.Optional;
+
+import picocli.CommandLine.IParameterExceptionHandler;
+import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.UnmatchedArgumentException;
+
+/**
+ * Bridges an unknown top-level subcommand to a Helm plugin. When Picocli cannot match a
+ * subcommand on the root {@code jhelm} command, this handler checks whether the unmatched
+ * name is an installed Helm plugin; if so it runs the plugin with the remaining arguments
+ * (as {@code helm} does), otherwise it defers to the default handler so the normal
+ * "Unmatched argument" error is shown.
+ */
+public class HelmPluginParameterExceptionHandler implements IParameterExceptionHandler {
+
+	private final IParameterExceptionHandler delegate;
+
+	private final HelmPluginDispatcher dispatcher;
+
+	/**
+	 * Creates the handler.
+	 * @param delegate the handler to fall back to when the unmatched name is not a plugin
+	 * @param dispatcher resolves and runs installed Helm plugins
+	 */
+	public HelmPluginParameterExceptionHandler(IParameterExceptionHandler delegate, HelmPluginDispatcher dispatcher) {
+		this.delegate = delegate;
+		this.dispatcher = dispatcher;
+	}
+
+	@Override
+	public int handleParseException(ParameterException ex, String[] args) throws Exception {
+		if (ex instanceof UnmatchedArgumentException unmatchedEx && ex.getCommandLine().getParent() == null) {
+			List<String> unmatched = unmatchedEx.getUnmatched();
+			if (!unmatched.isEmpty()) {
+				String name = unmatched.get(0);
+				Optional<DiscoveredHelmPlugin> plugin = this.dispatcher.find(name);
+				if (plugin.isPresent()) {
+					return this.dispatcher.dispatch(plugin.get(), unmatched.subList(1, unmatched.size()));
+				}
+			}
+		}
+		return this.delegate.handleParseException(ex, args);
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginRunner.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginRunner.java
@@ -1,0 +1,27 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runs a resolved Helm-plugin command as a child process. Abstracted behind an interface
+ * so the dispatcher can be unit-tested against a fake runner while production uses a real
+ * {@link ProcessHelmPluginRunner}.
+ */
+public interface HelmPluginRunner {
+
+	/**
+	 * Executes a plugin command, wiring the process's stdio to the current terminal and
+	 * exporting the given environment.
+	 * @param command the full argument vector (plugin command plus its arguments)
+	 * @param env the {@code HELM_*} environment to add to the child process
+	 * @param workingDir the working directory for the child process (the plugin dir)
+	 * @return the child process exit code
+	 * @throws IOException if the process cannot be started
+	 * @throws InterruptedException if the current thread is interrupted while waiting
+	 */
+	int run(List<String> command, Map<String, String> env, Path workingDir) throws IOException, InterruptedException;
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/ProcessHelmPluginRunner.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/ProcessHelmPluginRunner.java
@@ -1,0 +1,30 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Runs a Helm plugin as a child process with inherited stdio, so an interactive plugin
+ * (helm-diff, helm-secrets, …) reads and writes the user's terminal directly and its exit
+ * code becomes jhelm's exit code — matching how {@code helm} invokes a plugin.
+ */
+@Component
+public class ProcessHelmPluginRunner implements HelmPluginRunner {
+
+	@Override
+	public int run(List<String> command, Map<String, String> env, Path workingDir)
+			throws IOException, InterruptedException {
+		ProcessBuilder builder = new ProcessBuilder(command).inheritIO();
+		if (workingDir != null) {
+			builder.directory(workingDir.toFile());
+		}
+		builder.environment().putAll(env);
+		Process process = builder.start();
+		return process.waitFor();
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginDispatcherTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginDispatcherTest.java
@@ -1,0 +1,108 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import picocli.CommandLine.ExitCode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledOnOs({ OS.LINUX, OS.MAC })
+class HelmPluginDispatcherTest {
+
+	@TempDir
+	Path pluginsDir;
+
+	private Path installPlugin(String name, String script) throws Exception {
+		Path dir = Files.createDirectories(this.pluginsDir.resolve(name));
+		Files.writeString(dir.resolve("plugin.yaml"),
+				"name: " + name + "\nversion: 1.0.0\ncommand: \"$HELM_PLUGIN_DIR/run.sh\"\n");
+		Path run = dir.resolve("run.sh");
+		Files.writeString(run, script);
+		run.toFile().setExecutable(true);
+		return dir;
+	}
+
+	private Supplier<HelmPluginEnvironment> env() {
+		HelmPluginPaths paths = new HelmPluginPaths(Map.of("HELM_PLUGINS", this.pluginsDir.toString())::get,
+				Path.of("/home/tester"));
+		return () -> HelmPluginEnvironment.builder().paths(paths).namespace("testns").build();
+	}
+
+	private HelmPluginDispatcher dispatcher(JhelmAccessMode mode) {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(mode);
+		return HelmPluginDispatcher.forTesting(this.pluginsDir, env(), new JhelmSecurityPolicy(props),
+				new ProcessHelmPluginRunner());
+	}
+
+	@Test
+	void runsPluginForwardingArgsAndHelmEnv() throws Exception {
+		installPlugin("echoargs", """
+				#!/usr/bin/env bash
+				out="$1"; shift
+				{
+				  echo "args:$*"
+				  echo "HELM_NAMESPACE=$HELM_NAMESPACE"
+				  echo "HELM_PLUGIN_NAME=$HELM_PLUGIN_NAME"
+				  echo "HELM_PLUGIN_DIR=$HELM_PLUGIN_DIR"
+				} > "$out"
+				""");
+		Path out = this.pluginsDir.resolve("out.txt");
+		HelmPluginDispatcher dispatcher = dispatcher(JhelmAccessMode.FULL);
+		DiscoveredHelmPlugin plugin = dispatcher.find("echoargs").orElseThrow();
+
+		int code = dispatcher.dispatch(plugin, List.of(out.toString(), "hello", "world"));
+
+		assertEquals(0, code);
+		Set<String> lines = Set.copyOf(Files.readAllLines(out));
+		assertTrue(lines.contains("args:hello world"), lines.toString());
+		assertTrue(lines.contains("HELM_NAMESPACE=testns"));
+		assertTrue(lines.contains("HELM_PLUGIN_NAME=echoargs"));
+		assertTrue(lines.contains("HELM_PLUGIN_DIR=" + plugin.directory()));
+	}
+
+	@Test
+	void propagatesPluginExitCode() throws Exception {
+		installPlugin("failing", """
+				#!/usr/bin/env bash
+				exit 7
+				""");
+		HelmPluginDispatcher dispatcher = dispatcher(JhelmAccessMode.FULL);
+		int code = dispatcher.dispatch(dispatcher.find("failing").orElseThrow(), List.of());
+		assertEquals(7, code);
+	}
+
+	@Test
+	void readOnlyModeBlocksExecution() throws Exception {
+		installPlugin("echoargs", """
+				#!/usr/bin/env bash
+				touch "$1"
+				""");
+		Path marker = this.pluginsDir.resolve("ran.marker");
+		HelmPluginDispatcher dispatcher = dispatcher(JhelmAccessMode.READ_ONLY);
+		int code = dispatcher.dispatch(dispatcher.find("echoargs").orElseThrow(), List.of(marker.toString()));
+		assertEquals(ExitCode.SOFTWARE, code);
+		assertFalse(Files.exists(marker), "plugin must not run in READ_ONLY mode");
+	}
+
+	@Test
+	void findReturnsEmptyForUnknownPlugin() {
+		assertTrue(dispatcher(JhelmAccessMode.FULL).find("nope").isEmpty());
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginParameterExceptionHandlerTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginParameterExceptionHandlerTest.java
@@ -1,0 +1,91 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import picocli.CommandLine;
+import picocli.CommandLine.IParameterExceptionHandler;
+import picocli.CommandLine.ParameterException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HelmPluginParameterExceptionHandlerTest {
+
+	@TempDir
+	Path pluginsDir;
+
+	private ParameterException parseFailure(String... args) {
+		try {
+			new CommandLine(new Root()).parseArgs(args);
+			throw new AssertionError("expected a parse failure");
+		}
+		catch (ParameterException ex) {
+			return ex;
+		}
+	}
+
+	private HelmPluginDispatcher dispatcher(HelmPluginRunner runner) {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(JhelmAccessMode.FULL);
+		HelmPluginPaths paths = new HelmPluginPaths(Map.of("HELM_PLUGINS", this.pluginsDir.toString())::get,
+				Path.of("/home/tester"));
+		Supplier<HelmPluginEnvironment> env = () -> HelmPluginEnvironment.builder().paths(paths).build();
+		return HelmPluginDispatcher.forTesting(this.pluginsDir, env, new JhelmSecurityPolicy(props), runner);
+	}
+
+	private void installPlugin(String name) throws Exception {
+		Path dir = Files.createDirectories(this.pluginsDir.resolve(name));
+		Files.writeString(dir.resolve("plugin.yaml"), "name: " + name + "\ncommand: run-" + name + "\n");
+	}
+
+	@Test
+	void dispatchesUnmatchedNameThatIsAPlugin() throws Exception {
+		installPlugin("diff");
+		AtomicReference<List<String>> ranCommand = new AtomicReference<>();
+		HelmPluginRunner runner = (command, environment, dir) -> {
+			ranCommand.set(command);
+			return 42;
+		};
+		IParameterExceptionHandler delegate = (ex, args) -> {
+			throw new AssertionError("delegate must not be called for a plugin");
+		};
+		HelmPluginParameterExceptionHandler handler = new HelmPluginParameterExceptionHandler(delegate,
+				dispatcher(runner));
+
+		int code = handler.handleParseException(parseFailure("diff", "upgrade", "rel"),
+				new String[] { "diff", "upgrade", "rel" });
+
+		assertEquals(42, code, "should return the plugin exit code");
+		assertEquals(List.of("run-diff", "upgrade", "rel"), ranCommand.get());
+	}
+
+	@Test
+	void delegatesWhenUnmatchedNameIsNotAPlugin() throws Exception {
+		HelmPluginRunner runner = (command, environment, dir) -> {
+			throw new AssertionError("runner must not be called for a non-plugin");
+		};
+		IParameterExceptionHandler delegate = (ex, args) -> 2;
+		HelmPluginParameterExceptionHandler handler = new HelmPluginParameterExceptionHandler(delegate,
+				dispatcher(runner));
+
+		int code = handler.handleParseException(parseFailure("bogus"), new String[] { "bogus" });
+
+		assertEquals(2, code, "should defer to the default handler");
+	}
+
+	@CommandLine.Command(name = "jhelm")
+	static class Root {
+
+	}
+
+}


### PR DESCRIPTION
Second slice of the Helm-plugin epic (#733). Makes `jhelm <name>` run an installed **Helm subcommand plugin** (helm-diff, helm-secrets, …) — the headline of Helm-plugin compatibility.

## What's here
- **`HelmPluginRunner` / `ProcessHelmPluginRunner`** — run the resolved plugin command as a child process with inherited stdio; the plugin's exit code becomes jhelm's exit code (matching helm).
- **`HelmPluginDispatcher`** — resolves the platform command, builds the `HELM_*` env from jhelm's runtime config (`RepoManager`/`RegistryManager`/kube props, same source as `jhelm env`), and runs it. Gated on `FULL` mode via `HelmPluginExecGuard` (native code = same trust boundary as helm).
- **`HelmPluginParameterExceptionHandler`** — hooks Picocli's unmatched-subcommand path on the root command; a name that isn't a plugin falls through to the normal `Unmatched argument` error.
- Wired the handler in `HelmJavaApplication` before `cmd.execute`.

## Verified end-to-end (real CLI jar + stub plugin)
- `jhelm hello world foo` → plugin runs, args `[world foo]` forwarded, `HELM_NAMESPACE`/`HELM_PLUGIN_DIR` set, exit 0
- plugin `exit 5` → `jhelm` exits 5
- unknown non-plugin → normal `Unmatched argument at index 0` error
- `-Djhelm.security.mode=READ_ONLY` → refused with the gate message, plugin not run

## Tests
6 unit tests using a **real bash-script plugin fixture** (no mocks, per repo rules): dispatch + arg/env forwarding + exit-code propagation + READ_ONLY refusal, and handler routing (plugin vs delegate). Full `clean install` green locally.

Part of #733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)