### PR TITLE
feat(cli): 'jhelm outdated' chart version upgrade-check command (#771)

### DIFF
--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/JHelmCommand.java
@@ -9,6 +9,7 @@ import org.alexmond.jhelm.app.command.HistoryCommand;
 import org.alexmond.jhelm.app.command.InstallCommand;
 import org.alexmond.jhelm.app.command.LintCommand;
 import org.alexmond.jhelm.app.command.ListCommand;
+import org.alexmond.jhelm.app.command.OutdatedCommand;
 import org.alexmond.jhelm.app.command.PackageCommand;
 import org.alexmond.jhelm.app.command.PluginCommand;
 import org.alexmond.jhelm.app.command.PullCommand;
@@ -56,7 +57,8 @@ import picocli.CommandLine;
 				RollbackCommand.class, ShowCommand.class, GetCommand.class, TestCommand.class, DependencyCommand.class,
 				PullCommand.class, PushCommand.class, PackageCommand.class, VerifyCommand.class, LintCommand.class,
 				RepoCommand.class, RegistryCommand.class, PluginCommand.class, SearchCommand.class,
-				VersionCommand.class, EnvCommand.class, EncryptCommand.class, DecryptCommand.class })
+				OutdatedCommand.class, VersionCommand.class, EnvCommand.class, EncryptCommand.class,
+				DecryptCommand.class })
 public class JHelmCommand implements Callable<Integer> {
 
 	private final Environment environment;

--- a/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/OutdatedCommand.java
+++ b/jhelm-cli/src/main/java/org/alexmond/jhelm/app/command/OutdatedCommand.java
@@ -1,0 +1,127 @@
+package org.alexmond.jhelm.app.command;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import lombok.extern.slf4j.Slf4j;
+import org.alexmond.jhelm.app.output.CliOutput;
+import org.alexmond.jhelm.core.output.OutputFormat;
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.core.service.RepoManager.ChartMatch;
+import org.alexmond.jhelm.core.util.ChartVersions;
+import org.springframework.stereotype.Component;
+import picocli.CommandLine;
+
+/**
+ * Implements {@code jhelm outdated CHART}, reporting the latest version of a chart across
+ * every configured repository and — when a {@code --current} version is supplied —
+ * whether an upgrade is available.
+ *
+ * <p>
+ * This is a repository-only command: it consults {@link RepoManager} and never needs a
+ * Kubernetes cluster. Version precedence uses
+ * {@link ChartVersions#compare(String, String)} so the "upgrade available?" decision
+ * matches how jhelm selects the latest chart.
+ */
+@Component
+@CommandLine.Command(name = "outdated", mixinStandardHelpOptions = true,
+		description = "Report the latest available version of a chart across the configured repositories, "
+				+ "and whether an upgrade is available")
+@Slf4j
+public class OutdatedCommand implements Callable<Integer> {
+
+	private final RepoManager repoManager;
+
+	@CommandLine.Parameters(index = "0", description = "chart name (short name, without a repo/ prefix)")
+	private String chart;
+
+	@CommandLine.Option(names = { "-c", "--current" },
+			description = "current chart version to check for an available upgrade")
+	private String current;
+
+	@CommandLine.Option(names = { "-o", "--output" }, defaultValue = "table",
+			description = "output format: table, json, or yaml")
+	private String output;
+
+	/**
+	 * Creates the command.
+	 * @param repoManager the repository manager that resolves cross-repo chart versions
+	 */
+	public OutdatedCommand(RepoManager repoManager) {
+		this.repoManager = repoManager;
+	}
+
+	@Override
+	public Integer call() {
+		try {
+			Optional<ChartMatch> latest = repoManager.latestOf(chart);
+			ChartMatch match = latest.orElse(null);
+			switch (output.toLowerCase(Locale.ROOT)) {
+				case "json" -> System.out.println(OutputFormat.json(toRow(match)));
+				case "yaml" -> System.out.print(OutputFormat.yaml(toRow(match)));
+				default -> {
+					if (match == null) {
+						CliOutput.println(CliOutput.warn("No versions of \"" + chart
+								+ "\" found in the configured repositories. Make sure a repo containing it is added "
+								+ "(jhelm repo add) and updated (jhelm repo update)."));
+					}
+					else {
+						printTable(match);
+					}
+				}
+			}
+			return CommandLine.ExitCode.OK;
+		}
+		catch (IOException ex) {
+			CliOutput.errPrintln(CliOutput.error("Error looking up chart versions: " + ex.getMessage()));
+			return CommandLine.ExitCode.SOFTWARE;
+		}
+	}
+
+	private void printTable(ChartMatch match) {
+		String latestVersion = match.version().getChartVersion();
+		CliOutput.printf("%-30s %-16s %-16s %s%n", CliOutput.bold("NAME"), CliOutput.bold("LATEST VERSION"),
+				CliOutput.bold("APP VERSION"), CliOutput.bold("REPOSITORY"));
+		CliOutput.printf("%-30s %-16s %-16s %s%n", chart, nv(latestVersion), nv(match.version().getAppVersion()),
+				match.repoName());
+
+		if (current != null && !current.isBlank()) {
+			if (ChartVersions.compare(current, latestVersion) < 0) {
+				CliOutput.println(CliOutput
+					.success("Upgrade available: " + current + " -> " + latestVersion + " (" + match.repoName() + ")"));
+			}
+			else {
+				CliOutput.println(CliOutput.info("\"" + chart + "\" is up to date (" + current + ")"));
+			}
+		}
+	}
+
+	// Mirrors the fields the table shows, with an upgrade verdict when --current is set.
+	private Map<String, Object> toRow(ChartMatch match) {
+		Map<String, Object> row = new LinkedHashMap<>();
+		row.put("name", chart);
+		if (match == null) {
+			row.put("found", false);
+			return row;
+		}
+		String latestVersion = match.version().getChartVersion();
+		row.put("found", true);
+		row.put("latest_version", latestVersion);
+		row.put("app_version", match.version().getAppVersion());
+		row.put("repository", match.repoName());
+		if (current != null && !current.isBlank()) {
+			row.put("current_version", current);
+			row.put("upgrade_available", ChartVersions.compare(current, latestVersion) < 0);
+		}
+		return row;
+	}
+
+	private String nv(String s) {
+		return (s != null) ? s : "";
+	}
+
+}

--- a/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/OutdatedCommandTest.java
+++ b/jhelm-cli/src/test/java/org/alexmond/jhelm/app/command/OutdatedCommandTest.java
@@ -1,0 +1,116 @@
+package org.alexmond.jhelm.app.command;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Optional;
+
+import org.alexmond.jhelm.core.service.RepoManager;
+import org.alexmond.jhelm.core.service.RepoManager.ChartMatch;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+class OutdatedCommandTest {
+
+	@Mock
+	private RepoManager repoManager;
+
+	private OutdatedCommand command;
+
+	private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+	private final PrintStream originalOut = System.out;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		command = new OutdatedCommand(repoManager);
+		System.setOut(new PrintStream(outputStream));
+	}
+
+	@AfterEach
+	void tearDown() {
+		System.setOut(originalOut);
+	}
+
+	private static ChartMatch match(String repo, String version) {
+		return new ChartMatch(repo, new RepoManager.ChartVersion("nginx", version, "1.21.0", "Nginx web server"));
+	}
+
+	@Test
+	void testReportsLatestVersion() throws IOException {
+		when(repoManager.latestOf(anyString())).thenReturn(Optional.of(match("bitnami", "1.2.0")));
+
+		int exit = new CommandLine(command).execute("nginx");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		String out = outputStream.toString();
+		assertTrue(out.contains("LATEST VERSION"), out);
+		assertTrue(out.contains("1.2.0"), out);
+		assertTrue(out.contains("bitnami"), out);
+	}
+
+	@Test
+	void testUpgradeAvailable() throws IOException {
+		when(repoManager.latestOf(anyString())).thenReturn(Optional.of(match("bitnami", "1.2.0")));
+
+		int exit = new CommandLine(command).execute("nginx", "--current", "1.0.0");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		String out = outputStream.toString();
+		assertTrue(out.contains("Upgrade available: 1.0.0 -> 1.2.0 (bitnami)"), out);
+	}
+
+	@Test
+	void testUpToDate() throws IOException {
+		when(repoManager.latestOf(anyString())).thenReturn(Optional.of(match("bitnami", "1.2.0")));
+
+		int exit = new CommandLine(command).execute("nginx", "--current", "1.2.0");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		String out = outputStream.toString();
+		assertTrue(out.contains("up to date"), out);
+		assertTrue(!out.contains("Upgrade available"), out);
+	}
+
+	@Test
+	void testNoVersionsFound() throws IOException {
+		when(repoManager.latestOf(anyString())).thenReturn(Optional.empty());
+
+		int exit = new CommandLine(command).execute("nonexistent");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		assertTrue(outputStream.toString().contains("No versions of \"nonexistent\""), outputStream.toString());
+	}
+
+	@Test
+	void testJsonOutputWithUpgradeVerdict() throws IOException {
+		when(repoManager.latestOf(anyString())).thenReturn(Optional.of(match("bitnami", "1.2.0")));
+
+		int exit = new CommandLine(command).execute("nginx", "--current", "1.0.0", "-o", "json");
+
+		assertEquals(CommandLine.ExitCode.OK, exit);
+		String out = outputStream.toString();
+		assertTrue(out.contains("\"latest_version\":\"1.2.0\""), out);
+		assertTrue(out.contains("\"upgrade_available\":true"), out);
+	}
+
+	@Test
+	void testError() throws IOException {
+		when(repoManager.latestOf(anyString())).thenThrow(new IOException("boom"));
+
+		int exit = new CommandLine(command).execute("nginx");
+
+		assertEquals(CommandLine.ExitCode.SOFTWARE, exit);
+	}
+
+}


