### PR TITLE
build(core): pin snakeyaml-engine >= 3.0.1 explicitly (#770)

### DIFF
--- a/jhelm-core/pom.xml
+++ b/jhelm-core/pom.xml
@@ -39,6 +39,16 @@
             <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+        <!--
+            ValuesLoader calls CoreScalarResolver(boolean), added in snakeyaml-engine 3.x.
+            Declared directly (version managed in the root pom) so the 3.x floor is explicit
+            and self-contained rather than relying on jackson-dataformat-yaml's transitive
+            version — see #770.
+        -->
+        <dependency>
+            <groupId>org.snakeyaml</groupId>
+            <artifactId>snakeyaml-engine</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.alexmond</groupId>
             <artifactId>gotmpl4j-core</artifactId>

--- a/jhelm-gotemplate-helm/pom.xml
+++ b/jhelm-gotemplate-helm/pom.xml
@@ -41,6 +41,12 @@
             <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-toml</artifactId>
         </dependency>
+        <!-- ConversionFunctions calls CoreScalarResolver(boolean) (snakeyaml-engine 3.x); pin
+             the floor explicitly, version managed in the root pom (#770). -->
+        <dependency>
+            <groupId>org.snakeyaml</groupId>
+            <artifactId>snakeyaml-engine</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,14 @@
         <fabric8-client.version>6.13.5</fabric8-client.version>
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>
+        <!--
+            jhelm-core and jhelm-gotemplate-helm call CoreScalarResolver(boolean), added in
+            snakeyaml-engine 3.x. Spring Boot's BOM does not manage snakeyaml-engine (only
+            classic org.yaml:snakeyaml), and it arrives transitively via jackson-dataformat-yaml,
+            so pin a floor here or a downstream graph can resolve an older 2.x → runtime
+            NoSuchMethodError on the first chart load (#770).
+        -->
+        <snakeyaml-engine.version>3.0.1</snakeyaml-engine.version>
         <bouncycastle.version>1.84</bouncycastle.version>
         <!-- Only the config-server sample uses Spring Cloud; 2025.1.x (Oakwood) targets Boot 4.0. -->
         <spring-cloud.version>2025.1.2</spring-cloud.version>
@@ -192,6 +200,12 @@
                 <groupId>org.semver4j</groupId>
                 <artifactId>semver4j</artifactId>
                 <version>${semver4j.version}</version>
+            </dependency>
+            <!-- Explicit floor; see the snakeyaml-engine.version note above (#770). -->
+            <dependency>
+                <groupId>org.snakeyaml</groupId>
+                <artifactId>snakeyaml-engine</artifactId>
+                <version>${snakeyaml-engine.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.alexmond</groupId>


### PR DESCRIPTION
jhelm-core (`ValuesLoader:82`) and jhelm-gotemplate-helm (`ConversionFunctions:101`) call `new CoreScalarResolver(boolean)`, added in **snakeyaml-engine 3.x**. Spring Boot's BOM doesn't manage `snakeyaml-engine` (only classic `org.yaml:snakeyaml`), and it only arrives transitively via `jackson-dataformat-yaml`, so a downstream Boot graph can resolve an older **2.x** → runtime `NoSuchMethodError` on the first chart load (not a build error).

## Fix
- Root pom `dependencyManagement`: pin `org.snakeyaml:snakeyaml-engine` to a `3.0.1` floor.
- Declare it as a **direct** (versionless, managed) dependency in `jhelm-core` and `jhelm-gotemplate-helm`, so the floor is explicit in their published POMs rather than inherited from a transitive.

## Verification
`./mvnw dependency:tree -pl jhelm-core -Dincludes=org.snakeyaml:snakeyaml-engine` → `snakeyaml-engine:3.0.1:compile`; full build of both modules green.

Closes #770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)