### PR TITLE
feat(rest): opt out of the access interceptor for host-secured embeds (#774)

### DIFF
--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestAutoConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.info.BuildProperties;
@@ -140,24 +141,33 @@ public class JhelmRestAutoConfiguration {
 
 	/**
 	 * Registers the access-mode interceptor that gates cluster-mutating endpoints behind
-	 * the unified security policy (deny-by-default 403, then API-key 401).
+	 * the unified security policy (deny-by-default 403, then API-key 401). Skipped when
+	 * {@code jhelm.rest.access-interceptor.enabled=false} — set that when the host
+	 * application secures the endpoints itself (e.g. its own Spring Security) to avoid
+	 * double-gating.
 	 * @param securityPolicy the unified security policy that gates mutating operations
 	 * @return the access-mode interceptor bean
 	 */
 	@Bean
 	@ConditionalOnMissingBean
+	@ConditionalOnProperty(prefix = "jhelm.rest", name = "access-interceptor.enabled", havingValue = "true",
+			matchIfMissing = true)
 	public AccessModeInterceptor accessModeInterceptor(JhelmSecurityPolicy securityPolicy) {
 		return new AccessModeInterceptor(securityPolicy);
 	}
 
 	/**
 	 * Registers a {@link WebMvcConfigurer} that applies the {@link AccessModeInterceptor}
-	 * to all REST paths.
+	 * to all REST paths. Skipped when {@code jhelm.rest.access-interceptor.enabled=false}
+	 * so the interceptor is not registered and mutating requests pass through to the host
+	 * application's own security.
 	 * @param accessModeInterceptor the interceptor enforcing the access mode
 	 * @return the web MVC configurer bean
 	 */
 	@Bean
 	@ConditionalOnMissingBean(name = "jhelmAccessModeWebMvcConfigurer")
+	@ConditionalOnProperty(prefix = "jhelm.rest", name = "access-interceptor.enabled", havingValue = "true",
+			matchIfMissing = true)
 	public WebMvcConfigurer jhelmAccessModeWebMvcConfigurer(AccessModeInterceptor accessModeInterceptor) {
 		return new WebMvcConfigurer() {
 			@Override

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/config/JhelmRestProperties.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/config/JhelmRestProperties.java
@@ -37,6 +37,12 @@ public class JhelmRestProperties {
 	private DataSize maxUploadSize = DataSize.ofMegabytes(100);
 
 	/**
+	 * Configuration for jhelm's built-in access-mode interceptor that gates
+	 * cluster-mutating REST endpoints.
+	 */
+	private AccessInterceptor accessInterceptor = new AccessInterceptor();
+
+	/**
 	 * Returns the configured temp directory, or the system default if not set. The
 	 * returned path is always absolute and normalized.
 	 * @return the temp directory path
@@ -51,6 +57,25 @@ public class JhelmRestProperties {
 		Path workspace = getTempDir();
 		Files.createDirectories(workspace);
 		log.info("jhelm workspace: {}", workspace);
+	}
+
+	/**
+	 * Settings for jhelm's built-in access-mode interceptor.
+	 */
+	@Getter
+	@Setter
+	public static class AccessInterceptor {
+
+		/**
+		 * Whether jhelm registers its built-in access-mode interceptor, which gates
+		 * cluster-mutating REST endpoints behind the shared {@code jhelm.security.*}
+		 * policy (deny-by-default). Set to {@code false} when the host application embeds
+		 * jhelm-rest under its own Spring Security so mutating operations are not
+		 * double-gated; the interceptor is then not registered and requests pass through
+		 * to the host's own security. Defaults to {@code true}.
+		 */
+		private boolean enabled = true;
+
 	}
 
 }

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/JhelmRestAutoConfigurationTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/JhelmRestAutoConfigurationTest.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.rest;
 
 import org.alexmond.jhelm.core.JhelmCoreAutoConfiguration;
 import org.alexmond.jhelm.rest.config.JhelmRestProperties;
+import org.alexmond.jhelm.rest.security.AccessModeInterceptor;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -58,6 +60,25 @@ class JhelmRestAutoConfigurationTest {
 		this.contextRunner.withUserConfiguration(CustomOpenApiConfig.class).run((context) -> {
 			OpenAPI openApi = context.getBean(OpenAPI.class);
 			assertEquals("Custom API", openApi.getInfo().getTitle());
+		});
+	}
+
+	@Test
+	void accessInterceptorEnabledByDefault() {
+		this.contextRunner.run((context) -> {
+			assertTrue(context.getBean(JhelmRestProperties.class).getAccessInterceptor().isEnabled());
+			assertNotNull(context.getBean(AccessModeInterceptor.class));
+			assertTrue(context.containsBean("jhelmAccessModeWebMvcConfigurer"));
+		});
+	}
+
+	@Test
+	void accessInterceptorCanBeDisabled() {
+		this.contextRunner.withPropertyValues("jhelm.rest.access-interceptor.enabled=false").run((context) -> {
+			assertFalse(context.getBean(JhelmRestProperties.class).getAccessInterceptor().isEnabled());
+			assertFalse(context.containsBean("accessModeInterceptor"));
+			assertEquals(0, context.getBeansOfType(AccessModeInterceptor.class).size());
+			assertFalse(context.containsBean("jhelmAccessModeWebMvcConfigurer"));
 		});
 	}
 


### PR DESCRIPTION
When a host app embeds jhelm-rest under its OWN Spring Security, jhelm's `AccessModeInterceptor` double-gates mutating operations. This adds a first-class opt-out.

## Change (jhelm-rest only)
- New property **`jhelm.rest.access-interceptor.enabled`** (default `true`) — a nested `AccessInterceptor` holder on `JhelmRestProperties`.
- Both the `accessModeInterceptor` and `jhelmAccessModeWebMvcConfigurer` beans are now gated with `@ConditionalOnProperty(prefix="jhelm.rest", name="access-interceptor.enabled", havingValue="true", matchIfMissing=true)`. Set it to `false` and the interceptor is never registered, so mutating ops pass through to the host app's own security. Default behavior unchanged.
- Tests: `accessInterceptorEnabledByDefault` (present by default) and `accessInterceptorCanBeDisabled` (absent when `=false`).

Issue #774's second ask (`Release.MapConfig.getValues()`) needs no change — it already exists as a Lombok `@Value`-generated getter.

`verify` green: 90 tests, jacoco coverage met.

Closes #774.

🤖 Generated with [Claude Code](https://claude.com/claude-code)