### PR TITLE
feat(cli): plugin list/update/uninstall parity for Helm plugins (#737)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PluginCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/PluginCommand.java
@@ -21,7 +21,8 @@ import org.alexmond.jhelm.app.output.CliOutput;
  */
 @Component
 @CommandLine.Command(name = "plugin", mixinStandardHelpOptions = true, description = "Manage plugins",
-		subcommands = { PluginCommand.Install.class, PluginCommand.Uninstall.class, PluginCommand.ListPlugins.class })
+		subcommands = { PluginCommand.Install.class, PluginCommand.Uninstall.class, PluginCommand.Update.class,
+				PluginCommand.ListPlugins.class })
 public class PluginCommand implements Callable<Integer> {
 
 	/** Creates the command. */
@@ -125,25 +126,48 @@ public class PluginCommand implements Callable<Integer> {
 
 		private final ObjectProvider<PluginManager> pluginManagerProvider;
 
+		private final HelmPluginInstaller helmInstaller;
+
 		/**
 		 * Creates the command.
-		 * @param pluginManagerProvider provider for the plugin manager (may be absent
-		 * when plugins are disabled)
+		 * @param pluginManagerProvider provider for the WASM plugin manager (may be
+		 * absent when the {@code .jhp} plugin system is disabled)
+		 * @param helmInstaller uninstalls Helm plugins from the Helm plugins directory
 		 */
-		public Uninstall(ObjectProvider<PluginManager> pluginManagerProvider) {
+		public Uninstall(ObjectProvider<PluginManager> pluginManagerProvider, HelmPluginInstaller helmInstaller) {
 			this.pluginManagerProvider = pluginManagerProvider;
+			this.helmInstaller = helmInstaller;
 		}
 
 		@Override
 		public Integer call() {
-			PluginManager pm = pluginManagerProvider.getIfAvailable();
+			try {
+				if (this.helmInstaller.uninstall(this.pluginName)) {
+					CliOutput.println(CliOutput.success("Uninstalled plugin: " + this.pluginName));
+					return CommandLine.ExitCode.OK;
+				}
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				CliOutput.errPrintln(CliOutput.error("Interrupted while uninstalling plugin"));
+				return CommandLine.ExitCode.SOFTWARE;
+			}
+			catch (IOException ex) {
+				CliOutput.errPrintln(CliOutput.error("Failed to uninstall plugin: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
+			}
+			return uninstallWasm();
+		}
+
+		private Integer uninstallWasm() {
+			PluginManager pm = this.pluginManagerProvider.getIfAvailable();
 			if (pm == null) {
-				CliOutput.errPrintln(CliOutput.error("Plugin system is not enabled. Set jhelm.plugins.enabled=true"));
+				CliOutput.errPrintln(CliOutput.error("Plugin '" + this.pluginName + "' is not installed"));
 				return CommandLine.ExitCode.SOFTWARE;
 			}
 			try {
-				pm.uninstall(pluginName);
-				CliOutput.println(CliOutput.success("Uninstalled plugin: " + pluginName));
+				pm.uninstall(this.pluginName);
+				CliOutput.println(CliOutput.success("Uninstalled plugin: " + this.pluginName));
 				return CommandLine.ExitCode.OK;
 			}
 			catch (Exception ex) {
@@ -154,41 +178,92 @@ public class PluginCommand implements Callable<Integer> {
 
 	}
 
-	/** Implements {@code plugin list}: prints the installed plugins as a table. */
+	/** Implements {@code plugin update}: refreshes an installed Helm plugin by name. */
+	@Component
+	@CommandLine.Command(name = "update", mixinStandardHelpOptions = true,
+			description = "Update an installed Helm plugin (git pull + update hook)")
+	public static class Update implements Callable<Integer> {
+
+		@CommandLine.Parameters(index = "0", description = "Plugin name")
+		private String pluginName;
+
+		private final HelmPluginInstaller helmInstaller;
+
+		/**
+		 * Creates the command.
+		 * @param helmInstaller updates Helm plugins in the Helm plugins directory
+		 */
+		public Update(HelmPluginInstaller helmInstaller) {
+			this.helmInstaller = helmInstaller;
+		}
+
+		@Override
+		public Integer call() {
+			try {
+				if (this.helmInstaller.update(this.pluginName).isEmpty()) {
+					CliOutput.errPrintln(CliOutput.error("Plugin '" + this.pluginName + "' is not installed"));
+					return CommandLine.ExitCode.SOFTWARE;
+				}
+				CliOutput.println(CliOutput.success("Updated plugin: " + this.pluginName));
+				return CommandLine.ExitCode.OK;
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				CliOutput.errPrintln(CliOutput.error("Interrupted while updating plugin"));
+				return CommandLine.ExitCode.SOFTWARE;
+			}
+			catch (IOException ex) {
+				CliOutput.errPrintln(CliOutput.error("Failed to update plugin: " + ex.getMessage()));
+				return CommandLine.ExitCode.SOFTWARE;
+			}
+		}
+
+	}
+
+	/** Implements {@code plugin list}: prints the installed Helm and WASM plugins. */
 	@Component
 	@CommandLine.Command(name = "list", mixinStandardHelpOptions = true, description = "List installed plugins")
 	public static class ListPlugins implements Callable<Integer> {
 
 		private final ObjectProvider<PluginManager> pluginManagerProvider;
 
+		private final HelmPluginInstaller helmInstaller;
+
 		/**
 		 * Creates the command.
-		 * @param pluginManagerProvider provider for the plugin manager (may be absent
-		 * when plugins are disabled)
+		 * @param pluginManagerProvider provider for the WASM plugin manager (may be
+		 * absent when the {@code .jhp} plugin system is disabled)
+		 * @param helmInstaller lists Helm plugins from the Helm plugins directory
 		 */
-		public ListPlugins(ObjectProvider<PluginManager> pluginManagerProvider) {
+		public ListPlugins(ObjectProvider<PluginManager> pluginManagerProvider, HelmPluginInstaller helmInstaller) {
 			this.pluginManagerProvider = pluginManagerProvider;
+			this.helmInstaller = helmInstaller;
 		}
 
 		@Override
 		public Integer call() {
-			PluginManager pm = pluginManagerProvider.getIfAvailable();
-			if (pm == null) {
-				CliOutput.errPrintln(CliOutput.error("Plugin system is not enabled. Set jhelm.plugins.enabled=true"));
-				return CommandLine.ExitCode.SOFTWARE;
-			}
-			List<PluginDescriptor> plugins = pm.list();
-			if (plugins.isEmpty()) {
+			List<DiscoveredHelmPlugin> helmPlugins = this.helmInstaller.list();
+			PluginManager pm = this.pluginManagerProvider.getIfAvailable();
+			List<PluginDescriptor> wasmPlugins = (pm != null) ? pm.list() : List.of();
+			if (helmPlugins.isEmpty() && wasmPlugins.isEmpty()) {
 				CliOutput.println("No plugins installed.");
 				return CommandLine.ExitCode.OK;
 			}
-			CliOutput.printf("%-20s %-15s %-10s%n", CliOutput.bold("NAME"), CliOutput.bold("TYPE"),
-					CliOutput.bold("VERSION"));
-			for (PluginDescriptor desc : plugins) {
-				CliOutput.printf("%-20s %-15s %-10s%n", desc.getManifest().getName(),
-						desc.getManifest().getType().getValue(), desc.getManifest().getVersion());
+			CliOutput.printf("%-24s %-6s %-12s %s%n", CliOutput.bold("NAME"), CliOutput.bold("KIND"),
+					CliOutput.bold("VERSION"), CliOutput.bold("DESCRIPTION"));
+			for (DiscoveredHelmPlugin plugin : helmPlugins) {
+				CliOutput.printf("%-24s %-6s %-12s %s%n", plugin.name(), "helm", orDash(plugin.manifest().getVersion()),
+						orDash(plugin.manifest().getUsage()));
+			}
+			for (PluginDescriptor desc : wasmPlugins) {
+				CliOutput.printf("%-24s %-6s %-12s %s%n", desc.getManifest().getName(), "wasm",
+						orDash(desc.getManifest().getVersion()), orDash(desc.getManifest().getDescription()));
 			}
 			return CommandLine.ExitCode.OK;
+		}
+
+		private static String orDash(String value) {
+			return (value != null && !value.isBlank()) ? value : "-";
 		}
 
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/GitUpdater.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/GitUpdater.java
@@ -1,0 +1,21 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Refreshes a git-checked-out plugin in place (a {@code git pull}). Abstracted so the
+ * installer can be unit-tested without a network or a git binary.
+ */
+@FunctionalInterface
+public interface GitUpdater {
+
+	/**
+	 * Updates the git working tree at {@code dir} to the latest of its tracked branch.
+	 * @param dir the plugin directory (a git checkout)
+	 * @throws IOException if the update fails
+	 * @throws InterruptedException if interrupted while waiting for git
+	 */
+	void update(Path dir) throws IOException, InterruptedException;
+
+}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginInstaller.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginInstaller.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
@@ -55,11 +56,13 @@ public class HelmPluginInstaller {
 
 	private final GitCloner gitCloner;
 
+	private final GitUpdater gitUpdater;
+
 	/**
 	 * Spring constructor.
 	 * @param environmentFactory builds the {@code HELM_*} environment for hooks
 	 * @param policy the security policy that gates hook execution
-	 * @param runner runs install hooks as a child process
+	 * @param runner runs install/update/delete hooks as a child process
 	 */
 	@Autowired
 	public HelmPluginInstaller(HelmPluginEnvironmentFactory environmentFactory, JhelmSecurityPolicy policy,
@@ -70,11 +73,81 @@ public class HelmPluginInstaller {
 
 	HelmPluginInstaller(HelmPluginPaths paths, Supplier<HelmPluginEnvironment> environment, JhelmSecurityPolicy policy,
 			HelmPluginRunner runner, GitCloner gitCloner) {
+		this(paths, environment, policy, runner, gitCloner, HelmPluginInstaller::gitPull);
+	}
+
+	HelmPluginInstaller(HelmPluginPaths paths, Supplier<HelmPluginEnvironment> environment, JhelmSecurityPolicy policy,
+			HelmPluginRunner runner, GitCloner gitCloner, GitUpdater gitUpdater) {
 		this.paths = paths;
 		this.environment = environment;
 		this.policy = policy;
 		this.runner = runner;
 		this.gitCloner = gitCloner;
+		this.gitUpdater = gitUpdater;
+	}
+
+	/**
+	 * Lists the Helm plugins installed under the Helm plugins directory.
+	 * @return the installed Helm plugins, sorted by name
+	 */
+	public List<DiscoveredHelmPlugin> list() {
+		return new HelmPluginDiscovery(this.paths).discover();
+	}
+
+	/**
+	 * Uninstalls an installed Helm plugin: runs its {@code delete} hook, then removes its
+	 * directory.
+	 * @param name the plugin name
+	 * @return {@code true} if a plugin was removed, {@code false} if none was installed
+	 * under that name
+	 * @throws IOException if the directory cannot be removed
+	 * @throws InterruptedException if interrupted while running the delete hook
+	 */
+	public boolean uninstall(String name) throws IOException, InterruptedException {
+		Optional<DiscoveredHelmPlugin> found = new HelmPluginDiscovery(this.paths).find(name);
+		if (found.isEmpty()) {
+			return false;
+		}
+		DiscoveredHelmPlugin plugin = found.get();
+		String hook = (plugin.manifest().getHooks() != null) ? plugin.manifest().getHooks().getDelete() : null;
+		try {
+			runHook(plugin, hook, "delete");
+		}
+		catch (IOException ex) {
+			// A failing delete hook must not strand the plugin files; log and remove
+			// anyway.
+			log.warn("delete hook for plugin '{}' failed, removing anyway: {}", name, ex.getMessage());
+		}
+		FileUtils.deleteDirectory(plugin.directory().toFile());
+		return true;
+	}
+
+	/**
+	 * Updates an installed Helm plugin: for a git-checked-out plugin, refreshes it with a
+	 * {@code git pull}; then runs its {@code update} hook.
+	 * @param name the plugin name
+	 * @return the updated plugin, or empty if none is installed under that name
+	 * @throws IOException if the update fails
+	 * @throws InterruptedException if interrupted while updating or running the hook
+	 */
+	public Optional<DiscoveredHelmPlugin> update(String name) throws IOException, InterruptedException {
+		HelmPluginDiscovery discovery = new HelmPluginDiscovery(this.paths);
+		Optional<DiscoveredHelmPlugin> found = discovery.find(name);
+		if (found.isEmpty()) {
+			return Optional.empty();
+		}
+		DiscoveredHelmPlugin plugin = found.get();
+		if (Files.isDirectory(plugin.directory().resolve(".git"))) {
+			this.gitUpdater.update(plugin.directory());
+		}
+		else {
+			log.warn("plugin '{}' was not installed from git; running its update hook without refreshing sources",
+					name);
+		}
+		DiscoveredHelmPlugin refreshed = discovery.find(name).orElse(plugin);
+		String hook = (refreshed.manifest().getHooks() != null) ? refreshed.manifest().getHooks().getUpdate() : null;
+		runHook(refreshed, hook, "update");
+		return Optional.of(refreshed);
 	}
 
 	/**
@@ -225,11 +298,16 @@ public class HelmPluginInstaller {
 
 	private void runInstallHook(DiscoveredHelmPlugin plugin) throws IOException, InterruptedException {
 		String hook = (plugin.manifest().getHooks() != null) ? plugin.manifest().getHooks().getInstall() : null;
+		runHook(plugin, hook, "install");
+	}
+
+	private void runHook(DiscoveredHelmPlugin plugin, String hook, String phase)
+			throws IOException, InterruptedException {
 		if (hook == null || hook.isBlank()) {
 			return;
 		}
 		if (HelmPluginExecGuard.blocked(this.policy)) {
-			log.warn("install hook for plugin '{}' skipped in READ_ONLY mode — the plugin may be incomplete",
+			log.warn("{} hook for plugin '{}' skipped in READ_ONLY mode — the plugin may be incomplete", phase,
 					plugin.name());
 			return;
 		}
@@ -237,7 +315,19 @@ public class HelmPluginInstaller {
 		String expanded = DiscoveredHelmPlugin.expand(hook, env);
 		int code = this.runner.run(List.of("sh", "-c", expanded), env, plugin.directory());
 		if (code != 0) {
-			throw new IOException("install hook for plugin '" + plugin.name() + "' failed (exit " + code + ')');
+			throw new IOException(phase + " hook for plugin '" + plugin.name() + "' failed (exit " + code + ')');
+		}
+	}
+
+	private static void gitPull(Path dir) throws IOException, InterruptedException {
+		List<String> command = List.of("git", "-C", dir.toString(), "pull", "--ff-only");
+		ProcessBuilder builder = new ProcessBuilder(command).redirectErrorStream(true);
+		builder.environment().put("GIT_TERMINAL_PROMPT", "0");
+		Process process = builder.start();
+		String output = new String(process.getInputStream().readAllBytes());
+		int code = process.waitFor();
+		if (code != 0) {
+			throw new IOException("git pull failed (exit " + code + "): " + output.strip());
 		}
 	}
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginInstallerTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginInstallerTest.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
@@ -126,6 +128,58 @@ class HelmPluginInstallerTest {
 		assertTrue(Files.isRegularFile(this.pluginsDir.resolve("hooked/plugin.yaml")), "files still installed");
 		assertFalse(Files.exists(marker), "install hook must not run in READ_ONLY mode");
 		assertEquals("hooked", plugin.name());
+	}
+
+	@Test
+	void listReturnsInstalledPlugins() throws Exception {
+		installer(JhelmAccessMode.FULL, failCloner()).install(pluginSourceDir("aaa", "").toString(), null);
+		installer(JhelmAccessMode.FULL, failCloner()).install(pluginSourceDir("bbb", "").toString(), null);
+		List<DiscoveredHelmPlugin> list = installer(JhelmAccessMode.FULL, failCloner()).list();
+		assertEquals(List.of("aaa", "bbb"), list.stream().map(DiscoveredHelmPlugin::name).toList());
+	}
+
+	@Test
+	void uninstallRemovesThePluginDirectory() throws Exception {
+		installer(JhelmAccessMode.FULL, failCloner()).install(pluginSourceDir("gone", "").toString(), null);
+		assertTrue(installer(JhelmAccessMode.FULL, failCloner()).uninstall("gone"));
+		assertFalse(Files.exists(this.pluginsDir.resolve("gone")));
+		assertFalse(installer(JhelmAccessMode.FULL, failCloner()).uninstall("gone"), "second uninstall finds nothing");
+	}
+
+	@Test
+	@EnabledOnOs({ OS.LINUX, OS.MAC })
+	void uninstallRunsDeleteHook() throws Exception {
+		Path marker = this.work.resolve("deleted");
+		installer(JhelmAccessMode.FULL, failCloner())
+			.install(pluginSourceDir("hd", "hooks:\n  delete: \"touch " + marker + "\"\n").toString(), null);
+		installer(JhelmAccessMode.FULL, failCloner()).uninstall("hd");
+		assertTrue(Files.exists(marker), "delete hook should run");
+		assertFalse(Files.exists(this.pluginsDir.resolve("hd")), "directory removed");
+	}
+
+	@Test
+	void updateGitPluginPullsThroughTheUpdater() throws Exception {
+		installer(JhelmAccessMode.FULL, failCloner()).install(pluginSourceDir("gp", "").toString(), null);
+		Files.createDirectories(this.pluginsDir.resolve("gp/.git"));
+		AtomicBoolean pulled = new AtomicBoolean();
+		HelmPluginInstaller inst = installer6(JhelmAccessMode.FULL, (dir) -> pulled.set(true));
+		assertTrue(inst.update("gp").isPresent());
+		assertTrue(pulled.get(), "git-checked-out plugin should be pulled");
+	}
+
+	@Test
+	void updateReturnsEmptyForUnknownPlugin() throws Exception {
+		assertTrue(installer(JhelmAccessMode.FULL, failCloner()).update("nope").isEmpty());
+	}
+
+	private HelmPluginInstaller installer6(JhelmAccessMode mode, GitUpdater updater) {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(mode);
+		HelmPluginPaths paths = new HelmPluginPaths(Map.of("HELM_PLUGINS", this.pluginsDir.toString())::get,
+				Path.of("/home/tester"));
+		Supplier<HelmPluginEnvironment> env = () -> HelmPluginEnvironment.builder().paths(paths).build();
+		return new HelmPluginInstaller(paths, env, new JhelmSecurityPolicy(props), new ProcessHelmPluginRunner(),
+				failCloner(), updater);
 	}
 
 	private static GitCloner failCloner() {


### PR DESCRIPTION
Fourth slice of the Helm-plugin epic (#733): `plugin list` / `uninstall` / `update` reach Helm parity and reconcile with the WASM (`.jhp`) plugins.

## What's here
- **`plugin list`** — shows Helm plugins (from `$HELM_PLUGINS`) alongside the WASM plugins in one table with a **KIND** column (`helm`/`wasm`), plus NAME/VERSION/DESCRIPTION.
- **`plugin uninstall <name>`** — removes a Helm plugin: runs its **delete hook** (gated FULL; a failing hook logs and still removes the files), deletes the dir; falls back to the WASM manager when the name isn't a Helm plugin. Clean "not installed" message otherwise.
- **`plugin update <name>`** (new) — **`git pull`** for a git-checked-out plugin, then runs its **update hook**; a non-git plugin runs the hook with a warning that sources aren't refreshed.

`HelmPluginInstaller` gains `list()`/`uninstall()`/`update()`; hook execution generalized (install/update/delete), gated on FULL. New **`GitUpdater`** abstraction (real impl `git -C <dir> pull --ff-only`, `GIT_TERMINAL_PROMPT=0`), injectable for tests.

## Verified end-to-end (real CLI jar)
`list` shows both kinds → `update` (non-git warns + runs hook) → `uninstall` runs the delete hook (`bye`) and removes the dir → `list` shows it gone → unknown name reports cleanly.

## Tests
13 installer unit tests (real dir/tarball/hook fixtures, fake `GitCloner`/`GitUpdater`, injection guard). jhelm-cli `install` (PMD/checkstyle/format/tests) green locally.

Part of #733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)