### PR TITLE
fix(rest): resolve latest chart version on show when version omitted (#772)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/RepoManager.java
@@ -772,10 +772,36 @@ public class RepoManager {
 				chart = chart.substring(0, colon);
 			}
 			if (resolvedVersion == null || resolvedVersion.isBlank()) {
-				throw new IOException("version is required for repository chart pulls");
+				resolvedVersion = resolveLatestVersion(chart);
 			}
 			pull(chart, null, resolvedVersion, destDir, withProv);
 		}
+	}
+
+	/**
+	 * Resolves the newest available version of a {@code repo/chart} reference from that
+	 * repository's index, mirroring {@code helm show}/{@code helm pull} behaviour when no
+	 * explicit version is requested.
+	 * @param chartFullName the chart reference, expected as {@code repo/chart}
+	 * @return the newest version string for the chart
+	 * @throws IllegalArgumentException if the reference has no {@code repo/} prefix, or
+	 * the repository index contains no version of the chart (so no latest can be
+	 * resolved)
+	 * @throws IOException if the repository index cannot be read
+	 */
+	private String resolveLatestVersion(String chartFullName) throws IOException {
+		int slashIndex = chartFullName.lastIndexOf('/');
+		if (slashIndex < 0) {
+			throw new IllegalArgumentException("version is required for repository chart pulls: " + chartFullName);
+		}
+		String repoName = chartFullName.substring(0, slashIndex);
+		String chartName = chartFullName.substring(slashIndex + 1);
+		List<ChartVersion> versions = getChartVersions(repoName, chartName);
+		if (versions.isEmpty()) {
+			throw new IllegalArgumentException("No chart '" + chartName + "' found in repository '" + repoName
+					+ "'; cannot resolve latest version");
+		}
+		return versions.getFirst().getChartVersion();
 	}
 
 	public static String deriveOciFileName(String ociUrl) {

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/RepoManagerTest.java
@@ -304,6 +304,57 @@ class RepoManagerTest {
 	}
 
 	@Test
+	void testPullResolvesLatestVersionWhenOmitted() throws Exception {
+		Path cache = tempDir.resolve("cache");
+		RepoManager rm = newRepoManagerWithCache(cache);
+		rm.addRepo(RepositoryConfig.Repository.builder().name("myrepo").url("https://charts.example.com").build(),
+				false, false);
+		// Two versions in the index; the newer (1.5.0) is what "latest" must resolve to.
+		writeIndex(cache, "myrepo", """
+				  mychart:
+				  - version: 1.2.0
+				    urls:
+				    - "https://charts.example.com/mychart-1.2.0.tgz"
+				  - version: 1.5.0
+				    urls:
+				    - "https://charts.example.com/mychart-1.5.0.tgz"
+				""");
+		CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+		rm.setHttpClientForTest(mockClient);
+		byte[] tgz = createMinimalTgz();
+		when(mockClient.execute(isA(HttpGet.class), any(HttpClientResponseHandler.class)))
+			.thenAnswer(httpAnswer(200, tgz));
+
+		Path dest = tempDir.resolve("dest");
+		Files.createDirectories(dest);
+		// version omitted (null) => must resolve and pull the newest version.
+		rm.pull("myrepo/mychart", null, dest.toString());
+
+		assertTrue(dest.resolve("mychart-1.5.0.tgz").toFile().exists(),
+				"the newest version (1.5.0) must be the one resolved and pulled");
+		assertFalse(dest.resolve("mychart-1.2.0.tgz").toFile().exists(), "the older version must not be pulled");
+	}
+
+	@Test
+	void testPullUnknownChartWithoutVersionThrowsIllegalArgument() throws Exception {
+		Path cache = tempDir.resolve("cache");
+		RepoManager rm = newRepoManagerWithCache(cache);
+		rm.addRepo(RepositoryConfig.Repository.builder().name("myrepo").url("https://charts.example.com").build(),
+				false, false);
+		writeIndex(cache, "myrepo", """
+				  mychart:
+				  - version: 1.5.0
+				    urls:
+				    - "https://charts.example.com/mychart-1.5.0.tgz"
+				""");
+		// A chart the index does not contain must fail as a bad request
+		// (IllegalArgumentException),
+		// not a bare IOException that surfaces as HTTP 500.
+		assertThrows(IllegalArgumentException.class,
+				() -> rm.pull("myrepo/nope", null, tempDir.resolve("dest").toString()));
+	}
+
+	@Test
 	void testComputeFileSha256() throws IOException {
 		RepoManager repoManager = new RepoManager();
 		File file = tempDir.resolve("test.bin").toFile();

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ChartControllerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/controller/ChartControllerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -232,6 +233,33 @@ class ChartControllerTest {
 			.perform(get("/api/v1/charts/show").param("chartRef", "bitnami/nginx").accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(content().string("name: nginx"));
+	}
+
+	@Test
+	void showValuesWithoutVersionResolvesLatest() throws Exception {
+		stubPull();
+		when(this.showAction.showValues(anyString())).thenReturn("replicas: 1");
+
+		this.mockMvc
+			.perform(get("/api/v1/charts/show/values").param("chartRef", "bitnami/nginx")
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string("replicas: 1"));
+	}
+
+	@Test
+	void showValuesUnknownChartReturnsBadRequest() throws Exception {
+		// When no version resolves (repo has no such chart), RepoManager throws
+		// IllegalArgumentException, which must map to 400 — never a 500.
+		doThrow(new IllegalArgumentException(
+				"No chart 'nope' found in repository 'bitnami'; cannot resolve latest version"))
+			.when(this.repoManager)
+			.pull(anyString(), any(), anyString());
+
+		this.mockMvc
+			.perform(get("/api/v1/charts/show/values").param("chartRef", "bitnami/nope")
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest());
 	}
 
 	private void stubPull() throws Exception {


### PR DESCRIPTION
`GET {base}/charts/show/*` declared `version` optional, but a `repo/chart` ref with no version threw `IOException("version is required…")` at `RepoManager.java:791`, which fell through to a generic **HTTP 500**.

## Fix (jhelm-core `RepoManager.pull`)
- In the repo-chart (non-OCI) branch, when `version` is null/blank, resolve the **newest** version from that repo's index via the existing `getChartVersions(repo, chart)` (newest-first) — matching `helm show`/`helm pull`. OCI, local-path, and tar handling untouched. `ChartController` needed no change (already passes null through).
- Genuinely-unresolvable (no `repo/` prefix, or repo index has no such chart) now throws `IllegalArgumentException` → **400 Bad Request** via `JhelmRestExceptionHandler`, never 500.

## Tests
- jhelm-core `RepoManagerTest`: `testPullResolvesLatestVersionWhenOmitted` (two-version index → newer pulled), `testPullUnknownChartWithoutVersionThrowsIllegalArgument`.
- jhelm-rest `ChartControllerTest`: `showValuesWithoutVersionResolvesLatest` (200), `showValuesUnknownChartReturnsBadRequest` (400).

`verify` green: jhelm-rest 92 tests; both modules' jacoco met.

Closes #772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)