### PR TITLE
feat(cli): dispatch custom chart URL schemes to Helm downloader plugins (#738)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginChartDownloader.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPluginChartDownloader.java
@@ -1,0 +1,148 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.service.ChartDownloader;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bridges jhelm's {@link ChartDownloader} SPI to installed Helm <em>downloader</em>
+ * plugins (helm-s3, helm-gcs, …). When a chart URL uses a custom scheme a plugin declares
+ * (its {@code plugin.yaml} {@code downloaders[].protocols}), the plugin's downloader
+ * command is run with Helm's contract — {@code command <cert> <key> <ca> <full-URL>} —
+ * and the chart bytes are read from its standard output.
+ *
+ * <p>
+ * Registered as a bean, so jhelm's core auto-configuration wires it into
+ * {@code RepoManager} alongside the built-in HTTP/OCI paths. Running the plugin is gated
+ * on the CLI's {@code FULL} security mode (the plugin is arbitrary local code).
+ */
+@Component
+public class HelmPluginChartDownloader implements ChartDownloader {
+
+	private final HelmPluginPaths paths;
+
+	private final Supplier<HelmPluginEnvironment> environment;
+
+	private final JhelmSecurityPolicy policy;
+
+	/**
+	 * Spring constructor. The environment factory is injected as an
+	 * {@link ObjectProvider} and resolved lazily at download time: it depends on
+	 * {@code RepoManager}, which in turn registers this downloader, so an eager
+	 * dependency here would be circular.
+	 * @param environmentFactory provides the {@code HELM_*} environment builder (resolved
+	 * lazily)
+	 * @param policy the security policy that gates native plugin execution
+	 */
+	@Autowired
+	public HelmPluginChartDownloader(ObjectProvider<HelmPluginEnvironmentFactory> environmentFactory,
+			JhelmSecurityPolicy policy) {
+		this(HelmPluginPaths.fromEnvironment(), () -> environmentFactory.getObject().create(), policy);
+	}
+
+	HelmPluginChartDownloader(HelmPluginPaths paths, Supplier<HelmPluginEnvironment> environment,
+			JhelmSecurityPolicy policy) {
+		this.paths = paths;
+		this.environment = environment;
+		this.policy = policy;
+	}
+
+	@Override
+	public boolean supportsProtocol(String protocol) {
+		return findDownloader(protocol).isPresent();
+	}
+
+	@Override
+	public byte[] download(String url) throws IOException {
+		int schemeEnd = url.indexOf("://");
+		String scheme = (schemeEnd > 0) ? url.substring(0, schemeEnd) : url;
+		Match match = findDownloader(scheme)
+			.orElseThrow(() -> new IOException("no Helm downloader plugin handles scheme '" + scheme + '\''));
+		if (this.policy.mode() != JhelmAccessMode.FULL) {
+			throw new IOException("running native Helm plugins is disabled in READ_ONLY mode — set "
+					+ "jhelm.security.mode=FULL to enable");
+		}
+		return invoke(match, url);
+	}
+
+	private Optional<Match> findDownloader(String protocol) {
+		for (DiscoveredHelmPlugin plugin : new HelmPluginDiscovery(this.paths).discover()) {
+			for (HelmPluginManifest.Downloader downloader : plugin.manifest().getDownloaders()) {
+				boolean handles = downloader.getProtocols().stream().anyMatch((p) -> p.equalsIgnoreCase(protocol));
+				if (handles && downloader.getCommand() != null && !downloader.getCommand().isBlank()) {
+					return Optional.of(new Match(plugin, downloader.getCommand()));
+				}
+			}
+		}
+		return Optional.empty();
+	}
+
+	private byte[] invoke(Match match, String url) throws IOException {
+		Map<String, String> env = this.environment.get().forPlugin(match.plugin());
+		String expanded = DiscoveredHelmPlugin.expand(match.command(), env);
+		List<String> argv = new ArrayList<>(DiscoveredHelmPlugin.tokenize(expanded));
+		if (argv.isEmpty()) {
+			throw new IOException("downloader plugin '" + match.plugin().name() + "' declares no command");
+		}
+		// Helm's downloader contract: <cert-file> <key-file> <ca-file> <full-URL>.
+		argv.add("");
+		argv.add("");
+		argv.add("");
+		argv.add(url);
+		ProcessBuilder builder = new ProcessBuilder(argv).directory(match.plugin().directory().toFile());
+		builder.environment().putAll(env);
+		Process process = builder.start();
+		CompletableFuture<byte[]> stderr = CompletableFuture.supplyAsync(() -> readAll(process.getErrorStream()));
+		byte[] chart = readAll(process.getInputStream());
+		int code;
+		try {
+			code = process.waitFor();
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			throw new IOException("interrupted while running downloader plugin '" + match.plugin().name() + '\'', ex);
+		}
+		if (code != 0) {
+			String message = new String(stderr.join(), StandardCharsets.UTF_8).strip();
+			throw new IOException(
+					"downloader plugin '" + match.plugin().name() + "' failed (exit " + code + "): " + message);
+		}
+		return chart;
+	}
+
+	private static byte[] readAll(InputStream in) {
+		try (in) {
+			return in.readAllBytes();
+		}
+		catch (IOException ex) {
+			throw new UncheckedIOException(ex);
+		}
+	}
+
+	// Retained for test construction over an explicit plugins directory.
+	static HelmPluginChartDownloader forTesting(Path pluginsDir, Supplier<HelmPluginEnvironment> environment,
+			JhelmSecurityPolicy policy) {
+		HelmPluginPaths paths = new HelmPluginPaths(Map.of("HELM_PLUGINS", pluginsDir.toString())::get,
+				Path.of(System.getProperty("user.home", ".")));
+		return new HelmPluginChartDownloader(paths, environment, policy);
+	}
+
+	private record Match(DiscoveredHelmPlugin plugin, String command) {
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginChartDownloaderTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginChartDownloaderTest.java
@@ -1,0 +1,86 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledOnOs({ OS.LINUX, OS.MAC })
+class HelmPluginChartDownloaderTest {
+
+	@TempDir
+	Path pluginsDir;
+
+	private void installDownloaderPlugin() throws IOException {
+		Path dir = Files.createDirectories(this.pluginsDir.resolve("s3"));
+		Files.writeString(dir.resolve("plugin.yaml"), """
+				name: s3
+				version: 1.0.0
+				command: "$HELM_PLUGIN_DIR/dl.sh"
+				downloaders:
+				  - command: "$HELM_PLUGIN_DIR/dl.sh"
+				    protocols:
+				      - test
+				""");
+		// Emits chart bytes on stdout; the URL is the 4th arg (after cert/key/ca).
+		Path dl = dir.resolve("dl.sh");
+		Files.writeString(dl, "#!/usr/bin/env bash\nprintf 'CHART-FOR:%s' \"$4\"\n");
+		dl.toFile().setExecutable(true);
+	}
+
+	private HelmPluginChartDownloader downloader(JhelmAccessMode mode) {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(mode);
+		HelmPluginPaths paths = new HelmPluginPaths(Map.of("HELM_PLUGINS", this.pluginsDir.toString())::get,
+				Path.of("/home/tester"));
+		Supplier<HelmPluginEnvironment> env = () -> HelmPluginEnvironment.builder().paths(paths).build();
+		return HelmPluginChartDownloader.forTesting(this.pluginsDir, env, new JhelmSecurityPolicy(props));
+	}
+
+	@Test
+	void supportsDeclaredProtocolOnly() throws Exception {
+		installDownloaderPlugin();
+		assertTrue(downloader(JhelmAccessMode.FULL).supportsProtocol("test"));
+		assertFalse(downloader(JhelmAccessMode.FULL).supportsProtocol("s3"));
+		assertFalse(downloader(JhelmAccessMode.FULL).supportsProtocol("nope"));
+	}
+
+	@Test
+	void downloadsChartBytesViaTheContract() throws Exception {
+		installDownloaderPlugin();
+		byte[] bytes = downloader(JhelmAccessMode.FULL).download("test://bucket/mychart-1.0.0.tgz");
+		assertEquals("CHART-FOR:test://bucket/mychart-1.0.0.tgz", new String(bytes, StandardCharsets.UTF_8));
+	}
+
+	@Test
+	void readOnlyModeRefusesDownload() throws Exception {
+		installDownloaderPlugin();
+		IOException ex = assertThrows(IOException.class,
+				() -> downloader(JhelmAccessMode.READ_ONLY).download("test://bucket/x.tgz"));
+		assertTrue(ex.getMessage().contains("READ_ONLY"));
+	}
+
+	@Test
+	void unknownSchemeThrows() throws Exception {
+		installDownloaderPlugin();
+		IOException ex = assertThrows(IOException.class,
+				() -> downloader(JhelmAccessMode.FULL).download("gs://bucket/x.tgz"));
+		assertTrue(ex.getMessage().contains("gs"));
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -37,6 +37,7 @@ import org.alexmond.jhelm.core.action.TemplateAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.action.VerifyAction;
+import org.alexmond.jhelm.core.service.ChartDownloader;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.ConfigServerClient;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
@@ -108,13 +109,15 @@ public class JhelmCoreAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public RepoManager repoManager(JhelmCoreProperties props, JhelmSecurityProperties securityProps,
-			RegistryManager registryManager, ObjectProvider<JhelmMetrics> metrics) {
+			RegistryManager registryManager, ObjectProvider<JhelmMetrics> metrics,
+			ObjectProvider<ChartDownloader> chartDownloaders) {
 		boolean blockPrivate = securityProps.isBlockPrivateNetworks();
 		RepoManager repoManager = (props.getConfigPath() != null)
 				? new RepoManager(props.getConfigPath(), registryManager, props.isInsecureSkipTlsVerify(), blockPrivate)
 				: new RepoManager(registryManager, props.isInsecureSkipTlsVerify(), blockPrivate);
 		repoManager.setMetrics(metrics.getIfAvailable());
 		repoManager.setRepositoryCacheOverride(props.getRepositoryCachePath());
+		repoManager.setChartDownloaders(chartDownloaders.stream().toList());
 		return repoManager;
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -67,6 +67,10 @@ public class RepoManager {
 	// Null in library/direct-construction use (no instrumentation, no overhead).
 	private JhelmMetrics metrics;
 
+	// Custom-protocol chart downloaders (Helm downloader plugins: s3://, gs://, ...),
+	// consulted before the HTTP path in pullFromUrl. Set by the auto-configuration.
+	private List<ChartDownloader> chartDownloaders = List.of();
+
 	// Optional repository-cache directory override (Helm's --repository-cache), set by
 	// the
 	// auto-configuration from jhelm.repository-cache-path. Null -> standard resolution.
@@ -162,6 +166,16 @@ public class RepoManager {
 	 */
 	public void setMetrics(JhelmMetrics metrics) {
 		this.metrics = metrics;
+	}
+
+	/**
+	 * Registers custom-protocol chart downloaders (Helm downloader plugins). When a chart
+	 * URL uses a scheme one of these supports (for example {@code s3://}), it is fetched
+	 * via that downloader instead of the built-in HTTP path.
+	 * @param chartDownloaders the downloaders to consult (never {@code null})
+	 */
+	public void setChartDownloaders(List<ChartDownloader> chartDownloaders) {
+		this.chartDownloaders = (chartDownloaders != null) ? List.copyOf(chartDownloaders) : List.of();
 	}
 
 	private void recordChartPull(String source, JhelmMetrics.IoRunnable op) throws IOException {
@@ -1014,7 +1028,38 @@ public class RepoManager {
 			pullOci(chartUrl, destDir, fileName);
 			return;
 		}
+		ChartDownloader downloader = findChartDownloader(chartUrl);
+		if (downloader != null) {
+			recordChartPull("plugin", () -> doDownloaderPull(downloader, chartUrl, destDir, fileName));
+			return;
+		}
 		recordChartPull("http", () -> doHttpPull(chartUrl, destDir, fileName, repo));
+	}
+
+	// Finds a registered downloader for a non-HTTP(S) URL scheme (s3://, gs://, ...);
+	// returns null for http/https so the built-in HTTP path handles those.
+	private ChartDownloader findChartDownloader(String chartUrl) {
+		int schemeEnd = chartUrl.indexOf("://");
+		if (schemeEnd <= 0) {
+			return null;
+		}
+		String scheme = chartUrl.substring(0, schemeEnd);
+		if ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) {
+			return null;
+		}
+		return this.chartDownloaders.stream().filter((d) -> d.supportsProtocol(scheme)).findFirst().orElse(null);
+	}
+
+	private void doDownloaderPull(ChartDownloader downloader, String chartUrl, String destDir, String fileName)
+			throws IOException {
+		if (log.isInfoEnabled()) {
+			log.info("Pulling chart from {} via a downloader plugin to {}", chartUrl, destDir);
+		}
+		byte[] data = downloader.download(chartUrl);
+		File destFile = new File(destDir, fileName);
+		destFile.getParentFile().mkdirs();
+		Files.write(destFile.toPath(), data);
+		untar(destFile, new File(destDir));
 	}
 
 	private void doHttpPull(String chartUrl, String destDir, String fileName, RepositoryConfig.Repository repo)

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerDownloaderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerDownloaderTest.java
@@ -1,0 +1,66 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.GZIPOutputStream;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RepoManagerDownloaderTest {
+
+	@TempDir
+	Path work;
+
+	@Test
+	void routesCustomSchemeToRegisteredDownloader() throws Exception {
+		byte[] tgz = chartArchive();
+		AtomicReference<String> requestedUrl = new AtomicReference<>();
+		ChartDownloader downloader = new ChartDownloader() {
+			@Override
+			public boolean supportsProtocol(String protocol) {
+				return "test".equalsIgnoreCase(protocol);
+			}
+
+			@Override
+			public byte[] download(String url) {
+				requestedUrl.set(url);
+				return tgz;
+			}
+		};
+		RepoManager repoManager = new RepoManager();
+		repoManager.setChartDownloaders(List.of(downloader));
+		Path dest = Files.createDirectories(this.work.resolve("out"));
+
+		repoManager.pullFromUrl("test://bucket/mychart-1.0.0.tgz", dest.toString(), "mychart-1.0.0.tgz");
+
+		assertEquals("test://bucket/mychart-1.0.0.tgz", requestedUrl.get(), "downloader was consulted with the URL");
+		assertTrue(Files.exists(dest.resolve("mychart-1.0.0.tgz")), "chart archive written");
+		assertTrue(Files.exists(dest.resolve("mychart/Chart.yaml")), "chart archive was untarred");
+	}
+
+	private static byte[] chartArchive() throws Exception {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		try (OutputStream gz = new GZIPOutputStream(bytes);
+				TarArchiveOutputStream tar = new TarArchiveOutputStream(gz)) {
+			byte[] content = "apiVersion: v2\nname: mychart\nversion: 1.0.0\n".getBytes(StandardCharsets.UTF_8);
+			TarArchiveEntry entry = new TarArchiveEntry("mychart/Chart.yaml");
+			entry.setSize(content.length);
+			tar.putArchiveEntry(entry);
+			tar.write(content);
+			tar.closeArchiveEntry();
+		}
+		return bytes.toByteArray();
+	}
+
+}


### PR DESCRIPTION
Fifth slice of the Helm-plugin epic (#733). Charts referenced with a **custom URL scheme** (`s3://`, `gs://`, …) are fetched via the matching Helm **downloader plugin** (helm-s3, helm-gcs, …).

## What's here
- **`RepoManager.pullFromUrl`** now consults registered `ChartDownloader`s before the HTTP path: a scheme a downloader supports is fetched via `downloader.download(url)`, written to disk, and untarred. `http`/`https`/`oci` keep the built-in paths. Adds `setChartDownloaders()`. (The previously **dormant** `ChartDownloader` SPI is finally wired.)
- **`JhelmCoreAutoConfiguration`** injects `ChartDownloader` beans into `RepoManager`.
- **`HelmPluginChartDownloader`** (jhelm-cli) implements `ChartDownloader` over installed downloader plugins: matches `plugin.yaml` `downloaders[].protocols`, runs the downloader command with Helm's contract **`command <cert> <key> <ca> <full-URL>`**, reads chart bytes from **stdout** (stderr drained concurrently to avoid deadlock). Gated on **FULL** mode.
- The env factory is injected **lazily** (`ObjectProvider`) to break a `RepoManager` ↔ downloader-bean cycle.

## Tests
- **Core** `RepoManagerDownloaderTest`: a fake downloader returns a real `.tgz`; asserts routing by scheme + untar.
- **CLI** `HelmPluginChartDownloaderTest`: real bash downloader fixture — protocol match (only declared scheme), URL passed as the 4th arg, READ_ONLY refusal, unknown-scheme error.
- Full reactor build + Spring context load green locally.

Part of #733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)