### PR TITLE
feat(kube): opt out of the Kubernetes health indicator via jhelm.kubernetes.health.enabled (#800)

### DIFF
--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/ClientJavaKubeConfiguration.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/ClientJavaKubeConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -161,6 +162,7 @@ class ClientJavaKubeConfiguration {
 		@Bean
 		@ConditionalOnBean(KubeClient.class)
 		@ConditionalOnMissingBean(KubernetesHealthIndicator.class)
+		@ConditionalOnProperty(prefix = "jhelm.kubernetes", name = "health.enabled", matchIfMissing = true)
 		KubernetesHealthIndicator kubernetesHealthIndicator(KubeClient kubeClient) {
 			return new KubernetesHealthIndicator(kubeClient);
 		}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
@@ -56,6 +56,11 @@ public class JhelmKubernetesProperties {
 	private Retry retry = new Retry();
 
 	/**
+	 * Kubernetes health indicator configuration.
+	 */
+	private Health health = new Health();
+
+	/**
 	 * Retry configuration for transient Kubernetes API failures, controlling the maximum
 	 * number of attempts and the exponential backoff between them.
 	 */
@@ -94,6 +99,34 @@ public class JhelmKubernetesProperties {
 		 * Maximum interval between retries in milliseconds.
 		 */
 		private long maxIntervalMs = 10000;
+
+	}
+
+	/**
+	 * Health indicator configuration for the Kubernetes integration. Controls whether the
+	 * {@code KubernetesHealthIndicator} — which probes the ambient client's cluster
+	 * connectivity and contributes to the aggregate {@code /actuator/health} — is
+	 * registered when Spring Boot Actuator is on the classpath. A host that embeds jhelm
+	 * but does not want jhelm's single-cluster health folded into its own aggregate (e.g.
+	 * a multi-cluster application) can turn it off even when an ambient client exists.
+	 */
+	@Getter
+	@Setter
+	public static class Health {
+
+		/**
+		 * Creates the health settings with default values.
+		 */
+		@SuppressWarnings("PMD.UnnecessaryConstructor")
+		public Health() {
+		}
+
+		/**
+		 * Whether the Kubernetes health indicator is registered. Defaults to
+		 * {@code true}; set to {@code false} to opt out even when a Kubernetes client is
+		 * present.
+		 */
+		private boolean enabled = true;
 
 	}
 

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfigurationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/JhelmKubeAutoConfigurationTest.java
@@ -7,14 +7,17 @@ import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.kube.service.internal.HelmKubeService;
 import org.alexmond.jhelm.kube.service.internal.KubeClient;
+import org.alexmond.jhelm.kube.service.internal.KubernetesHealthIndicator;
 import org.alexmond.jhelm.kube.service.internal.ObservableKubeService;
 import org.alexmond.jhelm.kube.service.internal.RetryableKubeService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class JhelmKubeAutoConfigurationTest {
@@ -75,6 +78,30 @@ class JhelmKubeAutoConfigurationTest {
 			// wrapper)
 			assertInstanceOf(RetryableKubeService.class, kubeService);
 		});
+	}
+
+	// A KubeClient bean is supplied directly (rather than only an ApiClient) so the
+	// indicator's @ConditionalOnBean(KubeClient) precondition is met regardless of
+	// bean-definition ordering, isolating the jhelm.kubernetes.health.enabled toggle.
+	@Test
+	void testHealthIndicatorRegisteredByDefault() {
+		KubeClient kubeClient = new KubeClient(mock(ApiClient.class));
+		contextRunner.withBean(KubeClient.class, () -> kubeClient).run((ctx) -> {
+			assertTrue(ctx.containsBean("kubernetesHealthIndicator"));
+			assertNotNull(ctx.getBean(KubernetesHealthIndicator.class));
+		});
+	}
+
+	@Test
+	void testHealthIndicatorAbsentWhenDisabled() {
+		KubeClient kubeClient = new KubeClient(mock(ApiClient.class));
+		contextRunner.withBean(KubeClient.class, () -> kubeClient)
+			.withPropertyValues("jhelm.kubernetes.health.enabled=false")
+			.run((ctx) -> {
+				assertNotNull(ctx.getBean(KubeClient.class));
+				assertFalse(ctx.containsBean("kubernetesHealthIndicator"));
+				assertTrue(ctx.getBeansOfType(KubernetesHealthIndicator.class).isEmpty());
+			});
 	}
 
 	@Test


### PR DESCRIPTION
`KubernetesHealthIndicator` health-checks a single ambient client. A multi-cluster embed (which brings its own per-cluster clients, often with `backend=none`) doesn't want that one client's health standing in for "Kubernetes" in its aggregate `/actuator/health`.

## Change
- New nested `Health` holder on `JhelmKubernetesProperties` → `jhelm.kubernetes.health.enabled` (default `true`), mirroring the `Retry` holder.
- `@ConditionalOnProperty(prefix="jhelm.kubernetes", name="health.enabled", matchIfMissing=true)` on the `kubernetesHealthIndicator` bean. Absent → active as before; `=false` → not registered.
- (Already off when there's no ambient client via `@ConditionalOnBean(KubeClient.class)`; this adds the explicit toggle for when a client exists.)

## Note
Fabric8 has no health indicator (the indicator is intrinsically client-java-specific) — the `Health` holder is backend-neutral and would serve a future Fabric8 indicator if added.

## Tests
`testHealthIndicatorRegisteredByDefault` / `testHealthIndicatorAbsentWhenDisabled` in `JhelmKubeAutoConfigurationTest`. `verify` green.

Closes #800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)