### PR TITLE
docs(kube): document the pluggable Kubernetes client backend (#781)

### DIFF
--- a/docs/modules/ROOT/pages/architecture.adoc
+++ b/docs/modules/ROOT/pages/architecture.adoc
@@ -63,9 +63,14 @@ Core Helm logic and models. Ships with Spring Boot auto-configuration (`JhelmCor
 === jhelm-kube
 
 Kubernetes client integration. Ships with Spring Boot auto-configuration (`JhelmKubeAutoConfiguration`).
+The concrete backend is chosen from the client library on the classpath — the official
+`io.kubernetes:client-java` or Fabric8 `io.fabric8:kubernetes-client` — via
+`jhelm.kubernetes.backend` (see xref:configuration.adoc#choosing-a-kubernetes-client-backend[Choosing a Kubernetes client backend]).
+Both implement the same `KubeService` surface behind identical, Helm-compatible on-cluster
+state.
 
-* *HelmKubeService* -- Kubernetes operations using the official Java client: resource apply/delete via server-side PATCH, ConfigMap-based release storage (Helm-compatible format), resource status checking (Deployments, StatefulSets, Jobs, Pods)
-* *AsyncHelmKubeService* -- extends `HelmKubeService` with `CompletableFuture`-based async methods using Java 21 virtual threads (`Executors.newVirtualThreadPerTaskExecutor()`)
+* *HelmKubeService / Fabric8KubeService* -- Kubernetes operations for each backend: resource apply/delete via server-side apply, Secret-based release storage (Helm-compatible `sh.helm.release.v1.*` format), resource status checking (Deployments, StatefulSets, Jobs, Pods)
+* *AsyncHelmKubeService / Fabric8AsyncKubeService* -- extend the base service with `CompletableFuture`-based async methods using Java 21 virtual threads (`Executors.newVirtualThreadPerTaskExecutor()`)
 
 === jhelm-cli
 

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -1,5 +1,27 @@
 = Changelog
 
+== 1.5.0
+
+=== Pluggable Kubernetes client backend
+
+jhelm can now run on *either* Kubernetes client library — the official
+`io.kubernetes:client-java` (the historical default) or Fabric8
+`io.fabric8:kubernetes-client` — selected by whichever one is on the classpath. Both
+backends are behaviorally identical, down to a byte-identical `sh.helm.release.v1.*` release
+Secret format (a release written by one backend is readable by the other). See
+xref:configuration.adoc#choosing-a-kubernetes-client-backend[Choosing a Kubernetes client backend].
+
+* *Classpath-selected backend* -- `jhelm-kube` now declares both clients as optional, so it
+  ships neither transitively; the consumer puts one on the classpath (the CLI bundles
+  `client-java`). A new Fabric8 backend implements the full cluster surface — release
+  storage, server-side apply, delete/cascade, wait/status, and the `lookup`/`kubeVersion`
+  template data — at parity with the official-client backend (#776, #777, #778, #779).
+* *`jhelm.kubernetes.backend`* -- `auto` (default; prefers `client-java` when both are
+  present), `client-java`, or `fabric8`. Selection is deterministic — exactly one backend
+  activates even with both libraries on the classpath (#778).
+* *Library-agnostic retry* -- transient-failure classification reads the HTTP status from
+  either client's exception, so retry works on whichever backend is active (#780).
+
 == 1.4.0
 
 === External Java plugin JARs

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -190,7 +190,53 @@ Provided by `JhelmKubeAutoConfiguration` when `jhelm-kube` is on the classpath.
 | `String`
 | `null`
 | Path to the kubeconfig file. When not set, uses standard Kubernetes auto-detection: `~/.kube/config` or in-cluster credentials.
+
+| `jhelm.kubernetes.backend`
+| `String`
+| `auto`
+| Which Kubernetes client backend to use — `auto`, `client-java`, or `fabric8`. See <<Choosing a Kubernetes client backend>>.
 |===
+
+[#choosing-a-kubernetes-client-backend]
+== Choosing a Kubernetes client backend
+
+jhelm can talk to the cluster through either of two Kubernetes client libraries, and picks
+the backend based on which one is on the classpath. jhelm-kube declares both as *optional*
+dependencies, so it ships neither transitively — **the consumer puts exactly one on the
+classpath** (the `jhelm` CLI bundles the official client by default):
+
+[cols="1,3"]
+|===
+| Backend | Dependency to add
+
+| `client-java` (default)
+| `io.kubernetes:client-java` — the official Kubernetes Java client.
+
+| `fabric8`
+| `io.fabric8:kubernetes-client` — the Fabric8 Kubernetes client.
+|===
+
+Both backends are behaviorally identical from a chart's point of view: they store releases
+in the same `sh.helm.release.v1.*` Secret format (a release written by one backend is
+readable by the other), apply and delete with the same semantics, and expose the same
+`lookup`/`kubeVersion` template data.
+
+`jhelm.kubernetes.backend` selects the backend:
+
+* `auto` (default) — use the backend whose client library is present; if *both* are on the
+  classpath, prefer `client-java` (jhelm's historical default).
+* `client-java` / `fabric8` — force that backend. The named client library must be present,
+  otherwise no Kubernetes backend is configured.
+
+Selection is deterministic — exactly one backend activates regardless of configuration
+order — so having both libraries on the classpath is well-defined rather than a conflict.
+
+[source,yaml]
+----
+jhelm:
+  kubernetes:
+    backend: fabric8   # requires io.fabric8:kubernetes-client on the classpath
+----
 
 == Precedence
 


### PR DESCRIPTION
Slice 5 of #775 — the final slice. Documents the pluggable Kubernetes client backend. The deterministic selection logic itself shipped in Slice 2 (#778); this slice is docs + changelog.

## Changes
- **configuration.adoc** — adds `jhelm.kubernetes.backend` to the Kubernetes properties table and a new **"Choosing a Kubernetes client backend"** section: the two clients (`client-java` / Fabric8), the provided-dependency model (jhelm-kube ships neither; the consumer brings one), `auto`/explicit selection, and the deterministic both-present tiebreak.
- **changelog.adoc** — adds `== 1.5.0` summarizing the epic (#776–#780).
- **architecture.adoc** — jhelm-kube now describes both backends (`HelmKubeService` / `Fabric8KubeService`, and the async variants) and corrects the release-storage description to Secret-based.

Both-present selection is already covered by tests (`KubeBackendSelectionTest`, added in #778 and extended in #780).

Closes #781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)