### PR TITLE
feat(cli): --plugin-dir + docs for external plugin JARs (#766)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -1,5 +1,20 @@
 = Changelog
 
+== 1.4.0
+
+=== External Java plugin JARs
+
+Java plugins built against `jhelm-plugin-api` can now be loaded from a directory at runtime,
+without being on the build classpath. See xref:java-plugin-api.adoc#_loading_external_plugin_jars[Loading external plugin JARs].
+
+* *`jhelm.plugins.path`* -- one or more directories scanned for external plugin JARs. Each
+  jar is loaded in its own class loader (isolated so plugins can carry conflicting
+  transitive dependencies) and its declared `ServiceLoader` services are merged with the
+  classpath and Spring-bean plugins. Works on every surface (CLI/REST/MCP/embedded),
+  independent of how the application is launched (#765).
+* *CLI `--plugin-dir`* -- a global flag (also `JHELM_PLUGINS_PATH`) to set the plugin
+  directory for a run (#766).
+
 == 1.3.0
 
 === Helm plugin compatibility

--- a/docs/modules/ROOT/pages/java-plugin-api.adoc
+++ b/docs/modules/ROOT/pages/java-plugin-api.adoc
@@ -90,6 +90,51 @@ JhelmPostRenderer bannerPostRenderer() {
 jhelm unions both sources and de-duplicates by implementation class (a Spring bean that is
 also a declared service is registered once, preferring the bean instance).
 
+== Loading external plugin JARs
+
+The two mechanisms above discover plugins already on the application classpath. To load a
+plugin *without* rebuilding jhelm — dropping a JAR into a directory — point
+`jhelm.plugins.path` at one or more directories:
+
+[source,yaml]
+----
+jhelm:
+  plugins:
+    path: /opt/jhelm-plugins        # or a comma-separated list of directories
+----
+
+Every `*.jar` in each directory is loaded in its own class loader (parented on jhelm-core,
+so the plugin resolves the `jhelm-plugin-api` types; isolating each jar tolerates
+conflicting transitive dependencies between plugins), and its declared `ServiceLoader`
+services are discovered and merged with the classpath and Spring-bean plugins. This works on
+every surface — the CLI, the REST and MCP servers, and an embedded library — and is
+independent of how the application is launched. Empty by default, so nothing is scanned
+until a directory is configured.
+
+On the CLI, set it with the global `--plugin-dir` flag, the `JHELM_PLUGINS_PATH` environment
+variable, or the property directly:
+
+[source,bash]
+----
+jhelm --plugin-dir /opt/jhelm-plugins template my-release ./chart
+----
+
+=== Packaging a plugin as a self-contained JAR
+
+Build an ordinary JAR that (1) compiles against `jhelm-plugin-api` (scope `provided` — jhelm
+supplies it at runtime) and (2) contains a `META-INF/services/` file for each extension
+point it implements, as in <<Registering a plugin>>. Bundle any third-party libraries your
+plugin needs into the JAR (a shaded/uber JAR), since only that JAR is added to the plugin's
+class loader. Drop the finished JAR into a `jhelm.plugins.path` directory.
+
+[NOTE]
+====
+This is jhelm's own Java plugin store, distinct from the native-Helm plugin store
+(`$HELM_PLUGINS`) and the WASM `.jhp` store. A JAR here is in-process Java code — the same
+trust model as a classpath plugin — so, like the other Java plugins, it is not gated on the
+`FULL` security posture; the directory you point at is the trust boundary.
+====
+
 == Worked examples
 
 The `jhelm-plugin-api-sample` module in the source tree implements one plugin of each kind

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/GlobalOptionsPreParser.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/GlobalOptionsPreParser.java
@@ -44,11 +44,17 @@ public final class GlobalOptionsPreParser {
 	/** Enable verbose (debug) logging. */
 	public static final String DEBUG = "--debug";
 
+	/**
+	 * Directory (or comma-separated directories) scanned for external jhelm Java plugin
+	 * JARs. jhelm-specific — Helm has no equivalent flag.
+	 */
+	public static final String PLUGIN_DIR = "--plugin-dir";
+
 	// Value-taking global flags mapped to their jhelm Spring property.
 	private static final Map<String, String> VALUE_FLAGS = Map.of(KUBE_CONTEXT, "jhelm.kubernetes.context", KUBECONFIG,
 			"jhelm.kubernetes.kubeconfig-path", KUBE_APISERVER, "jhelm.kubernetes.api-server", REGISTRY_CONFIG,
 			"jhelm.registry-config-path", REPOSITORY_CONFIG, "jhelm.config-path", REPOSITORY_CACHE,
-			"jhelm.repository-cache-path");
+			"jhelm.repository-cache-path", PLUGIN_DIR, "jhelm.plugins.path");
 
 	private GlobalOptionsPreParser() {
 	}

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
@@ -117,6 +117,11 @@ public class JHelmCommand implements Callable<Integer> {
 			scope = CommandLine.ScopeType.INHERIT)
 	boolean debug;
 
+	@CommandLine.Option(names = GlobalOptionsPreParser.PLUGIN_DIR, paramLabel = "<dir>",
+			description = "director(y|ies) of external Java plugin JARs (comma-separated)",
+			scope = CommandLine.ScopeType.INHERIT)
+	String pluginDir;
+
 	/**
 	 * Prints the jhelm banner (to stderr, so piped stdout stays clean) followed by the
 	 * usage help when {@code jhelm} is invoked without a subcommand.

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/GlobalOptionsPreParserTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/GlobalOptionsPreParserTest.java
@@ -29,6 +29,15 @@ class GlobalOptionsPreParserTest {
 	}
 
 	@Test
+	void mapsPluginDirToPluginsPathAndStripsIt() {
+		GlobalOptionsPreParser.Result r = GlobalOptionsPreParser
+			.parse(new String[] { "--plugin-dir", "/opt/jhelm-plugins", "template", "./chart" });
+
+		assertEquals("/opt/jhelm-plugins", r.systemProperties().get("jhelm.plugins.path"));
+		assertArrayEquals(new String[] { "template", "./chart" }, r.springArgs());
+	}
+
+	@Test
 	void debugMapsToLogLevelAndIsStripped() {
 		GlobalOptionsPreParser.Result r = GlobalOptionsPreParser.parse(new String[] { "--debug", "status", "rel" });
 
@@ -47,9 +56,10 @@ class GlobalOptionsPreParserTest {
 
 	@Test
 	void mapsEveryGlobalFlag() {
-		GlobalOptionsPreParser.Result r = GlobalOptionsPreParser.parse(new String[] { "--kubeconfig", "/k",
-				"--kube-context", "c", "--kube-apiserver", "https://s:6443", "--registry-config", "/rc",
-				"--repository-config", "/rp", "--repository-cache", "/rch", "--debug", "version" });
+		GlobalOptionsPreParser.Result r = GlobalOptionsPreParser
+			.parse(new String[] { "--kubeconfig", "/k", "--kube-context", "c", "--kube-apiserver", "https://s:6443",
+					"--registry-config", "/rc", "--repository-config", "/rp", "--repository-cache", "/rch",
+					"--plugin-dir", "/pd", "--debug", "version" });
 
 		Map<String, String> p = r.systemProperties();
 		assertEquals("/k", p.get("jhelm.kubernetes.kubeconfig-path"));
@@ -58,6 +68,7 @@ class GlobalOptionsPreParserTest {
 		assertEquals("/rc", p.get("jhelm.registry-config-path"));
 		assertEquals("/rp", p.get("jhelm.config-path"));
 		assertEquals("/rch", p.get("jhelm.repository-cache-path"));
+		assertEquals("/pd", p.get("jhelm.plugins.path"));
 		assertEquals("DEBUG", p.get("logging.level.org.alexmond.jhelm"));
 		assertArrayEquals(new String[] { "version" }, r.springArgs());
 	}


### PR DESCRIPTION
Part of #764 (Route B slice 2). Builds on the slice-1 core loader (#767).

## What
- **CLI `--plugin-dir <dir>`** — a global flag (comma-separated dirs; also settable via `JHELM_PLUGINS_PATH` or the `jhelm.plugins.path` property) mapped through `GlobalOptionsPreParser` so it's resolved **before** the Spring context builds, letting the `PluginLoader` bean pick it up.
- **Docs** — `java-plugin-api.adoc` gains a "Loading external plugin JARs" section (`jhelm.plugins.path`, per-jar classloader isolation, packaging a self-contained plugin jar, relation to the native `$HELM_PLUGINS` and WASM `.jhp` stores). Changelog gets a `== 1.4.0` section.

## Verification
- `GlobalOptionsPreParserTest` — new `--plugin-dir` mapping case + folded into the "every global flag" test.
- **Real CLI smoke test** (launched `jhelm` binary): a chart using `{{ sample_greet "world" }}` fails without the flag (function unknown), and with `--plugin-dir <dir-holding-the-sample-jar>` renders `greeting: hello, world` — proving the full chain (`--plugin-dir` → pre-parser → property → `PluginLoader` → engine) through a jar that is **not** on the CLI classpath.

Full reactor green (17 modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)