### PR TITLE
feat(cli): resolve --post-renderer to installed Helm plugins (#739)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/InstallCommand.java
@@ -21,6 +21,7 @@ import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
+import org.alexmond.jhelm.app.plugin.HelmPostRendererResolver;
 import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.util.ReleaseNames;
@@ -55,6 +56,8 @@ public class InstallCommand implements Callable<Integer> {
 	private final ConfigServerValuesLoader configServerValuesLoader;
 
 	private final DependencyUpdateAction dependencyUpdateAction;
+
+	private final HelmPostRendererResolver postRendererResolver;
 
 	@CommandLine.Mixin
 	private final ConfigServerCliOptions configServerOptions = new ConfigServerCliOptions();
@@ -130,8 +133,12 @@ public class InstallCommand implements Callable<Integer> {
 	@Option(names = { "--atomic" }, description = "uninstall on failure (implies --wait)")
 	private boolean atomic;
 
-	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
+	@Option(names = { "--post-renderer" },
+			description = "path to an executable, or an installed plugin name, to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
+
+	@Option(names = { "--post-renderer-args" }, description = "arguments to pass to the post-renderer")
+	private List<String> postRendererArgs = new ArrayList<>();
 
 	@Option(names = { "--no-hooks" }, description = "prevent hooks from running during this operation")
 	private boolean noHooks;
@@ -170,7 +177,8 @@ public class InstallCommand implements Callable<Integer> {
 	 */
 	public InstallCommand(InstallAction installAction, UninstallAction uninstallAction, KubeService kubeService,
 			ChartResolver chartResolver, JhelmSecurityPolicy securityPolicy, JhelmCoreProperties coreProperties,
-			ConfigServerValuesLoader configServerValuesLoader, DependencyUpdateAction dependencyUpdateAction) {
+			ConfigServerValuesLoader configServerValuesLoader, DependencyUpdateAction dependencyUpdateAction,
+			HelmPostRendererResolver postRendererResolver) {
 		this.installAction = installAction;
 		this.uninstallAction = uninstallAction;
 		this.kubeService = kubeService;
@@ -179,6 +187,7 @@ public class InstallCommand implements Callable<Integer> {
 		this.coreProperties = coreProperties;
 		this.configServerValuesLoader = configServerValuesLoader;
 		this.dependencyUpdateAction = dependencyUpdateAction;
+		this.postRendererResolver = postRendererResolver;
 	}
 
 	@Override
@@ -312,7 +321,9 @@ public class InstallCommand implements Callable<Integer> {
 		}
 		String manifest = release.getManifest();
 		for (String renderer : postRenderers) {
-			manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
+			manifest = new ExternalCommandPostRenderer(
+					this.postRendererResolver.resolve(renderer, this.postRendererArgs))
+				.process(manifest);
 		}
 		return release.toBuilder().manifest(manifest).build();
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/TemplateCommand.java
@@ -16,6 +16,7 @@ import org.alexmond.jhelm.core.action.DependencyUpdateAction;
 import org.alexmond.jhelm.core.action.TemplateAction;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
+import org.alexmond.jhelm.app.plugin.HelmPostRendererResolver;
 import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
 import org.alexmond.jhelm.core.util.RenderedManifest;
 import org.alexmond.jhelm.core.util.ValuesOverrides;
@@ -40,6 +41,8 @@ public class TemplateCommand implements Callable<Integer> {
 	private final ConfigServerValuesLoader configServerValuesLoader;
 
 	private final DependencyUpdateAction dependencyUpdateAction;
+
+	private final HelmPostRendererResolver postRendererResolver;
 
 	@CommandLine.Mixin
 	private final ConfigServerCliOptions configServerOptions = new ConfigServerCliOptions();
@@ -81,8 +84,12 @@ public class TemplateCommand implements Callable<Integer> {
 			description = "update dependencies from Chart.yaml to charts/ before rendering (local chart dir only)")
 	private boolean dependencyUpdate;
 
-	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
+	@Option(names = { "--post-renderer" },
+			description = "path to an executable, or an installed plugin name, to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
+
+	@Option(names = { "--post-renderer-args" }, description = "arguments to pass to the post-renderer")
+	private List<String> postRendererArgs = new ArrayList<>();
 
 	@Option(names = { "--kube-version" },
 			description = "Kubernetes version used for .Capabilities.KubeVersion (e.g. v1.29.0)")
@@ -119,11 +126,13 @@ public class TemplateCommand implements Callable<Integer> {
 	 * by default)
 	 */
 	public TemplateCommand(TemplateAction templateAction, JhelmCoreProperties coreProperties,
-			ConfigServerValuesLoader configServerValuesLoader, DependencyUpdateAction dependencyUpdateAction) {
+			ConfigServerValuesLoader configServerValuesLoader, DependencyUpdateAction dependencyUpdateAction,
+			HelmPostRendererResolver postRendererResolver) {
 		this.templateAction = templateAction;
 		this.coreProperties = coreProperties;
 		this.configServerValuesLoader = configServerValuesLoader;
 		this.dependencyUpdateAction = dependencyUpdateAction;
+		this.postRendererResolver = postRendererResolver;
 	}
 
 	@Override
@@ -145,7 +154,9 @@ public class TemplateCommand implements Callable<Integer> {
 			String manifest = templateAction.render(chartPath, name, namespace, overrides, profiles, kubeVersion,
 					apiVersions, isUpgrade, includeCrds);
 			for (String renderer : postRenderers) {
-				manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
+				manifest = new ExternalCommandPostRenderer(
+						this.postRendererResolver.resolve(renderer, this.postRendererArgs))
+					.process(manifest);
 			}
 			if (skipTests) {
 				manifest = RenderedManifest.skipTests(manifest);

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/UpgradeCommand.java
@@ -25,6 +25,7 @@ import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.model.Chart;
 import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.app.plugin.HelmPostRendererResolver;
 import org.alexmond.jhelm.core.service.ExternalCommandPostRenderer;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
@@ -63,6 +64,8 @@ public class UpgradeCommand implements Callable<Integer> {
 	private final ConfigServerValuesLoader configServerValuesLoader;
 
 	private final DependencyUpdateAction dependencyUpdateAction;
+
+	private final HelmPostRendererResolver postRendererResolver;
 
 	@CommandLine.Mixin
 	private final ConfigServerCliOptions configServerOptions = new ConfigServerCliOptions();
@@ -138,8 +141,12 @@ public class UpgradeCommand implements Callable<Integer> {
 			+ "(may cause downtime or data loss for stateful resources)")
 	private boolean force;
 
-	@Option(names = { "--post-renderer" }, description = "path to an executable to use as a post-renderer")
+	@Option(names = { "--post-renderer" },
+			description = "path to an executable, or an installed plugin name, to use as a post-renderer")
 	private List<String> postRenderers = new ArrayList<>();
+
+	@Option(names = { "--post-renderer-args" }, description = "arguments to pass to the post-renderer")
+	private List<String> postRendererArgs = new ArrayList<>();
 
 	@Option(names = { "--reset-values" },
 			description = "when upgrading, reset the values to the ones built into the chart")
@@ -193,7 +200,8 @@ public class UpgradeCommand implements Callable<Integer> {
 	public UpgradeCommand(KubeService kubeService, InstallAction installAction, UninstallAction uninstallAction,
 			UpgradeAction upgradeAction, RollbackAction rollbackAction, ChartResolver chartResolver,
 			JhelmSecurityPolicy securityPolicy, JhelmCoreProperties coreProperties,
-			ConfigServerValuesLoader configServerValuesLoader, DependencyUpdateAction dependencyUpdateAction) {
+			ConfigServerValuesLoader configServerValuesLoader, DependencyUpdateAction dependencyUpdateAction,
+			HelmPostRendererResolver postRendererResolver) {
 		this.kubeService = kubeService;
 		this.installAction = installAction;
 		this.uninstallAction = uninstallAction;
@@ -204,6 +212,7 @@ public class UpgradeCommand implements Callable<Integer> {
 		this.coreProperties = coreProperties;
 		this.configServerValuesLoader = configServerValuesLoader;
 		this.dependencyUpdateAction = dependencyUpdateAction;
+		this.postRendererResolver = postRendererResolver;
 	}
 
 	@Override
@@ -363,7 +372,9 @@ public class UpgradeCommand implements Callable<Integer> {
 		}
 		String manifest = release.getManifest();
 		for (String renderer : postRenderers) {
-			manifest = new ExternalCommandPostRenderer(List.of(renderer)).process(manifest);
+			manifest = new ExternalCommandPostRenderer(
+					this.postRendererResolver.resolve(renderer, this.postRendererArgs))
+				.process(manifest);
 		}
 		return release.toBuilder().manifest(manifest).build();
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPostRendererResolver.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/plugin/HelmPostRendererResolver.java
@@ -1,0 +1,107 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves a {@code --post-renderer} value into the command to run. Mirrors Helm 3.10+:
+ * the value is used as a filesystem path when it points at an existing file, otherwise it
+ * is looked up as an installed Helm plugin by name and resolved to that plugin's command
+ * (expanding {@code $HELM_PLUGIN_DIR}). Any {@code --post-renderer-args} are appended.
+ *
+ * <p>
+ * Resolving to a plugin (arbitrary local code) is gated on the CLI's {@code FULL}
+ * security mode; a plain path keeps jhelm's existing behavior.
+ */
+@Component
+public class HelmPostRendererResolver {
+
+	private final HelmPluginPaths paths;
+
+	private final Supplier<HelmPluginEnvironment> environment;
+
+	private final JhelmSecurityPolicy policy;
+
+	/**
+	 * Spring constructor.
+	 * @param environmentFactory builds the {@code HELM_*} environment used to expand the
+	 * plugin command
+	 * @param policy the security policy that gates resolving to a native plugin
+	 */
+	@Autowired
+	public HelmPostRendererResolver(HelmPluginEnvironmentFactory environmentFactory, JhelmSecurityPolicy policy) {
+		this(HelmPluginPaths.fromEnvironment(), environmentFactory::create, policy);
+	}
+
+	HelmPostRendererResolver(HelmPluginPaths paths, Supplier<HelmPluginEnvironment> environment,
+			JhelmSecurityPolicy policy) {
+		this.paths = paths;
+		this.environment = environment;
+		this.policy = policy;
+	}
+
+	/**
+	 * Creates a resolver with no plugins directory, so every post-renderer reference
+	 * resolves as a plain file path (no plugin lookup). Intended for callers and tests
+	 * that do not use plugin post-renderers.
+	 * @param policy the security policy
+	 * @return a file-path-only resolver
+	 */
+	public static HelmPostRendererResolver fileOnly(JhelmSecurityPolicy policy) {
+		HelmPluginPaths paths = new HelmPluginPaths(Map.of("HELM_PLUGINS", "/nonexistent-jhelm-plugins")::get,
+				Path.of("/nonexistent-jhelm-plugins"));
+		return new HelmPostRendererResolver(paths, () -> HelmPluginEnvironment.builder().paths(paths).build(), policy);
+	}
+
+	/**
+	 * Resolves a post-renderer reference to a concrete command.
+	 * @param value a path to an executable, or the name of an installed Helm plugin
+	 * @param args extra arguments to append (from {@code --post-renderer-args}), may be
+	 * {@code null}
+	 * @return the command vector to run as a post-renderer
+	 * @throws IOException if the value names a plugin but plugin execution is disallowed,
+	 * or the plugin declares no command for the current platform
+	 */
+	public List<String> resolve(String value, List<String> args) throws IOException {
+		List<String> extra = (args != null) ? args : List.of();
+		if (Files.isRegularFile(Path.of(value))) {
+			return append(List.of(value), extra);
+		}
+		Optional<DiscoveredHelmPlugin> plugin = new HelmPluginDiscovery(this.paths).find(value);
+		if (plugin.isPresent()) {
+			if (this.policy.mode() != JhelmAccessMode.FULL) {
+				throw new IOException("running native Helm plugins is disabled in READ_ONLY mode — set "
+						+ "jhelm.security.mode=FULL to enable");
+			}
+			Map<String, String> env = this.environment.get().forPlugin(plugin.get());
+			List<String> command = plugin.get()
+				.resolveCommand(HelmPlatform.currentOs(), HelmPlatform.currentArch(), env);
+			if (command.isEmpty()) {
+				throw new IOException("post-renderer plugin '" + value + "' declares no command for this platform");
+			}
+			return append(command, extra);
+		}
+		// Not a file and not an installed plugin: pass through verbatim (fails at exec,
+		// as
+		// Helm does when a post-renderer cannot be found).
+		return append(List.of(value), extra);
+	}
+
+	private static List<String> append(List<String> command, List<String> extra) {
+		List<String> full = new ArrayList<>(command);
+		full.addAll(extra);
+		return full;
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/InstallCommandTest.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
+import org.alexmond.jhelm.app.plugin.HelmPostRendererResolver;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.alexmond.jhelm.core.config.ConfigServerProperties;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
@@ -83,7 +84,7 @@ class InstallCommandTest {
 			.thenReturn(defaultChart);
 		installCommand = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver, enabledPolicy(),
 				new JhelmCoreProperties(), new ConfigServerValuesLoader(new ConfigServerProperties(), null),
-				dependencyUpdateAction);
+				dependencyUpdateAction, HelmPostRendererResolver.fileOnly(enabledPolicy()));
 	}
 
 	private static JhelmSecurityPolicy enabledPolicy() {
@@ -267,7 +268,8 @@ class InstallCommandTest {
 		File chartDir = createMockChart();
 		InstallCommand readOnly = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver,
 				readOnlyPolicy(), new JhelmCoreProperties(),
-				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction);
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction,
+				HelmPostRendererResolver.fileOnly(enabledPolicy()));
 
 		int exitCode = new CommandLine(readOnly).execute("my-release", chartDir.getAbsolutePath());
 
@@ -286,7 +288,8 @@ class InstallCommandTest {
 		when(installAction.install(any(InstallOptions.class))).thenReturn(createMockRelease("my-release", 1));
 		InstallCommand full = new InstallCommand(installAction, uninstallAction, kubeService, chartResolver,
 				new JhelmSecurityPolicy(props), new JhelmCoreProperties(),
-				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction);
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction,
+				HelmPostRendererResolver.fileOnly(enabledPolicy()));
 
 		int exitCode = new CommandLine(full).execute("my-release", chartDir.getAbsolutePath(), "-n", "default");
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/TemplateCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/TemplateCommandTest.java
@@ -10,6 +10,9 @@ import java.util.List;
 
 import org.alexmond.jhelm.core.action.DependencyUpdateAction;
 import org.alexmond.jhelm.core.action.TemplateAction;
+import org.alexmond.jhelm.app.plugin.HelmPostRendererResolver;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.alexmond.jhelm.core.config.ConfigServerProperties;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
@@ -48,7 +51,8 @@ class TemplateCommandTest {
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
 		templateCommand = new TemplateCommand(templateAction, new JhelmCoreProperties(),
-				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction);
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction,
+				HelmPostRendererResolver.fileOnly(new JhelmSecurityPolicy(new JhelmSecurityProperties())));
 	}
 
 	@Test
@@ -191,7 +195,8 @@ class TemplateCommandTest {
 
 	private ValuesProfiles runAndCaptureProfiles(JhelmCoreProperties props, String... args) {
 		TemplateCommand command = new TemplateCommand(templateAction, props,
-				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction);
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction,
+				HelmPostRendererResolver.fileOnly(new JhelmSecurityPolicy(new JhelmSecurityProperties())));
 		ArgumentCaptor<ValuesProfiles> captor = ArgumentCaptor.forClass(ValuesProfiles.class);
 		when(templateAction.render(anyString(), anyString(), anyString(), anyMap(), captor.capture(), any(), anyList(),
 				anyBoolean(), anyBoolean()))

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/UpgradeCommandTest.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.app.command;
 
+import org.alexmond.jhelm.app.plugin.HelmPostRendererResolver;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.alexmond.jhelm.core.config.ConfigServerProperties;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
@@ -91,7 +92,8 @@ class UpgradeCommandTest {
 			.thenReturn(defaultChart);
 		upgradeCommand = new UpgradeCommand(kubeService, installAction, uninstallAction, upgradeAction, rollbackAction,
 				chartResolver, enabledPolicy(), new JhelmCoreProperties(),
-				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction);
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction,
+				HelmPostRendererResolver.fileOnly(enabledPolicy()));
 	}
 
 	private static JhelmSecurityPolicy enabledPolicy() {
@@ -148,7 +150,8 @@ class UpgradeCommandTest {
 		File chartDir = createMockChart();
 		UpgradeCommand readOnly = new UpgradeCommand(kubeService, installAction, uninstallAction, upgradeAction,
 				rollbackAction, chartResolver, readOnlyPolicy(), new JhelmCoreProperties(),
-				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction);
+				new ConfigServerValuesLoader(new ConfigServerProperties(), null), dependencyUpdateAction,
+				HelmPostRendererResolver.fileOnly(enabledPolicy()));
 
 		int exitCode = new CommandLine(readOnly).execute("my-release", chartDir.getAbsolutePath());
 

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPostRendererResolverTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPostRendererResolverTest.java
@@ -1,0 +1,67 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HelmPostRendererResolverTest {
+
+	@TempDir
+	Path pluginsDir;
+
+	@TempDir
+	Path work;
+
+	private HelmPostRendererResolver resolver(JhelmAccessMode mode) {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(mode);
+		HelmPluginPaths paths = new HelmPluginPaths(Map.of("HELM_PLUGINS", this.pluginsDir.toString())::get,
+				Path.of("/home/tester"));
+		Supplier<HelmPluginEnvironment> env = () -> HelmPluginEnvironment.builder().paths(paths).build();
+		return new HelmPostRendererResolver(paths, env, new JhelmSecurityPolicy(props));
+	}
+
+	@Test
+	void passesAnExistingFileThroughWithArgs() throws Exception {
+		Path exe = Files.writeString(this.work.resolve("kustomize.sh"), "#!/bin/sh\n");
+		List<String> command = resolver(JhelmAccessMode.FULL).resolve(exe.toString(), List.of("--enable-alpha"));
+		assertEquals(List.of(exe.toString(), "--enable-alpha"), command);
+	}
+
+	@Test
+	void resolvesAnInstalledPluginNameToItsCommand() throws Exception {
+		Path dir = Files.createDirectories(this.pluginsDir.resolve("kustomize"));
+		Files.writeString(dir.resolve("plugin.yaml"), "name: kustomize\ncommand: \"$HELM_PLUGIN_DIR/bin/render\"\n");
+		List<String> command = resolver(JhelmAccessMode.FULL).resolve("kustomize", List.of("build"));
+		assertEquals(List.of(dir.resolve("bin/render").toString(), "build"), command);
+	}
+
+	@Test
+	void readOnlyModeRefusesAPluginPostRenderer() throws Exception {
+		Path dir = Files.createDirectories(this.pluginsDir.resolve("kustomize"));
+		Files.writeString(dir.resolve("plugin.yaml"), "name: kustomize\ncommand: run\n");
+		IOException ex = assertThrows(IOException.class,
+				() -> resolver(JhelmAccessMode.READ_ONLY).resolve("kustomize", List.of()));
+		assertTrue(ex.getMessage().contains("READ_ONLY"));
+	}
+
+	@Test
+	void passesAnUnknownValueThroughVerbatim() throws Exception {
+		List<String> command = resolver(JhelmAccessMode.FULL).resolve("/usr/local/bin/some-renderer", List.of("-x"));
+		assertEquals(List.of("/usr/local/bin/some-renderer", "-x"), command);
+	}
+
+}


### PR DESCRIPTION
Sixth slice of the Helm-plugin epic (#733). `--post-renderer` gains Helm 3.10+ **plugin-name resolution**, plus `--post-renderer-args`.

## What's here
- **`HelmPostRendererResolver`** — a `--post-renderer` value that is an existing file is used as-is (jhelm's existing behavior); otherwise it's looked up as an **installed Helm plugin** and resolved to that plugin's command (expanding `$HELM_PLUGIN_DIR`), **gated on FULL**. Unknown values pass through verbatim (fail at exec, as helm does). `--post-renderer-args` are appended.
- Wired into **template / install / upgrade**. `ExternalCommandPostRenderer` already matches Helm's stdin→stdout post-renderer contract, so it just receives the resolved command.

## Verified end-to-end (real CLI jar)
`jhelm template … --post-renderer upper` (a plugin **name**, whose command uppercases) → manifest transformed (`kind: ConfigMap` → `KIND: CONFIGMAP`).

## Tests
4 resolver unit tests (path passthrough + args, plugin-name resolution, READ_ONLY refusal, unknown passthrough); the 3 command tests updated for the new constructor arg. Full reactor build + context load green locally.

Part of #733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)