### PR TITLE
feat(core): load external plugin JARs from jhelm.plugins.path (#765)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -8,6 +8,7 @@ import org.alexmond.jhelm.core.config.ConfigServerProperties;
 import org.alexmond.jhelm.core.config.JhelmAccessMode;
 import org.alexmond.jhelm.core.config.JhelmCoreProperties;
 import org.alexmond.jhelm.core.config.JhelmEncryptProperties;
+import org.alexmond.jhelm.core.config.JhelmPluginProperties;
 import org.alexmond.jhelm.core.config.JhelmSecurityPolicy;
 import org.alexmond.jhelm.core.config.JhelmSecurityProperties;
 import org.alexmond.jhelm.core.metrics.JhelmMetrics;
@@ -46,9 +47,11 @@ import org.alexmond.jhelm.core.service.JhelmPostRendererAdapter;
 import org.alexmond.jhelm.core.service.JhelmTemplateFunctionAdapter;
 import org.alexmond.jhelm.pluginapi.JhelmChartDownloader;
 import org.alexmond.jhelm.pluginapi.JhelmLifecycleListener;
+import org.alexmond.jhelm.pluginapi.JhelmPlugin;
 import org.alexmond.jhelm.pluginapi.JhelmPlugins;
 import org.alexmond.jhelm.pluginapi.JhelmPostRenderer;
 import org.alexmond.jhelm.pluginapi.JhelmTemplateFunctionProvider;
+import org.alexmond.jhelm.core.service.PluginLoader;
 import org.alexmond.jhelm.core.service.ConfigServerClient;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.service.Engine;
@@ -70,7 +73,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClients;
 @Slf4j
 @AutoConfiguration(after = JhelmMetricsAutoConfiguration.class)
 @EnableConfigurationProperties({ JhelmCoreProperties.class, JhelmSecurityProperties.class, ConfigServerProperties.class,
-		JhelmEncryptProperties.class })
+		JhelmEncryptProperties.class, JhelmPluginProperties.class })
 public class JhelmCoreAutoConfiguration {
 
 	/**
@@ -110,6 +113,40 @@ public class JhelmCoreAutoConfiguration {
 	}
 
 	/**
+	 * Loads jhelm Java plugins from external JAR files listed under
+	 * {@code jhelm.plugins.path} (directories not on the application classpath). The
+	 * loaded plugins are merged with classpath and Spring-bean plugins wherever those are
+	 * consumed. Closed on context shutdown so the plugin class loaders are released.
+	 * @param props the external-plugin configuration
+	 * @return the plugin loader bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public PluginLoader jhelmPluginLoader(JhelmPluginProperties props) {
+		return new PluginLoader(props.getPath());
+	}
+
+	/**
+	 * Unions Spring-bean plugins, classpath {@code ServiceLoader} plugins, and
+	 * external-JAR plugins for one plugin interface, de-duplicated by implementation
+	 * class.
+	 * @param type the plugin interface
+	 * @param springBeans the plugins supplied as Spring beans (may be empty)
+	 * @param pluginLoader the external-JAR loader (may be {@code null} when none is
+	 * configured)
+	 * @param <T> the plugin type
+	 * @return the merged plugin list
+	 */
+	private static <T extends JhelmPlugin> List<T> mergePlugins(Class<T> type, List<? extends T> springBeans,
+			PluginLoader pluginLoader) {
+		List<T> supplied = new ArrayList<>(springBeans);
+		if (pluginLoader != null) {
+			supplied.addAll(pluginLoader.load(type));
+		}
+		return JhelmPlugins.merge(type, supplied);
+	}
+
+	/**
 	 * Provides the chart repository manager, configured from the jhelm properties.
 	 * @param props the jhelm core configuration properties
 	 * @param registryManager the OCI registry auth provider
@@ -120,8 +157,8 @@ public class JhelmCoreAutoConfiguration {
 	@ConditionalOnMissingBean
 	public RepoManager repoManager(JhelmCoreProperties props, JhelmSecurityProperties securityProps,
 			RegistryManager registryManager, ObjectProvider<JhelmMetrics> metrics,
-			ObjectProvider<ChartDownloader> chartDownloaders,
-			ObjectProvider<JhelmChartDownloader> javaChartDownloaders) {
+			ObjectProvider<ChartDownloader> chartDownloaders, ObjectProvider<JhelmChartDownloader> javaChartDownloaders,
+			ObjectProvider<PluginLoader> pluginLoader) {
 		boolean blockPrivate = securityProps.isBlockPrivateNetworks();
 		RepoManager repoManager = (props.getConfigPath() != null)
 				? new RepoManager(props.getConfigPath(), registryManager, props.isInsecureSkipTlsVerify(), blockPrivate)
@@ -129,7 +166,7 @@ public class JhelmCoreAutoConfiguration {
 		repoManager.setMetrics(metrics.getIfAvailable());
 		repoManager.setRepositoryCacheOverride(props.getRepositoryCachePath());
 		List<ChartDownloader> downloaders = new ArrayList<>(chartDownloaders.stream().toList());
-		JhelmPlugins.merge(JhelmChartDownloader.class, javaChartDownloaders.stream().toList())
+		mergePlugins(JhelmChartDownloader.class, javaChartDownloaders.stream().toList(), pluginLoader.getIfAvailable())
 			.forEach((plugin) -> downloaders.add(new JhelmChartDownloaderAdapter(plugin)));
 		repoManager.setChartDownloaders(downloaders);
 		return repoManager;
@@ -231,11 +268,12 @@ public class JhelmCoreAutoConfiguration {
 	@ConditionalOnMissingBean
 	public Engine engine(ObjectProvider<TemplateCache> templateCache, SchemaValidator schemaValidator,
 			ObjectProvider<JhelmMetrics> metrics, ObjectProvider<KubernetesProvider> kubernetesProvider,
-			ObjectProvider<JhelmTemplateFunctionProvider> templateFunctionPlugins) {
+			ObjectProvider<JhelmTemplateFunctionProvider> templateFunctionPlugins,
+			ObjectProvider<PluginLoader> pluginLoader) {
 		Engine engine = new Engine(templateCache.getIfAvailable(), schemaValidator, metrics.getIfAvailable());
 		engine.setKubernetesProvider(kubernetesProvider.getIfAvailable());
-		engine.setPluginFunctions(JhelmTemplateFunctionAdapter.collect(
-				JhelmPlugins.merge(JhelmTemplateFunctionProvider.class, templateFunctionPlugins.stream().toList())));
+		engine.setPluginFunctions(JhelmTemplateFunctionAdapter.collect(mergePlugins(JhelmTemplateFunctionProvider.class,
+				templateFunctionPlugins.stream().toList(), pluginLoader.getIfAvailable())));
 		return engine;
 	}
 
@@ -268,8 +306,10 @@ public class JhelmCoreAutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	public List<PostRenderProcessor> jhelmPostRenderProcessors(ObjectProvider<JhelmPostRenderer> postRendererPlugins) {
-		return JhelmPlugins.merge(JhelmPostRenderer.class, postRendererPlugins.stream().toList())
+	public List<PostRenderProcessor> jhelmPostRenderProcessors(ObjectProvider<JhelmPostRenderer> postRendererPlugins,
+			ObjectProvider<PluginLoader> pluginLoader) {
+		return mergePlugins(JhelmPostRenderer.class, postRendererPlugins.stream().toList(),
+				pluginLoader.getIfAvailable())
 			.stream()
 			.<PostRenderProcessor>map(JhelmPostRendererAdapter::new)
 			.toList();
@@ -284,8 +324,10 @@ public class JhelmCoreAutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	public List<LifecycleListener> jhelmLifecycleListeners(ObjectProvider<JhelmLifecycleListener> listenerPlugins) {
-		return JhelmPlugins.merge(JhelmLifecycleListener.class, listenerPlugins.stream().toList())
+	public List<LifecycleListener> jhelmLifecycleListeners(ObjectProvider<JhelmLifecycleListener> listenerPlugins,
+			ObjectProvider<PluginLoader> pluginLoader) {
+		return mergePlugins(JhelmLifecycleListener.class, listenerPlugins.stream().toList(),
+				pluginLoader.getIfAvailable())
 			.stream()
 			.<LifecycleListener>map(JhelmLifecycleListenerAdapter::new)
 			.toList();

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmPluginProperties.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/config/JhelmPluginProperties.java
@@ -1,0 +1,28 @@
+package org.alexmond.jhelm.core.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for loading jhelm Java plugins from external JAR files that are not on
+ * the application classpath. Distinct from the native-Helm plugin store
+ * ({@code $HELM_PLUGINS}) and the WASM {@code .jhp} store — this covers Java plugins
+ * built against {@code jhelm-plugin-api}.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jhelm.plugins")
+public class JhelmPluginProperties {
+
+	/**
+	 * Directories scanned for external plugin JARs. Every {@code *.jar} in each directory
+	 * is loaded in its own class loader and its declared plugin services are discovered.
+	 * Empty by default, so external-JAR loading is off unless a directory is configured.
+	 */
+	private List<String> path = new ArrayList<>();
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/PluginLoader.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/PluginLoader.java
@@ -1,0 +1,136 @@
+package org.alexmond.jhelm.core.service;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.ServiceLoader;
+import java.util.stream.Stream;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Loads jhelm Java plugins from external JAR files that are not on the application
+ * classpath. Each configured directory is scanned for {@code *.jar}; every jar gets its
+ * own {@link URLClassLoader} whose parent is jhelm-core's class loader, so the plugin
+ * resolves the {@code jhelm-plugin-api} types while its declared
+ * {@link java.util.ServiceLoader} services are discovered per plugin interface. Isolating
+ * each jar in its own loader tolerates conflicting transitive dependency versions between
+ * plugins.
+ *
+ * <p>
+ * This complements {@link org.alexmond.jhelm.pluginapi.JhelmPlugins}, which discovers
+ * plugins already on the classpath (as Spring beans or classpath {@code ServiceLoader}
+ * services); the plugins returned here are supplied to
+ * {@link org.alexmond.jhelm.pluginapi.JhelmPlugins#merge(Class, java.util.Collection)}
+ * alongside them.
+ */
+// This class deliberately manages plugin class loaders: it parents them on jhelm-core's
+// own loader (UseProperClassLoader), holds them open for the application lifetime and
+// closes them in close() (CloseResource), and compares defining-loader identity to keep
+// only jar-defined plugins (CompareObjectsWithEquals).
+@SuppressWarnings({ "PMD.UseProperClassLoader", "PMD.CloseResource", "PMD.CompareObjectsWithEquals" })
+@Slf4j
+public class PluginLoader implements AutoCloseable {
+
+	private final List<URLClassLoader> loaders;
+
+	/**
+	 * Scans the given directories for plugin jars and opens a class loader for each.
+	 * @param directories directories to scan for {@code *.jar} files (may be {@code null}
+	 * or empty, in which case nothing is loaded)
+	 */
+	public PluginLoader(List<String> directories) {
+		this.loaders = buildLoaders(directories);
+	}
+
+	private static List<URLClassLoader> buildLoaders(List<String> directories) {
+		if (directories == null || directories.isEmpty()) {
+			return List.of();
+		}
+		List<URLClassLoader> built = new ArrayList<>();
+		ClassLoader parent = PluginLoader.class.getClassLoader();
+		for (String dir : directories) {
+			if (dir == null || dir.isBlank()) {
+				continue;
+			}
+			Path root = Path.of(dir);
+			if (!Files.isDirectory(root)) {
+				log.warn("jhelm plugin directory does not exist or is not a directory: {}", root);
+				continue;
+			}
+			collectJars(root, parent, built);
+		}
+		return built;
+	}
+
+	private static void collectJars(Path root, ClassLoader parent, List<URLClassLoader> built) {
+		try (Stream<Path> entries = Files.list(root)) {
+			List<Path> jars = entries
+				.filter((p) -> Files.isRegularFile(p)
+						&& p.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".jar"))
+				.sorted()
+				.toList();
+			for (Path jar : jars) {
+				try {
+					URL url = jar.toUri().toURL();
+					built.add(new URLClassLoader(new URL[] { url }, parent));
+					log.info("Loaded jhelm plugin jar: {}", jar);
+				}
+				catch (MalformedURLException ex) {
+					log.warn("Skipping unreadable plugin jar {}: {}", jar, ex.getMessage());
+				}
+			}
+		}
+		catch (IOException ex) {
+			log.warn("Failed to scan jhelm plugin directory {}: {}", root, ex.getMessage());
+		}
+	}
+
+	/**
+	 * Discovers external-jar plugins of the given interface across every loaded jar. Only
+	 * plugin classes actually defined by a plugin jar are returned; services that resolve
+	 * to the shared parent classpath are left for the caller's classpath discovery to
+	 * avoid double-counting.
+	 * @param service the plugin interface to load
+	 * @param <T> the plugin type
+	 * @return the discovered plugin instances (empty if no external jars were loaded)
+	 */
+	public <T> List<T> load(Class<T> service) {
+		List<T> found = new ArrayList<>();
+		for (URLClassLoader loader : loaders) {
+			for (T plugin : ServiceLoader.load(service, loader)) {
+				if (plugin.getClass().getClassLoader() == loader) {
+					found.add(plugin);
+				}
+			}
+		}
+		return found;
+	}
+
+	/**
+	 * Returns the number of external plugin jars that were loaded.
+	 * @return the loaded jar count
+	 */
+	public int jarCount() {
+		return this.loaders.size();
+	}
+
+	@Override
+	public void close() {
+		for (URLClassLoader loader : this.loaders) {
+			try {
+				loader.close();
+			}
+			catch (IOException ex) {
+				log.debug("Error closing plugin class loader: {}", ex.getMessage());
+			}
+		}
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/PluginLoaderTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/PluginLoaderTest.java
@@ -1,0 +1,163 @@
+package org.alexmond.jhelm.core.service;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.stream.Stream;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
+import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
+import org.alexmond.jhelm.core.JhelmMetricsAutoConfiguration;
+import org.alexmond.jhelm.core.model.Chart;
+import org.alexmond.jhelm.core.model.ChartMetadata;
+import org.alexmond.jhelm.core.model.ReleaseContext;
+import org.alexmond.jhelm.pluginapi.JhelmPostRenderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies {@link PluginLoader} discovers jhelm plugins from JARs that are <em>not</em>
+ * on the application classpath. Each plugin is compiled and packaged at test time so its
+ * implementation class exists only inside the jar — proving genuine external loading
+ * rather than classpath leakage — and the full auto-configuration wiring is exercised end
+ * to end.
+ */
+class PluginLoaderTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withConfiguration(
+			AutoConfigurations.of(JhelmMetricsAutoConfiguration.class, JhelmCoreAutoConfiguration.class));
+
+	@Test
+	void emptyPathLoadsNothing() {
+		try (PluginLoader loader = new PluginLoader(List.of())) {
+			assertEquals(0, loader.jarCount());
+			assertTrue(loader.load(JhelmPostRenderer.class).isEmpty());
+		}
+	}
+
+	@Test
+	void discoversAndIsolatesExternalPostRenderer(@TempDir Path tmp) throws Exception {
+		Path pluginsDir = Files.createDirectories(tmp.resolve("plugins"));
+		String fqcn = "ext.render.BannerPostRenderer";
+		String source = """
+				package ext.render;
+				import org.alexmond.jhelm.pluginapi.JhelmPostRenderer;
+				import org.alexmond.jhelm.pluginapi.JhelmPluginException;
+				public class BannerPostRenderer implements JhelmPostRenderer {
+					public String postRender(String manifest) throws JhelmPluginException {
+						return "# external\\n" + manifest;
+					}
+				}
+				""";
+		buildPluginJar(tmp, pluginsDir.resolve("banner-plugin.jar"), Map.of(fqcn, source),
+				Map.of("org.alexmond.jhelm.pluginapi.JhelmPostRenderer", List.of(fqcn)));
+
+		// The plugin class must not be reachable from the application classpath.
+		assertThrows(ClassNotFoundException.class, () -> Class.forName(fqcn));
+
+		try (PluginLoader loader = new PluginLoader(List.of(pluginsDir.toString()))) {
+			assertEquals(1, loader.jarCount());
+			List<JhelmPostRenderer> found = loader.load(JhelmPostRenderer.class);
+			assertEquals(1, found.size());
+			JhelmPostRenderer plugin = found.get(0);
+			assertEquals(fqcn, plugin.getClass().getName());
+			assertNotSame(PluginLoader.class.getClassLoader(), plugin.getClass().getClassLoader());
+			assertEquals("# external\nspec: {}", plugin.postRender("spec: {}"));
+		}
+	}
+
+	@Test
+	void autoConfigWiresExternalTemplateFunctionIntoEngine(@TempDir Path tmp) throws Exception {
+		Path pluginsDir = Files.createDirectories(tmp.resolve("plugins"));
+		String fqcn = "ext.fn.ExtFunctions";
+		String source = """
+				package ext.fn;
+				import java.util.Map;
+				import org.alexmond.jhelm.pluginapi.JhelmTemplateFunction;
+				import org.alexmond.jhelm.pluginapi.JhelmTemplateFunctionProvider;
+				public class ExtFunctions implements JhelmTemplateFunctionProvider {
+					public Map<String, JhelmTemplateFunction> functions() {
+						return Map.of("ext_greet", (JhelmTemplateFunction) (args) -> "hi, " + args[0]);
+					}
+				}
+				""";
+		buildPluginJar(tmp, pluginsDir.resolve("fn-plugin.jar"), Map.of(fqcn, source),
+				Map.of("org.alexmond.jhelm.pluginapi.JhelmTemplateFunctionProvider", List.of(fqcn)));
+
+		this.contextRunner.withPropertyValues("jhelm.plugins.path=" + pluginsDir).run((ctx) -> {
+			PluginLoader loader = ctx.getBean(PluginLoader.class);
+			assertEquals(1, loader.jarCount());
+
+			Engine engine = ctx.getBean(Engine.class);
+			Chart chart = Chart.builder()
+				.metadata(ChartMetadata.builder().name("mychart").version("1.0.0").build())
+				.templates(List
+					.of(Chart.Template.builder().name("cm.yaml").data("greeting: {{ ext_greet \"world\" }}").build()))
+				.values(Map.of())
+				.build();
+
+			String result = engine.render(chart, Map.of(),
+					ReleaseContext.builder().name("rel").namespace("default").install(true).revision(1).build());
+
+			assertTrue(result.contains("greeting: hi, world"), result);
+		});
+	}
+
+	/**
+	 * Compiles the given sources against jhelm-plugin-api and packages them, with the
+	 * given {@code META-INF/services} entries, into {@code outJar}.
+	 */
+	private static void buildPluginJar(Path workDir, Path outJar, Map<String, String> sources,
+			Map<String, List<String>> services) throws Exception {
+		Path srcDir = Files.createDirectories(workDir.resolve("src-" + outJar.getFileName()));
+		Path classesDir = Files.createDirectories(workDir.resolve("classes-" + outJar.getFileName()));
+		List<String> sourceFiles = new ArrayList<>();
+		for (Map.Entry<String, String> entry : sources.entrySet()) {
+			Path file = srcDir.resolve(entry.getKey().replace('.', '/') + ".java");
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, entry.getValue());
+			sourceFiles.add(file.toString());
+		}
+
+		String apiClasspath = Path
+			.of(JhelmPostRenderer.class.getProtectionDomain().getCodeSource().getLocation().toURI())
+			.toString();
+		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+		assertTrue(compiler != null, "a JDK (system Java compiler) is required for this test");
+		List<String> args = new ArrayList<>(List.of("-classpath", apiClasspath, "-d", classesDir.toString()));
+		args.addAll(sourceFiles);
+		int rc = compiler.run(null, null, null, args.toArray(String[]::new));
+		assertEquals(0, rc, "external plugin compilation failed");
+
+		try (JarOutputStream jar = new JarOutputStream(Files.newOutputStream(outJar))) {
+			try (Stream<Path> walk = Files.walk(classesDir)) {
+				List<Path> classFiles = walk.filter(Files::isRegularFile).sorted().toList();
+				for (Path classFile : classFiles) {
+					jar.putNextEntry(new JarEntry(classesDir.relativize(classFile).toString().replace('\\', '/')));
+					Files.copy(classFile, jar);
+					jar.closeEntry();
+				}
+			}
+			for (Map.Entry<String, List<String>> service : services.entrySet()) {
+				jar.putNextEntry(new JarEntry("META-INF/services/" + service.getKey()));
+				jar.write(String.join("\n", service.getValue()).getBytes(StandardCharsets.UTF_8));
+				jar.closeEntry();
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Part of #764 (Route B slice 1).

Lets Java plugins built against `jhelm-plugin-api` be **dropped into a directory and loaded at runtime**, without being on the build classpath.

## What
- **`JhelmPluginProperties`** — `jhelm.plugins.path`, the directories to scan (empty by default → feature off).
- **`PluginLoader`** (jhelm-core) — scans each dir for `*.jar`, gives every jar its own `URLClassLoader` (parent = jhelm-core's loader so plugins resolve the API types; per-jar isolation tolerates version clashes), and `ServiceLoader.load(iface, cl)` per jar — keeping only jar-defined classes so shared-classpath plugins aren't double-counted. `AutoCloseable`; loaders closed on context shutdown.
- **`JhelmCoreAutoConfiguration`** — a `mergePlugins()` helper folds external-jar plugins into the existing four provider beans (post-render, downloader, lifecycle, template-function) via `JhelmPlugins.merge()`. No change to the `jhelm-plugin-api` module.

Works on every surface (CLI/REST/MCP/embedded), launcher-independent.

## Test
`PluginLoaderTest` compiles plugin sources into jars **at test time** (via the system Java compiler + `jar`), so the impl classes exist **only** inside the jar — proving genuine external loading, not classpath leakage:
- classloader isolation + execution for an external post-renderer (asserts `Class.forName` fails on the app classpath);
- full auto-config wiring of an external **template function** into the engine render path (`jhelm.plugins.path` → `PluginLoader` bean → engine renders `{{ ext_greet "world" }}`).

Full reactor green (17 modules); `PluginLoaderTest` 3/0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)