### PR TITLE
feat(kube): public KubeServices/KubernetesProviders factories from a supplied client (#795)

### DIFF
--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/KubeServices.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/KubeServices.java
@@ -1,0 +1,110 @@
+package org.alexmond.jhelm.kube;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.kubernetes.client.openapi.ApiClient;
+import org.alexmond.jhelm.core.metrics.JhelmMetrics;
+import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
+import org.alexmond.jhelm.kube.service.internal.AsyncHelmKubeService;
+import org.alexmond.jhelm.kube.service.internal.Fabric8AsyncKubeService;
+import org.alexmond.jhelm.kube.service.internal.KubeClient;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.ObjectProvider;
+
+/**
+ * Factory for building a fully-decorated {@link KubeService} from a Kubernetes client the
+ * caller already owns. This is the supported way for a host that manages its own clients
+ * (for example a multi-cluster host holding one client per cluster) to obtain a
+ * {@link KubeService} that behaves identically to the auto-configured one — the same
+ * module-wide decorator chain (retry, metrics) is applied — without depending on the
+ * auto-configuration or on any {@code ...service.internal} type.
+ *
+ * <p>
+ * Pair this with the {@code KubeServiceResolver} multi-cluster routing seam (issue #773):
+ * build one {@link KubeService} per cluster here, then register each with the resolver so
+ * requests are routed to the right cluster.
+ *
+ * <p>
+ * Two client backends are supported: the Fabric8 client ({@link #fabric8}) and the
+ * official Kubernetes Java client ({@link #clientJava}). Each has a convenience overload
+ * that uses default properties (retry enabled) and no metrics, and a full-control
+ * overload accepting explicit {@link JhelmKubernetesProperties} and a nullable
+ * {@link JhelmMetrics}.
+ */
+public final class KubeServices {
+
+	private KubeServices() {
+	}
+
+	/**
+	 * Builds a decorated {@link KubeService} from a Fabric8 client, using default
+	 * properties (retry enabled) and no metrics.
+	 * @param client the Fabric8 Kubernetes client to back the service
+	 * @return the decorated Kubernetes service
+	 */
+	public static KubeService fabric8(KubernetesClient client) {
+		return fabric8(client, new JhelmKubernetesProperties(), null);
+	}
+
+	/**
+	 * Builds a decorated {@link KubeService} from a Fabric8 client with full control over
+	 * the decorator chain.
+	 * @param client the Fabric8 Kubernetes client to back the service
+	 * @param props the Kubernetes configuration properties, providing the retry settings
+	 * @param metrics the metrics used to enable operation timing and counting, or
+	 * {@code null} to disable metrics
+	 * @return the (possibly decorated) Kubernetes service
+	 */
+	public static KubeService fabric8(KubernetesClient client, JhelmKubernetesProperties props, JhelmMetrics metrics) {
+		return KubeServiceDecorators.decorate(new Fabric8AsyncKubeService(client), props, metricsProvider(metrics));
+	}
+
+	/**
+	 * Builds a decorated {@link KubeService} from an official-client {@link ApiClient},
+	 * using default properties (retry enabled) and no metrics.
+	 * @param apiClient the official Kubernetes Java client to back the service
+	 * @return the decorated Kubernetes service
+	 */
+	public static KubeService clientJava(ApiClient apiClient) {
+		return clientJava(apiClient, new JhelmKubernetesProperties(), null);
+	}
+
+	/**
+	 * Builds a decorated {@link KubeService} from an official-client {@link ApiClient}
+	 * with full control over the decorator chain.
+	 * @param apiClient the official Kubernetes Java client to back the service
+	 * @param props the Kubernetes configuration properties, providing the retry settings
+	 * @param metrics the metrics used to enable operation timing and counting, or
+	 * {@code null} to disable metrics
+	 * @return the (possibly decorated) Kubernetes service
+	 */
+	public static KubeService clientJava(ApiClient apiClient, JhelmKubernetesProperties props, JhelmMetrics metrics) {
+		AsyncHelmKubeService base = new AsyncHelmKubeService(new KubeClient(apiClient));
+		return KubeServiceDecorators.decorate(base, props, metricsProvider(metrics));
+	}
+
+	/**
+	 * Adapts a nullable {@link JhelmMetrics} to the {@link ObjectProvider} expected by
+	 * {@link KubeServiceDecorators#decorate}, which enables metrics only when
+	 * {@link ObjectProvider#getIfAvailable()} returns a non-null instance.
+	 * @param metrics the metrics instance, or {@code null}
+	 * @return a provider whose {@code getIfAvailable()} yields the given instance
+	 */
+	private static ObjectProvider<JhelmMetrics> metricsProvider(JhelmMetrics metrics) {
+		return new ObjectProvider<>() {
+			@Override
+			public JhelmMetrics getObject() {
+				if (metrics == null) {
+					throw new NoSuchBeanDefinitionException(JhelmMetrics.class);
+				}
+				return metrics;
+			}
+
+			@Override
+			public JhelmMetrics getIfAvailable() {
+				return metrics;
+			}
+		};
+	}
+
+}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/KubernetesProviders.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/KubernetesProviders.java
@@ -1,0 +1,50 @@
+package org.alexmond.jhelm.kube;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.kubernetes.client.openapi.ApiClient;
+import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.gotemplate.helm.functions.KubernetesProvider;
+import org.alexmond.jhelm.kube.service.internal.Fabric8KubernetesProvider;
+import org.alexmond.jhelm.kube.service.internal.KubeClient;
+import org.alexmond.jhelm.kube.service.internal.KubernetesClientProvider;
+
+/**
+ * Factory for building a cluster-backed {@link KubernetesProvider} (the
+ * {@code lookup}/{@code kubeVersion} SPI) from a Kubernetes client the caller already
+ * owns. This is the supported way for a host that manages its own clients (for example a
+ * multi-cluster host holding one client per cluster) to obtain a provider without
+ * depending on the auto-configuration or on any {@code ...service.internal} type.
+ *
+ * <p>
+ * Pair this with the {@code KubeServiceResolver} multi-cluster routing seam (issue #773):
+ * build one provider per cluster here alongside the matching {@link KubeService} from
+ * {@link KubeServices}, so template {@code lookup} queries hit the right cluster.
+ *
+ * @see KubeServices
+ */
+public final class KubernetesProviders {
+
+	private KubernetesProviders() {
+	}
+
+	/**
+	 * Builds a {@link KubernetesProvider} backed by a Fabric8 client.
+	 * @param client the Fabric8 Kubernetes client used to look up resources and query
+	 * cluster version information
+	 * @return the cluster-backed lookup provider
+	 */
+	public static KubernetesProvider fabric8(KubernetesClient client) {
+		return new Fabric8KubernetesProvider(client);
+	}
+
+	/**
+	 * Builds a {@link KubernetesProvider} backed by the official Kubernetes Java client.
+	 * @param apiClient the official Kubernetes Java client used to look up resources and
+	 * query cluster version information
+	 * @return the cluster-backed lookup provider
+	 */
+	public static KubernetesProvider clientJava(ApiClient apiClient) {
+		return new KubernetesClientProvider(new KubeClient(apiClient));
+	}
+
+}

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/KubeServicesTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/KubeServicesTest.java
@@ -1,0 +1,85 @@
+package org.alexmond.jhelm.kube;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.kubernetes.client.openapi.ApiClient;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.alexmond.jhelm.core.metrics.JhelmMetrics;
+import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.gotemplate.helm.functions.KubernetesProvider;
+import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
+import org.alexmond.jhelm.kube.service.internal.AsyncHelmKubeService;
+import org.alexmond.jhelm.kube.service.internal.Fabric8AsyncKubeService;
+import org.alexmond.jhelm.kube.service.internal.Fabric8KubernetesProvider;
+import org.alexmond.jhelm.kube.service.internal.KubernetesClientProvider;
+import org.alexmond.jhelm.kube.service.internal.ObservableKubeService;
+import org.alexmond.jhelm.kube.service.internal.RetryableKubeService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Verifies the public {@link KubeServices} and {@link KubernetesProviders} factories
+ * build the same decorator chain as the auto-configuration from a caller-supplied client,
+ * using mocked clients (a live cluster is unavailable in unit tests).
+ */
+class KubeServicesTest {
+
+	private static JhelmKubernetesProperties retryDisabled() {
+		JhelmKubernetesProperties props = new JhelmKubernetesProperties();
+		props.getRetry().setEnabled(false);
+		return props;
+	}
+
+	@Test
+	void fabric8IsRetryableByDefault() {
+		KubeService service = KubeServices.fabric8(mock(KubernetesClient.class));
+		assertInstanceOf(RetryableKubeService.class, service);
+	}
+
+	@Test
+	void fabric8IsObservableWithMetrics() {
+		JhelmMetrics metrics = new JhelmMetrics(new SimpleMeterRegistry());
+		KubeService service = KubeServices.fabric8(mock(KubernetesClient.class), new JhelmKubernetesProperties(),
+				metrics);
+		assertInstanceOf(ObservableKubeService.class, service);
+	}
+
+	@Test
+	void fabric8IsBareBaseWhenRetryDisabled() {
+		KubeService service = KubeServices.fabric8(mock(KubernetesClient.class), retryDisabled(), null);
+		assertInstanceOf(Fabric8AsyncKubeService.class, service);
+	}
+
+	@Test
+	void clientJavaIsRetryableByDefault() {
+		KubeService service = KubeServices.clientJava(mock(ApiClient.class));
+		assertInstanceOf(RetryableKubeService.class, service);
+	}
+
+	@Test
+	void clientJavaIsObservableWithMetrics() {
+		JhelmMetrics metrics = new JhelmMetrics(new SimpleMeterRegistry());
+		KubeService service = KubeServices.clientJava(mock(ApiClient.class), new JhelmKubernetesProperties(), metrics);
+		assertInstanceOf(ObservableKubeService.class, service);
+	}
+
+	@Test
+	void clientJavaIsBareBaseWhenRetryDisabled() {
+		KubeService service = KubeServices.clientJava(mock(ApiClient.class), retryDisabled(), null);
+		assertInstanceOf(AsyncHelmKubeService.class, service);
+	}
+
+	@Test
+	void providersFabric8ReturnsFabric8Provider() {
+		KubernetesProvider provider = KubernetesProviders.fabric8(mock(KubernetesClient.class));
+		assertInstanceOf(Fabric8KubernetesProvider.class, provider);
+	}
+
+	@Test
+	void providersClientJavaReturnsClientJavaProvider() {
+		KubernetesProvider provider = KubernetesProviders.clientJava(mock(ApiClient.class));
+		assertInstanceOf(KubernetesClientProvider.class, provider);
+	}
+
+}


### PR DESCRIPTION
A multi-cluster host holds one client per cluster and needs to build a fully-decorated `KubeService` per cluster from a client it already owns — without reaching into `org.alexmond.jhelm.kube.service.internal`.

## New public API (package `org.alexmond.jhelm.kube`)
```java
KubeServices.fabric8(kubernetesClient);                    // + (client, props, metrics)
KubeServices.clientJava(apiClient);                        // + (apiClient, props, metrics)
KubernetesProviders.fabric8(kubernetesClient);
KubernetesProviders.clientJava(apiClient);
```
- Applies the SAME retry+metrics decorator chain as the autoconfigured bean (`KubeServiceDecorators.decorate`). The no-props overloads use default `JhelmKubernetesProperties` (retry on); the full overloads take props + a nullable `JhelmMetrics`.
- Placed in the same package as `KubeServiceDecorators`, so **no visibility changes** and **no internal type on any public signature** (signatures use only `KubeService`, `KubernetesProvider`, `KubernetesClient`, `ApiClient`, `JhelmKubernetesProperties`, `JhelmMetrics`).
- Pairs with `KubeServiceResolver` (#773): the host feeds per-cluster `KubeService`s built here into its resolver.

## Tests
`KubeServicesTest` (8): retry-by-default, observable-with-metrics, bare-base-when-retry-disabled for both backends; provider factories return the right types.

`verify` green: 296 unit + 19 integration tests; jacoco/PMD/checkstyle clean.

Closes #795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)