### PR TITLE
feat(kube): jhelm.kubernetes.backend=none to run with no ambient backend (#796)

### DIFF
--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/OnKubeBackendCondition.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/OnKubeBackendCondition.java
@@ -16,7 +16,11 @@ import org.springframework.util.ClassUtils;
  * backend, and only when its client library is on the classpath;</li>
  * <li>{@code auto} (the default) activates the first backend, in {@link KubeBackend}
  * declaration order, whose client library is present — so {@code client-java} is
- * preferred over Fabric8 when both are available.</li>
+ * preferred over Fabric8 when both are available;</li>
+ * <li>{@code none} activates no backend at all, so jhelm-kube builds no ambient
+ * {@code KubernetesClient} and no default {@code KubeService} /
+ * {@code KubernetesProvider} even when a client library is on the classpath — the host
+ * supplies its own {@code KubeService}(s).</li>
  * </ul>
  */
 public class OnKubeBackendCondition implements Condition {
@@ -25,10 +29,17 @@ public class OnKubeBackendCondition implements Condition {
 
 	private static final String AUTO = "auto";
 
+	private static final String NONE = "none";
+
 	@Override
 	public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
 		KubeBackend target = targetBackend(metadata);
 		String configured = context.getEnvironment().getProperty(PROPERTY, AUTO).trim().toLowerCase(Locale.ROOT);
+		if (NONE.equals(configured)) {
+			// No ambient backend: the host brings its own KubeService(s). Suppress every
+			// backend-gated bean regardless of what client libraries are present.
+			return false;
+		}
 		ClassLoader classLoader = context.getClassLoader();
 		if (!AUTO.equals(configured)) {
 			// Explicit selection: only the named backend, and only if its library is

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
@@ -44,7 +44,9 @@ public class JhelmKubernetesProperties {
 	 * Selects the Kubernetes client backend. {@code auto} (the default) picks the
 	 * preferred backend among those on the classpath (the official {@code client-java}
 	 * over Fabric8 when both are present); {@code client-java} or {@code fabric8} force a
-	 * specific backend, which then requires that client library to be present. jhelm
+	 * specific backend, which then requires that client library to be present;
+	 * {@code none} builds no ambient Kubernetes client and no default {@code KubeService}
+	 * even when a client library is on the classpath — the host supplies its own. jhelm
 	 * ships neither client itself — the consumer puts one on the classpath. See
 	 * {@code ClientJavaKubeConfiguration} / {@code Fabric8KubeConfiguration}.
 	 */

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/KubeBackendSelectionTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/KubeBackendSelectionTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
@@ -77,6 +78,21 @@ class KubeBackendSelectionTest {
 			.withPropertyValues("jhelm.kubernetes.backend=fabric8", "jhelm.kubernetes.retry.enabled=false")
 			.withBean(KubernetesClient.class, () -> mock(KubernetesClient.class))
 			.run((ctx) -> assertInstanceOf(Fabric8AsyncKubeService.class, ctx.getBean(KubeService.class)));
+	}
+
+	@Test
+	void noneBuildsNoAmbientBackendEvenWithBothClientsPresent() {
+		// Both client libraries are on the test classpath, yet backend=none must suppress
+		// every ambient backend bean so the host can supply its own KubeService(s).
+		this.contextRunner.withPropertyValues("jhelm.kubernetes.backend=none").run((ctx) -> {
+			assertEquals(0, ctx.getBeanNamesForType(KubeService.class).length,
+					"backend=none must not create a default KubeService");
+			assertEquals(0, ctx.getBeanNamesForType(KubernetesProvider.class).length,
+					"backend=none must not create a default KubernetesProvider");
+			assertFalse(ctx.containsBean("kubeClient"), "backend=none must not create the client-java KubeClient");
+			assertFalse(ctx.containsBean("kubernetesClient"),
+					"backend=none must not create the Fabric8 KubernetesClient");
+		});
 	}
 
 }


### PR DESCRIPTION
A multi-cluster host that supplies its own per-cluster `KubeService`s (via #795's factory / #773's `KubeServiceResolver`) doesn't want jhelm's default ambient client/`KubeService`. The only prior opt-out was excluding `JhelmKubeAutoConfiguration` by class name — brittle.

## Change
`OnKubeBackendCondition`: a `jhelm.kubernetes.backend=none` short-circuit returns `false` for both backends, so every ambient bean (client, `KubeService`, `KubernetesProvider`, health indicator — all inside the `@ConditionalOnKubeBackend`-gated configs) is suppressed. Core actions (`@ConditionalOnBean(KubeService.class)`) then simply don't register. The `backend` javadoc documents `none`.

## Test
`KubeBackendSelectionTest.noneBuildsNoAmbientBackendEvenWithBothClientsPresent` — with both client libs on the classpath and `backend=none`, no `KubeService`/`KubernetesProvider`/client beans exist.

`verify` green. Only 3 files (condition, properties, test); the `*KubeConfiguration` classes untouched.

Closes #796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)