### PR TITLE
feat(core): deliver release lifecycle events to Java JhelmLifecycleListener plugins (#753)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -41,8 +41,10 @@ import org.alexmond.jhelm.core.action.VerifyAction;
 import org.alexmond.jhelm.core.service.ChartDownloader;
 import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.JhelmChartDownloaderAdapter;
+import org.alexmond.jhelm.core.service.JhelmLifecycleListenerAdapter;
 import org.alexmond.jhelm.core.service.JhelmPostRendererAdapter;
 import org.alexmond.jhelm.pluginapi.JhelmChartDownloader;
+import org.alexmond.jhelm.pluginapi.JhelmLifecycleListener;
 import org.alexmond.jhelm.pluginapi.JhelmPlugins;
 import org.alexmond.jhelm.pluginapi.JhelmPostRenderer;
 import org.alexmond.jhelm.core.service.ConfigServerClient;
@@ -265,6 +267,22 @@ public class JhelmCoreAutoConfiguration {
 		return JhelmPlugins.merge(JhelmPostRenderer.class, postRendererPlugins.stream().toList())
 			.stream()
 			.<PostRenderProcessor>map(JhelmPostRendererAdapter::new)
+			.toList();
+	}
+
+	/**
+	 * Collects Java {@link JhelmLifecycleListener} plugins — discovered as Spring beans
+	 * and via {@link java.util.ServiceLoader} — as internal {@link LifecycleListener}s
+	 * notified on release lifecycle events (install, upgrade, rollback).
+	 * @param listenerPlugins the lifecycle-listener plugin beans (if any)
+	 * @return the lifecycle listeners, or an empty list if no plugins are present
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public List<LifecycleListener> jhelmLifecycleListeners(ObjectProvider<JhelmLifecycleListener> listenerPlugins) {
+		return JhelmPlugins.merge(JhelmLifecycleListener.class, listenerPlugins.stream().toList())
+			.stream()
+			.<LifecycleListener>map(JhelmLifecycleListenerAdapter::new)
 			.toList();
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/JhelmLifecycleListenerAdapter.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/JhelmLifecycleListenerAdapter.java
@@ -1,0 +1,56 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.alexmond.jhelm.pluginapi.JhelmLifecycleListener;
+import org.alexmond.jhelm.pluginapi.JhelmReleaseEvent;
+
+/**
+ * Adapts a Java {@link JhelmLifecycleListener} plugin to the internal
+ * {@link LifecycleListener}, mapping the internal {@link LifecyclePhase} to the public
+ * {@link JhelmReleaseEvent.Phase} and delivering a {@link JhelmReleaseEvent}. A listener
+ * that throws is logged and ignored so it cannot corrupt the release operation.
+ */
+@Slf4j
+public class JhelmLifecycleListenerAdapter implements LifecycleListener {
+
+	private final JhelmLifecycleListener plugin;
+
+	/**
+	 * Wraps a lifecycle-listener plugin.
+	 * @param plugin the Java lifecycle-listener plugin
+	 */
+	public JhelmLifecycleListenerAdapter(JhelmLifecycleListener plugin) {
+		this.plugin = plugin;
+	}
+
+	@Override
+	public void onEvent(LifecyclePhase phase, String releaseName, String namespace, Map<String, Object> metadata) {
+		JhelmReleaseEvent.Phase mapped = map(phase);
+		if (mapped == null) {
+			return;
+		}
+		try {
+			this.plugin.onEvent(new JhelmReleaseEvent(mapped, releaseName, namespace, metadata));
+		}
+		catch (RuntimeException ex) {
+			log.warn("lifecycle listener plugin '{}' failed on {}: {}", this.plugin.name(), phase, ex.getMessage());
+		}
+	}
+
+	private static JhelmReleaseEvent.Phase map(LifecyclePhase phase) {
+		return switch (phase) {
+			case PRE_INSTALL -> JhelmReleaseEvent.Phase.PRE_INSTALL;
+			case POST_INSTALL -> JhelmReleaseEvent.Phase.POST_INSTALL;
+			case PRE_UPGRADE -> JhelmReleaseEvent.Phase.PRE_UPGRADE;
+			case POST_UPGRADE -> JhelmReleaseEvent.Phase.POST_UPGRADE;
+			case PRE_ROLLBACK -> JhelmReleaseEvent.Phase.PRE_ROLLBACK;
+			case POST_ROLLBACK -> JhelmReleaseEvent.Phase.POST_ROLLBACK;
+			case PRE_DELETE -> JhelmReleaseEvent.Phase.PRE_UNINSTALL;
+			case POST_DELETE -> JhelmReleaseEvent.Phase.POST_UNINSTALL;
+		};
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/JhelmLifecycleListenerAdapterTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/JhelmLifecycleListenerAdapterTest.java
@@ -1,0 +1,61 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.jhelm.pluginapi.JhelmLifecycleListener;
+import org.alexmond.jhelm.pluginapi.JhelmReleaseEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JhelmLifecycleListenerAdapterTest {
+
+	@Test
+	void deliversMappedEventWithReleaseDetails() throws Exception {
+		List<JhelmReleaseEvent> received = new ArrayList<>();
+		LifecycleListener adapter = new JhelmLifecycleListenerAdapter(received::add);
+
+		adapter.onEvent(LifecyclePhase.POST_INSTALL, "rel", "ns", Map.of("revision", 1));
+
+		assertEquals(1, received.size());
+		assertEquals(JhelmReleaseEvent.Phase.POST_INSTALL, received.get(0).phase());
+		assertEquals("rel", received.get(0).releaseName());
+		assertEquals("ns", received.get(0).namespace());
+		assertEquals(1, received.get(0).metadata().get("revision"));
+	}
+
+	@Test
+	void mapsDeletePhaseToUninstall() throws Exception {
+		List<JhelmReleaseEvent> received = new ArrayList<>();
+		LifecycleListener adapter = new JhelmLifecycleListenerAdapter(received::add);
+
+		adapter.onEvent(LifecyclePhase.PRE_DELETE, "rel", "ns", Map.of());
+		adapter.onEvent(LifecyclePhase.POST_ROLLBACK, "rel", "ns", Map.of());
+
+		assertEquals(JhelmReleaseEvent.Phase.PRE_UNINSTALL, received.get(0).phase());
+		assertEquals(JhelmReleaseEvent.Phase.POST_ROLLBACK, received.get(1).phase());
+	}
+
+	@Test
+	void everyInternalPhaseMapsToAPublicPhase() throws Exception {
+		List<JhelmReleaseEvent> received = new ArrayList<>();
+		LifecycleListener adapter = new JhelmLifecycleListenerAdapter(received::add);
+		for (LifecyclePhase phase : LifecyclePhase.values()) {
+			adapter.onEvent(phase, "rel", "ns", Map.of());
+		}
+		assertEquals(LifecyclePhase.values().length, received.size(), "no phase dropped");
+	}
+
+	@Test
+	void aThrowingListenerIsSwallowed() {
+		JhelmLifecycleListener throwing = (event) -> {
+			throw new IllegalStateException("boom");
+		};
+		LifecycleListener adapter = new JhelmLifecycleListenerAdapter(throwing);
+		assertDoesNotThrow(() -> adapter.onEvent(LifecyclePhase.POST_UPGRADE, "rel", "ns", Map.of()));
+	}
+
+}

--- a/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmReleaseEvent.java
+++ b/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmReleaseEvent.java
@@ -24,6 +24,10 @@ public record JhelmReleaseEvent(Phase phase, String releaseName, String namespac
 		PRE_UPGRADE,
 		/** After a successful upgrade. */
 		POST_UPGRADE,
+		/** Before a rollback. */
+		PRE_ROLLBACK,
+		/** After a successful rollback. */
+		POST_ROLLBACK,
 		/** Before an uninstall. */
 		PRE_UNINSTALL,
 		/** After a successful uninstall. */


### PR DESCRIPTION
Fourth slice of the Java plugin API epic (#749). Wires **`JhelmLifecycleListener`** plugins into release events.

## What's here
Discovered `JhelmLifecycleListener` plugins (Spring beans **+** ServiceLoader) are notified on release lifecycle events (install, upgrade, rollback) fired by the action layer.

- **`JhelmReleaseEvent.Phase`** gains `PRE_ROLLBACK`/`POST_ROLLBACK` (additive to the API).
- **`JhelmLifecycleListenerAdapter`** bridges the internal `LifecycleListener` → a Java `JhelmLifecycleListener`, mapping `LifecyclePhase` → `JhelmReleaseEvent.Phase` (`DELETE` → `UNINSTALL`). A **throwing listener is logged and ignored** so it can't corrupt the operation.
- **`JhelmCoreAutoConfiguration`** contributes a `List<LifecycleListener>` from `JhelmPlugins.merge(beans + ServiceLoader)`, applied by the existing action wiring.

## Tests
Phase mapping (incl. `DELETE`→`UNINSTALL` and every phase covered, none dropped), event payload, exception swallowing. Full reactor + Spring context load green.

Note: uninstall doesn't emit lifecycle events in the action layer yet, so uninstall listeners fire only once that's added (tracked separately); install/upgrade/rollback work today.

Part of #749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)