### PR TITLE
feat(kube): Fabric8 backend skeleton + deterministic backend selection (#778)

### DIFF
--- a/jhelm-kube/pom.xml
+++ b/jhelm-kube/pom.xml
@@ -27,6 +27,13 @@
             <artifactId>client-java</artifactId>
             <optional>true</optional>
         </dependency>
+        <!-- Alternative Kubernetes backend, also optional: selected when Fabric8 is the
+             client on the consumer's classpath. See Fabric8KubeConfiguration. -->
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/ClientJavaKubeConfiguration.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/ClientJavaKubeConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(ApiClient.class)
+@ConditionalOnKubeBackend(KubeBackend.CLIENT_JAVA)
 class ClientJavaKubeConfiguration {
 
 	/**

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/ConditionalOnKubeBackend.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/ConditionalOnKubeBackend.java
@@ -1,0 +1,31 @@
+package org.alexmond.jhelm.kube;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Conditional;
+
+/**
+ * Marks a Kubernetes backend configuration as active only when the annotated
+ * {@link KubeBackend} is the one jhelm selects. Selection is driven by the
+ * {@code jhelm.kubernetes.backend} property and the client libraries on the classpath
+ * (see {@link OnKubeBackendCondition}), guaranteeing that <em>exactly one</em> backend
+ * activates even when both client libraries are present — independent of configuration
+ * import order.
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Conditional(OnKubeBackendCondition.class)
+public @interface ConditionalOnKubeBackend {
+
+	/**
+	 * The backend this configuration provides.
+	 * @return the backend guarded by this condition
+	 */
+	KubeBackend value();
+
+}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/Fabric8KubeConfiguration.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/Fabric8KubeConfiguration.java
@@ -1,0 +1,103 @@
+package org.alexmond.jhelm.kube;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import org.alexmond.jhelm.gotemplate.helm.functions.KubernetesProvider;
+import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
+import org.alexmond.jhelm.kube.service.internal.Fabric8KubernetesProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Kubernetes backend backed by the Fabric8 Kubernetes client
+ * ({@code io.fabric8:kubernetes-client}). Guarded by {@link ConditionalOnClass} on
+ * {@link KubernetesClient} — so the entire configuration and its client types are only
+ * introspected when Fabric8 is on the classpath — and by {@link ConditionalOnKubeBackend}
+ * so it activates only when Fabric8 is the selected backend (see
+ * {@link OnKubeBackendCondition}).
+ *
+ * <p>
+ * This slice provides the client and the cluster-backed {@link KubernetesProvider} (the
+ * {@code lookup}/{@code kubeVersion} SPI). The full {@code KubeService} implementation
+ * (install/upgrade/uninstall cluster operations) is added in a later slice; until then a
+ * Fabric8-only classpath renders templates and resolves {@code lookup}, but does not yet
+ * perform releases.
+ *
+ * <p>
+ * Imported by {@link JhelmKubeAutoConfiguration}, which owns the module-wide,
+ * client-agnostic concerns.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(KubernetesClient.class)
+@ConditionalOnKubeBackend(KubeBackend.FABRIC8)
+class Fabric8KubeConfiguration {
+
+	/**
+	 * Registers the Fabric8 {@link KubernetesClient}. Consumers may supply their own
+	 * {@link KubernetesClient} bean (the customization seam), in which case this one
+	 * backs off; otherwise a client is built from the configured kubeconfig path /
+	 * context, falling back to Fabric8's default auto-configuration (in-cluster or
+	 * {@code ~/.kube/config}).
+	 * @param props the Kubernetes configuration properties
+	 * @return the Fabric8 client
+	 * @throws IOException if the configured kubeconfig file cannot be read
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	KubernetesClient kubernetesClient(JhelmKubernetesProperties props) throws IOException {
+		return new KubernetesClientBuilder().withConfig(buildConfig(props)).build();
+	}
+
+	/**
+	 * Registers the cluster-backed {@link KubernetesProvider} that powers the
+	 * {@code lookup} template function, backed by the Fabric8 client.
+	 * @param client the Fabric8 client
+	 * @return the lookup provider bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean(KubernetesProvider.class)
+	KubernetesProvider kubernetesClientProvider(KubernetesClient client) {
+		return new Fabric8KubernetesProvider(client);
+	}
+
+	private Config buildConfig(JhelmKubernetesProperties props) throws IOException {
+		Config config;
+		String kubeconfigPath = props.getKubeconfigPath();
+		String context = props.getContext();
+		if (kubeconfigPath != null || (context != null && !context.isBlank())) {
+			// A configured kubeconfig path, or an explicit --kube-context, means load the
+			// kubeconfig ourselves so the requested context can be selected.
+			String path = (kubeconfigPath != null) ? kubeconfigPath : defaultKubeconfigPath();
+			String contents = Files.readString(Path.of(path), StandardCharsets.UTF_8);
+			config = Config.fromKubeconfig(context, contents, path);
+		}
+		else {
+			config = Config.autoConfigure(null);
+		}
+		if (props.getApiServer() != null && !props.getApiServer().isBlank()) {
+			config.setMasterUrl(props.getApiServer());
+		}
+		return config;
+	}
+
+	// The kubeconfig Fabric8 would auto-detect: the first entry of $KUBECONFIG, else
+	// ~/.kube/config. Used only when a context is requested without an explicit
+	// --kubeconfig.
+	private static String defaultKubeconfigPath() {
+		String env = System.getenv("KUBECONFIG");
+		if (env != null && !env.isBlank()) {
+			return env.split(File.pathSeparator, 2)[0];
+		}
+		return System.getProperty("user.home") + "/.kube/config";
+	}
+
+}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfiguration.java
@@ -16,9 +16,11 @@ import org.springframework.context.annotation.Import;
  * client-agnostic concerns — the {@link JhelmKubernetesProperties} binding and the
  * {@link KubeService} decorator chain (see {@link KubeServiceDecorators}) — and imports
  * the client-specific backend configuration(s). The concrete Kubernetes backend is
- * selected by whichever client library is on the classpath:
- * {@link ClientJavaKubeConfiguration} activates when the official
- * {@code io.kubernetes:client-java} is present.
+ * selected by the {@code jhelm.kubernetes.backend} property and whichever client library
+ * is on the classpath (see {@link OnKubeBackendCondition}):
+ * {@link ClientJavaKubeConfiguration} for the official {@code io.kubernetes:client-java}
+ * and {@link Fabric8KubeConfiguration} for {@code io.fabric8:kubernetes-client}. Exactly
+ * one activates.
  *
  * <p>
  * The selected backend produces the base {@link KubeService}, which is wrapped with
@@ -29,7 +31,7 @@ import org.springframework.context.annotation.Import;
  */
 @AutoConfiguration(before = JhelmCoreAutoConfiguration.class, after = JhelmMetricsAutoConfiguration.class)
 @EnableConfigurationProperties(JhelmKubernetesProperties.class)
-@Import(ClientJavaKubeConfiguration.class)
+@Import({ ClientJavaKubeConfiguration.class, Fabric8KubeConfiguration.class })
 public class JhelmKubeAutoConfiguration {
 
 	/**

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/KubeBackend.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/KubeBackend.java
@@ -1,0 +1,44 @@
+package org.alexmond.jhelm.kube;
+
+/**
+ * The Kubernetes client backends jhelm can run on. Declaration order is the preference
+ * order used when {@code jhelm.kubernetes.backend=auto} and more than one backend's
+ * client library is on the classpath: the first available wins, so {@link #CLIENT_JAVA}
+ * is preferred over {@link #FABRIC8} to preserve jhelm's historical default.
+ */
+public enum KubeBackend {
+
+	/** The official Kubernetes Java client, {@code io.kubernetes:client-java}. */
+	CLIENT_JAVA("client-java", "io.kubernetes.client.openapi.ApiClient"),
+
+	/** The Fabric8 Kubernetes client, {@code io.fabric8:kubernetes-client}. */
+	FABRIC8("fabric8", "io.fabric8.kubernetes.client.KubernetesClient");
+
+	private final String id;
+
+	private final String markerClass;
+
+	KubeBackend(String id, String markerClass) {
+		this.id = id;
+		this.markerClass = markerClass;
+	}
+
+	/**
+	 * Returns the value used in the {@code jhelm.kubernetes.backend} property to select
+	 * this backend explicitly (e.g. {@code client-java}, {@code fabric8}).
+	 * @return the property token for this backend
+	 */
+	public String id() {
+		return this.id;
+	}
+
+	/**
+	 * Returns the fully qualified name of the client class whose presence on the
+	 * classpath indicates this backend's library is available.
+	 * @return the marker class name
+	 */
+	public String markerClass() {
+		return this.markerClass;
+	}
+
+}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/OnKubeBackendCondition.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/OnKubeBackendCondition.java
@@ -1,0 +1,60 @@
+package org.alexmond.jhelm.kube;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Decides which Kubernetes backend configuration is active, so that exactly one backend
+ * wins regardless of import order. Reads {@code jhelm.kubernetes.backend}:
+ * <ul>
+ * <li>an explicit backend id ({@code client-java} / {@code fabric8}) activates only that
+ * backend, and only when its client library is on the classpath;</li>
+ * <li>{@code auto} (the default) activates the first backend, in {@link KubeBackend}
+ * declaration order, whose client library is present — so {@code client-java} is
+ * preferred over Fabric8 when both are available.</li>
+ * </ul>
+ */
+public class OnKubeBackendCondition implements Condition {
+
+	private static final String PROPERTY = "jhelm.kubernetes.backend";
+
+	private static final String AUTO = "auto";
+
+	@Override
+	public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		KubeBackend target = targetBackend(metadata);
+		String configured = context.getEnvironment().getProperty(PROPERTY, AUTO).trim().toLowerCase(Locale.ROOT);
+		ClassLoader classLoader = context.getClassLoader();
+		if (!AUTO.equals(configured)) {
+			// Explicit selection: only the named backend, and only if its library is
+			// here.
+			return target.id().equals(configured) && isPresent(target, classLoader);
+		}
+		// Auto: the highest-preference backend that is actually on the classpath wins.
+		for (KubeBackend candidate : KubeBackend.values()) {
+			if (isPresent(candidate, classLoader)) {
+				return candidate == target;
+			}
+		}
+		return false;
+	}
+
+	private static KubeBackend targetBackend(AnnotatedTypeMetadata metadata) {
+		Map<String, Object> attributes = metadata.getAnnotationAttributes(ConditionalOnKubeBackend.class.getName());
+		if (attributes == null) {
+			throw new IllegalStateException(
+					"@ConditionalOnKubeBackend is required to use " + OnKubeBackendCondition.class.getSimpleName());
+		}
+		return (KubeBackend) attributes.get("value");
+	}
+
+	private static boolean isPresent(KubeBackend backend, ClassLoader classLoader) {
+		return ClassUtils.isPresent(backend.markerClass(), classLoader);
+	}
+
+}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
@@ -41,6 +41,16 @@ public class JhelmKubernetesProperties {
 	private String apiServer;
 
 	/**
+	 * Selects the Kubernetes client backend. {@code auto} (the default) picks the
+	 * preferred backend among those on the classpath (the official {@code client-java}
+	 * over Fabric8 when both are present); {@code client-java} or {@code fabric8} force a
+	 * specific backend, which then requires that client library to be present. jhelm
+	 * ships neither client itself — the consumer puts one on the classpath. See
+	 * {@code ClientJavaKubeConfiguration} / {@code Fabric8KubeConfiguration}.
+	 */
+	private String backend = "auto";
+
+	/**
 	 * Retry configuration for transient Kubernetes API failures.
 	 */
 	private Retry retry = new Retry();

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/Fabric8KubernetesProvider.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/Fabric8KubernetesProvider.java
@@ -1,0 +1,150 @@
+package org.alexmond.jhelm.kube.service.internal;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.VersionInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.gotemplate.helm.functions.KubernetesProvider;
+
+/**
+ * {@link KubernetesProvider} implementation backed by the Fabric8 Kubernetes client. It
+ * mirrors the official-client provider: real cluster access for the {@code lookup} and
+ * {@code kubeVersion} template functions, degrading to empty results or stub version
+ * information when the API server is unreachable.
+ *
+ * <p>
+ * Resources are fetched through Fabric8's generic (unstructured) API, which discovers the
+ * resource mapping from {@code apiVersion} + {@code kind}, and serialized with the
+ * client's own {@code KubernetesSerialization} so field names match the wire format and
+ * {@code Secret.data} values stay base64-encoded — matching Helm's {@code lookup}.
+ */
+@Slf4j
+public class Fabric8KubernetesProvider implements KubernetesProvider {
+
+	private final KubernetesClient client;
+
+	private volatile Boolean available;
+
+	/**
+	 * Creates a provider backed by the given Fabric8 client.
+	 * @param client the configured Fabric8 Kubernetes client used to look up resources
+	 * and query cluster version information
+	 */
+	public Fabric8KubernetesProvider(KubernetesClient client) {
+		this.client = client;
+	}
+
+	@Override
+	public Map<String, Object> lookup(String apiVersion, String kind, String namespace, String name) {
+		if (!isAvailable()) {
+			if (log.isWarnEnabled()) {
+				log.warn("Kubernetes API not available, returning empty result for lookup");
+			}
+			return Map.of();
+		}
+		try {
+			if (log.isDebugEnabled()) {
+				log.debug("Looking up Kubernetes resource: apiVersion={}, kind={}, namespace={}, name={}", apiVersion,
+						kind, namespace, name);
+			}
+			boolean namespaced = namespace != null && !namespace.isBlank();
+			var operation = this.client.genericKubernetesResources(apiVersion, kind);
+			if (name == null || name.isEmpty()) {
+				Object list = namespaced ? operation.inNamespace(namespace).list() : operation.inAnyNamespace().list();
+				return toMap(list);
+			}
+			GenericKubernetesResource resource = namespaced ? operation.inNamespace(namespace).withName(name).get()
+					: operation.withName(name).get();
+			return (resource != null) ? toMap(resource) : Map.of();
+		}
+		catch (RuntimeException ex) {
+			if (log.isErrorEnabled()) {
+				log.error("Error looking up Kubernetes resource {}/{}: {}", apiVersion, kind, ex.getMessage(), ex);
+			}
+			return Map.of();
+		}
+	}
+
+	@Override
+	public Map<String, Object> getVersion() {
+		if (!isAvailable()) {
+			if (log.isWarnEnabled()) {
+				log.warn("Kubernetes API not available, returning stub version info");
+			}
+			return getStubVersion();
+		}
+		try {
+			VersionInfo info = this.client.getKubernetesVersion();
+			Map<String, Object> version = new LinkedHashMap<>();
+			version.put("Major", info.getMajor());
+			version.put("Minor", info.getMinor());
+			version.put("GitVersion", info.getGitVersion());
+			version.put("GitCommit", info.getGitCommit());
+			version.put("Platform", info.getPlatform());
+			version.put("BuildDate", info.getBuildDate());
+			return version;
+		}
+		catch (RuntimeException ex) {
+			if (log.isErrorEnabled()) {
+				log.error("Error fetching Kubernetes version: {}", ex.getMessage(), ex);
+			}
+			return getStubVersion();
+		}
+	}
+
+	@Override
+	public boolean isAvailable() {
+		if (this.available != null) {
+			return this.available;
+		}
+		try {
+			this.client.getKubernetesVersion();
+			this.available = true;
+			if (log.isInfoEnabled()) {
+				log.info("Kubernetes API is available");
+			}
+			return true;
+		}
+		catch (RuntimeException ex) {
+			this.available = false;
+			if (log.isWarnEnabled()) {
+				log.warn("Kubernetes API is not available: {}", ex.getMessage());
+			}
+			return false;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> toMap(Object resource) {
+		if (resource == null) {
+			return Map.of();
+		}
+		Object converted = this.client.getKubernetesSerialization().convertValue(resource, Map.class);
+		if (converted instanceof Map) {
+			return (Map<String, Object>) converted;
+		}
+		Map<String, Object> wrapper = new LinkedHashMap<>();
+		wrapper.put("value", converted);
+		return wrapper;
+	}
+
+	/**
+	 * Return stub version when the Kubernetes API is not available. Kept aligned with the
+	 * engine's default {@code .Capabilities.KubeVersion} ({@code v1.35.0}) so the
+	 * {@code kubeVersion} template function and {@code .Capabilities.KubeVersion} agree
+	 * when no live cluster is reachable.
+	 */
+	private Map<String, Object> getStubVersion() {
+		Map<String, Object> version = new LinkedHashMap<>();
+		version.put("Major", "1");
+		version.put("Minor", "35");
+		version.put("GitVersion", "v1.35.0");
+		version.put("GitCommit", "unknown");
+		version.put("Platform", "linux/amd64");
+		return version;
+	}
+
+}

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/KubeBackendSelectionTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/KubeBackendSelectionTest.java
@@ -1,0 +1,54 @@
+package org.alexmond.jhelm.kube;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.kubernetes.client.openapi.ApiClient;
+import org.alexmond.jhelm.core.JhelmMetricsAutoConfiguration;
+import org.alexmond.jhelm.gotemplate.helm.functions.KubernetesProvider;
+import org.alexmond.jhelm.kube.service.internal.Fabric8KubernetesProvider;
+import org.alexmond.jhelm.kube.service.internal.KubernetesClientProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Verifies that the Kubernetes backend is selected deterministically from
+ * {@code jhelm.kubernetes.backend} and the client libraries on the classpath. Both client
+ * libraries are on this module's test classpath (each declared {@code optional}), so
+ * these tests exercise the genuine both-present case.
+ */
+class KubeBackendSelectionTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withConfiguration(
+			AutoConfigurations.of(JhelmMetricsAutoConfiguration.class, JhelmKubeAutoConfiguration.class));
+
+	@Test
+	void autoPrefersClientJavaWhenBothOnClasspath() {
+		this.contextRunner.withBean(ApiClient.class, () -> mock(ApiClient.class)).run((ctx) -> {
+			assertInstanceOf(KubernetesClientProvider.class, ctx.getBean(KubernetesProvider.class));
+			assertFalse(ctx.containsBean("kubernetesClient"),
+					"Fabric8 client bean must not be created for client-java");
+		});
+	}
+
+	@Test
+	void explicitClientJavaSelectsClientJavaBackend() {
+		this.contextRunner.withPropertyValues("jhelm.kubernetes.backend=client-java")
+			.withBean(ApiClient.class, () -> mock(ApiClient.class))
+			.run((ctx) -> assertInstanceOf(KubernetesClientProvider.class, ctx.getBean(KubernetesProvider.class)));
+	}
+
+	@Test
+	void explicitFabric8SelectsFabric8Backend() {
+		this.contextRunner.withPropertyValues("jhelm.kubernetes.backend=fabric8")
+			.withBean(KubernetesClient.class, () -> mock(KubernetesClient.class))
+			.run((ctx) -> {
+				assertInstanceOf(Fabric8KubernetesProvider.class, ctx.getBean(KubernetesProvider.class));
+				assertFalse(ctx.containsBean("kubeClient"), "client-java backend must be inactive when fabric8 chosen");
+			});
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <jhelm.test.maxHeap>512m</jhelm.test.maxHeap>
         <gotmpl4j.version>1.3.0</gotmpl4j.version>
         <kubernetes-client.version>26.0.0</kubernetes-client.version>
+        <fabric8-client.version>6.13.5</fabric8-client.version>
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>
         <bouncycastle.version>1.84</bouncycastle.version>
@@ -178,6 +179,14 @@
                 <groupId>io.kubernetes</groupId>
                 <artifactId>client-java</artifactId>
                 <version>${kubernetes-client.version}</version>
+            </dependency>
+            <!-- Alternative Kubernetes backend; the BOM keeps its transitive versions consistent. -->
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-client-bom</artifactId>
+                <version>${fabric8-client.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.semver4j</groupId>


### PR DESCRIPTION
Slice 2 of #775. Introduces the **Fabric8** backend on the smallest surface (the `KubernetesProvider` lookup/version SPI) and the mechanism that selects, deterministically, which backend activates.

### Answering "what if both jars are on the classpath?"
This slice brings the tiebreak **forward** (it was originally Slice 5) so `main` never resolves a both-jars classpath by `@Import` order:

- New `jhelm.kubernetes.backend = auto | client-java | fabric8`.
- `auto` (default) picks the first available backend in `KubeBackend` declaration order → **client-java preferred over Fabric8**, preserving today's behavior.
- Explicit ids force a backend (and require that client to be present).
- Enforced by a custom `@ConditionalOnKubeBackend` condition, so exactly one backend wins **by rule, not by import order or `@ConditionalOnMissingBean` race**.

### What's here
- `KubeBackend`, `@ConditionalOnKubeBackend`, `OnKubeBackendCondition`.
- `Fabric8KubeConfiguration` — gated `@ConditionalOnClass(KubernetesClient)` + `@ConditionalOnKubeBackend(FABRIC8)`; builds the Fabric8 client from the same `jhelm.kubernetes.*` properties.
- `Fabric8KubernetesProvider` — `lookup` via Fabric8's generic (unstructured) API (mapping discovered from `apiVersion`+`kind`), version via `getKubernetesVersion`, serialized with the client's `KubernetesSerialization` so `Secret.data` stays base64 — matching Helm's `lookup` and the client-java provider.
- `ClientJavaKubeConfiguration` gated `@ConditionalOnKubeBackend(CLIENT_JAVA)`.
- `io.fabric8:kubernetes-client` optional in jhelm-kube; version via the Fabric8 BOM in root dependencyManagement.

### Scope boundary
The Fabric8 `KubeService` (install/upgrade/uninstall cluster ops) lands in Slice 3 (#779). Until then a Fabric8-only classpath renders templates and resolves `lookup`, but does not yet perform releases.

### Verification
- Full reactor build green.
- `KubeBackendSelectionTest` (3 tests) proves `auto`→client-java, explicit `client-java`, and explicit `fabric8` selection with **both** client libraries on the test classpath.
- The shipped CLI jar bundles **zero** Fabric8 jars — the optional dep stays non-transitive.

Closes #778.

🤖 Generated with [Claude Code](https://claude.com/claude-code)