### PR TITLE
feat(cli): install Helm plugins from git/tarball/dir + hooks (#736)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PluginCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PluginCommand.java
@@ -1,9 +1,13 @@
 package org.alexmond.jhelm.app.command;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.Callable;
 
+import org.alexmond.jhelm.app.plugin.DiscoveredHelmPlugin;
+import org.alexmond.jhelm.app.plugin.HelmPluginInstaller;
 import org.alexmond.jhelm.plugin.model.PluginDescriptor;
 import org.alexmond.jhelm.plugin.service.PluginManager;
 import org.springframework.beans.factory.ObjectProvider;
@@ -35,36 +39,70 @@ public class PluginCommand implements Callable<Integer> {
 	}
 
 	/**
-	 * Implements {@code plugin install}: installs a plugin from a {@code .jhp} archive.
+	 * Implements {@code plugin install}: installs a Helm plugin from a git URL, a
+	 * {@code .tar.gz}/{@code .tgz} archive, or a local directory (mirroring
+	 * {@code helm plugin install}), or a jhelm {@code .jhp} WASM archive.
 	 */
 	@Component
 	@CommandLine.Command(name = "install", mixinStandardHelpOptions = true,
-			description = "Install a plugin from a .jhp archive")
+			description = "Install a plugin from a git URL, a .tar.gz/.tgz, a directory, or a .jhp archive")
 	public static class Install implements Callable<Integer> {
 
-		@CommandLine.Parameters(index = "0", description = "Path to plugin archive (.jhp)")
-		private File archivePath;
+		@CommandLine.Parameters(index = "0",
+				description = "Plugin source: a git URL, a .tar.gz/.tgz path or URL, a directory, or a .jhp archive")
+		private String source;
+
+		@CommandLine.Option(names = { "--version" },
+				description = "git ref (tag, branch, or commit) to install for a git source")
+		private String version;
 
 		private final ObjectProvider<PluginManager> pluginManagerProvider;
 
+		private final HelmPluginInstaller helmInstaller;
+
 		/**
 		 * Creates the command.
-		 * @param pluginManagerProvider provider for the plugin manager (may be absent
-		 * when plugins are disabled)
+		 * @param pluginManagerProvider provider for the WASM plugin manager (may be
+		 * absent when the {@code .jhp} plugin system is disabled)
+		 * @param helmInstaller installs Helm plugins from a git URL, archive, or
+		 * directory
 		 */
-		public Install(ObjectProvider<PluginManager> pluginManagerProvider) {
+		public Install(ObjectProvider<PluginManager> pluginManagerProvider, HelmPluginInstaller helmInstaller) {
 			this.pluginManagerProvider = pluginManagerProvider;
+			this.helmInstaller = helmInstaller;
 		}
 
 		@Override
 		public Integer call() {
-			PluginManager pm = pluginManagerProvider.getIfAvailable();
+			if (this.source.toLowerCase(Locale.ROOT).endsWith(".jhp")) {
+				return installWasm();
+			}
+			try {
+				DiscoveredHelmPlugin plugin = this.helmInstaller.install(this.source, this.version);
+				String ver = plugin.manifest().getVersion();
+				CliOutput.println(CliOutput.success(
+						"Installed plugin: " + plugin.name() + ((ver != null && !ver.isBlank()) ? " " + ver : "")));
+				return CommandLine.ExitCode.OK;
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				CliOutput.errPrintln(CliOutput.error("Interrupted while installing plugin"));
+				return CommandLine.ExitCode.SOFTWARE;
+			}
+			catch (IOException ex) {
+				CliOutput.errPrintln(CliOutput.error("Failed to install plugin: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
+			}
+		}
+
+		private Integer installWasm() {
+			PluginManager pm = this.pluginManagerProvider.getIfAvailable();
 			if (pm == null) {
 				CliOutput.errPrintln(CliOutput.error("Plugin system is not enabled. Set jhelm.plugins.enabled=true"));
 				return CommandLine.ExitCode.SOFTWARE;
 			}
 			try {
-				PluginDescriptor desc = pm.install(archivePath);
+				PluginDescriptor desc = pm.install(new File(this.source));
 				CliOutput.println(CliOutput.success("Installed plugin: " + desc.getManifest().getName() + " (type: "
 						+ desc.getManifest().getType().getValue() + ")"));
 				return CommandLine.ExitCode.OK;

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/GitCloner.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/GitCloner.java
@@ -1,0 +1,24 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Clones a git repository into a destination directory. Abstracted so the installer can
+ * be unit-tested without a network or a git binary.
+ */
+@FunctionalInterface
+public interface GitCloner {
+
+	/**
+	 * Clones {@code url} into {@code dest}, checking out {@code ref} when non-null.
+	 * @param url the git repository URL
+	 * @param ref an optional branch/tag/commit to check out, or {@code null} for the
+	 * default branch
+	 * @param dest the destination directory (created by the clone)
+	 * @throws IOException if the clone fails
+	 * @throws InterruptedException if interrupted while waiting for git
+	 */
+	void clone(String url, String ref, Path dest) throws IOException, InterruptedException;
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginDispatcher.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginDispatcher.java
@@ -2,7 +2,6 @@ package org.alexmond.jhelm.app.plugin;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -13,9 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.alexmond.jhelm.app.output.CliOutput;
 import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
-import org.alexmond.jhelm.core.service.RegistryManager;
-import org.alexmond.jhelm.core.service.RepoManager;
-import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine.ExitCode;
@@ -45,19 +41,17 @@ public class HelmPluginDispatcher {
 	private final HelmPluginRunner runner;
 
 	/**
-	 * Spring constructor: builds the discovery and {@code HELM_*} environment from
-	 * jhelm's already-resolved runtime configuration.
-	 * @param repoManager supplies the repository config and cache paths
-	 * @param registryManager supplies the registry config path
-	 * @param kubeProperties supplies the configured kubeconfig override, if any
+	 * Spring constructor: builds the discovery from the Helm plugins directory and
+	 * sources the {@code HELM_*} environment from the shared factory.
+	 * @param environmentFactory builds the {@code HELM_*} environment for plugin
+	 * processes
 	 * @param policy the security policy that gates native plugin execution
 	 * @param runner runs the resolved plugin command as a child process
 	 */
 	@Autowired
-	public HelmPluginDispatcher(RepoManager repoManager, RegistryManager registryManager,
-			JhelmKubernetesProperties kubeProperties, JhelmSecurityPolicy policy, HelmPluginRunner runner) {
-		this(new HelmPluginDiscovery(HelmPluginPaths.fromEnvironment()),
-				() -> springEnvironment(repoManager, registryManager, kubeProperties), policy, runner);
+	public HelmPluginDispatcher(HelmPluginEnvironmentFactory environmentFactory, JhelmSecurityPolicy policy,
+			HelmPluginRunner runner) {
+		this(new HelmPluginDiscovery(HelmPluginPaths.fromEnvironment()), environmentFactory::create, policy, runner);
 	}
 
 	HelmPluginDispatcher(HelmPluginDiscovery discovery, Supplier<HelmPluginEnvironment> environment,
@@ -113,33 +107,6 @@ public class HelmPluginDispatcher {
 			CliOutput.errPrintln(CliOutput.error("interrupted while running plugin '" + plugin.name() + '\''));
 			return ExitCode.SOFTWARE;
 		}
-	}
-
-	private static HelmPluginEnvironment springEnvironment(RepoManager repoManager, RegistryManager registryManager,
-			JhelmKubernetesProperties kubeProperties) {
-		return HelmPluginEnvironment.builder()
-			.paths(HelmPluginPaths.fromEnvironment())
-			.namespace(envOrDefault("HELM_NAMESPACE", "default"))
-			.kubeConfig(resolveKubeconfig(kubeProperties))
-			.registryConfig(registryManager.getConfigPath())
-			.repositoryConfig(repoManager.getConfigPath())
-			.repositoryCache(repoManager.getRepositoryCachePath())
-			.debug(Boolean.parseBoolean(envOrDefault("HELM_DEBUG", "false")))
-			.build();
-	}
-
-	private static String resolveKubeconfig(JhelmKubernetesProperties kubeProperties) {
-		String configured = kubeProperties.getKubeconfigPath();
-		if (configured != null && !configured.isBlank()) {
-			return configured;
-		}
-		return envOrDefault("KUBECONFIG",
-				Paths.get(System.getProperty("user.home", "."), ".kube", "config").toString());
-	}
-
-	private static String envOrDefault(String name, String fallback) {
-		String value = System.getenv(name);
-		return (value != null && !value.isBlank()) ? value : fallback;
 	}
 
 	// Retained for symmetry with test construction over an explicit plugins directory.

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginEnvironmentFactory.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginEnvironmentFactory.java
@@ -1,0 +1,68 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.nio.file.Paths;
+
+import org.alexmond.jhelm.core.service.RegistryManager;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Builds the {@code HELM_*} environment exported to Helm plugin processes (subcommand
+ * dispatch and install/update/delete hooks) from jhelm's already-resolved runtime
+ * configuration — the same sources {@code jhelm env} reports. Centralized here so the
+ * dispatcher and the installer export an identical environment.
+ */
+@Component
+public class HelmPluginEnvironmentFactory {
+
+	private final RepoManager repoManager;
+
+	private final RegistryManager registryManager;
+
+	private final JhelmKubernetesProperties kubeProperties;
+
+	/**
+	 * Creates the factory.
+	 * @param repoManager supplies the repository config and cache paths
+	 * @param registryManager supplies the registry config path
+	 * @param kubeProperties supplies the configured kubeconfig override, if any
+	 */
+	public HelmPluginEnvironmentFactory(RepoManager repoManager, RegistryManager registryManager,
+			JhelmKubernetesProperties kubeProperties) {
+		this.repoManager = repoManager;
+		this.registryManager = registryManager;
+		this.kubeProperties = kubeProperties;
+	}
+
+	/**
+	 * Builds a {@link HelmPluginEnvironment} from the current runtime configuration.
+	 * @return the environment source for plugin invocations
+	 */
+	public HelmPluginEnvironment create() {
+		return HelmPluginEnvironment.builder()
+			.paths(HelmPluginPaths.fromEnvironment())
+			.namespace(envOrDefault("HELM_NAMESPACE", "default"))
+			.kubeConfig(resolveKubeconfig())
+			.registryConfig(this.registryManager.getConfigPath())
+			.repositoryConfig(this.repoManager.getConfigPath())
+			.repositoryCache(this.repoManager.getRepositoryCachePath())
+			.debug(Boolean.parseBoolean(envOrDefault("HELM_DEBUG", "false")))
+			.build();
+	}
+
+	private String resolveKubeconfig() {
+		String configured = this.kubeProperties.getKubeconfigPath();
+		if (configured != null && !configured.isBlank()) {
+			return configured;
+		}
+		return envOrDefault("KUBECONFIG",
+				Paths.get(System.getProperty("user.home", "."), ".kube", "config").toString());
+	}
+
+	private static String envOrDefault(String name, String fallback) {
+		String value = System.getenv(name);
+		return (value != null && !value.isBlank()) ? value : fallback;
+	}
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginInstaller.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginInstaller.java
@@ -1,0 +1,272 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import java.util.zip.GZIPInputStream;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.io.FileUtils;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+/**
+ * Installs a Helm plugin from a Helm-style source — a git repository URL, a
+ * {@code .tar.gz}/{@code .tgz} archive (local file or {@code http(s)} URL), or a local
+ * directory — into the Helm plugins directory, then runs the plugin's {@code install}
+ * hook. Mirrors {@code helm plugin install}: the plugin lands under
+ * {@code $HELM_PLUGINS/<name>/}, keyed on the {@code name} from its {@code plugin.yaml}.
+ *
+ * <p>
+ * Copying files is inert and runs in any posture; running the {@code install} hook is
+ * arbitrary code, so it is gated on the CLI's {@code FULL} security mode (see
+ * {@link HelmPluginExecGuard}). In {@code READ_ONLY} the files are installed and the hook
+ * is skipped with a warning.
+ */
+@Slf4j
+@Component
+public class HelmPluginInstaller {
+
+	private static final YAMLMapper YAML = YAMLMapper.builder().build();
+
+	private final HelmPluginPaths paths;
+
+	private final Supplier<HelmPluginEnvironment> environment;
+
+	private final JhelmSecurityPolicy policy;
+
+	private final HelmPluginRunner runner;
+
+	private final GitCloner gitCloner;
+
+	/**
+	 * Spring constructor.
+	 * @param environmentFactory builds the {@code HELM_*} environment for hooks
+	 * @param policy the security policy that gates hook execution
+	 * @param runner runs install hooks as a child process
+	 */
+	@Autowired
+	public HelmPluginInstaller(HelmPluginEnvironmentFactory environmentFactory, JhelmSecurityPolicy policy,
+			HelmPluginRunner runner) {
+		this(HelmPluginPaths.fromEnvironment(), environmentFactory::create, policy, runner,
+				HelmPluginInstaller::gitClone);
+	}
+
+	HelmPluginInstaller(HelmPluginPaths paths, Supplier<HelmPluginEnvironment> environment, JhelmSecurityPolicy policy,
+			HelmPluginRunner runner, GitCloner gitCloner) {
+		this.paths = paths;
+		this.environment = environment;
+		this.policy = policy;
+		this.runner = runner;
+		this.gitCloner = gitCloner;
+	}
+
+	/**
+	 * Installs a plugin from the given source.
+	 * @param source a git URL, a {@code .tar.gz}/{@code .tgz} path or URL, or a local
+	 * directory
+	 * @param version an optional git ref (tag/branch/commit) for a git source, else
+	 * {@code null}
+	 * @return the installed plugin
+	 * @throws IOException if the source cannot be fetched, is malformed, or the plugin is
+	 * already installed
+	 * @throws InterruptedException if interrupted while cloning or running the hook
+	 */
+	public DiscoveredHelmPlugin install(String source, String version) throws IOException, InterruptedException {
+		Path staging = Files.createTempDirectory("jhelm-plugin-install");
+		try {
+			Path pluginRoot = stage(source, version, staging);
+			HelmPluginManifest manifest = readManifest(pluginRoot);
+			String name = resolveName(manifest, pluginRoot);
+			manifest.setName(name);
+			Path dest = this.paths.pluginsDir().resolve(name);
+			if (Files.exists(dest)) {
+				throw new IOException("plugin '" + name + "' is already installed (" + dest + ')');
+			}
+			Files.createDirectories(dest.getParent());
+			FileUtils.copyDirectory(pluginRoot.toFile(), dest.toFile());
+			DiscoveredHelmPlugin plugin = new DiscoveredHelmPlugin(name, dest, manifest);
+			runInstallHook(plugin);
+			return plugin;
+		}
+		finally {
+			FileUtils.deleteQuietly(staging.toFile());
+		}
+	}
+
+	private Path stage(String source, String version, Path staging) throws IOException, InterruptedException {
+		String lower = source.toLowerCase(Locale.ROOT);
+		if (isTarball(lower)) {
+			Path archive = isUrl(lower) ? download(source, staging) : Path.of(source);
+			extractTarGz(archive, staging);
+			return findPluginRoot(staging);
+		}
+		if (isGit(lower)) {
+			// Reject leading-dash values before cloning so a crafted source/ref cannot be
+			// smuggled to git as a flag, regardless of the cloner implementation.
+			if (source.startsWith("-")) {
+				throw new IOException("invalid git url: " + source);
+			}
+			if (version != null && version.startsWith("-")) {
+				throw new IOException("invalid git ref: " + version);
+			}
+			this.gitCloner.clone(source, version, staging);
+			return findPluginRoot(staging);
+		}
+		Path dir = Path.of(source);
+		if (Files.isDirectory(dir)) {
+			FileUtils.copyDirectory(dir.toFile(), staging.toFile());
+			return findPluginRoot(staging);
+		}
+		throw new IOException(
+				"unrecognized plugin source (expected a git URL, a .tar.gz/.tgz, or a directory): " + source);
+	}
+
+	private static boolean isUrl(String lower) {
+		return lower.startsWith("http://") || lower.startsWith("https://") || lower.startsWith("git://")
+				|| lower.startsWith("ssh://");
+	}
+
+	private static boolean isTarball(String lower) {
+		return lower.endsWith(".tar.gz") || lower.endsWith(".tgz");
+	}
+
+	private static boolean isGit(String lower) {
+		return lower.endsWith(".git") || lower.startsWith("git@") || lower.startsWith("git://")
+				|| lower.startsWith("ssh://") || (isUrl(lower) && !isTarball(lower));
+	}
+
+	private static Path download(String url, Path staging) throws IOException, InterruptedException {
+		Path target = staging.resolve("download.tgz");
+		HttpRequest request = HttpRequest.newBuilder(URI.create(url)).GET().build();
+		try (HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()) {
+			HttpResponse<Path> response = client.send(request, HttpResponse.BodyHandlers.ofFile(target));
+			if (response.statusCode() / 100 != 2) {
+				throw new IOException(
+						"failed to download plugin archive: HTTP " + response.statusCode() + " for " + url);
+			}
+			return target;
+		}
+	}
+
+	private static void extractTarGz(Path archive, Path dest) throws IOException {
+		try (InputStream in = Files.newInputStream(archive);
+				GZIPInputStream gzip = new GZIPInputStream(in);
+				TarArchiveInputStream tar = new TarArchiveInputStream(gzip)) {
+			TarArchiveEntry entry;
+			while ((entry = tar.getNextEntry()) != null) {
+				Path resolved = dest.resolve(entry.getName()).normalize();
+				if (!resolved.startsWith(dest)) {
+					throw new IOException("archive entry escapes target directory: " + entry.getName());
+				}
+				if (entry.isDirectory()) {
+					Files.createDirectories(resolved);
+				}
+				else {
+					Files.createDirectories(resolved.getParent());
+					Files.copy(tar, resolved);
+					// 0x40 is the owner-execute bit (S_IXUSR); preserve it so plugin
+					// scripts stay runnable.
+					if ((entry.getMode() & 0x40) != 0) {
+						resolved.toFile().setExecutable(true);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Finds the directory containing {@code plugin.yaml}, descending through wrappers.
+	 */
+	private static Path findPluginRoot(Path base) throws IOException {
+		if (hasManifest(base)) {
+			return base;
+		}
+		try (Stream<Path> tree = Files.walk(base)) {
+			return tree.filter(Files::isDirectory)
+				.filter(HelmPluginInstaller::hasManifest)
+				.findFirst()
+				.orElseThrow(() -> new IOException("no plugin.yaml found in the plugin source"));
+		}
+	}
+
+	private static boolean hasManifest(Path dir) {
+		return Files.isRegularFile(dir.resolve("plugin.yaml")) || Files.isRegularFile(dir.resolve("plugin.yml"));
+	}
+
+	private static HelmPluginManifest readManifest(Path pluginRoot) throws IOException {
+		Path manifest = Files.isRegularFile(pluginRoot.resolve("plugin.yaml")) ? pluginRoot.resolve("plugin.yaml")
+				: pluginRoot.resolve("plugin.yml");
+		return YAML.readValue(manifest.toFile(), HelmPluginManifest.class);
+	}
+
+	private static String resolveName(HelmPluginManifest manifest, Path pluginRoot) {
+		if (manifest.getName() != null && !manifest.getName().isBlank()) {
+			return manifest.getName();
+		}
+		return pluginRoot.getFileName().toString();
+	}
+
+	private void runInstallHook(DiscoveredHelmPlugin plugin) throws IOException, InterruptedException {
+		String hook = (plugin.manifest().getHooks() != null) ? plugin.manifest().getHooks().getInstall() : null;
+		if (hook == null || hook.isBlank()) {
+			return;
+		}
+		if (HelmPluginExecGuard.blocked(this.policy)) {
+			log.warn("install hook for plugin '{}' skipped in READ_ONLY mode — the plugin may be incomplete",
+					plugin.name());
+			return;
+		}
+		Map<String, String> env = this.environment.get().forPlugin(plugin);
+		String expanded = DiscoveredHelmPlugin.expand(hook, env);
+		int code = this.runner.run(List.of("sh", "-c", expanded), env, plugin.directory());
+		if (code != 0) {
+			throw new IOException("install hook for plugin '" + plugin.name() + "' failed (exit " + code + ')');
+		}
+	}
+
+	private static void gitClone(String url, String ref, Path dest) throws IOException, InterruptedException {
+		// Reject leading-dash values so a crafted url/ref cannot smuggle git flags, and
+		// end
+		// option parsing with "--" before the positional url/dest (defense in depth).
+		if (url.startsWith("-")) {
+			throw new IOException("invalid git url: " + url);
+		}
+		if (ref != null && ref.startsWith("-")) {
+			throw new IOException("invalid git ref: " + ref);
+		}
+		List<String> command = new ArrayList<>(List.of("git", "clone", "--depth", "1"));
+		if (ref != null && !ref.isBlank()) {
+			command.add("--branch");
+			command.add(ref);
+		}
+		command.add("--");
+		command.add(url);
+		command.add(dest.toString());
+		ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true);
+		builder.environment().put("GIT_TERMINAL_PROMPT", "0");
+		Process process = builder.start();
+		String output = new String(process.getInputStream().readAllBytes());
+		int code = process.waitFor();
+		if (code != 0) {
+			throw new IOException("git clone failed (exit " + code + "): " + output.strip());
+		}
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginInstallerTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginInstallerTest.java
@@ -1,0 +1,153 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import java.util.zip.GZIPOutputStream;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.io.FileUtils;
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HelmPluginInstallerTest {
+
+	@TempDir
+	Path pluginsDir;
+
+	@TempDir
+	Path work;
+
+	private HelmPluginInstaller installer(JhelmAccessMode mode, GitCloner cloner) {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(mode);
+		HelmPluginPaths paths = new HelmPluginPaths(Map.of("HELM_PLUGINS", this.pluginsDir.toString())::get,
+				Path.of("/home/tester"));
+		Supplier<HelmPluginEnvironment> env = () -> HelmPluginEnvironment.builder().paths(paths).build();
+		return new HelmPluginInstaller(paths, env, new JhelmSecurityPolicy(props), new ProcessHelmPluginRunner(),
+				cloner);
+	}
+
+	private Path pluginSourceDir(String name, String extraYaml) throws IOException {
+		Path dir = Files.createDirectories(this.work.resolve(name + "-src"));
+		Files.writeString(dir.resolve("plugin.yaml"), "name: " + name + "\nversion: 1.2.3\ncommand: run\n" + extraYaml);
+		return dir;
+	}
+
+	@Test
+	void installsFromLocalDirectory() throws Exception {
+		Path src = pluginSourceDir("mydiff", "");
+		HelmPluginInstaller installer = installer(JhelmAccessMode.FULL, failCloner());
+
+		DiscoveredHelmPlugin plugin = installer.install(src.toString(), null);
+
+		assertEquals("mydiff", plugin.name());
+		assertTrue(Files.isRegularFile(this.pluginsDir.resolve("mydiff/plugin.yaml")));
+		assertEquals("1.2.3", plugin.manifest().getVersion());
+	}
+
+	@Test
+	void installsFromLocalTarball() throws Exception {
+		Path src = pluginSourceDir("tarplugin", "");
+		Path tgz = this.work.resolve("tarplugin.tar.gz");
+		makeTarGz(src, tgz);
+		HelmPluginInstaller installer = installer(JhelmAccessMode.FULL, failCloner());
+
+		DiscoveredHelmPlugin plugin = installer.install(tgz.toString(), null);
+
+		assertEquals("tarplugin", plugin.name());
+		assertTrue(Files.isRegularFile(this.pluginsDir.resolve("tarplugin/plugin.yaml")));
+	}
+
+	@Test
+	void installsFromGitViaCloner() throws Exception {
+		Path src = pluginSourceDir("gitplugin", "");
+		GitCloner cloner = (url, ref, dest) -> FileUtils.copyDirectory(src.toFile(), dest.toFile());
+		HelmPluginInstaller installer = installer(JhelmAccessMode.FULL, cloner);
+
+		DiscoveredHelmPlugin plugin = installer.install("https://github.com/example/gitplugin.git", "v1");
+
+		assertEquals("gitplugin", plugin.name());
+		assertTrue(Files.isRegularFile(this.pluginsDir.resolve("gitplugin/plugin.yaml")));
+	}
+
+	@Test
+	void refusesToInstallOverExistingPlugin() throws Exception {
+		Path src = pluginSourceDir("dup", "");
+		installer(JhelmAccessMode.FULL, failCloner()).install(src.toString(), null);
+		IOException ex = assertThrows(IOException.class,
+				() -> installer(JhelmAccessMode.FULL, failCloner()).install(src.toString(), null));
+		assertTrue(ex.getMessage().contains("already installed"));
+	}
+
+	@Test
+	void rejectsUnrecognizedSource() {
+		assertThrows(IOException.class,
+				() -> installer(JhelmAccessMode.FULL, failCloner()).install("not-a-source", null));
+	}
+
+	@Test
+	void rejectsGitRefThatSmugglesAFlag() {
+		IOException ex = assertThrows(IOException.class, () -> installer(JhelmAccessMode.FULL, failCloner())
+			.install("git://example.com/x.git", "--upload-pack=touch /tmp/pwned"));
+		assertTrue(ex.getMessage().contains("invalid git ref"));
+	}
+
+	@Test
+	@EnabledOnOs({ OS.LINUX, OS.MAC })
+	void runsInstallHookInFullMode() throws Exception {
+		Path marker = this.work.resolve("hook-ran");
+		Path src = pluginSourceDir("hooked", "hooks:\n  install: \"touch " + marker + "\"\n");
+		installer(JhelmAccessMode.FULL, failCloner()).install(src.toString(), null);
+		assertTrue(Files.exists(marker), "install hook should run in FULL mode");
+	}
+
+	@Test
+	@EnabledOnOs({ OS.LINUX, OS.MAC })
+	void skipsInstallHookInReadOnlyMode() throws Exception {
+		Path marker = this.work.resolve("hook-skipped");
+		Path src = pluginSourceDir("hooked", "hooks:\n  install: \"touch " + marker + "\"\n");
+		DiscoveredHelmPlugin plugin = installer(JhelmAccessMode.READ_ONLY, failCloner()).install(src.toString(), null);
+		assertTrue(Files.isRegularFile(this.pluginsDir.resolve("hooked/plugin.yaml")), "files still installed");
+		assertFalse(Files.exists(marker), "install hook must not run in READ_ONLY mode");
+		assertEquals("hooked", plugin.name());
+	}
+
+	private static GitCloner failCloner() {
+		return (url, ref, dest) -> {
+			throw new AssertionError("git cloner should not be used");
+		};
+	}
+
+	private static void makeTarGz(Path sourceDir, Path target) throws IOException {
+		try (OutputStream fileOut = Files.newOutputStream(target);
+				GZIPOutputStream gzip = new GZIPOutputStream(fileOut);
+				TarArchiveOutputStream tar = new TarArchiveOutputStream(gzip);
+				Stream<Path> tree = Files.walk(sourceDir)) {
+			tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+			for (Path path : tree.filter(Files::isRegularFile).toList()) {
+				String name = sourceDir.getFileName() + "/" + sourceDir.relativize(path);
+				TarArchiveEntry entry = new TarArchiveEntry(path.toFile(), name);
+				tar.putArchiveEntry(entry);
+				Files.copy(path, tar);
+				tar.closeArchiveEntry();
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Third slice of the Helm-plugin epic (#733). `jhelm plugin install` gains **Helm-source parity**.

## What's here
`jhelm plugin install <source>` now accepts:
- a **git URL** (`--version <tag/branch/commit>`)
- a **`.tar.gz`/`.tgz`** (local file or `http(s)` URL)
- a **local directory**
- (still) a **`.jhp`** WASM archive

The plugin is materialized under `$HELM_PLUGINS/<name>/` (keyed on `plugin.yaml` `name`), then its **install hook** runs.

- **`HelmPluginInstaller`** — stage (git clone / download+extract / copy) → parse manifest → install → run install hook (`sh -c`) with the `HELM_*` env. Refuses to overwrite an existing plugin; **zip-slip guarded**; finds the plugin root through wrapper dirs (e.g. GitHub tarball).
- Install-hook execution is **gated on FULL mode** (arbitrary code); `READ_ONLY` installs files and skips the hook with a warning.
- **`HelmPluginEnvironmentFactory`** — shared `HELM_*` builder now used by both installer and dispatcher (dispatcher de-duplicated onto it).
- **`GitCloner`** — abstraction (real impl `git clone --depth 1`), injectable for tests. **Hardened against argv flag-smuggling** (per security review): reject leading-dash url/ref, `--` before positionals, `GIT_TERMINAL_PROMPT=0`.
- **`PluginCommand.Install`** — routes `.jhp` to the WASM manager, everything else to the Helm installer; adds `--version`.

## Verified end-to-end (real CLI jar)
install from dir + tarball → install hook runs → the installed plugin dispatches via `jhelm <name>` → re-install refused.

## Tests
8 installer unit tests with real dir/tarball/hook fixtures + a fake `GitCloner` + the injection guard (no mocks). Full jhelm-cli `install` (PMD/checkstyle/format/tests) green locally.

Part of #733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)