### PR TITLE
feat(kube): library-agnostic transient classification + Fabric8 decorator parity (#780)

### DIFF
--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeService.java
@@ -2,8 +2,8 @@ package org.alexmond.jhelm.kube.service.internal;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
-import io.kubernetes.client.openapi.ApiException;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.model.Capabilities;
@@ -28,6 +28,14 @@ import java.net.SocketException;
  */
 @Slf4j
 public class RetryableKubeService implements KubeService {
+
+	// Kubernetes client exception types (by name, so neither client library is
+	// hard-linked
+	// — jhelm may run on whichever one is on the classpath). Each exposes an int
+	// getCode()
+	// returning the HTTP status, read reflectively in clientHttpCode.
+	private static final Set<String> CLIENT_EXCEPTION_CLASSES = Set.of("io.kubernetes.client.openapi.ApiException",
+			"io.fabric8.kubernetes.client.KubernetesClientException");
 
 	private final KubeService delegate;
 
@@ -191,15 +199,17 @@ public class RetryableKubeService implements KubeService {
 	 * that may succeed on retry. Transient errors include HTTP 429 rate-limiting
 	 * responses, 5xx server errors, connection-level failures
 	 * ({@link SocketException}/{@link ConnectException}), and any wrapped cause that is
-	 * itself transient.
+	 * itself transient. The HTTP status is read from either Kubernetes client's exception
+	 * (official client-java or Fabric8) without hard-linking the client type, so this
+	 * works whichever client backend is active.
 	 * @param ex the exception to classify; its wrapped {@link Throwable#getCause() cause}
 	 * is inspected when the exception itself is not transient
 	 * @return {@code true} if the error is transient and the operation may be retried,
 	 * {@code false} otherwise
 	 */
 	public static boolean isTransient(Throwable ex) {
-		if (ex instanceof ApiException apiEx) {
-			int code = apiEx.getCode();
+		Integer code = clientHttpCode(ex);
+		if (code != null) {
 			return code == 429 || (code >= 500 && code < 600);
 		}
 		if (ex instanceof KubernetesOperationException kubeEx) {
@@ -214,6 +224,27 @@ public class RetryableKubeService implements KubeService {
 			return isTransient(ex.getCause());
 		}
 		return false;
+	}
+
+	// Returns the HTTP status from a Kubernetes client exception (client-java's
+	// ApiException
+	// or Fabric8's KubernetesClientException, including subclasses) via a reflective
+	// getCode(), or null if the exception is not one of those. Matching by class name
+	// keeps
+	// both client libraries off this class's hard dependencies.
+	private static Integer clientHttpCode(Throwable ex) {
+		for (Class<?> type = ex.getClass(); type != null && type != Object.class; type = type.getSuperclass()) {
+			if (CLIENT_EXCEPTION_CLASSES.contains(type.getName())) {
+				try {
+					Object code = ex.getClass().getMethod("getCode").invoke(ex);
+					return (code instanceof Integer value) ? value : null;
+				}
+				catch (ReflectiveOperationException | RuntimeException ignored) {
+					return null;
+				}
+			}
+		}
+		return null;
 	}
 
 }

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/KubeBackendSelectionTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/KubeBackendSelectionTest.java
@@ -2,10 +2,15 @@ package org.alexmond.jhelm.kube;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.kubernetes.client.openapi.ApiClient;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.alexmond.jhelm.core.JhelmMetricsAutoConfiguration;
+import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.gotemplate.helm.functions.KubernetesProvider;
+import org.alexmond.jhelm.kube.service.internal.Fabric8AsyncKubeService;
 import org.alexmond.jhelm.kube.service.internal.Fabric8KubernetesProvider;
 import org.alexmond.jhelm.kube.service.internal.KubernetesClientProvider;
+import org.alexmond.jhelm.kube.service.internal.ObservableKubeService;
+import org.alexmond.jhelm.kube.service.internal.RetryableKubeService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -49,6 +54,29 @@ class KubeBackendSelectionTest {
 				assertInstanceOf(Fabric8KubernetesProvider.class, ctx.getBean(KubernetesProvider.class));
 				assertFalse(ctx.containsBean("kubeClient"), "client-java backend must be inactive when fabric8 chosen");
 			});
+	}
+
+	@Test
+	void fabric8BackendGetsTheSameDecoratorChain() {
+		this.contextRunner.withPropertyValues("jhelm.kubernetes.backend=fabric8")
+			.withBean(KubernetesClient.class, () -> mock(KubernetesClient.class))
+			.run((ctx) -> assertInstanceOf(RetryableKubeService.class, ctx.getBean(KubeService.class)));
+	}
+
+	@Test
+	void fabric8BackendIsObservableWhenMetricsAvailable() {
+		this.contextRunner.withPropertyValues("jhelm.kubernetes.backend=fabric8")
+			.withBean(KubernetesClient.class, () -> mock(KubernetesClient.class))
+			.withBean(SimpleMeterRegistry.class, SimpleMeterRegistry::new)
+			.run((ctx) -> assertInstanceOf(ObservableKubeService.class, ctx.getBean(KubeService.class)));
+	}
+
+	@Test
+	void fabric8BackendBaseIsAsyncCapable() {
+		this.contextRunner
+			.withPropertyValues("jhelm.kubernetes.backend=fabric8", "jhelm.kubernetes.retry.enabled=false")
+			.withBean(KubernetesClient.class, () -> mock(KubernetesClient.class))
+			.run((ctx) -> assertInstanceOf(Fabric8AsyncKubeService.class, ctx.getBean(KubeService.class)));
 	}
 
 }

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeServiceTest.java
@@ -5,6 +5,7 @@ import java.net.SocketException;
 import java.util.List;
 import java.util.Optional;
 
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.kubernetes.client.openapi.ApiException;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.model.Capabilities;
@@ -223,6 +224,30 @@ class RetryableKubeServiceTest {
 	@Test
 	void testIsNotTransientForGenericException() {
 		assertFalse(RetryableKubeService.isTransient(new IllegalArgumentException("bad arg")));
+	}
+
+	// --- isTransient with the Fabric8 client exception (classified by reflected getCode)
+	// ---
+
+	@Test
+	void testIsTransientForFabric8_503() {
+		assertTrue(RetryableKubeService.isTransient(new KubernetesClientException("Unavailable", 503, null)));
+	}
+
+	@Test
+	void testIsTransientForFabric8_429() {
+		assertTrue(RetryableKubeService.isTransient(new KubernetesClientException("Too Many", 429, null)));
+	}
+
+	@Test
+	void testIsNotTransientForFabric8_404() {
+		assertFalse(RetryableKubeService.isTransient(new KubernetesClientException("Not Found", 404, null)));
+	}
+
+	@Test
+	void testIsTransientForWrappedFabric8Cause() {
+		assertTrue(RetryableKubeService
+			.isTransient(new RuntimeException(new KubernetesClientException("wrapped", 500, null))));
 	}
 
 }


### PR DESCRIPTION
Slice 4 of #775. Brings the cross-cutting retry/metrics decorators to full parity for the Fabric8 backend.

## The fix
`RetryableKubeService.isTransient` hard-linked the official client's `ApiException` (`import` + `instanceof`), which would `NoClassDefFoundError` on a **Fabric8-only** runtime — exactly the classpath the epic enables. It now reads the HTTP status from **either** client's exception (client-java `ApiException` or Fabric8 `KubernetesClientException`, including subclasses) via a reflective `getCode()` matched by class name, so no client type is hard-linked and it works whichever client is present. Connection-level (`SocketException`/`ConnectException`), `KubernetesOperationException`, and cause-chain handling are unchanged.

## Tests
- `RetryableKubeServiceTest` (+4): Fabric8 `KubernetesClientException` 503/429 → retry, 404 → no retry, wrapped-cause → retry. Existing `ApiException` cases still pass (the reflective path classifies them identically).
- `KubeBackendSelectionTest` (+3): with `backend=fabric8`, the `KubeService` bean is `RetryableKubeService`, becomes `ObservableKubeService` when a meter registry is present, and its base is `Fabric8AsyncKubeService` — proving the Fabric8 backend gets the same decorator chain and async capability as the official-client backend.

The decorator wiring itself already landed in Slice 3 (`Fabric8KubeConfiguration` uses the shared `KubeServiceDecorators.decorate`); this slice makes the retry predicate library-safe and verifies the chain.

Closes #780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)