### PR DESCRIPTION
CLI follow-up to #771 — surfaces the cross-repo "latest version of chart X" / upgrade-available check on the command line (building on the `RepoManager.latestOf` / `ChartVersions.compare` API added in #771).

## Command
`jhelm outdated CHART` — a new top-level repo-only subcommand (`OutdatedCommand`, no cluster needed).
- `CHART` (positional) — short chart name (no `repo/` prefix)
- `-c, --current <version>` — optional installed version; enables the upgrade check
- `-o, --output <table|json|yaml>` — default `table`

Examples:
- `jhelm outdated nginx` → prints `NAME / LATEST VERSION / APP VERSION / REPOSITORY`
- `jhelm outdated nginx --current 1.0.0` → `Upgrade available: 1.0.0 -> 1.2.0 (bitnami)`
- `jhelm outdated nginx --current 1.2.0` → `"nginx" is up to date (1.2.0)`
- No match → yellow warning, exit OK. JSON/YAML rows include `found`, `latest_version`, `app_version`, `repository`, and `current_version`/`upgrade_available` when `--current` is set.

Constructor-injected `RepoManager` (same pattern as `RepoCommand`); output via `CliOutput`/`OutputFormat`; registered in `JHelmCommand` subcommands.

## Test
`OutdatedCommandTest` — 6 tests (latest, upgrade-available, up-to-date, no-match, json verdict, error) via `CommandLine` with a stubbed `RepoManager`, mirroring `RepoCommandTest`.

`verify` green: 335 tests; jacoco met.

Closes #771 (CLI follow-up; library part landed in #791).

🤖 Generated with [Claude Code](https://claude.com/claude-code)