### PR TITLE
feat(core): apply Java JhelmPostRenderer plugins in the render path (#751)

### DIFF
--- a/jhelm-core/pom.xml
+++ b/jhelm-core/pom.xml
@@ -49,6 +49,10 @@
         </dependency>
         <dependency>
             <groupId>org.alexmond</groupId>
+            <artifactId>jhelm-plugin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.alexmond</groupId>
             <artifactId>jhelm-gotemplate-helm</artifactId>
         </dependency>
         <dependency>

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -39,6 +39,9 @@ import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.action.VerifyAction;
 import org.alexmond.jhelm.core.service.ChartDownloader;
 import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.JhelmPostRendererAdapter;
+import org.alexmond.jhelm.pluginapi.JhelmPlugins;
+import org.alexmond.jhelm.pluginapi.JhelmPostRenderer;
 import org.alexmond.jhelm.core.service.ConfigServerClient;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.service.Engine;
@@ -240,6 +243,22 @@ public class JhelmCoreAutoConfiguration {
 	@ConditionalOnMissingBean
 	public CreateAction createAction() {
 		return new CreateAction();
+	}
+
+	/**
+	 * Collects Java {@link JhelmPostRenderer} plugins — discovered as Spring beans and
+	 * via {@link java.util.ServiceLoader} — as {@link PostRenderProcessor}s applied in
+	 * the render path (install, upgrade, template) across every jhelm surface.
+	 * @param postRendererPlugins the post-renderer plugin beans (if any)
+	 * @return the post-render processors, or an empty list if no plugins are present
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public List<PostRenderProcessor> jhelmPostRenderProcessors(ObjectProvider<JhelmPostRenderer> postRendererPlugins) {
+		return JhelmPlugins.merge(JhelmPostRenderer.class, postRendererPlugins.stream().toList())
+			.stream()
+			.<PostRenderProcessor>map(JhelmPostRendererAdapter::new)
+			.toList();
 	}
 
 	/**

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/JhelmPostRendererAdapter.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/JhelmPostRendererAdapter.java
@@ -1,0 +1,35 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.IOException;
+
+import org.alexmond.jhelm.pluginapi.JhelmPluginException;
+import org.alexmond.jhelm.pluginapi.JhelmPostRenderer;
+
+/**
+ * Adapts a Java {@link JhelmPostRenderer} plugin to the internal
+ * {@link PostRenderProcessor} used by the render pipeline, translating a
+ * {@link JhelmPluginException} into the {@link IOException} the pipeline expects.
+ */
+public class JhelmPostRendererAdapter implements PostRenderProcessor {
+
+	private final JhelmPostRenderer plugin;
+
+	/**
+	 * Wraps a post-renderer plugin.
+	 * @param plugin the Java post-renderer plugin
+	 */
+	public JhelmPostRendererAdapter(JhelmPostRenderer plugin) {
+		this.plugin = plugin;
+	}
+
+	@Override
+	public String process(String renderedManifest) throws IOException {
+		try {
+			return this.plugin.postRender(renderedManifest);
+		}
+		catch (JhelmPluginException ex) {
+			throw new IOException("post-renderer plugin '" + this.plugin.name() + "' failed: " + ex.getMessage(), ex);
+		}
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/JhelmPostRendererAdapterTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/JhelmPostRendererAdapterTest.java
@@ -1,0 +1,47 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.alexmond.jhelm.pluginapi.JhelmPluginException;
+import org.alexmond.jhelm.pluginapi.JhelmPostRenderer;
+import org.alexmond.jhelm.pluginapi.JhelmPlugins;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JhelmPostRendererAdapterTest {
+
+	@Test
+	void adapterDelegatesToThePlugin() throws Exception {
+		PostRenderProcessor processor = new JhelmPostRendererAdapter((manifest) -> manifest + "\n# rendered");
+		assertEquals("kind: X\n# rendered", processor.process("kind: X"));
+	}
+
+	@Test
+	void adapterTranslatesPluginExceptionToIoException() {
+		JhelmPostRenderer failing = (manifest) -> {
+			throw new JhelmPluginException("boom");
+		};
+		IOException ex = assertThrows(IOException.class, () -> new JhelmPostRendererAdapter(failing).process("x"));
+		assertTrue(ex.getMessage().contains("boom"));
+	}
+
+	@Test
+	void serviceLoaderPluginIsDiscoveredAdaptedAndApplied() throws Exception {
+		List<PostRenderProcessor> processors = JhelmPlugins.merge(JhelmPostRenderer.class, List.of())
+			.stream()
+			.<PostRenderProcessor>map(JhelmPostRendererAdapter::new)
+			.toList();
+		String result = processors.stream()
+			.filter((p) -> p instanceof JhelmPostRendererAdapter)
+			.findFirst()
+			.orElseThrow()
+			.process("hello");
+		// The ServiceLoader-registered UppercaseTestPostRenderer uppercases the manifest.
+		assertEquals("HELLO", result);
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/UppercaseTestPostRenderer.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/UppercaseTestPostRenderer.java
@@ -1,0 +1,20 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.Locale;
+
+import org.alexmond.jhelm.pluginapi.JhelmPostRenderer;
+
+/** ServiceLoader-registered test post-renderer (uppercases the manifest). */
+public class UppercaseTestPostRenderer implements JhelmPostRenderer {
+
+	@Override
+	public String name() {
+		return "uppercase-test";
+	}
+
+	@Override
+	public String postRender(String manifest) {
+		return manifest.toUpperCase(Locale.ROOT);
+	}
+
+}

--- a/jhelm-core/src/test/resources/META-INF/services/org.alexmond.jhelm.pluginapi.JhelmPostRenderer
+++ b/jhelm-core/src/test/resources/META-INF/services/org.alexmond.jhelm.pluginapi.JhelmPostRenderer
@@ -1,0 +1,1 @@
+org.alexmond.jhelm.core.service.UppercaseTestPostRenderer

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
             <!-- Internal Modules -->
             <dependency>
                 <groupId>org.alexmond</groupId>
+                <artifactId>jhelm-plugin-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.alexmond</groupId>
                 <artifactId>jhelm-gotemplate-helm</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Second slice of the Java plugin API epic (#749). Wires **`JhelmPostRenderer`** plugins into rendering.

## What's here
Discovered `JhelmPostRenderer` plugins (Spring beans **+** ServiceLoader) now run in the render pipeline for `install`/`upgrade`/`template` across **every** jhelm surface (CLI/REST/MCP/library), alongside the CLI's `--post-renderer` and the WASM post-renderers.

- **jhelm-core → jhelm-plugin-api** dependency (added to root `dependencyManagement`).
- **`JhelmPostRendererAdapter`** bridges `JhelmPostRenderer` → the internal `PostRenderProcessor` (`JhelmPluginException` → `IOException`).
- **`JhelmCoreAutoConfiguration`** contributes a `List<PostRenderProcessor>` built from `JhelmPlugins.merge(beans + ServiceLoader)`, which the existing action wiring applies. No security gate — in-process classpath code, unlike a spawned binary.

## Tests
Adapter delegate + exception translation, and a **ServiceLoader-registered post-renderer discovered → adapted → applied** (uppercases a manifest). Full reactor + Spring context load green locally. (A real plugin-on-classpath end-to-end lands with the sample module in #755.)

Part of #749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)