### PR TITLE
build(kube): make client-java optional; consumers select the backend (#777)

### DIFF
--- a/jhelm-cli/pom.xml
+++ b/jhelm-cli/pom.xml
@@ -21,6 +21,11 @@
             <groupId>org.alexmond</groupId>
             <artifactId>jhelm-kube</artifactId>
         </dependency>
+        <!-- jhelm-kube's client is optional; select the official Kubernetes client backend. -->
+        <dependency>
+            <groupId>io.kubernetes</groupId>
+            <artifactId>client-java</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.alexmond</groupId>
             <artifactId>jhelm-plugin</artifactId>

--- a/jhelm-kube/pom.xml
+++ b/jhelm-kube/pom.xml
@@ -16,9 +16,16 @@
             <groupId>org.alexmond</groupId>
             <artifactId>jhelm-core</artifactId>
         </dependency>
+        <!--
+            The Kubernetes client is optional so it is not forced onto consumers
+            transitively: jhelm selects its backend by whichever client library is on the
+            classpath. Consumers (the CLI, the sample apps) declare the client they ship —
+            the official client-java here, or Fabric8. See ClientJavaKubeConfiguration.
+        -->
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/jhelm-mcp-sample/pom.xml
+++ b/jhelm-mcp-sample/pom.xml
@@ -25,6 +25,11 @@
 			<groupId>org.alexmond</groupId>
 			<artifactId>jhelm-kube</artifactId>
 		</dependency>
+		<!-- jhelm-kube's client is optional; select the official Kubernetes client backend. -->
+		<dependency>
+			<groupId>io.kubernetes</groupId>
+			<artifactId>client-java</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/jhelm-rest-sample/pom.xml
+++ b/jhelm-rest-sample/pom.xml
@@ -25,6 +25,11 @@
 			<groupId>org.alexmond</groupId>
 			<artifactId>jhelm-kube</artifactId>
 		</dependency>
+		<!-- jhelm-kube's client is optional; select the official Kubernetes client backend. -->
+		<dependency>
+			<groupId>io.kubernetes</groupId>
+			<artifactId>client-java</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>


### PR DESCRIPTION
Slice 1 of #775. Makes the Kubernetes client a **swappable, non-transitive** dependency so jhelm can select its backend by whichever client library is on the classpath.

## What changed
- `jhelm-kube/pom.xml` — `io.kubernetes:client-java` marked `<optional>true</optional>`. It stays on jhelm-kube's own compile/test classpath (the client-java backend still compiles and its tests still run) but is no longer inherited transitively.
- `jhelm-cli`, `jhelm-mcp-sample`, `jhelm-rest-sample` — add an explicit `client-java` dependency, so their runtime classpath and the shipped CLI binary are unchanged.

## Verification
- Full reactor build green (all 13 modules, tests pass).
- The shipped CLI jar (`jhelm-1.3.1-SNAPSHOT.jar`) still bundles `client-java-26.0.0.jar` (+ `-api`, `-proto`) in `BOOT-INF/lib` — behavior preserved.
- `jhelm-rest` / `jhelm-mcp` depend only on `jhelm-core` (the client-free seam), so they are unaffected.

Closes #777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)