### PR TITLE
feat(core): per-request KubeService resolver for multi-cluster hosts (#773)

### DIFF
--- a/docs/modules/ROOT/pages/rest-api.adoc
+++ b/docs/modules/ROOT/pages/rest-api.adoc
@@ -600,6 +600,35 @@ public class CustomReleaseController {
 }
 ----
 
+=== Multi-cluster / per-request cluster selection
+
+By default jhelm-rest is *single-cluster*: every release action is wired to the one singleton
+`KubeService`, and endpoints scope only by namespace. A host that embeds jhelm against more than
+one cluster — addressing clusters by id — can route each request to a per-cluster `KubeService`
+without changing any controller or action.
+
+Supply a `KubeServiceResolver` bean (from `org.alexmond.jhelm.core.service`). It is a functional
+interface with a single `KubeService resolve()` method that inspects the current request — a
+header, a path variable, a thread-local, an id on the security context — and returns the
+`KubeService` for the target cluster. When such a bean is present, jhelm-core exposes a
+`@Primary` delegating `KubeService` that routes every call through the resolver, so the release
+API transparently operates on the selected cluster. With no resolver bean the delegating service
+is absent and the default single-cluster behavior is unchanged.
+
+[source,java]
+----
+@Bean
+@RequestScope
+public KubeServiceResolver kubeServiceResolver(HttpServletRequest request,
+        ClusterRegistry clusters) {
+    // e.g. read a cluster id from a request header and look up its KubeService
+    return () -> clusters.kubeServiceFor(request.getHeader("X-Cluster-Id"));
+}
+----
+
+The resolver is consulted once per `KubeService` method call, so a request-scoped bean picks the
+target cluster for the in-flight request. `resolve()` must return a non-`null` `KubeService`.
+
 == MCP Server
 
 In addition to the REST API, jhelm ships an https://modelcontextprotocol.io[Model Context

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/JhelmCoreAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
 import org.springframework.beans.factory.ObjectProvider;
 import lombok.extern.slf4j.Slf4j;
@@ -57,7 +58,9 @@ import org.alexmond.jhelm.core.service.ConfigServerClient;
 import org.alexmond.jhelm.core.service.ConfigServerValuesLoader;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.ValueEncryptor;
+import org.alexmond.jhelm.core.service.DelegatingKubeService;
 import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.core.service.KubeServiceResolver;
 import org.alexmond.jhelm.core.service.LifecycleListener;
 import org.alexmond.jhelm.core.service.PostRenderProcessor;
 import org.alexmond.jhelm.core.service.RegistryManager;
@@ -349,6 +352,25 @@ public class JhelmCoreAutoConfiguration {
 	@ConditionalOnMissingBean
 	public ChartLoader chartLoader() {
 		return new ChartLoader();
+	}
+
+	/**
+	 * Exposes a {@link Primary @Primary} delegating {@link KubeService} when — and only
+	 * when — the host has supplied a {@link KubeServiceResolver} bean. The delegating
+	 * service routes every call through the resolver, so the release actions operate on
+	 * the per-request cluster the host selects. With no resolver bean (the default,
+	 * including the CLI and single-cluster REST) this bean is absent, the
+	 * {@code @Primary} marker never applies, and the actions inject the real singleton
+	 * {@link KubeService} exactly as before. The bean depends only on the resolver — not
+	 * on the real {@link KubeService} — so no bean-definition cycle is introduced.
+	 * @param resolver the host-supplied per-request cluster selector
+	 * @return the delegating {@link KubeService} routed through the resolver
+	 */
+	@Bean
+	@ConditionalOnBean(KubeServiceResolver.class)
+	@Primary
+	public KubeService delegatingKubeService(KubeServiceResolver resolver) {
+		return new DelegatingKubeService(resolver);
 	}
 
 	/**

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/DelegatingKubeService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/DelegatingKubeService.java
@@ -1,0 +1,124 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.alexmond.jhelm.core.model.Capabilities;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ResourceStatus;
+
+/**
+ * A {@link KubeService} that owns no cluster connection of its own: it forwards every
+ * call to the {@link KubeService} returned by a {@link KubeServiceResolver}, resolved
+ * fresh on each invocation. This lets a multi-cluster host route each request to a
+ * per-cluster {@link KubeService} without the action layer knowing about cluster
+ * selection.
+ * <p>
+ * The resolver is consulted once per method call, so a request-scoped resolver picks the
+ * target cluster for the in-flight request. See {@link KubeServiceResolver} for the
+ * wiring and the single-cluster default.
+ */
+public class DelegatingKubeService implements KubeService {
+
+	private final KubeServiceResolver resolver;
+
+	/**
+	 * Creates a delegating service backed by the given resolver.
+	 * @param resolver supplies the target {@link KubeService} for each call; must not be
+	 * {@code null}
+	 */
+	public DelegatingKubeService(KubeServiceResolver resolver) {
+		this.resolver = resolver;
+	}
+
+	@Override
+	public void storeRelease(Release release) {
+		resolver.resolve().storeRelease(release);
+	}
+
+	@Override
+	public Optional<Release> getRelease(String name, String namespace) {
+		return resolver.resolve().getRelease(name, namespace);
+	}
+
+	@Override
+	public List<Release> listReleases(String namespace) {
+		return resolver.resolve().listReleases(namespace);
+	}
+
+	@Override
+	public List<Release> listAllReleases() {
+		return resolver.resolve().listAllReleases();
+	}
+
+	@Override
+	public List<Release> getReleaseHistory(String name, String namespace) {
+		return resolver.resolve().getReleaseHistory(name, namespace);
+	}
+
+	@Override
+	public void deleteReleaseHistory(String name, String namespace) {
+		resolver.resolve().deleteReleaseHistory(name, namespace);
+	}
+
+	@Override
+	public void pruneReleaseHistory(String name, String namespace, int maxHistory) {
+		resolver.resolve().pruneReleaseHistory(name, namespace, maxHistory);
+	}
+
+	@Override
+	public void ensureNamespace(String namespace) {
+		resolver.resolve().ensureNamespace(namespace);
+	}
+
+	@Override
+	public void apply(String namespace, String yamlContent) {
+		resolver.resolve().apply(namespace, yamlContent);
+	}
+
+	@Override
+	public void applyDryRun(String namespace, String yamlContent) {
+		resolver.resolve().applyDryRun(namespace, yamlContent);
+	}
+
+	@Override
+	public void delete(String namespace, String yamlContent) {
+		resolver.resolve().delete(namespace, yamlContent);
+	}
+
+	@Override
+	public void delete(String namespace, String yamlContent, CascadePolicy cascade) {
+		resolver.resolve().delete(namespace, yamlContent, cascade);
+	}
+
+	@Override
+	public void waitForDeleted(String namespace, String manifest, int timeoutSeconds) {
+		resolver.resolve().waitForDeleted(namespace, manifest, timeoutSeconds);
+	}
+
+	@Override
+	public void restartWorkloads(String namespace, String manifest) {
+		resolver.resolve().restartWorkloads(namespace, manifest);
+	}
+
+	@Override
+	public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) {
+		return resolver.resolve().getResourceStatuses(namespace, manifest);
+	}
+
+	@Override
+	public void waitForReady(String namespace, String manifest, int timeoutSeconds) {
+		resolver.resolve().waitForReady(namespace, manifest, timeoutSeconds);
+	}
+
+	@Override
+	public void waitForReady(String namespace, String manifest, int timeoutSeconds, boolean waitForJobs) {
+		resolver.resolve().waitForReady(namespace, manifest, timeoutSeconds, waitForJobs);
+	}
+
+	@Override
+	public Capabilities getCapabilities() {
+		return resolver.resolve().getCapabilities();
+	}
+
+}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeServiceResolver.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeServiceResolver.java
@@ -1,0 +1,36 @@
+package org.alexmond.jhelm.core.service;
+
+/**
+ * Per-request cluster-selection seam for hosts that embed jhelm against more than one
+ * Kubernetes cluster.
+ * <p>
+ * By default jhelm is single-cluster: every action bean is wired to the one singleton
+ * {@link KubeService}. A multi-cluster host (one that addresses clusters by id) can
+ * instead supply a {@code KubeServiceResolver} bean — typically request-scoped — that
+ * inspects the current request (a header, a path variable, a thread-local, an id on a
+ * {@code SecurityContext}, etc.) and returns the {@link KubeService} for the target
+ * cluster.
+ * <p>
+ * When a {@code KubeServiceResolver} bean is present, jhelm-core exposes a
+ * {@link org.springframework.context.annotation.Primary @Primary} delegating
+ * {@link KubeService} that routes every call through {@link #resolve()}, so the release
+ * actions transparently operate on the per-request cluster. With no resolver bean the
+ * delegating service is absent and the actions inject the real singleton
+ * {@link KubeService} exactly as before — the default single-cluster behavior is
+ * unchanged.
+ * <p>
+ * Implementations must return a non-{@code null} {@link KubeService}; {@link #resolve()}
+ * is invoked once per {@link KubeService} method call, so an implementation is free to
+ * return a different service on each invocation.
+ */
+@FunctionalInterface
+public interface KubeServiceResolver {
+
+	/**
+	 * Returns the {@link KubeService} for the cluster selected by the current request.
+	 * Invoked once per delegated {@link KubeService} method call.
+	 * @return the target cluster's {@link KubeService}, never {@code null}
+	 */
+	KubeService resolve();
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/config/JhelmCoreAutoConfigurationTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/config/JhelmCoreAutoConfigurationTest.java
@@ -10,8 +10,11 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import org.alexmond.jhelm.core.action.CreateAction;
 import org.alexmond.jhelm.core.action.GetAction;
 import org.alexmond.jhelm.core.action.SearchHubAction;
@@ -25,8 +28,10 @@ import org.alexmond.jhelm.core.action.TemplateAction;
 import org.alexmond.jhelm.core.action.UninstallAction;
 import org.alexmond.jhelm.core.action.UpgradeAction;
 import org.alexmond.jhelm.core.service.ChartLoader;
+import org.alexmond.jhelm.core.service.DelegatingKubeService;
 import org.alexmond.jhelm.core.service.Engine;
 import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.core.service.KubeServiceResolver;
 import org.alexmond.jhelm.core.service.RegistryManager;
 import org.alexmond.jhelm.core.service.RepoManager;
 import java.util.Map;
@@ -149,6 +154,45 @@ class JhelmCoreAutoConfigurationTest {
 	@Test
 	void jhelmMetricsBeanAbsentWithoutMeterRegistry() {
 		contextRunner.run((ctx) -> assertEquals(0, ctx.getBeanNamesForType(JhelmMetrics.class).length));
+	}
+
+	@Test
+	void testDelegatingKubeServiceAbsentWithoutResolver() {
+		// Default single-cluster behavior: with no resolver bean the delegating service
+		// is
+		// never created, so the KubeService the context resolves — and that the actions
+		// inject — is the real singleton exactly as before.
+		KubeService real = mock(KubeService.class);
+		contextRunner.withBean("realKubeService", KubeService.class, () -> real).run((ctx) -> {
+			assertEquals(0, ctx.getBeanNamesForType(DelegatingKubeService.class).length);
+			assertSame(real, ctx.getBean(KubeService.class));
+			assertNotNull(ctx.getBean(InstallAction.class));
+		});
+	}
+
+	@Test
+	void testResolverPresentRoutesActionsThroughDelegating() {
+		// With a resolver bean present, the @Primary delegating KubeService wins
+		// injection
+		// wherever a single KubeService is required (the actions), and every call routes
+		// through the host's resolver to the per-request cluster service.
+		KubeService real = mock(KubeService.class);
+		KubeService resolved = mock(KubeService.class);
+		KubeServiceResolver resolver = () -> resolved;
+		contextRunner.withBean("realKubeService", KubeService.class, () -> real)
+			.withBean(KubeServiceResolver.class, () -> resolver)
+			.run((ctx) -> {
+				// The @Primary bean a by-type single lookup resolves — the same
+				// resolution
+				// Spring uses to inject KubeService into the actions — is the delegating
+				// one.
+				KubeService primary = ctx.getBean(KubeService.class);
+				assertInstanceOf(DelegatingKubeService.class, primary);
+				assertNotNull(ctx.getBean(InstallAction.class));
+				// A call through the delegating service reaches the resolved service.
+				primary.listAllReleases();
+				verify(resolved).listAllReleases();
+			});
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/DelegatingKubeServiceTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/DelegatingKubeServiceTest.java
@@ -1,0 +1,91 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.alexmond.jhelm.core.model.Capabilities;
+import org.alexmond.jhelm.core.model.Release;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DelegatingKubeServiceTest {
+
+	private final KubeService delegate = mock(KubeService.class);
+
+	private final DelegatingKubeService service = new DelegatingKubeService(() -> this.delegate);
+
+	@Test
+	void testResolverConsultedOncePerCall() {
+		AtomicInteger resolveCount = new AtomicInteger();
+		KubeService target = mock(KubeService.class);
+		DelegatingKubeService counting = new DelegatingKubeService(() -> {
+			resolveCount.incrementAndGet();
+			return target;
+		});
+		counting.ensureNamespace("ns");
+		counting.ensureNamespace("ns");
+		assertEquals(2, resolveCount.get());
+		verify(target, times(2)).ensureNamespace("ns");
+	}
+
+	@Test
+	void testReadOperationsForwardAndReturn() {
+		Release release = mock(Release.class);
+		when(this.delegate.getRelease("r", "ns")).thenReturn(Optional.of(release));
+		when(this.delegate.listReleases("ns")).thenReturn(List.of(release));
+		when(this.delegate.listAllReleases()).thenReturn(List.of(release));
+		when(this.delegate.getReleaseHistory("r", "ns")).thenReturn(List.of(release));
+		when(this.delegate.getResourceStatuses("ns", "m")).thenReturn(List.of());
+		when(this.delegate.getCapabilities()).thenReturn(Capabilities.DEFAULT);
+
+		assertEquals(Optional.of(release), this.service.getRelease("r", "ns"));
+		assertEquals(List.of(release), this.service.listReleases("ns"));
+		assertEquals(List.of(release), this.service.listAllReleases());
+		assertEquals(List.of(release), this.service.getReleaseHistory("r", "ns"));
+		assertEquals(List.of(), this.service.getResourceStatuses("ns", "m"));
+		assertSame(Capabilities.DEFAULT, this.service.getCapabilities());
+	}
+
+	@Test
+	void testMutatingOperationsForward() {
+		Release release = mock(Release.class);
+		this.service.storeRelease(release);
+		this.service.deleteReleaseHistory("r", "ns");
+		this.service.pruneReleaseHistory("r", "ns", 3);
+		this.service.ensureNamespace("ns");
+		this.service.apply("ns", "yaml");
+		this.service.applyDryRun("ns", "yaml");
+		this.service.delete("ns", "yaml");
+		this.service.delete("ns", "yaml", CascadePolicy.FOREGROUND);
+		this.service.restartWorkloads("ns", "m");
+
+		verify(this.delegate).storeRelease(release);
+		verify(this.delegate).deleteReleaseHistory("r", "ns");
+		verify(this.delegate).pruneReleaseHistory("r", "ns", 3);
+		verify(this.delegate).ensureNamespace("ns");
+		verify(this.delegate).apply("ns", "yaml");
+		verify(this.delegate).applyDryRun("ns", "yaml");
+		verify(this.delegate).delete("ns", "yaml");
+		verify(this.delegate).delete("ns", "yaml", CascadePolicy.FOREGROUND);
+		verify(this.delegate).restartWorkloads("ns", "m");
+	}
+
+	@Test
+	void testWaitOperationsForward() {
+		this.service.waitForDeleted("ns", "m", 30);
+		this.service.waitForReady("ns", "m", 30);
+		this.service.waitForReady("ns", "m", 30, true);
+
+		verify(this.delegate).waitForDeleted("ns", "m", 30);
+		verify(this.delegate).waitForReady("ns", "m", 30);
+		verify(this.delegate).waitForReady("ns", "m", 30, true);
+	}
+
+}


### PR DESCRIPTION
jhelm-rest was single-cluster: `ReleaseController`'s action beans bind to one singleton `KubeService` and endpoints scope only by `namespace`, so a multi-cluster host (kweblens) couldn't reuse the release API. This adds a bounded, **non-breaking** seam for per-request cluster selection.

## Design
- **`KubeServiceResolver`** (new SPI, jhelm-core) — `@FunctionalInterface { KubeService resolve(); }`. A host supplies a (typically request-scoped) bean that reads a header/path/thread-local and returns the target cluster's `KubeService`.
- **`DelegatingKubeService`** (new, jhelm-core) — implements `KubeService`, forwards all 17 methods to `resolver.resolve().<method>(...)`, resolved fresh per call. (Release actions inject `KubeService`, not `AsyncKubeService`, so no async forwarding needed.)
- **Wiring** in `JhelmCoreAutoConfiguration`:
  ```java
  @Bean @ConditionalOnBean(KubeServiceResolver.class) @Primary
  KubeService delegatingKubeService(KubeServiceResolver resolver) { return new DelegatingKubeService(resolver); }
  ```

## Non-breaking
With **no** resolver bean (default — CLI and today's REST), the `@ConditionalOnBean` gate keeps the delegating bean absent and actions inject the real singleton `KubeService` exactly as before. With a resolver present, `@Primary` routes the actions through it. No bean cycle; the actions' `@ConditionalOnBean(KubeService.class)` gate stays satisfied either way.

## Tests + docs
- `testDelegatingKubeServiceAbsentWithoutResolver` (default), `testResolverPresentRoutesActionsThroughDelegating` (resolver routes; `verify(resolved).listAllReleases()`), `DelegatingKubeServiceTest` (all forwarders + resolve-once-per-call).
- Docs: "Multi-cluster / per-request cluster selection" in `rest-api.adoc` with a `@RequestScope` resolver sketch.

`verify` green: 896 tests; jacoco line + branch met.

Closes #773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)