### PR TITLE
refactor(kube): isolate client-java wiring behind @ConditionalOnClass (#776)

### DIFF
--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/ClientJavaKubeConfiguration.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/ClientJavaKubeConfiguration.java
@@ -1,0 +1,169 @@
+package org.alexmond.jhelm.kube;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.util.Config;
+import io.kubernetes.client.util.KubeConfig;
+import org.alexmond.jhelm.core.metrics.JhelmMetrics;
+import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.gotemplate.helm.functions.KubernetesProvider;
+import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
+import org.alexmond.jhelm.kube.service.internal.AsyncHelmKubeService;
+import org.alexmond.jhelm.kube.service.internal.KubeClient;
+import org.alexmond.jhelm.kube.service.internal.KubernetesClientProvider;
+import org.alexmond.jhelm.kube.service.internal.KubernetesHealthIndicator;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Kubernetes backend backed by the official Kubernetes Java client
+ * ({@code io.kubernetes:client-java}). Guarded by {@link ConditionalOnClass} on
+ * {@link ApiClient} so the entire configuration — and the client types it references — is
+ * only introspected when that client is on the classpath. This lets jhelm ship a second
+ * backend gated on a different client library and select between them by whichever client
+ * the consumer puts on the classpath.
+ *
+ * <p>
+ * Imported by {@link JhelmKubeAutoConfiguration}, which owns the module-wide,
+ * client-agnostic concerns (properties, decorator chain).
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(ApiClient.class)
+class ClientJavaKubeConfiguration {
+
+	/**
+	 * Registers the {@link KubeClient} used by the module. If a consumer supplies their
+	 * own {@link ApiClient} bean (the intentional, documented customization seam) it is
+	 * wrapped as-is; otherwise a client is built from the configured kubeconfig path,
+	 * falling back to the default in-cluster or local client.
+	 * @param props the Kubernetes configuration properties, providing the optional
+	 * kubeconfig path
+	 * @param apiClientOverride provider for an optional consumer-supplied API client used
+	 * to override the built-in client
+	 * @return the registered {@link KubeClient}
+	 * @throws IOException if the configured kubeconfig file cannot be read
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	KubeClient kubeClient(JhelmKubernetesProperties props, ObjectProvider<ApiClient> apiClientOverride)
+			throws IOException {
+		ApiClient override = apiClientOverride.getIfAvailable();
+		ApiClient client = (override != null) ? override : buildApiClient(props);
+		return new KubeClient(client);
+	}
+
+	/**
+	 * Registers the cluster-backed {@link KubernetesProvider} that powers the
+	 * {@code lookup} template function. The core {@code Engine} wires this in so
+	 * {@code lookup} queries the live Kubernetes API (returning full resource data, incl.
+	 * Secret/ConfigMap {@code data}) during install/upgrade, as Helm does. It degrades to
+	 * an empty result on its own when the API is unreachable (e.g. offline
+	 * {@code template} rendering).
+	 * @param kubeClient the shared Kubernetes client
+	 * @return the lookup provider bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean(KubernetesProvider.class)
+	KubernetesProvider kubernetesClientProvider(KubeClient kubeClient) {
+		return new KubernetesClientProvider(kubeClient);
+	}
+
+	/**
+	 * Builds the {@link KubeService} bean from the official-client base implementation,
+	 * applying the module-wide decorator chain (retry, metrics) owned by
+	 * {@link JhelmKubeAutoConfiguration}.
+	 * @param kubeClient the registered Kubernetes client wrapper
+	 * @param props the Kubernetes configuration properties, providing the retry settings
+	 * @param metricsProvider provider for the optional metrics bean used to enable
+	 * operation timing and counting
+	 * @return the (possibly decorated) Kubernetes service
+	 */
+	@Bean
+	@ConditionalOnMissingBean(KubeService.class)
+	KubeService kubeService(KubeClient kubeClient, JhelmKubernetesProperties props,
+			ObjectProvider<JhelmMetrics> metricsProvider) {
+		AsyncHelmKubeService base = new AsyncHelmKubeService(kubeClient);
+		return KubeServiceDecorators.decorate(base, props, metricsProvider);
+	}
+
+	/**
+	 * Builds the Kubernetes {@link ApiClient} used by the module. When a kubeconfig path
+	 * is configured the client is built from that file, otherwise the default in-cluster
+	 * or local client is used.
+	 * @param props the Kubernetes configuration properties, providing the optional
+	 * kubeconfig path
+	 * @return the configured Kubernetes API client
+	 * @throws IOException if the configured kubeconfig file cannot be read
+	 */
+	private ApiClient buildApiClient(JhelmKubernetesProperties props) throws IOException {
+		ApiClient client;
+		String kubeconfigPath = props.getKubeconfigPath();
+		String context = props.getContext();
+		if (kubeconfigPath != null || (context != null && !context.isBlank())) {
+			// A configured kubeconfig path, or an explicit --kube-context, means load the
+			// kubeconfig ourselves so the requested context can be selected.
+			String path = (kubeconfigPath != null) ? kubeconfigPath : defaultKubeconfigPath();
+			try (FileReader reader = new FileReader(path, StandardCharsets.UTF_8)) {
+				KubeConfig kubeConfig = KubeConfig.loadKubeConfig(reader);
+				if (context != null && !context.isBlank() && !kubeConfig.setContext(context)) {
+					throw new IOException("kube context not found in kubeconfig: " + context);
+				}
+				client = Config.fromConfig(kubeConfig);
+			}
+		}
+		else {
+			client = Config.defaultClient();
+		}
+		if (props.getApiServer() != null && !props.getApiServer().isBlank()) {
+			client.setBasePath(props.getApiServer());
+		}
+		return client;
+	}
+
+	// The kubeconfig the Kubernetes client would auto-detect: the first entry of
+	// $KUBECONFIG, else ~/.kube/config. Used only when a context is requested without an
+	// explicit --kubeconfig.
+	private static String defaultKubeconfigPath() {
+		String env = System.getenv("KUBECONFIG");
+		if (env != null && !env.isBlank()) {
+			return env.split(File.pathSeparator, 2)[0];
+		}
+		return System.getProperty("user.home") + "/.kube/config";
+	}
+
+	/**
+	 * Kubernetes health-indicator configuration, isolated in a nested class guarded by
+	 * {@link ConditionalOnClass} so the actuator {@code HealthIndicator} type is only
+	 * referenced when Spring Boot Actuator is on the classpath. This keeps the enclosing
+	 * configuration introspectable by consumers (e.g. the CLI) that do not depend on
+	 * actuator.
+	 */
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(HealthIndicator.class)
+	static class KubernetesHealthContributorConfiguration {
+
+		/**
+		 * Registers a Kubernetes connectivity health indicator reporting up/down based on
+		 * reaching the cluster {@code /version} endpoint.
+		 * @param kubeClient the client wrapper to probe
+		 * @return the health indicator bean
+		 */
+		@Bean
+		@ConditionalOnBean(KubeClient.class)
+		@ConditionalOnMissingBean(KubernetesHealthIndicator.class)
+		KubernetesHealthIndicator kubernetesHealthIndicator(KubeClient kubeClient) {
+			return new KubernetesHealthIndicator(kubeClient);
+		}
+
+	}
+
+}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
@@ -1,49 +1,35 @@
 package org.alexmond.jhelm.kube;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-import io.kubernetes.client.openapi.ApiClient;
-import io.kubernetes.client.util.Config;
-import io.kubernetes.client.util.KubeConfig;
 import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
 import org.alexmond.jhelm.core.JhelmMetricsAutoConfiguration;
 import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
-import org.alexmond.jhelm.gotemplate.helm.functions.KubernetesProvider;
-import org.alexmond.jhelm.kube.service.internal.AsyncHelmKubeService;
-import org.alexmond.jhelm.kube.service.internal.KubeClient;
-import org.alexmond.jhelm.kube.service.internal.KubernetesClientProvider;
-import org.alexmond.jhelm.kube.service.internal.KubernetesHealthIndicator;
 import org.alexmond.jhelm.kube.service.internal.ObservableKubeService;
 import org.alexmond.jhelm.kube.service.internal.RetryableKubeService;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.retry.RetryPolicy;
-import org.springframework.core.retry.RetryTemplate;
-import java.time.Duration;
+import org.springframework.context.annotation.Import;
 
 /**
- * Auto-configuration for the jhelm Kubernetes integration module. Registers a
- * {@link KubeClient} and a {@link KubeService} implementation. When retry is enabled (the
- * default), the service is wrapped with {@link RetryableKubeService} for transient
- * failure recovery. When a {@link JhelmMetrics} bean is available, the service is further
- * wrapped with {@link ObservableKubeService} for operation timing and counting. Runs
+ * Auto-configuration for the jhelm Kubernetes integration module. Owns the module-wide,
+ * client-agnostic concerns — the {@link JhelmKubernetesProperties} binding and the
+ * {@link KubeService} decorator chain (see {@link KubeServiceDecorators}) — and imports
+ * the client-specific backend configuration(s). The concrete Kubernetes backend is
+ * selected by whichever client library is on the classpath:
+ * {@link ClientJavaKubeConfiguration} activates when the official
+ * {@code io.kubernetes:client-java} is present.
+ *
+ * <p>
+ * The selected backend produces the base {@link KubeService}, which is wrapped with
+ * {@link RetryableKubeService} when retry is enabled (the default) and with
+ * {@link ObservableKubeService} when a {@link JhelmMetrics} bean is available. Runs
  * before {@link JhelmCoreAutoConfiguration} so that the {@link KubeService} bean is
  * available for its {@code @ConditionalOnBean} checks.
  */
 @AutoConfiguration(before = JhelmCoreAutoConfiguration.class, after = JhelmMetricsAutoConfiguration.class)
 @EnableConfigurationProperties(JhelmKubernetesProperties.class)
+@Import(ClientJavaKubeConfiguration.class)
 public class JhelmKubeAutoConfiguration {
 
 	/**
@@ -52,157 +38,6 @@ public class JhelmKubeAutoConfiguration {
 	 */
 	@SuppressWarnings("PMD.UnnecessaryConstructor")
 	public JhelmKubeAutoConfiguration() {
-	}
-
-	/**
-	 * Registers the {@link KubeClient} used by the module. If a consumer supplies their
-	 * own {@link ApiClient} bean (the intentional, documented customization seam) it is
-	 * wrapped as-is; otherwise a client is built from the configured kubeconfig path,
-	 * falling back to the default in-cluster or local client.
-	 * @param props the Kubernetes configuration properties, providing the optional
-	 * kubeconfig path
-	 * @param apiClientOverride provider for an optional consumer-supplied API client used
-	 * to override the built-in client
-	 * @return the registered {@link KubeClient}
-	 * @throws IOException if the configured kubeconfig file cannot be read
-	 */
-	@Bean
-	@ConditionalOnMissingBean
-	public KubeClient kubeClient(JhelmKubernetesProperties props, ObjectProvider<ApiClient> apiClientOverride)
-			throws IOException {
-		ApiClient override = apiClientOverride.getIfAvailable();
-		ApiClient client = (override != null) ? override : buildApiClient(props);
-		return new KubeClient(client);
-	}
-
-	/**
-	 * Registers the cluster-backed {@link KubernetesProvider} that powers the
-	 * {@code lookup} template function. The core {@code Engine} wires this in so
-	 * {@code lookup} queries the live Kubernetes API (returning full resource data, incl.
-	 * Secret/ConfigMap {@code data}) during install/upgrade, as Helm does. It degrades to
-	 * an empty result on its own when the API is unreachable (e.g. offline
-	 * {@code template} rendering).
-	 * @param kubeClient the shared Kubernetes client
-	 * @return the lookup provider bean
-	 */
-	@Bean
-	@ConditionalOnMissingBean(KubernetesProvider.class)
-	public KubernetesProvider kubernetesClientProvider(KubeClient kubeClient) {
-		return new KubernetesClientProvider(kubeClient);
-	}
-
-	/**
-	 * Builds the Kubernetes {@link ApiClient} used by the module. When a kubeconfig path
-	 * is configured the client is built from that file, otherwise the default in-cluster
-	 * or local client is used.
-	 * @param props the Kubernetes configuration properties, providing the optional
-	 * kubeconfig path
-	 * @return the configured Kubernetes API client
-	 * @throws IOException if the configured kubeconfig file cannot be read
-	 */
-	private ApiClient buildApiClient(JhelmKubernetesProperties props) throws IOException {
-		ApiClient client;
-		String kubeconfigPath = props.getKubeconfigPath();
-		String context = props.getContext();
-		if (kubeconfigPath != null || (context != null && !context.isBlank())) {
-			// A configured kubeconfig path, or an explicit --kube-context, means load the
-			// kubeconfig ourselves so the requested context can be selected.
-			String path = (kubeconfigPath != null) ? kubeconfigPath : defaultKubeconfigPath();
-			try (FileReader reader = new FileReader(path, StandardCharsets.UTF_8)) {
-				KubeConfig kubeConfig = KubeConfig.loadKubeConfig(reader);
-				if (context != null && !context.isBlank() && !kubeConfig.setContext(context)) {
-					throw new IOException("kube context not found in kubeconfig: " + context);
-				}
-				client = Config.fromConfig(kubeConfig);
-			}
-		}
-		else {
-			client = Config.defaultClient();
-		}
-		if (props.getApiServer() != null && !props.getApiServer().isBlank()) {
-			client.setBasePath(props.getApiServer());
-		}
-		return client;
-	}
-
-	// The kubeconfig the Kubernetes client would auto-detect: the first entry of
-	// $KUBECONFIG, else ~/.kube/config. Used only when a context is requested without an
-	// explicit --kubeconfig.
-	private static String defaultKubeconfigPath() {
-		String env = System.getenv("KUBECONFIG");
-		if (env != null && !env.isBlank()) {
-			return env.split(File.pathSeparator, 2)[0];
-		}
-		return System.getProperty("user.home") + "/.kube/config";
-	}
-
-	/**
-	 * Builds the {@link KubeService} bean. The base {@link AsyncHelmKubeService} is
-	 * wrapped with {@link RetryableKubeService} when retry is enabled, and further
-	 * wrapped with {@link ObservableKubeService} when a {@link JhelmMetrics} bean is
-	 * available.
-	 * @param kubeClient the registered Kubernetes client wrapper
-	 * @param props the Kubernetes configuration properties, providing the retry settings
-	 * @param metricsProvider provider for the optional metrics bean used to enable
-	 * operation timing and counting
-	 * @return the (possibly decorated) Kubernetes service
-	 */
-	@Bean
-	@ConditionalOnMissingBean(KubeService.class)
-	public KubeService kubeService(KubeClient kubeClient, JhelmKubernetesProperties props,
-			ObjectProvider<JhelmMetrics> metricsProvider) {
-		AsyncHelmKubeService base = new AsyncHelmKubeService(kubeClient);
-		KubeService service = base;
-		JhelmKubernetesProperties.Retry retryConfig = props.getRetry();
-		if (retryConfig.isEnabled()) {
-			service = new RetryableKubeService(base, buildRetryTemplate(retryConfig));
-		}
-		JhelmMetrics metrics = metricsProvider.getIfAvailable();
-		if (metrics != null) {
-			service = new ObservableKubeService(service, metrics);
-		}
-		return service;
-	}
-
-	private RetryTemplate buildRetryTemplate(JhelmKubernetesProperties.Retry config) {
-		RetryPolicy policy = RetryPolicy.builder()
-			// maxRetries excludes the initial call, so subtract one to preserve the
-			// total invocation count of the old SimpleRetryPolicy(maxAttempts).
-			.maxRetries(Math.max(0, config.getMaxAttempts() - 1))
-			.delay(Duration.ofMillis(config.getInitialIntervalMs()))
-			.multiplier(config.getMultiplier())
-			.maxDelay(Duration.ofMillis(config.getMaxIntervalMs()))
-			// Only transient errors are retried; non-transient failures stop immediately
-			// (replaces the old TransientRetryListener.setExhaustedOnly logic).
-			.predicate(RetryableKubeService::isTransient)
-			.build();
-		return new RetryTemplate(policy);
-	}
-
-	/**
-	 * Kubernetes health-indicator configuration, isolated in a nested class guarded by
-	 * {@link ConditionalOnClass} so the actuator {@code HealthIndicator} type is only
-	 * referenced when Spring Boot Actuator is on the classpath. This keeps the enclosing
-	 * {@link JhelmKubeAutoConfiguration} introspectable by consumers (e.g. the CLI) that
-	 * do not depend on actuator.
-	 */
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(HealthIndicator.class)
-	static class KubernetesHealthContributorConfiguration {
-
-		/**
-		 * Registers a Kubernetes connectivity health indicator reporting up/down based on
-		 * reaching the cluster {@code /version} endpoint.
-		 * @param kubeClient the client wrapper to probe
-		 * @return the health indicator bean
-		 */
-		@Bean
-		@ConditionalOnBean(KubeClient.class)
-		@ConditionalOnMissingBean(KubernetesHealthIndicator.class)
-		KubernetesHealthIndicator kubernetesHealthIndicator(KubeClient kubeClient) {
-			return new KubernetesHealthIndicator(kubeClient);
-		}
-
 	}
 
 }

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/KubeServiceDecorators.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/KubeServiceDecorators.java
@@ -1,0 +1,64 @@
+package org.alexmond.jhelm.kube;
+
+import java.time.Duration;
+
+import org.alexmond.jhelm.core.metrics.JhelmMetrics;
+import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
+import org.alexmond.jhelm.kube.service.internal.ObservableKubeService;
+import org.alexmond.jhelm.kube.service.internal.RetryableKubeService;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
+
+/**
+ * Applies the module-wide, client-agnostic {@link KubeService} decorator chain to a
+ * backend's base implementation. Shared by every client backend (official client-java,
+ * Fabric8, …) so retry and metrics behave identically regardless of the underlying client
+ * library: the backend produces the undecorated service and delegates here for wrapping.
+ */
+final class KubeServiceDecorators {
+
+	private KubeServiceDecorators() {
+	}
+
+	/**
+	 * Wraps a backend's base {@link KubeService} with {@link RetryableKubeService} when
+	 * retry is enabled, and further with {@link ObservableKubeService} when a
+	 * {@link JhelmMetrics} bean is available.
+	 * @param base the backend's undecorated service
+	 * @param props the Kubernetes configuration properties, providing the retry settings
+	 * @param metricsProvider provider for the optional metrics bean used to enable
+	 * operation timing and counting
+	 * @return the (possibly decorated) Kubernetes service
+	 */
+	static KubeService decorate(KubeService base, JhelmKubernetesProperties props,
+			ObjectProvider<JhelmMetrics> metricsProvider) {
+		KubeService service = base;
+		JhelmKubernetesProperties.Retry retryConfig = props.getRetry();
+		if (retryConfig.isEnabled()) {
+			service = new RetryableKubeService(base, buildRetryTemplate(retryConfig));
+		}
+		JhelmMetrics metrics = metricsProvider.getIfAvailable();
+		if (metrics != null) {
+			service = new ObservableKubeService(service, metrics);
+		}
+		return service;
+	}
+
+	private static RetryTemplate buildRetryTemplate(JhelmKubernetesProperties.Retry config) {
+		RetryPolicy policy = RetryPolicy.builder()
+			// maxRetries excludes the initial call, so subtract one to preserve the
+			// total invocation count of the old SimpleRetryPolicy(maxAttempts).
+			.maxRetries(Math.max(0, config.getMaxAttempts() - 1))
+			.delay(Duration.ofMillis(config.getInitialIntervalMs()))
+			.multiplier(config.getMultiplier())
+			.maxDelay(Duration.ofMillis(config.getMaxIntervalMs()))
+			// Only transient errors are retried; non-transient failures stop immediately
+			// (replaces the old TransientRetryListener.setExhaustedOnly logic).
+			.predicate(RetryableKubeService::isTransient)
+			.build();
+		return new RetryTemplate(policy);
+	}
+
+}


### PR DESCRIPTION
Slice 0 of #775 — makes jhelm able to select its Kubernetes client backend by classpath, starting with a **pure, behavior-preserving refactor**.

## What changed
- **`ClientJavaKubeConfiguration`** (new) — all `io.kubernetes.*` beans (`KubeClient`, `KubernetesProvider`, `KubeService`, health indicator) + kubeconfig/context loading, gated `@ConditionalOnClass(io.kubernetes.client.openapi.ApiClient)`. Only introspected when the official client is on the classpath, so a Fabric8 backend gated on its own client type can coexist.
- **`KubeServiceDecorators`** (new) — extracts the client-agnostic retry + metrics decorator chain so every backend wraps its base service identically.
- **`JhelmKubeAutoConfiguration`** — now an annotations-only parent (properties binding + `@Import` of the backend config); no `io.kubernetes.*` reference at class level.

## Why it's safe
No behavior change. The `client-java` dependency is still mandatory here (that flips in Slice 1). The existing `JhelmKubeAutoConfigurationTest` (mocked `ApiClient`, retry/metrics/override cases) passes unchanged, and the full build is green including **`jhelm-cli`**, which lacks actuator and is where autoconfig-introspection regressions surface.

Closes #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)