### PR TITLE
docs(plugins): Helm plugin compatibility page + integration test (#740)

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -8,6 +8,7 @@
 * xref:mcp.adoc[MCP Server]
 * xref:cli-reference.adoc[CLI Reference]
 * xref:cli-parity.adoc[CLI Flag Parity with Helm]
+* xref:plugin-parity.adoc[Helm Plugin Compatibility]
 * xref:configuration.adoc[Configuration]
 * xref:value-profiles.adoc[Value Profiles]
 * xref:interoperability.adoc[Interoperability with Helm]

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -1,5 +1,30 @@
 = Changelog
 
+== 1.2.2
+
+=== Helm plugin compatibility
+
+jhelm now consumes real Helm plugins from the existing ecosystem (helm-diff, helm-secrets,
+helm-s3, …), discovered from `$HELM_PLUGINS` and invoked the way Helm invokes them. See
+xref:plugin-parity.adoc[Helm Plugin Compatibility]. This is separate from jhelm's existing
+WASM (`.jhp`) plugin system, which stays as-is.
+
+* *Subcommand plugins* -- `jhelm <name>` runs an installed plugin (helm-diff, helm-secrets)
+  as a subprocess with the `HELM_*` environment, propagating its exit code (#735).
+* *`plugin install` from Helm sources* -- git URL (with `--version`), `.tar.gz`/`.tgz`
+  (local or `http(s)`), or a local directory, in addition to `.jhp`; runs the install hook
+  (#736).
+* *`plugin list` / `update` / `uninstall`* -- list shows Helm and WASM plugins with a
+  `KIND` column; update does `git pull` + update hook; uninstall runs the delete hook and
+  removes the plugin (#737).
+* *Downloader plugins* -- a chart URL with a custom scheme (`s3://`, `gs://`, …) is fetched
+  via the matching downloader plugin using Helm's downloader contract (#738).
+* *Post-renderer plugins* -- `--post-renderer <name>` resolves an installed plugin (Helm
+  3.10+), with `--post-renderer-args`, on `template`/`install`/`upgrade` (#739).
+
+Running a native plugin (dispatch, downloader, post-renderer, hooks) is gated on the CLI's
+`FULL` security posture -- the local kubeconfig is the trust boundary, as with `helm`.
+
 == 1.2.1
 
 === Dependencies

--- a/docs/modules/ROOT/pages/plugin-parity.adoc
+++ b/docs/modules/ROOT/pages/plugin-parity.adoc
@@ -1,0 +1,84 @@
+= Helm Plugin Compatibility
+:description: How jhelm consumes real Helm plugins — subcommand, downloader, and post-renderer plugins — from $HELM_PLUGINS.
+
+jhelm runs plugins from the existing Helm ecosystem (helm-diff, helm-secrets, helm-s3, …).
+Plugins are discovered from the same location Helm uses and invoked the same way, so most
+`helm` plugin workflows run unchanged against `jhelm`.
+
+[NOTE]
+====
+This is distinct from jhelm's own *WASM plugin system* (`.jhp` archives, `jhelm.plugins.enabled`),
+which sandboxes plugins in a WebAssembly runtime. Helm plugins are native executables and
+run as subprocesses; the two coexist and `jhelm plugin list` shows both (a `KIND` column
+distinguishes `helm` from `wasm`).
+====
+
+== Discovery and layout
+
+Plugins live under the Helm plugins directory, resolved exactly as Helm resolves it:
+
+* `$HELM_PLUGINS` if set, otherwise
+* `$HELM_DATA_HOME/plugins`, otherwise
+* `$XDG_DATA_HOME/helm/plugins`, otherwise
+* `~/.local/share/helm/plugins`.
+
+Each plugin is a directory containing a `plugin.yaml` (Helm's schema: `name`, `version`,
+`usage`, `command`, `platformCommand`, `hooks`, `downloaders`, `ignoreFlags`). The
+`command` is resolved for the current OS/architecture (via `platformCommand`) and
+environment-expanded (notably `$HELM_PLUGIN_DIR`).
+
+== The `HELM_*` environment
+
+Every plugin process receives the `HELM_*` environment Helm exports, built from jhelm's
+resolved configuration (the same values `jhelm env` reports): `HELM_BIN`, `HELM_PLUGINS`,
+`HELM_DATA_HOME`, `HELM_CONFIG_HOME`, `HELM_CACHE_HOME`, `HELM_NAMESPACE`,
+`HELM_KUBECONTEXT`, `KUBECONFIG`, `HELM_REGISTRY_CONFIG`, `HELM_REPOSITORY_CONFIG`,
+`HELM_REPOSITORY_CACHE`, plus per-plugin `HELM_PLUGIN_NAME` and `HELM_PLUGIN_DIR`.
+
+== Supported plugin kinds
+
+Subcommand plugins:: `jhelm <name>` where `<name>` is an installed plugin runs the
+plugin's command as a subprocess, forwarding the remaining arguments and propagating the
+exit code — e.g. `jhelm diff upgrade …`. An unknown name that is not a plugin still fails
+with the normal "unmatched command" error.
+
+Downloader plugins:: a chart referenced with a custom URL scheme (`s3://`, `gs://`, …) is
+fetched via the plugin whose `downloaders[].protocols` declare that scheme, invoked with
+Helm's contract `command <cert> <key> <ca> <full-URL>` (chart bytes on stdout). Enables
+helm-s3, helm-gcs, and similar.
+
+Post-renderer plugins:: `--post-renderer <name>` (on `template`, `install`, `upgrade`)
+resolves an installed plugin by name in addition to a filesystem path (Helm 3.10+),
+with `--post-renderer-args` passed through. The manifest is piped to the plugin on stdin
+and read back from stdout.
+
+== Managing plugins
+
+[source,console]
+----
+jhelm plugin install https://github.com/databus23/helm-diff   # git URL (optional --version)
+jhelm plugin install ./my-plugin.tar.gz                       # archive (local or http(s))
+jhelm plugin install ./my-plugin                              # local directory
+jhelm plugin list                                             # helm + wasm plugins
+jhelm plugin update  <name>                                   # git pull + update hook
+jhelm plugin uninstall <name>                                 # delete hook + remove
+----
+
+Installing runs the plugin's `install` hook; `update`/`uninstall` run the `update`/`delete`
+hooks. A git-checked-out plugin is refreshed with `git pull` on update.
+
+== Security
+
+A Helm plugin is arbitrary local code, so *running* one (subcommand dispatch, downloader,
+post-renderer, and install/update/delete hooks) requires the CLI's `FULL` security posture
+— the same gate as the cluster-mutating commands (`jhelm.security.mode=FULL`, the default
+for the CLI). Installing the plugin *files* works in any mode; hooks are skipped with a
+warning under `READ_ONLY`. The local kubeconfig is the trust boundary, as with `helm`.
+
+== Deliberate gaps
+
+* *Helm 4 WASM plugins* (the redesigned WebAssembly plugin ABI, signing, `plugin package`/`verify`,
+  OCI distribution) are not consumed as Helm-4 plugins; jhelm has its own WASM runtime for
+  `.jhp` plugins.
+* The `HELM_*` environment is not injected into post-renderer processes beyond what the
+  parent process already exports; `$HELM_PLUGIN_DIR` is expanded into the resolved command.

--- a/docs/modules/ROOT/pages/roadmap.adoc
+++ b/docs/modules/ROOT/pages/roadmap.adoc
@@ -132,7 +132,7 @@ The roadmap is divided into several phases focusing on compatibility, feature co
 | *Helm 4 must* Functions* | ❌ | ✅ | ✅ | P1 | ✅ *Complete*
 | Server-Side Apply | ❌ | ✅ | ❌ | P1 | Pending
 | Three-Way Merge | ✅ | ❌ | ✅ | P1 | Complete
-| Plugin System | ✅ | ✅ (new) | ❌ | P2 | Pending
+| Plugin System | ✅ | ✅ (new) | ✅ | P2 | ✅ Complete (Helm 3 plugins + WASM; see xref:plugin-parity.adoc[Plugin Compatibility])
 | OCI Registries | ✅ | ✅ (enhanced) | ⚠️ | P1 | Partial
 | Chart Dependencies | ✅ | ✅ | ✅ | P2 | ✅ Complete
 | Hooks | ✅ | ✅ | ✅ | P2 | ✅ Complete

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginInstallDispatchIntegrationTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/plugin/HelmPluginInstallDispatchIntegrationTest.java
@@ -1,0 +1,89 @@
+package org.alexmond.jhelm.app.plugin;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.alexmond.jhelm.core.config.JhelmAccessMode;
+import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
+import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end check that a plugin installed by {@link HelmPluginInstaller} is then found
+ * and run by {@link HelmPluginDispatcher} — the two agree on the {@code $HELM_PLUGINS}
+ * layout and the plugin's resolved command, exercised through the real filesystem and a
+ * real subprocess.
+ */
+@EnabledOnOs({ OS.LINUX, OS.MAC })
+class HelmPluginInstallDispatchIntegrationTest {
+
+	@TempDir
+	Path pluginsDir;
+
+	@TempDir
+	Path source;
+
+	private HelmPluginPaths paths() {
+		return new HelmPluginPaths(Map.of("HELM_PLUGINS", this.pluginsDir.toString())::get, Path.of("/home/tester"));
+	}
+
+	private Supplier<HelmPluginEnvironment> env() {
+		return () -> HelmPluginEnvironment.builder().paths(paths()).namespace("it-ns").build();
+	}
+
+	private JhelmSecurityPolicy fullPolicy() {
+		JhelmSecurityProperties props = new JhelmSecurityProperties();
+		props.setMode(JhelmAccessMode.FULL);
+		return new JhelmSecurityPolicy(props);
+	}
+
+	@Test
+	void installedSubcommandPluginIsDispatchable() throws Exception {
+		// A plugin source directory with a script that records its args + HELM_* env.
+		Path pluginSource = Files.createDirectories(this.source.resolve("greet"));
+		Files.writeString(pluginSource.resolve("plugin.yaml"), """
+				name: greet
+				version: 1.0.0
+				usage: "greet plugin"
+				command: "$HELM_PLUGIN_DIR/greet.sh"
+				""");
+		Path script = pluginSource.resolve("greet.sh");
+		Files.writeString(script, """
+				#!/usr/bin/env bash
+				out="$1"; shift
+				{ echo "args:$*"; echo "ns:$HELM_NAMESPACE"; echo "dir:$HELM_PLUGIN_DIR"; } > "$out"
+				""");
+		script.toFile().setExecutable(true);
+
+		HelmPluginInstaller installer = new HelmPluginInstaller(paths(), env(), fullPolicy(),
+				new ProcessHelmPluginRunner(), (u, r, d) -> {
+				});
+		HelmPluginDispatcher dispatcher = HelmPluginDispatcher.forTesting(this.pluginsDir, env(), fullPolicy(),
+				new ProcessHelmPluginRunner());
+
+		// Install, then dispatch the just-installed plugin.
+		DiscoveredHelmPlugin installed = installer.install(pluginSource.toString(), null);
+		assertEquals("greet", installed.name());
+
+		Path out = this.pluginsDir.resolve("out.txt");
+		DiscoveredHelmPlugin found = dispatcher.find("greet").orElseThrow();
+		int code = dispatcher.dispatch(found, List.of(out.toString(), "hello", "world"));
+
+		assertEquals(0, code);
+		Set<String> lines = Set.copyOf(Files.readAllLines(out));
+		assertTrue(lines.contains("args:hello world"), lines.toString());
+		assertTrue(lines.contains("ns:it-ns"));
+		assertTrue(lines.contains("dir:" + this.pluginsDir.resolve("greet")));
+	}
+
+}


### PR DESCRIPTION
Final slice of the Helm-plugin epic (#733).

## Docs
- **New `plugin-parity.adoc`** — the Helm-compatible plugin surface: discovery from `$HELM_PLUGINS`, the `HELM_*` env, the three plugin kinds (subcommand / downloader / post-renderer), `plugin install/list/update/uninstall`, the **FULL-mode security gate**, the `.jhp`/WASM vs Helm-plugin distinction, and deliberate gaps (Helm 4 WASM). Linked from the nav.
- **`roadmap.adoc`** — Plugin System row → ✅ Complete (Helm 3 plugins + WASM).
- **`changelog.adoc`** — `1.2.2` section summarizing the epic (#735–#739).

## Integration test
`HelmPluginInstallDispatchIntegrationTest` — end-to-end round-trip: a plugin installed by `HelmPluginInstaller` is discovered and run by `HelmPluginDispatcher` through the real filesystem + a real subprocess (asserts args + `HELM_*` env reach the plugin).

Full reactor build green locally. **Closes #733.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)