### PR TITLE
docs: prep 1.3.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 = jhelm
-:jhelm-version: 1.2.1
+:jhelm-version: 1.3.0
 :url-docs: https://www.alexmond.org/jhelm/current/
 :url-docs-mcp: https://www.alexmond.org/jhelm/current/mcp/
 :url-docs-rest: https://www.alexmond.org/jhelm/current/rest-api/

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -10,6 +10,7 @@ asciidoc:
     api-rest: 'https://javadoc.io/page/org.alexmond/jhelm-rest'
     api-mcp: 'https://javadoc.io/page/org.alexmond/jhelm-mcp'
     api-plugin: 'https://javadoc.io/page/org.alexmond/jhelm-plugin'
+    api-plugin-api: 'https://javadoc.io/page/org.alexmond/jhelm-plugin-api'
     toc: left
     sectnums: ''
     keywords: 'Helm, Java, Kubernetes, Spring Boot, Chart management, Template engine'

--- a/docs/modules/ROOT/pages/api.adoc
+++ b/docs/modules/ROOT/pages/api.adoc
@@ -32,6 +32,9 @@ the {page-component-version} release.
 
 | `jhelm-plugin` — WASM plugin runtime
 | {api-plugin}/{page-component-version}/index.html[browse^]
+
+| `jhelm-plugin-api` — Java plugin extension points (post-renderer, downloader, lifecycle, template functions)
+| {api-plugin-api}/{page-component-version}/index.html[browse^]
 |===
 
 [NOTE]
@@ -59,6 +62,11 @@ are not published to Maven Central.
 *Helm template functions* (`jhelm-gotemplate-helm`)
 
 * {api-gotemplate-helm}/{page-component-version}/org/alexmond/jhelm/gotemplate/helm/HelmFunctions.html[HelmFunctions^] — the Helm function provider. The Go template engine itself is the external https://github.com/alexmond/gotmpl4j[gotmpl4j] library, which publishes its own Javadoc.
+
+*Java plugin API* (`jhelm-plugin-api`, package `org.alexmond.jhelm.pluginapi`)
+
+* {api-plugin-api}/{page-component-version}/org/alexmond/jhelm/pluginapi/JhelmPlugin.html[JhelmPlugin^] — the marker base type; extend one of the four extension interfaces below.
+* {api-plugin-api}/{page-component-version}/org/alexmond/jhelm/pluginapi/JhelmPostRenderer.html[JhelmPostRenderer^], {api-plugin-api}/{page-component-version}/org/alexmond/jhelm/pluginapi/JhelmChartDownloader.html[JhelmChartDownloader^], {api-plugin-api}/{page-component-version}/org/alexmond/jhelm/pluginapi/JhelmLifecycleListener.html[JhelmLifecycleListener^], and {api-plugin-api}/{page-component-version}/org/alexmond/jhelm/pluginapi/JhelmTemplateFunctionProvider.html[JhelmTemplateFunctionProvider^] — the extension points, discovered via ServiceLoader or Spring beans. See xref:java-plugin-api.adoc[Java Plugin API].
 
 *Spring Boot auto-configuration entry points*
 

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -1,6 +1,6 @@
 = Changelog
 
-== 1.2.2
+== 1.3.0
 
 === Helm plugin compatibility
 


### PR DESCRIPTION
Release-prep for **1.3.0**, which ships two completed epics:

- **Helm-plugin compatibility** (epic #733) — consume real Helm plugins from `$HELM_PLUGINS`.
- **Java plugin API** (epic #749) — new published `jhelm-plugin-api` module.

## Changes (docs/version-bound text only — no code)
- **changelog** — rename the pending `== 1.2.2` section to `== 1.3.0` (content already covers both epics; verified complete against `git log 1.2.1..HEAD`).
- **README** — bump `:jhelm-version:` 1.2.1 → 1.3.0.
- **antora.yml** — add `api-plugin-api` javadoc base URL for the new published module.
- **api.adoc** — add the `jhelm-plugin-api` artifact row + a *Java plugin API* key-types section.

No Maven-compile-path files changed; `main` is CI-green on every merged slice. After merge, trigger `maven_release.yml` (releaseVersion 1.3.0, nextVersion 1.3.1-SNAPSHOT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)