### PR TITLE
feat(core): route custom chart schemes to Java JhelmChartDownloader plugins (#752)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.core;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.alexmond.jhelm.core.cache.TemplateCache;
@@ -39,7 +40,9 @@ import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.action.VerifyAction;
 import org.alexmond.jhelm.core.service.ChartDownloader;
 import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.JhelmChartDownloaderAdapter;
 import org.alexmond.jhelm.core.service.JhelmPostRendererAdapter;
+import org.alexmond.jhelm.pluginapi.JhelmChartDownloader;
 import org.alexmond.jhelm.pluginapi.JhelmPlugins;
 import org.alexmond.jhelm.pluginapi.JhelmPostRenderer;
 import org.alexmond.jhelm.core.service.ConfigServerClient;
@@ -113,14 +116,18 @@ public class JhelmCoreAutoConfiguration {
 	@ConditionalOnMissingBean
 	public RepoManager repoManager(JhelmCoreProperties props, JhelmSecurityProperties securityProps,
 			RegistryManager registryManager, ObjectProvider<JhelmMetrics> metrics,
-			ObjectProvider<ChartDownloader> chartDownloaders) {
+			ObjectProvider<ChartDownloader> chartDownloaders,
+			ObjectProvider<JhelmChartDownloader> javaChartDownloaders) {
 		boolean blockPrivate = securityProps.isBlockPrivateNetworks();
 		RepoManager repoManager = (props.getConfigPath() != null)
 				? new RepoManager(props.getConfigPath(), registryManager, props.isInsecureSkipTlsVerify(), blockPrivate)
 				: new RepoManager(registryManager, props.isInsecureSkipTlsVerify(), blockPrivate);
 		repoManager.setMetrics(metrics.getIfAvailable());
 		repoManager.setRepositoryCacheOverride(props.getRepositoryCachePath());
-		repoManager.setChartDownloaders(chartDownloaders.stream().toList());
+		List<ChartDownloader> downloaders = new ArrayList<>(chartDownloaders.stream().toList());
+		JhelmPlugins.merge(JhelmChartDownloader.class, javaChartDownloaders.stream().toList())
+			.forEach((plugin) -> downloaders.add(new JhelmChartDownloaderAdapter(plugin)));
+		repoManager.setChartDownloaders(downloaders);
 		return repoManager;
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/JhelmChartDownloaderAdapter.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/JhelmChartDownloaderAdapter.java
@@ -1,0 +1,41 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.IOException;
+
+import org.alexmond.jhelm.pluginapi.JhelmChartDownloader;
+import org.alexmond.jhelm.pluginapi.JhelmPluginException;
+
+/**
+ * Adapts a Java {@link JhelmChartDownloader} plugin to the internal
+ * {@link ChartDownloader} SPI consulted by {@code RepoManager}, translating a
+ * {@link JhelmPluginException} into the {@link IOException} the fetch path expects.
+ */
+public class JhelmChartDownloaderAdapter implements ChartDownloader {
+
+	private final JhelmChartDownloader plugin;
+
+	/**
+	 * Wraps a chart-downloader plugin.
+	 * @param plugin the Java chart-downloader plugin
+	 */
+	public JhelmChartDownloaderAdapter(JhelmChartDownloader plugin) {
+		this.plugin = plugin;
+	}
+
+	@Override
+	public boolean supportsProtocol(String protocol) {
+		return this.plugin.supports(protocol);
+	}
+
+	@Override
+	public byte[] download(String url) throws IOException {
+		try {
+			return this.plugin.download(url);
+		}
+		catch (JhelmPluginException ex) {
+			throw new IOException("chart-downloader plugin '" + this.plugin.name() + "' failed: " + ex.getMessage(),
+					ex);
+		}
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/JhelmChartDownloaderAdapterTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/JhelmChartDownloaderAdapterTest.java
@@ -1,0 +1,102 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.alexmond.jhelm.pluginapi.JhelmChartDownloader;
+import org.alexmond.jhelm.pluginapi.JhelmPluginException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JhelmChartDownloaderAdapterTest {
+
+	@TempDir
+	Path work;
+
+	@Test
+	void adapterDelegatesSupportsAndDownload() throws Exception {
+		JhelmChartDownloader plugin = new JhelmChartDownloader() {
+			@Override
+			public boolean supports(String scheme) {
+				return "jtest".equals(scheme);
+			}
+
+			@Override
+			public byte[] download(String url) {
+				return url.getBytes(StandardCharsets.UTF_8);
+			}
+		};
+		JhelmChartDownloaderAdapter adapter = new JhelmChartDownloaderAdapter(plugin);
+		assertTrue(adapter.supportsProtocol("jtest"));
+		assertEquals("jtest://x", new String(adapter.download("jtest://x"), StandardCharsets.UTF_8));
+	}
+
+	@Test
+	void adapterTranslatesPluginExceptionToIoException() {
+		JhelmChartDownloader failing = new JhelmChartDownloader() {
+			@Override
+			public boolean supports(String scheme) {
+				return true;
+			}
+
+			@Override
+			public byte[] download(String url) throws JhelmPluginException {
+				throw new JhelmPluginException("nope");
+			}
+		};
+		IOException ex = assertThrows(IOException.class,
+				() -> new JhelmChartDownloaderAdapter(failing).download("x://y"));
+		assertTrue(ex.getMessage().contains("nope"));
+	}
+
+	@Test
+	void repoManagerRoutesCustomSchemeToAJavaDownloader() throws Exception {
+		byte[] tgz = chartArchive();
+		JhelmChartDownloader plugin = new JhelmChartDownloader() {
+			@Override
+			public boolean supports(String scheme) {
+				return "jtest".equalsIgnoreCase(scheme);
+			}
+
+			@Override
+			public byte[] download(String url) {
+				return tgz;
+			}
+		};
+		RepoManager repoManager = new RepoManager();
+		repoManager.setChartDownloaders(List.of(new JhelmChartDownloaderAdapter(plugin)));
+		Path dest = Files.createDirectories(this.work.resolve("out"));
+
+		repoManager.pullFromUrl("jtest://bucket/mychart-1.0.0.tgz", dest.toString(), "mychart-1.0.0.tgz");
+
+		assertTrue(Files.exists(dest.resolve("mychart/Chart.yaml")),
+				"chart fetched via the Java downloader and untarred");
+	}
+
+	private static byte[] chartArchive() throws Exception {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		try (OutputStream gz = new GZIPOutputStream(bytes);
+				TarArchiveOutputStream tar = new TarArchiveOutputStream(gz)) {
+			byte[] content = "apiVersion: v2\nname: mychart\nversion: 1.0.0\n".getBytes(StandardCharsets.UTF_8);
+			TarArchiveEntry entry = new TarArchiveEntry("mychart/Chart.yaml");
+			entry.setSize(content.length);
+			tar.putArchiveEntry(entry);
+			tar.write(content);
+			tar.closeArchiveEntry();
+		}
+		return bytes.toByteArray();
+	}
+
+}


### PR DESCRIPTION
Third slice of the Java plugin API epic (#749). Wires **`JhelmChartDownloader`** plugins into chart fetching.

## What's here
Discovered `JhelmChartDownloader` plugins (Spring beans **+** ServiceLoader) are consulted for custom chart URL schemes (`s3://`, `gs://`, …), alongside the Helm downloader plugins from #738.

- **`JhelmChartDownloaderAdapter`** bridges `JhelmChartDownloader` → the core `ChartDownloader` SPI (`JhelmPluginException` → `IOException`).
- The **`repoManager`** bean collects Java downloaders via `JhelmPlugins.merge` and adds their adapters to `RepoManager.setChartDownloaders`, so `RepoManager.pullFromUrl` routes matching schemes to them (reusing the #738 fetch path).

## Tests
Adapter delegation + exception translation, and `RepoManager` routing a custom scheme to a Java downloader (bytes → untarred). Full reactor + Spring context load green (no bean cycle).

Part of #749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)