### PR TITLE
feat(core): register Java plugin template functions in the engine (#754)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -43,10 +43,12 @@ import org.alexmond.jhelm.core.service.ChartLoader;
 import org.alexmond.jhelm.core.service.JhelmChartDownloaderAdapter;
 import org.alexmond.jhelm.core.service.JhelmLifecycleListenerAdapter;
 import org.alexmond.jhelm.core.service.JhelmPostRendererAdapter;
+import org.alexmond.jhelm.core.service.JhelmTemplateFunctionAdapter;
 import org.alexmond.jhelm.pluginapi.JhelmChartDownloader;
 import org.alexmond.jhelm.pluginapi.JhelmLifecycleListener;
 import org.alexmond.jhelm.pluginapi.JhelmPlugins;
 import org.alexmond.jhelm.pluginapi.JhelmPostRenderer;
+import org.alexmond.jhelm.pluginapi.JhelmTemplateFunctionProvider;
 import org.alexmond.jhelm.core.service.ConfigServerClient;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.service.Engine;
@@ -228,9 +230,12 @@ public class JhelmCoreAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public Engine engine(ObjectProvider<TemplateCache> templateCache, SchemaValidator schemaValidator,
-			ObjectProvider<JhelmMetrics> metrics, ObjectProvider<KubernetesProvider> kubernetesProvider) {
+			ObjectProvider<JhelmMetrics> metrics, ObjectProvider<KubernetesProvider> kubernetesProvider,
+			ObjectProvider<JhelmTemplateFunctionProvider> templateFunctionPlugins) {
 		Engine engine = new Engine(templateCache.getIfAvailable(), schemaValidator, metrics.getIfAvailable());
 		engine.setKubernetesProvider(kubernetesProvider.getIfAvailable());
+		engine.setPluginFunctions(JhelmTemplateFunctionAdapter.collect(
+				JhelmPlugins.merge(JhelmTemplateFunctionProvider.class, templateFunctionPlugins.stream().toList())));
 		return engine;
 	}
 

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/Engine.java
@@ -117,6 +117,12 @@ public class Engine {
 	// to the ServiceLoader stub that returns an empty map. Set by the kube autoconfig.
 	private KubernetesProvider kubernetesProvider;
 
+	// Template functions contributed by Java JhelmTemplateFunctionProvider plugins,
+	// applied
+	// as overrides on every render. Empty unless plugins are present. Set by the
+	// autoconfig.
+	private Map<String, Function> pluginFunctions = Map.of();
+
 	// Per-render record of the text hash last parsed under each template name, so the
 	// render pass can skip re-parsing a template the collect pass already parsed (see
 	// parseWithCache). Reset each render in doRender alongside the factory.
@@ -168,6 +174,17 @@ public class Engine {
 	 */
 	public void setKubernetesProvider(KubernetesProvider kubernetesProvider) {
 		this.kubernetesProvider = kubernetesProvider;
+	}
+
+	/**
+	 * Registers template functions contributed by Java plugins, applied as overrides on
+	 * every render. Names that collide with a built-in override it, so plugins should use
+	 * distinctive/namespaced names (the built-in {@code lookup} is always preserved).
+	 * @param pluginFunctions the plugin functions keyed by template name (never
+	 * {@code null})
+	 */
+	public void setPluginFunctions(Map<String, Function> pluginFunctions) {
+		this.pluginFunctions = (pluginFunctions != null) ? Map.copyOf(pluginFunctions) : Map.of();
 	}
 
 	private void parseWithCache(String name, String text) {
@@ -340,9 +357,13 @@ public class Engine {
 		// during install/upgrade, as Helm does — withFunctions is applied on top of the
 		// registry-supplied providers, so the override wins.
 		GoTemplate.Builder builder = GoTemplate.builder().registry(this.templateRegistry);
+		Map<String, Function> overrides = new HashMap<>(this.pluginFunctions);
 		if (this.kubernetesProvider != null) {
-			Map<String, Function> overrides = new HashMap<>();
+			// Added after the plugin functions so the built-in lookup can never be
+			// clobbered by a plugin function named "lookup".
 			overrides.put("lookup", KubernetesFunctions.getFunctions(this.kubernetesProvider).get("lookup"));
+		}
+		if (!overrides.isEmpty()) {
 			builder.withFunctions(overrides);
 		}
 		this.factory = builder.build().option("missingkey=zero");

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/JhelmTemplateFunctionAdapter.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/JhelmTemplateFunctionAdapter.java
@@ -1,0 +1,54 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.alexmond.gotmpl4j.Function;
+import org.alexmond.jhelm.pluginapi.JhelmPluginException;
+import org.alexmond.jhelm.pluginapi.JhelmTemplateFunction;
+import org.alexmond.jhelm.pluginapi.JhelmTemplateFunctionProvider;
+
+/**
+ * Bridges Java {@link JhelmTemplateFunctionProvider} plugins to gotmpl4j
+ * {@link Function}s the render engine can register. A {@link JhelmPluginException} from a
+ * plugin function surfaces as an unchecked exception that aborts rendering.
+ */
+public final class JhelmTemplateFunctionAdapter {
+
+	private JhelmTemplateFunctionAdapter() {
+	}
+
+	/**
+	 * Collects the functions contributed by the given providers into a single map,
+	 * adapting each to a gotmpl4j {@link Function}. Later providers override earlier ones
+	 * on a name clash.
+	 * @param providers the template-function plugins
+	 * @return the adapted functions keyed by template name
+	 */
+	public static Map<String, Function> collect(List<JhelmTemplateFunctionProvider> providers) {
+		Map<String, Function> functions = new LinkedHashMap<>();
+		for (JhelmTemplateFunctionProvider provider : providers) {
+			provider.functions().forEach((name, function) -> functions.put(name, adapt(name, function)));
+		}
+		return functions;
+	}
+
+	/**
+	 * Adapts a single {@link JhelmTemplateFunction} to a gotmpl4j {@link Function}.
+	 * @param name the function name (for error messages)
+	 * @param function the plugin function
+	 * @return the adapted gotmpl4j function
+	 */
+	public static Function adapt(String name, JhelmTemplateFunction function) {
+		return (args) -> {
+			try {
+				return function.apply(args);
+			}
+			catch (JhelmPluginException ex) {
+				throw new IllegalStateException("template function '" + name + "' failed: " + ex.getMessage(), ex);
+			}
+		};
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/JhelmTemplateFunctionAdapterTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/JhelmTemplateFunctionAdapterTest.java
@@ -1,0 +1,64 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.alexmond.gotmpl4j.Function;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.model.ReleaseContext;
+import org.alexmond.jhelm.pluginapi.JhelmPluginException;
+import org.alexmond.jhelm.pluginapi.JhelmTemplateFunction;
+import org.alexmond.jhelm.pluginapi.JhelmTemplateFunctionProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JhelmTemplateFunctionAdapterTest {
+
+	@Test
+	void adaptInvokesThePluginFunction() {
+		Function fn = JhelmTemplateFunctionAdapter.adapt("shout",
+				(args) -> ((String) args[0]).toUpperCase(Locale.ROOT));
+		assertEquals("HI", fn.invoke("hi"));
+	}
+
+	@Test
+	void adaptTranslatesPluginExceptionToUnchecked() {
+		JhelmTemplateFunction failing = (args) -> {
+			throw new JhelmPluginException("bad args");
+		};
+		Function fn = JhelmTemplateFunctionAdapter.adapt("boom", failing);
+		IllegalStateException ex = assertThrows(IllegalStateException.class, () -> fn.invoke());
+		assertTrue(ex.getMessage().contains("bad args"));
+	}
+
+	@Test
+	void collectGathersFunctionsFromProviders() {
+		JhelmTemplateFunctionProvider provider = () -> Map.of("greet",
+				(JhelmTemplateFunction) (args) -> "hello " + args[0]);
+		Map<String, Function> functions = JhelmTemplateFunctionAdapter.collect(List.of(provider));
+		assertEquals("hello world", functions.get("greet").invoke("world"));
+	}
+
+	@Test
+	void pluginFunctionIsCallableFromAChartTemplate() {
+		Engine engine = new Engine();
+		engine.setPluginFunctions(JhelmTemplateFunctionAdapter.collect(List
+			.of(() -> Map.of("shout", (JhelmTemplateFunction) (args) -> ((String) args[0]).toUpperCase(Locale.ROOT)))));
+		Chart chart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
+			.templates(List.of(Chart.Template.builder().name("cm.yaml").data("name: {{ shout \"hi\" }}").build()))
+			.values(Map.of())
+			.build();
+
+		String result = engine.render(chart, Map.of(),
+				ReleaseContext.builder().name("rel").namespace("default").install(true).revision(1).build());
+
+		assertTrue(result.contains("name: HI"), result);
+	}
+
+}

--- a/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmTemplateFunctionProvider.java
+++ b/jhelm-plugin-api/src/main/java/org/alexmond/jhelm/pluginapi/JhelmTemplateFunctionProvider.java
@@ -8,8 +8,10 @@ import java.util.Map;
  * can call them like any built-in, Sprig, or Helm function.
  *
  * <p>
- * Function names should be namespaced or distinctive to avoid colliding with built-in
- * functions; a collision resolves in favor of the built-in and is logged.
+ * Function names should be namespaced or distinctive: a name that collides with a
+ * built-in (Sprig/Helm) function <em>overrides</em> it, so an accidental clash can change
+ * chart rendering. The engine's cluster-backed {@code lookup} is the one exception — it
+ * is always preserved.
  */
 public interface JhelmTemplateFunctionProvider extends JhelmPlugin {
 


### PR DESCRIPTION
Fifth slice of the Java plugin API epic (#749). Wires **`JhelmTemplateFunctionProvider`** plugins — the last of the four extension points.

## What's here
`JhelmTemplateFunctionProvider` plugins (Spring beans **+** ServiceLoader) can add Go-template functions callable from any chart, like built-in/Sprig/Helm functions.

- **`JhelmTemplateFunctionAdapter`** bridges `JhelmTemplateFunction` → gotmpl4j `Function` (`JhelmPluginException` → unchecked, aborting the render) and collects providers into a name→function map.
- **`Engine.setPluginFunctions`** holds them; `doRender` applies them via `withFunctions` on every render. The cluster-backed **`lookup` is added after**, so a plugin can never clobber it; other name collisions **override** the built-in (documented — namespace to avoid).
- **`JhelmCoreAutoConfiguration`** builds the map from `JhelmPlugins.merge` and sets it on the `Engine` bean.

## Tests
Adapt/collect + exception translation, and a plugin function called from a **real chart template** through `Engine.render` (`{{ shout "hi" }}` → `HI`). Full reactor + parity green.

Completes the four extension-point wirings; docs + sample + end-to-end test land in #755. Part of #749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)