### PR TITLE
docs(plugin-api): Java plugin API page + sample module + end-to-end test (#755)

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -9,6 +9,7 @@
 * xref:cli-reference.adoc[CLI Reference]
 * xref:cli-parity.adoc[CLI Flag Parity with Helm]
 * xref:plugin-parity.adoc[Helm Plugin Compatibility]
+* xref:java-plugin-api.adoc[Java Plugin API]
 * xref:configuration.adoc[Configuration]
 * xref:value-profiles.adoc[Value Profiles]
 * xref:interoperability.adoc[Interoperability with Helm]

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -25,6 +25,18 @@ WASM (`.jhp`) plugin system, which stays as-is.
 Running a native plugin (dispatch, downloader, post-renderer, hooks) is gated on the CLI's
 `FULL` security posture -- the local kubeconfig is the trust boundary, as with `helm`.
 
+=== Java plugin API
+
+New `jhelm-plugin-api` module: extend jhelm by implementing a Java interface, discovered via
+`ServiceLoader` or as a Spring bean. See xref:java-plugin-api.adoc[Java Plugin API].
+
+* *Post-renderers* (`JhelmPostRenderer`), *chart downloaders* (`JhelmChartDownloader`),
+  *lifecycle listeners* (`JhelmLifecycleListener`), and *template-function providers*
+  (`JhelmTemplateFunctionProvider`) run in the same render/fetch/lifecycle/engine paths as
+  the native-Helm and WASM plugins, across every jhelm surface (CLI/REST/MCP/library).
+* Java plugins run in-process (code already on the classpath), so they are not gated on the
+  security posture; a `jhelm-plugin-api-sample` module shows one of each.
+
 == 1.2.1
 
 === Dependencies

--- a/docs/modules/ROOT/pages/java-plugin-api.adoc
+++ b/docs/modules/ROOT/pages/java-plugin-api.adoc
@@ -1,0 +1,111 @@
+= Java Plugin API
+:description: Extend jhelm in plain Java — post-renderers, chart downloaders, lifecycle listeners, and template functions discovered via ServiceLoader or Spring beans.
+
+The `jhelm-plugin-api` module lets you extend jhelm by implementing a small Java interface —
+no WebAssembly to compile, no subprocess to spawn. Your plugin runs in-process and is
+discovered off the classpath, either as a JDK `ServiceLoader` service (any application) or
+as a Spring bean (the jhelm CLI/REST/MCP apps, or your own Spring app embedding jhelm).
+
+[NOTE]
+====
+This is one of three plugin surfaces. See also xref:plugin-parity.adoc[Helm plugin compatibility]
+(native Helm plugins as subprocesses) and the WASM `.jhp` system. Java plugins are the
+simplest way to extend jhelm from Java code.
+====
+
+== Dependency
+
+[source,xml,subs="attributes"]
+----
+<dependency>
+    <groupId>org.alexmond</groupId>
+    <artifactId>jhelm-plugin-api</artifactId>
+    <version>{page-component-version}</version>
+</dependency>
+----
+
+== Extension points
+
+All interfaces live in `org.alexmond.jhelm.pluginapi` and extend `JhelmPlugin` (which
+provides a `name()` for listings/logs).
+
+Post-renderer:: `JhelmPostRenderer` — transform the rendered manifest (install, upgrade,
+template).
++
+[source,java]
+----
+public class BannerPostRenderer implements JhelmPostRenderer {
+    public String postRender(String manifest) {
+        return "# rendered via my plugin\n" + manifest;
+    }
+}
+----
+
+Chart downloader:: `JhelmChartDownloader` — fetch charts for a custom URL scheme (`s3://`,
+`gs://`, …). `supports(scheme)` selects it; `download(url)` returns the chart archive bytes.
+
+Lifecycle listener:: `JhelmLifecycleListener` — react to release events. `onEvent(JhelmReleaseEvent)`
+receives the phase (`PRE_INSTALL`, `POST_INSTALL`, `PRE_UPGRADE`, `POST_UPGRADE`,
+`PRE_ROLLBACK`, `POST_ROLLBACK`, `PRE_UNINSTALL`, `POST_UNINSTALL`), release name, namespace,
+and metadata. A throwing listener is logged and ignored.
+
+Template functions:: `JhelmTemplateFunctionProvider` — contribute Go-template functions
+callable from any chart.
++
+[source,java]
+----
+public class MyFunctions implements JhelmTemplateFunctionProvider {
+    public Map<String, JhelmTemplateFunction> functions() {
+        return Map.of("my_greet", args -> "hello, " + args[0]);
+    }
+}
+----
++
+Name your functions distinctively — a name that collides with a built-in *overrides* it
+(the cluster-backed `lookup` is the one exception, always preserved).
+
+Any method may throw `JhelmPluginException`; jhelm surfaces the message and aborts the
+operation.
+
+== Registering a plugin
+
+ServiceLoader (any application):: add a file under `META-INF/services/` named for the
+interface, listing your implementation class. For a post-renderer:
++
+.`META-INF/services/org.alexmond.jhelm.pluginapi.JhelmPostRenderer`
+----
+com.example.BannerPostRenderer
+----
+
+Spring bean (jhelm CLI/REST/MCP, or your Spring app):: expose the plugin as a bean:
++
+[source,java]
+----
+@Bean
+JhelmPostRenderer bannerPostRenderer() {
+    return new BannerPostRenderer();
+}
+----
+
+jhelm unions both sources and de-duplicates by implementation class (a Spring bean that is
+also a declared service is registered once, preferring the bean instance).
+
+== Worked examples
+
+The `jhelm-plugin-api-sample` module in the source tree implements one plugin of each kind
+(post-renderer, downloader, lifecycle listener, template functions) with `ServiceLoader`
+registrations, and an integration test that runs them through jhelm-core end to end.
+
+== Stability
+
+The plugin API follows the project's semantic versioning: interfaces are additive within a
+minor line. New extension points and enum constants may be added; existing method
+signatures are kept stable within a major version.
+
+== Relation to the native-Helm and WASM plugin systems
+
+Java plugins run in-process, so — unlike native Helm plugins (arbitrary executables) — they
+are not gated on the `FULL` security posture; they are code you already put on the
+classpath. Use a Java plugin when you extend jhelm from Java, a
+xref:plugin-parity.adoc[Helm plugin] to reuse an existing Helm plugin, and the WASM `.jhp`
+system for a sandboxed, language-agnostic plugin.

--- a/docs/modules/ROOT/pages/roadmap.adoc
+++ b/docs/modules/ROOT/pages/roadmap.adoc
@@ -132,7 +132,7 @@ The roadmap is divided into several phases focusing on compatibility, feature co
 | *Helm 4 must* Functions* | ❌ | ✅ | ✅ | P1 | ✅ *Complete*
 | Server-Side Apply | ❌ | ✅ | ❌ | P1 | Pending
 | Three-Way Merge | ✅ | ❌ | ✅ | P1 | Complete
-| Plugin System | ✅ | ✅ (new) | ✅ | P2 | ✅ Complete (Helm 3 plugins + WASM; see xref:plugin-parity.adoc[Plugin Compatibility])
+| Plugin System | ✅ | ✅ (new) | ✅ | P2 | ✅ Complete (Helm 3 plugins + WASM + xref:java-plugin-api.adoc[Java plugin API]; see xref:plugin-parity.adoc[Plugin Compatibility])
 | OCI Registries | ✅ | ✅ (enhanced) | ⚠️ | P1 | Partial
 | Chart Dependencies | ✅ | ✅ | ✅ | P2 | ✅ Complete
 | Hooks | ✅ | ✅ | ✅ | P2 | ✅ Complete

--- a/jhelm-plugin-api-sample/pom.xml
+++ b/jhelm-plugin-api-sample/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.alexmond</groupId>
+        <artifactId>jhelm-parent</artifactId>
+        <version>1.2.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>jhelm-plugin-api-sample</artifactId>
+
+    <name>jhelm Plugin API Sample</name>
+    <description>Worked examples of the jhelm Java plugin API: one plugin per extension point, with an
+        end-to-end test that runs them through jhelm-core</description>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.alexmond</groupId>
+            <artifactId>jhelm-plugin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <!-- Test only: exercise the sample plugins end-to-end through the real engine/fetch path. -->
+        <dependency>
+            <groupId>org.alexmond</groupId>
+            <artifactId>jhelm-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jhelm-plugin-api-sample/pom.xml
+++ b/jhelm-plugin-api-sample/pom.xml
@@ -15,7 +15,10 @@
         end-to-end test that runs them through jhelm-core</description>
 
     <properties>
+        <!-- Example module: not published, and not coverage-gated (like jhelm-benchmarks). -->
         <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <jacoco.skip>true</jacoco.skip>
     </properties>
 
     <dependencies>

--- a/jhelm-plugin-api-sample/src/main/java/org/alexmond/jhelm/pluginapi/sample/BannerPostRenderer.java
+++ b/jhelm-plugin-api-sample/src/main/java/org/alexmond/jhelm/pluginapi/sample/BannerPostRenderer.java
@@ -1,0 +1,21 @@
+package org.alexmond.jhelm.pluginapi.sample;
+
+import org.alexmond.jhelm.pluginapi.JhelmPostRenderer;
+
+/**
+ * Sample {@link JhelmPostRenderer} that prepends a banner comment to the rendered
+ * manifest. A real post-renderer might run kustomize, inject sidecars, or redact values.
+ */
+public class BannerPostRenderer implements JhelmPostRenderer {
+
+	@Override
+	public String name() {
+		return "banner";
+	}
+
+	@Override
+	public String postRender(String manifest) {
+		return "# rendered via the jhelm sample post-renderer\n" + manifest;
+	}
+
+}

--- a/jhelm-plugin-api-sample/src/main/java/org/alexmond/jhelm/pluginapi/sample/FileChartDownloader.java
+++ b/jhelm-plugin-api-sample/src/main/java/org/alexmond/jhelm/pluginapi/sample/FileChartDownloader.java
@@ -1,0 +1,41 @@
+package org.alexmond.jhelm.pluginapi.sample;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.alexmond.jhelm.pluginapi.JhelmChartDownloader;
+import org.alexmond.jhelm.pluginapi.JhelmPluginException;
+
+/**
+ * Sample {@link JhelmChartDownloader} for a {@code samplefile://} scheme that reads a
+ * chart archive from the local filesystem. A real downloader would fetch from S3, GCS, an
+ * artifact registry, or another backend.
+ */
+public class FileChartDownloader implements JhelmChartDownloader {
+
+	private static final String SCHEME = "samplefile";
+
+	@Override
+	public String name() {
+		return "samplefile";
+	}
+
+	@Override
+	public boolean supports(String scheme) {
+		return SCHEME.equalsIgnoreCase(scheme);
+	}
+
+	@Override
+	public byte[] download(String url) throws JhelmPluginException {
+		int schemeEnd = url.indexOf("://");
+		String path = (schemeEnd > 0) ? url.substring(schemeEnd + 3) : url;
+		try {
+			return Files.readAllBytes(Path.of(path));
+		}
+		catch (IOException | RuntimeException ex) {
+			throw new JhelmPluginException("failed to read " + url + ": " + ex.getMessage(), ex);
+		}
+	}
+
+}

--- a/jhelm-plugin-api-sample/src/main/java/org/alexmond/jhelm/pluginapi/sample/LoggingLifecycleListener.java
+++ b/jhelm-plugin-api-sample/src/main/java/org/alexmond/jhelm/pluginapi/sample/LoggingLifecycleListener.java
@@ -1,0 +1,27 @@
+package org.alexmond.jhelm.pluginapi.sample;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.alexmond.jhelm.pluginapi.JhelmLifecycleListener;
+import org.alexmond.jhelm.pluginapi.JhelmReleaseEvent;
+
+/**
+ * Sample {@link JhelmLifecycleListener} that logs each release lifecycle event. A real
+ * listener might send a notification, write an audit record, or trigger a webhook.
+ */
+public class LoggingLifecycleListener implements JhelmLifecycleListener {
+
+	private static final Logger log = LoggerFactory.getLogger(LoggingLifecycleListener.class);
+
+	@Override
+	public String name() {
+		return "logging";
+	}
+
+	@Override
+	public void onEvent(JhelmReleaseEvent event) {
+		log.info("release lifecycle: {} {}/{}", event.phase(), event.namespace(), event.releaseName());
+	}
+
+}

--- a/jhelm-plugin-api-sample/src/main/java/org/alexmond/jhelm/pluginapi/sample/SampleTemplateFunctions.java
+++ b/jhelm-plugin-api-sample/src/main/java/org/alexmond/jhelm/pluginapi/sample/SampleTemplateFunctions.java
@@ -1,0 +1,27 @@
+package org.alexmond.jhelm.pluginapi.sample;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.alexmond.jhelm.pluginapi.JhelmTemplateFunction;
+import org.alexmond.jhelm.pluginapi.JhelmTemplateFunctionProvider;
+
+/**
+ * Sample {@link JhelmTemplateFunctionProvider} contributing a couple of namespaced
+ * template functions ({@code sample_greet}, {@code sample_shout}) callable from any
+ * chart. Names are prefixed to avoid clashing with built-in functions.
+ */
+public class SampleTemplateFunctions implements JhelmTemplateFunctionProvider {
+
+	@Override
+	public String name() {
+		return "sample-functions";
+	}
+
+	@Override
+	public Map<String, JhelmTemplateFunction> functions() {
+		return Map.of("sample_greet", (args) -> "hello, " + args[0], "sample_shout",
+				(args) -> String.valueOf(args[0]).toUpperCase(Locale.ROOT));
+	}
+
+}

--- a/jhelm-plugin-api-sample/src/main/resources/META-INF/services/org.alexmond.jhelm.pluginapi.JhelmChartDownloader
+++ b/jhelm-plugin-api-sample/src/main/resources/META-INF/services/org.alexmond.jhelm.pluginapi.JhelmChartDownloader
@@ -1,0 +1,1 @@
+org.alexmond.jhelm.pluginapi.sample.FileChartDownloader

--- a/jhelm-plugin-api-sample/src/main/resources/META-INF/services/org.alexmond.jhelm.pluginapi.JhelmLifecycleListener
+++ b/jhelm-plugin-api-sample/src/main/resources/META-INF/services/org.alexmond.jhelm.pluginapi.JhelmLifecycleListener
@@ -1,0 +1,1 @@
+org.alexmond.jhelm.pluginapi.sample.LoggingLifecycleListener

--- a/jhelm-plugin-api-sample/src/main/resources/META-INF/services/org.alexmond.jhelm.pluginapi.JhelmPostRenderer
+++ b/jhelm-plugin-api-sample/src/main/resources/META-INF/services/org.alexmond.jhelm.pluginapi.JhelmPostRenderer
@@ -1,0 +1,1 @@
+org.alexmond.jhelm.pluginapi.sample.BannerPostRenderer

--- a/jhelm-plugin-api-sample/src/main/resources/META-INF/services/org.alexmond.jhelm.pluginapi.JhelmTemplateFunctionProvider
+++ b/jhelm-plugin-api-sample/src/main/resources/META-INF/services/org.alexmond.jhelm.pluginapi.JhelmTemplateFunctionProvider
@@ -1,0 +1,1 @@
+org.alexmond.jhelm.pluginapi.sample.SampleTemplateFunctions

--- a/jhelm-plugin-api-sample/src/test/java/org/alexmond/jhelm/pluginapi/sample/JavaPluginSampleIntegrationTest.java
+++ b/jhelm-plugin-api-sample/src/test/java/org/alexmond/jhelm/pluginapi/sample/JavaPluginSampleIntegrationTest.java
@@ -1,0 +1,119 @@
+package org.alexmond.jhelm.pluginapi.sample;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPOutputStream;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.model.ReleaseContext;
+import org.alexmond.jhelm.core.service.Engine;
+import org.alexmond.jhelm.core.service.JhelmChartDownloaderAdapter;
+import org.alexmond.jhelm.core.service.JhelmLifecycleListenerAdapter;
+import org.alexmond.jhelm.core.service.JhelmPostRendererAdapter;
+import org.alexmond.jhelm.core.service.JhelmTemplateFunctionAdapter;
+import org.alexmond.jhelm.core.service.LifecycleListener;
+import org.alexmond.jhelm.core.service.LifecyclePhase;
+import org.alexmond.jhelm.core.service.PostRenderProcessor;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.pluginapi.JhelmChartDownloader;
+import org.alexmond.jhelm.pluginapi.JhelmLifecycleListener;
+import org.alexmond.jhelm.pluginapi.JhelmPlugins;
+import org.alexmond.jhelm.pluginapi.JhelmPostRenderer;
+import org.alexmond.jhelm.pluginapi.JhelmTemplateFunctionProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end check that the four sample plugins are discovered via {@code ServiceLoader}
+ * and work through jhelm-core's adapters, engine, and fetch path.
+ */
+class JavaPluginSampleIntegrationTest {
+
+	@TempDir
+	Path work;
+
+	@Test
+	void postRendererIsDiscoveredAndTransformsTheManifest() throws Exception {
+		JhelmPostRenderer plugin = JhelmPlugins.fromServiceLoader(JhelmPostRenderer.class)
+			.stream()
+			.filter((p) -> p instanceof BannerPostRenderer)
+			.findFirst()
+			.orElseThrow();
+		PostRenderProcessor processor = new JhelmPostRendererAdapter(plugin);
+		assertTrue(processor.process("kind: ConfigMap").startsWith("# rendered via the jhelm sample post-renderer"));
+	}
+
+	@Test
+	void chartDownloaderIsDiscoveredAndFetchesViaRepoManager() throws Exception {
+		Path tgz = this.work.resolve("mychart-1.0.0.tgz");
+		Files.write(tgz, chartArchive());
+		JhelmChartDownloader plugin = JhelmPlugins.fromServiceLoader(JhelmChartDownloader.class)
+			.stream()
+			.filter((p) -> p instanceof FileChartDownloader)
+			.findFirst()
+			.orElseThrow();
+		RepoManager repoManager = new RepoManager();
+		repoManager.setChartDownloaders(List.of(new JhelmChartDownloaderAdapter(plugin)));
+		Path dest = Files.createDirectories(this.work.resolve("out"));
+
+		repoManager.pullFromUrl("samplefile://" + tgz, dest.toString(), "mychart-1.0.0.tgz");
+
+		assertTrue(Files.exists(dest.resolve("mychart/Chart.yaml")));
+	}
+
+	@Test
+	void lifecycleListenerIsDiscoveredAndReceivesEvents() {
+		JhelmLifecycleListener plugin = JhelmPlugins.fromServiceLoader(JhelmLifecycleListener.class)
+			.stream()
+			.filter((p) -> p instanceof LoggingLifecycleListener)
+			.findFirst()
+			.orElseThrow();
+		LifecycleListener adapter = new JhelmLifecycleListenerAdapter(plugin);
+		assertDoesNotThrow(() -> adapter.onEvent(LifecyclePhase.POST_INSTALL, "rel", "default", Map.of()));
+	}
+
+	@Test
+	void templateFunctionIsDiscoveredAndCallableFromAChart() {
+		List<JhelmTemplateFunctionProvider> providers = JhelmPlugins
+			.fromServiceLoader(JhelmTemplateFunctionProvider.class);
+		Engine engine = new Engine();
+		engine.setPluginFunctions(JhelmTemplateFunctionAdapter.collect(providers));
+		Chart chart = Chart.builder()
+			.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
+			.templates(List
+				.of(Chart.Template.builder().name("cm.yaml").data("greeting: {{ sample_greet \"world\" }}").build()))
+			.values(Map.of())
+			.build();
+
+		String result = engine.render(chart, Map.of(),
+				ReleaseContext.builder().name("rel").namespace("default").install(true).revision(1).build());
+
+		assertTrue(result.contains("greeting: hello, world"), result);
+	}
+
+	private static byte[] chartArchive() throws Exception {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		try (OutputStream gz = new GZIPOutputStream(bytes);
+				TarArchiveOutputStream tar = new TarArchiveOutputStream(gz)) {
+			byte[] content = "apiVersion: v2\nname: mychart\nversion: 1.0.0\n".getBytes(StandardCharsets.UTF_8);
+			TarArchiveEntry entry = new TarArchiveEntry("mychart/Chart.yaml");
+			entry.setSize(content.length);
+			tar.putArchiveEntry(entry);
+			tar.write(content);
+			tar.closeArchiveEntry();
+		}
+		return bytes.toByteArray();
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <module>jhelm-rest-sample</module>
         <module>jhelm-mcp-sample</module>
         <module>jhelm-config-server-sample</module>
+        <module>jhelm-plugin-api-sample</module>
         <module>jhelm-benchmarks</module>
     </modules>
 
@@ -329,6 +330,7 @@
                             <excludeArtifact>jhelm-rest-sample</excludeArtifact>
                             <excludeArtifact>jhelm-mcp-sample</excludeArtifact>
                             <excludeArtifact>jhelm-config-server-sample</excludeArtifact>
+                            <excludeArtifact>jhelm-plugin-api-sample</excludeArtifact>
                             <excludeArtifact>jhelm-benchmarks</excludeArtifact>
                         </excludeArtifacts>
                     </configuration>


### PR DESCRIPTION
Final slice of the Java plugin API epic (#749).

## Docs
- **New `java-plugin-api.adoc`** — the four extension points with minimal examples, both discovery mechanisms (ServiceLoader `META-INF/services` + Spring `@Bean`), the Maven dependency, a stability note, and how Java plugins relate to the Helm/WASM plugin systems. Linked from nav; roadmap Plugin System row + changelog `1.2.2` updated.

## Sample module
- **New `jhelm-plugin-api-sample`** (Central-excluded) — one worked example per extension point: `BannerPostRenderer`, `FileChartDownloader` (`samplefile://`), `LoggingLifecycleListener`, `SampleTemplateFunctions` (`sample_greet`/`sample_shout`), with `ServiceLoader` registrations.

## Integration test
- **`JavaPluginSampleIntegrationTest`** discovers all four via `ServiceLoader` and runs them **end-to-end through jhelm-core**: post-render, `RepoManager` fetch+untar, lifecycle event, and a template function via `Engine.render`.

Full reactor build green (sample module 404-excluded from Central). **Closes #749.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)