### PR TITLE
feat(plugin-api): new jhelm-plugin-api module — Java extension interfaces + discovery (#750)

### DIFF
--- a/jhelm-plugin-api/pom.xml
+++ b/jhelm-plugin-api/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.alexmond</groupId>
+        <artifactId>jhelm-parent</artifactId>
+        <version>1.2.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>jhelm-plugin-api</artifactId>
+
+    <name>jhelm Plugin API</name>
+    <description>Public Java extension API for jhelm: post-renderer, chart-downloader, lifecycle, and template-function
+        plugins discovered via ServiceLoader or Spring beans</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmChartDownloader.java
+++ b/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmChartDownloader.java
@@ -1,0 +1,25 @@
+package org.alexmond.jhelm.pluginapi;
+
+/**
+ * A plugin that fetches charts for a custom URL scheme (for example {@code s3://},
+ * {@code gs://}) in Java — the in-process equivalent of a Helm downloader plugin. jhelm
+ * consults it when a chart URL uses a scheme it {@link #supports(String) supports}.
+ */
+public interface JhelmChartDownloader extends JhelmPlugin {
+
+	/**
+	 * Reports whether this downloader handles the given URL scheme.
+	 * @param scheme the URL scheme, without {@code ://} (for example {@code s3})
+	 * @return {@code true} if this downloader can fetch that scheme
+	 */
+	boolean supports(String scheme);
+
+	/**
+	 * Downloads a chart archive.
+	 * @param url the full chart URL (for example {@code s3://bucket/chart-1.0.0.tgz})
+	 * @return the raw chart archive bytes (a gzipped tar)
+	 * @throws JhelmPluginException if the download fails
+	 */
+	byte[] download(String url) throws JhelmPluginException;
+
+}

--- a/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmLifecycleListener.java
+++ b/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmLifecycleListener.java
@@ -1,0 +1,20 @@
+package org.alexmond.jhelm.pluginapi;
+
+/**
+ * A plugin that reacts to release lifecycle events (install, upgrade, uninstall — each
+ * with a pre and post phase). Useful for notifications, auditing, or external
+ * integrations.
+ *
+ * <p>
+ * A listener should be quick and side-effect-tolerant: an exception from a {@code POST_*}
+ * phase is logged and ignored so it cannot corrupt a completed operation.
+ */
+public interface JhelmLifecycleListener extends JhelmPlugin {
+
+	/**
+	 * Handles a lifecycle event.
+	 * @param event the event (phase, release, namespace, metadata)
+	 */
+	void onEvent(JhelmReleaseEvent event);
+
+}

--- a/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmPlugin.java
+++ b/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmPlugin.java
@@ -1,0 +1,23 @@
+package org.alexmond.jhelm.pluginapi;
+
+/**
+ * Base type for every jhelm Java plugin. A plugin is an ordinary Java object implementing
+ * one of the extension interfaces ({@link JhelmPostRenderer},
+ * {@link JhelmChartDownloader}, {@link JhelmLifecycleListener},
+ * {@link JhelmTemplateFunctionProvider}); jhelm discovers it via the JDK
+ * {@link java.util.ServiceLoader} or, in a Spring application, as a bean.
+ *
+ * @see JhelmPlugins
+ */
+public interface JhelmPlugin {
+
+	/**
+	 * A short, stable name used to identify the plugin in listings and logs. Defaults to
+	 * the implementing class's simple name.
+	 * @return the plugin name
+	 */
+	default String name() {
+		return getClass().getSimpleName();
+	}
+
+}

--- a/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmPluginException.java
+++ b/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmPluginException.java
@@ -1,0 +1,27 @@
+package org.alexmond.jhelm.pluginapi;
+
+/**
+ * Thrown by a jhelm plugin when it fails to carry out its work (a post-render transform,
+ * a chart download, a template-function call). jhelm surfaces the message to the user
+ * and, for a failed operation, aborts it.
+ */
+public class JhelmPluginException extends Exception {
+
+	/**
+	 * Creates an exception with a message.
+	 * @param message the failure description
+	 */
+	public JhelmPluginException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Creates an exception with a message and cause.
+	 * @param message the failure description
+	 * @param cause the underlying cause
+	 */
+	public JhelmPluginException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmPlugins.java
+++ b/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmPlugins.java
@@ -1,0 +1,72 @@
+package org.alexmond.jhelm.pluginapi;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Discovers jhelm Java plugins off the classpath. Plugins may be published as JDK
+ * {@link java.util.ServiceLoader} services (a {@code META-INF/services/<interface>} file)
+ * or, in a Spring application, supplied as beans; {@link #merge(Class, Collection)}
+ * unions both and de-duplicates by implementation class (preferring the supplied bean
+ * instance, which may carry injected dependencies).
+ */
+public final class JhelmPlugins {
+
+	private static final Logger log = LoggerFactory.getLogger(JhelmPlugins.class);
+
+	private JhelmPlugins() {
+	}
+
+	/**
+	 * Loads every plugin of the given type published as a {@code ServiceLoader} service.
+	 * @param type the plugin interface to load
+	 * @param <T> the plugin type
+	 * @return the discovered service instances (empty if none)
+	 */
+	public static <T extends JhelmPlugin> List<T> fromServiceLoader(Class<T> type) {
+		List<T> found = new ArrayList<>();
+		for (T plugin : ServiceLoader.load(type)) {
+			found.add(plugin);
+		}
+		if (!found.isEmpty() && log.isDebugEnabled()) {
+			log.debug("Discovered {} {} plugin(s) via ServiceLoader", found.size(), type.getSimpleName());
+		}
+		return found;
+	}
+
+	/**
+	 * Unions the supplied plugins (for example Spring beans) with the
+	 * {@code ServiceLoader} services of the same type, de-duplicated by implementation
+	 * class so a plugin that is both a bean and a declared service is not registered
+	 * twice. Supplied instances win.
+	 * @param type the plugin interface
+	 * @param supplied plugins provided by the caller (may be {@code null} or empty)
+	 * @param <T> the plugin type
+	 * @return the merged, de-duplicated plugin list
+	 */
+	public static <T extends JhelmPlugin> List<T> merge(Class<T> type, Collection<? extends T> supplied) {
+		List<T> merged = new ArrayList<>();
+		Set<Class<?>> seen = new HashSet<>();
+		if (supplied != null) {
+			for (T plugin : supplied) {
+				if (seen.add(plugin.getClass())) {
+					merged.add(plugin);
+				}
+			}
+		}
+		for (T plugin : fromServiceLoader(type)) {
+			if (seen.add(plugin.getClass())) {
+				merged.add(plugin);
+			}
+		}
+		return merged;
+	}
+
+}

--- a/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmPostRenderer.java
+++ b/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmPostRenderer.java
@@ -1,0 +1,18 @@
+package org.alexmond.jhelm.pluginapi;
+
+/**
+ * A plugin that post-processes a rendered manifest before it is applied or emitted — the
+ * in-process, Java equivalent of a Helm post-renderer. Applied by {@code template},
+ * {@code install}, and {@code upgrade} after rendering.
+ */
+public interface JhelmPostRenderer extends JhelmPlugin {
+
+	/**
+	 * Transforms a fully rendered manifest.
+	 * @param manifest the rendered multi-document YAML manifest
+	 * @return the transformed manifest
+	 * @throws JhelmPluginException if the transformation fails (aborts the operation)
+	 */
+	String postRender(String manifest) throws JhelmPluginException;
+
+}

--- a/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmReleaseEvent.java
+++ b/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmReleaseEvent.java
@@ -1,0 +1,45 @@
+package org.alexmond.jhelm.pluginapi;
+
+import java.util.Map;
+
+/**
+ * A release lifecycle event delivered to a {@link JhelmLifecycleListener}. Carries the
+ * phase, the release it concerns, and free-form metadata (for example the revision).
+ *
+ * @param phase the lifecycle phase
+ * @param releaseName the release name
+ * @param namespace the release namespace
+ * @param metadata additional, phase-specific details (never {@code null})
+ */
+public record JhelmReleaseEvent(Phase phase, String releaseName, String namespace, Map<String, Object> metadata) {
+
+	/** Release lifecycle phases, fired before and after each mutating operation. */
+	public enum Phase {
+
+		/** Before an install. */
+		PRE_INSTALL,
+		/** After a successful install. */
+		POST_INSTALL,
+		/** Before an upgrade. */
+		PRE_UPGRADE,
+		/** After a successful upgrade. */
+		POST_UPGRADE,
+		/** Before an uninstall. */
+		PRE_UNINSTALL,
+		/** After a successful uninstall. */
+		POST_UNINSTALL
+
+	}
+
+	/**
+	 * Canonical constructor; defaults {@code metadata} to an empty map when {@code null}.
+	 * @param phase the lifecycle phase
+	 * @param releaseName the release name
+	 * @param namespace the release namespace
+	 * @param metadata additional details, or {@code null} for none
+	 */
+	public JhelmReleaseEvent {
+		metadata = (metadata != null) ? Map.copyOf(metadata) : Map.of();
+	}
+
+}

--- a/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmTemplateFunction.java
+++ b/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmTemplateFunction.java
@@ -1,0 +1,19 @@
+package org.alexmond.jhelm.pluginapi;
+
+/**
+ * A single Go-template function contributed by a {@link JhelmTemplateFunctionProvider}.
+ * Invoked from a chart template as {@code {{ myFunc arg1 arg2 }}}; the arguments arrive
+ * as the values the template engine resolved, and the return value is rendered.
+ */
+@FunctionalInterface
+public interface JhelmTemplateFunction {
+
+	/**
+	 * Applies the function to the template-supplied arguments.
+	 * @param args the arguments passed in the template call (may be empty)
+	 * @return the result to render
+	 * @throws JhelmPluginException if the function fails (aborts rendering)
+	 */
+	Object apply(Object... args) throws JhelmPluginException;
+
+}

--- a/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmTemplateFunctionProvider.java
+++ b/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmTemplateFunctionProvider.java
@@ -1,0 +1,22 @@
+package org.alexmond.jhelm.pluginapi;
+
+import java.util.Map;
+
+/**
+ * A plugin that contributes Go-template functions usable in chart templates. jhelm
+ * registers the returned functions with the template engine before rendering, so a chart
+ * can call them like any built-in, Sprig, or Helm function.
+ *
+ * <p>
+ * Function names should be namespaced or distinctive to avoid colliding with built-in
+ * functions; a collision resolves in favor of the built-in and is logged.
+ */
+public interface JhelmTemplateFunctionProvider extends JhelmPlugin {
+
+	/**
+	 * The functions this plugin contributes, keyed by the name templates call them by.
+	 * @return an immutable map of function name to implementation (never {@code null})
+	 */
+	Map<String, JhelmTemplateFunction> functions();
+
+}

--- a/jhelm-plugin-api/src/test/java/org/alexmond/jhelm/pluginapi/ExampleServicePostRenderer.java
+++ b/jhelm-plugin-api/src/test/java/org/alexmond/jhelm/pluginapi/ExampleServicePostRenderer.java
@@ -1,0 +1,21 @@
+package org.alexmond.jhelm.pluginapi;
+
+import java.util.Locale;
+
+/**
+ * Test fixture registered as a {@code ServiceLoader} service (see
+ * {@code META-INF/services/org.alexmond.jhelm.pluginapi.JhelmPostRenderer}).
+ */
+public class ExampleServicePostRenderer implements JhelmPostRenderer {
+
+	@Override
+	public String name() {
+		return "example-service";
+	}
+
+	@Override
+	public String postRender(String manifest) {
+		return manifest.toUpperCase(Locale.ROOT);
+	}
+
+}

--- a/jhelm-plugin-api/src/test/java/org/alexmond/jhelm/pluginapi/JhelmPluginsTest.java
+++ b/jhelm-plugin-api/src/test/java/org/alexmond/jhelm/pluginapi/JhelmPluginsTest.java
@@ -1,0 +1,51 @@
+package org.alexmond.jhelm.pluginapi;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JhelmPluginsTest {
+
+	@Test
+	void fromServiceLoaderFindsRegisteredService() {
+		List<JhelmPostRenderer> found = JhelmPlugins.fromServiceLoader(JhelmPostRenderer.class);
+		assertTrue(found.stream().anyMatch((p) -> p instanceof ExampleServicePostRenderer),
+				"ServiceLoader should find the registered example");
+	}
+
+	@Test
+	void mergeUnionsBeansAndServices() {
+		List<JhelmPostRenderer> merged = JhelmPlugins.merge(JhelmPostRenderer.class, List.of(new BeanPostRenderer()));
+		assertTrue(merged.stream().anyMatch((p) -> p instanceof BeanPostRenderer), "bean present");
+		assertTrue(merged.stream().anyMatch((p) -> p instanceof ExampleServicePostRenderer), "service present");
+	}
+
+	@Test
+	void mergeDeduplicatesByClassPreferringTheSuppliedInstance() {
+		ExampleServicePostRenderer bean = new ExampleServicePostRenderer();
+		List<JhelmPostRenderer> merged = JhelmPlugins.merge(JhelmPostRenderer.class, List.of(bean));
+		long count = merged.stream().filter((p) -> p instanceof ExampleServicePostRenderer).count();
+		assertEquals(1, count, "the class that is both a bean and a service appears once");
+		assertTrue(merged.contains(bean), "the supplied bean instance is kept");
+	}
+
+	@Test
+	void defaultNameIsSimpleClassName() {
+		assertEquals("BeanPostRenderer", new BeanPostRenderer().name());
+	}
+
+	/** A second post-renderer supplied as a "bean" (not a registered service). */
+	static class BeanPostRenderer implements JhelmPostRenderer {
+
+		@Override
+		public String postRender(String manifest) {
+			return manifest.toLowerCase(Locale.ROOT);
+		}
+
+	}
+
+}

--- a/jhelm-plugin-api/src/test/java/org/alexmond/jhelm/pluginapi/JhelmReleaseEventTest.java
+++ b/jhelm-plugin-api/src/test/java/org/alexmond/jhelm/pluginapi/JhelmReleaseEventTest.java
@@ -1,0 +1,27 @@
+package org.alexmond.jhelm.pluginapi;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JhelmReleaseEventTest {
+
+	@Test
+	void nullMetadataDefaultsToEmptyMap() {
+		JhelmReleaseEvent event = new JhelmReleaseEvent(JhelmReleaseEvent.Phase.PRE_INSTALL, "rel", "ns", null);
+		assertTrue(event.metadata().isEmpty());
+	}
+
+	@Test
+	void metadataIsCopiedAndImmutable() {
+		JhelmReleaseEvent event = new JhelmReleaseEvent(JhelmReleaseEvent.Phase.POST_UPGRADE, "rel", "ns",
+				Map.of("revision", 3));
+		assertEquals(3, event.metadata().get("revision"));
+		assertThrows(UnsupportedOperationException.class, () -> event.metadata().put("x", 1));
+	}
+
+}

--- a/jhelm-plugin-api/src/test/resources/META-INF/services/org.alexmond.jhelm.pluginapi.JhelmPostRenderer
+++ b/jhelm-plugin-api/src/test/resources/META-INF/services/org.alexmond.jhelm.pluginapi.JhelmPostRenderer
@@ -1,0 +1,1 @@
+org.alexmond.jhelm.pluginapi.ExampleServicePostRenderer

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <url>https://github.com/alexmond/jhelm</url>
     </scm>
     <modules>
+        <module>jhelm-plugin-api</module>
         <module>jhelm-gotemplate-helm</module>
         <module>jhelm-core</module>
         <module>jhelm-kube</module>


### PR DESCRIPTION
Foundation slice of the **Java plugin API** epic (#749). A new published module of clean interfaces a developer implements in plain Java (no WASM, no subprocess), discovered via ServiceLoader or Spring beans.

## What's here
New `jhelm-plugin-api` module (deps: `slf4j-api` only), package `org.alexmond.jhelm.pluginapi`:
- **`JhelmPlugin`** base (default `name()`), and the four extension interfaces: **`JhelmPostRenderer`**, **`JhelmChartDownloader`**, **`JhelmLifecycleListener`**, **`JhelmTemplateFunctionProvider`** (+ `JhelmTemplateFunction`).
- **`JhelmReleaseEvent`** (record + `Phase` enum) and **`JhelmPluginException`**.
- **`JhelmPlugins`** — `fromServiceLoader(type)` + `merge(type, beans)` (ServiceLoader ∪ beans, deduped by impl class, supplied bean instances win).

Published to Central (not in `excludeArtifacts`). **Foundation only** — no wiring into jhelm-core yet; the four wiring slices (#751–#754) follow.

## Tests
6 unit tests including a real `META-INF/services` ServiceLoader fixture (discovery, merge/dedup, event defaults). Full reactor build green locally.

Part of #749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)