### PR TITLE
fix(rest): map KubernetesOperationException statusCode to HTTP; enrich list error messages (#797)

### DIFF
--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/Fabric8KubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/Fabric8KubeService.java
@@ -181,7 +181,8 @@ public class Fabric8KubeService implements KubeService {
 			secrets = this.client.secrets().inAnyNamespace().withLabel(OWNER_LABEL, OWNER_VALUE).list().getItems();
 		}
 		catch (KubernetesClientException ex) {
-			throw new KubernetesOperationException("Failed to list all releases", ex, ex.getCode());
+			throw new KubernetesOperationException("Failed to list all releases" + describeClientFailure(ex), ex,
+					ex.getCode());
 		}
 		return toLatestReleases(secrets);
 	}
@@ -257,8 +258,21 @@ public class Fabric8KubeService implements KubeService {
 			return this.client.secrets().inNamespace(namespace).withLabels(selector).list().getItems();
 		}
 		catch (KubernetesClientException ex) {
-			throw new KubernetesOperationException("Failed to " + operation, ex, ex.getCode());
+			throw new KubernetesOperationException("Failed to " + operation + describeClientFailure(ex), ex,
+					ex.getCode());
 		}
+	}
+
+	/**
+	 * Builds a human-readable suffix describing a {@link KubernetesClientException},
+	 * appending the client's message so the cluster's own reason (an RBAC denial, a
+	 * rate-limit note) is visible on the thrown message rather than only on the cause.
+	 * @param ex the fabric8 client exception
+	 * @return a suffix beginning with {@code ": "}, or an empty string if no detail is
+	 * available
+	 */
+	private static String describeClientFailure(KubernetesClientException ex) {
+		return (ex.getMessage() != null && !ex.getMessage().isBlank()) ? ": " + ex.getMessage() : "";
 	}
 
 	private static Map<String, String> ownerNameSelector(String name) {

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
@@ -321,7 +321,7 @@ public class HelmKubeService implements KubeService {
 			return api.listNamespacedSecret(namespace).labelSelector(labelSelector).execute();
 		}
 		catch (ApiException ex) {
-			throw new KubernetesOperationException("Failed to " + operation, ex, ex.getCode());
+			throw new KubernetesOperationException("Failed to " + operation + describeApiFailure(ex), ex, ex.getCode());
 		}
 	}
 
@@ -334,8 +334,29 @@ public class HelmKubeService implements KubeService {
 			return api.listSecretForAllNamespaces().labelSelector(labelSelector).execute();
 		}
 		catch (ApiException ex) {
-			throw new KubernetesOperationException("Failed to " + operation, ex, ex.getCode());
+			throw new KubernetesOperationException("Failed to " + operation + describeApiFailure(ex), ex, ex.getCode());
 		}
+	}
+
+	/**
+	 * Builds a human-readable suffix describing an {@link ApiException}, appending the
+	 * client's message and, when present, the raw API response body so the cluster's own
+	 * reason (an RBAC denial, a rate-limit note) is visible on the thrown message rather
+	 * than only on the cause.
+	 * @param ex the kubernetes-client API exception
+	 * @return a suffix beginning with {@code ": "}, or an empty string if no detail is
+	 * available
+	 */
+	private static String describeApiFailure(ApiException ex) {
+		StringBuilder detail = new StringBuilder();
+		if (ex.getMessage() != null && !ex.getMessage().isBlank()) {
+			detail.append(": ").append(ex.getMessage());
+		}
+		String body = ex.getResponseBody();
+		if (body != null && !body.isBlank()) {
+			detail.append(" (").append(body).append(')');
+		}
+		return detail.toString();
 	}
 
 	/**

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/Fabric8KubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/Fabric8KubeServiceTest.java
@@ -1,0 +1,73 @@
+package org.alexmond.jhelm.kube.service.internal;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import org.alexmond.jhelm.core.exception.KubernetesOperationException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the Fabric8 backend's error translation, verifying a list failure keeps
+ * the cluster's HTTP status code and surfaces the cluster reason on the thrown message
+ * (issue #797). The list query itself is exercised by the cluster-gated integration test;
+ * here only the {@link KubernetesClientException} catch/enrich path is asserted. The
+ * fluent Secrets DSL returns self-types, so one mock stands in for the whole
+ * {@code secrets().inNamespace(..).withLabels(..)} chain, with {@code list()} stubbed to
+ * fail.
+ */
+class Fabric8KubeServiceTest {
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private MixedOperation<Secret, SecretList, Resource<Secret>> failingSecrets(RuntimeException failure) {
+		MixedOperation secrets = mock(MixedOperation.class);
+		when(secrets.inNamespace(anyString())).thenReturn(secrets);
+		when(secrets.inAnyNamespace()).thenReturn(secrets);
+		when(secrets.withLabels(anyMap())).thenReturn(secrets);
+		when(secrets.withLabel(anyString(), anyString())).thenReturn(secrets);
+		when(secrets.list()).thenThrow(failure);
+		return secrets;
+	}
+
+	@Test
+	void listReleasesFailureKeepsStatusCodeAndReason() {
+		MixedOperation<Secret, SecretList, Resource<Secret>> secrets = failingSecrets(
+				new KubernetesClientException("Forbidden: cannot list secrets in namespace default", 403, null));
+		KubernetesClient client = mock(KubernetesClient.class);
+		when(client.secrets()).thenReturn(secrets);
+		Fabric8KubeService service = new Fabric8KubeService(client);
+
+		KubernetesOperationException ex = assertThrows(KubernetesOperationException.class,
+				() -> service.listReleases("default"));
+
+		assertEquals(403, ex.getStatusCode());
+		assertTrue(ex.getMessage().contains("list releases"), ex.getMessage());
+		assertTrue(ex.getMessage().contains("Forbidden"), ex.getMessage());
+	}
+
+	@Test
+	void listAllReleasesFailureKeepsStatusCodeAndReason() {
+		MixedOperation<Secret, SecretList, Resource<Secret>> secrets = failingSecrets(
+				new KubernetesClientException("Unauthorized: token expired", 401, null));
+		KubernetesClient client = mock(KubernetesClient.class);
+		when(client.secrets()).thenReturn(secrets);
+		Fabric8KubeService service = new Fabric8KubeService(client);
+
+		KubernetesOperationException ex = assertThrows(KubernetesOperationException.class, service::listAllReleases);
+
+		assertEquals(401, ex.getStatusCode());
+		assertTrue(ex.getMessage().contains("list all releases"), ex.getMessage());
+		assertTrue(ex.getMessage().contains("Unauthorized"), ex.getMessage());
+	}
+
+}

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceTest.java
@@ -385,7 +385,46 @@ class HelmKubeServiceTest {
 		assertTrue(kubeService.listReleases("staging").isEmpty());
 	}
 
+	@Test
+	void testListReleasesFailureKeepsStatusCodeAndReason() throws Exception {
+		// A 401/403 listing releases must reach callers with the cluster's status code
+		// and the reason on the message (issue #797), not a bare "Failed to list
+		// releases".
+		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
+			var listReq = mock(CoreV1Api.APIlistNamespacedSecretRequest.class);
+			when(listReq.labelSelector(anyString())).thenReturn(listReq);
+			when(listReq.execute())
+				.thenThrow(new ApiException("Forbidden", 403, null, "{\"reason\":\"Forbidden\",\"code\":403}"));
+			when(mock.listNamespacedSecret(anyString())).thenReturn(listReq);
+		});
+
+		KubernetesOperationException ex = assertThrows(KubernetesOperationException.class,
+				() -> kubeService.listReleases("default"));
+		assertEquals(403, ex.getStatusCode());
+		assertTrue(ex.getMessage().contains("list releases"), ex.getMessage());
+		assertTrue(ex.getMessage().contains("Forbidden"), ex.getMessage());
+		// the raw API response body is appended so the cluster's own reason is visible
+		assertTrue(ex.getMessage().contains("reason"), ex.getMessage());
+	}
+
 	// --- listAllReleases ---
+
+	@Test
+	void testListAllReleasesFailureKeepsStatusCodeAndReason() throws Exception {
+		coreV1ApiConstruction = mockConstruction(CoreV1Api.class, (mock, ctx) -> {
+			var listReq = mock(CoreV1Api.APIlistSecretForAllNamespacesRequest.class);
+			when(listReq.labelSelector(anyString())).thenReturn(listReq);
+			when(listReq.execute())
+				.thenThrow(new ApiException("Unauthorized", 401, null, "{\"reason\":\"Unauthorized\"}"));
+			when(mock.listSecretForAllNamespaces()).thenReturn(listReq);
+		});
+
+		KubernetesOperationException ex = assertThrows(KubernetesOperationException.class,
+				() -> kubeService.listAllReleases());
+		assertEquals(401, ex.getStatusCode());
+		assertTrue(ex.getMessage().contains("across all namespaces"), ex.getMessage());
+		assertTrue(ex.getMessage().contains("Unauthorized"), ex.getMessage());
+	}
 
 	@Test
 	void testListAllReleasesSpansNamespacesAndKeepsSameNameDistinct() throws Exception {

--- a/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandler.java
+++ b/jhelm-rest/src/main/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandler.java
@@ -17,6 +17,7 @@ import org.alexmond.jhelm.core.exception.TemplateRenderException;
 import org.alexmond.jhelm.core.exception.WaitTimeoutException;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -120,13 +121,33 @@ public class JhelmRestExceptionHandler {
 	}
 
 	/**
-	 * Maps a failure originating in the upstream Kubernetes cluster (API call,
-	 * deployment, or release storage) to a {@code 502 Bad Gateway} problem response.
+	 * Maps a Kubernetes API failure to an HTTP status derived from the cluster's own
+	 * response code. A client-error code (400&ndash;499) reported by the API &mdash; an
+	 * auth/RBAC denial (401/403), a missing resource (404), a conflict (409), or
+	 * rate-limiting (429) &mdash; propagates as that same status so the caller sees the
+	 * real reason. An unknown code ({@code -1}) or a server-side/transient code (5xx) is
+	 * treated as an upstream failure and mapped to {@code 502 Bad Gateway}.
 	 * @param ex the cluster-side operation exception
 	 * @return the problem detail
 	 */
-	@ExceptionHandler({ KubernetesOperationException.class, DeploymentFailedException.class,
-			ReleaseStorageException.class })
+	@ExceptionHandler(KubernetesOperationException.class)
+	public ProblemDetail handleKubernetesOperation(KubernetesOperationException ex) {
+		int code = ex.getStatusCode();
+		if (code >= 400 && code < 500) {
+			log.warn("Kubernetes API returned client error {}: {}", code, ex.getMessage());
+			return problem(HttpStatusCode.valueOf(code), ex.getMessage());
+		}
+		log.error("Upstream cluster operation failed", ex);
+		return problem(HttpStatus.BAD_GATEWAY, ex.getMessage());
+	}
+
+	/**
+	 * Maps a failure originating in the upstream Kubernetes cluster (deployment or
+	 * release storage) to a {@code 502 Bad Gateway} problem response.
+	 * @param ex the cluster-side operation exception
+	 * @return the problem detail
+	 */
+	@ExceptionHandler({ DeploymentFailedException.class, ReleaseStorageException.class })
 	public ProblemDetail handleUpstream(JhelmException ex) {
 		log.error("Upstream cluster operation failed", ex);
 		return problem(HttpStatus.BAD_GATEWAY, ex.getMessage());
@@ -157,7 +178,7 @@ public class JhelmRestExceptionHandler {
 		return problem(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
 	}
 
-	private ProblemDetail problem(HttpStatus status, String message) {
+	private ProblemDetail problem(HttpStatusCode status, String message) {
 		ProblemDetail problem = ProblemDetail.forStatusAndDetail(status, (message != null) ? message : "Unknown error");
 		problem.setProperty("timestamp", Instant.now().toString());
 		return problem;

--- a/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandlerTest.java
+++ b/jhelm-rest/src/test/java/org/alexmond/jhelm/rest/JhelmRestExceptionHandlerTest.java
@@ -132,14 +132,49 @@ class JhelmRestExceptionHandlerTest {
 
 	@Test
 	void upstreamClusterFailuresMapTo502() {
-		ProblemDetail kube = this.handler.handleUpstream(new KubernetesOperationException("apply failed"));
 		ProblemDetail deploy = this.handler
 			.handleUpstream(new DeploymentFailedException("deploy failed", new RuntimeException("api"), "manifest"));
 		ProblemDetail storage = this.handler.handleUpstream(new ReleaseStorageException("secret write failed"));
 
-		assertEquals(HttpStatus.BAD_GATEWAY.value(), kube.getStatus());
 		assertEquals(HttpStatus.BAD_GATEWAY.value(), deploy.getStatus());
 		assertEquals(HttpStatus.BAD_GATEWAY.value(), storage.getStatus());
+	}
+
+	@Test
+	void kubernetesClientErrorStatusPropagates() {
+		RuntimeException cause = new RuntimeException("api");
+		ProblemDetail unauthorized = this.handler.handleKubernetesOperation(
+				new KubernetesOperationException("Failed to list releases: Unauthorized", cause, 401));
+		ProblemDetail forbidden = this.handler.handleKubernetesOperation(
+				new KubernetesOperationException("Failed to list releases: Forbidden", cause, 403));
+		ProblemDetail notFound = this.handler.handleKubernetesOperation(
+				new KubernetesOperationException("Failed to list releases: NotFound", cause, 404));
+		ProblemDetail conflict = this.handler
+			.handleKubernetesOperation(new KubernetesOperationException("Failed to apply: Conflict", cause, 409));
+		ProblemDetail rateLimited = this.handler.handleKubernetesOperation(
+				new KubernetesOperationException("Failed to apply: TooManyRequests", cause, 429));
+
+		assertEquals(HttpStatus.UNAUTHORIZED.value(), unauthorized.getStatus());
+		assertEquals("Failed to list releases: Unauthorized", unauthorized.getDetail());
+		assertEquals(HttpStatus.FORBIDDEN.value(), forbidden.getStatus());
+		assertEquals(HttpStatus.NOT_FOUND.value(), notFound.getStatus());
+		assertEquals(HttpStatus.CONFLICT.value(), conflict.getStatus());
+		assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), rateLimited.getStatus());
+	}
+
+	@Test
+	void kubernetesUnknownOrServerErrorMapsTo502() {
+		RuntimeException cause = new RuntimeException("api");
+		ProblemDetail unknown = this.handler
+			.handleKubernetesOperation(new KubernetesOperationException("apply failed"));
+		ProblemDetail serverError = this.handler
+			.handleKubernetesOperation(new KubernetesOperationException("Failed to apply: InternalError", cause, 500));
+		ProblemDetail unavailable = this.handler.handleKubernetesOperation(
+				new KubernetesOperationException("Failed to apply: ServiceUnavailable", cause, 503));
+
+		assertEquals(HttpStatus.BAD_GATEWAY.value(), unknown.getStatus());
+		assertEquals(HttpStatus.BAD_GATEWAY.value(), serverError.getStatus());
+		assertEquals(HttpStatus.BAD_GATEWAY.value(), unavailable.getStatus());
 	}
 
 	@Test


### PR DESCRIPTION
An auth/RBAC failure (e.g. a 401 listing releases) surfaced as a blanket HTTP 502 with a generic message — the real status was only in server logs. `KubernetesOperationException.statusCode` was already populated end-to-end; the REST handler just ignored it.

## Primary — REST handler
`KubernetesOperationException` gets its own `@ExceptionHandler` reading `getStatusCode()`:
- **client-error code (400–499) → propagates as that HTTP status** (401/403/404/409/429 pass through);
- `-1` (unknown) or 5xx → **502 Bad Gateway** (unchanged upstream-failure behavior).
`DeploymentFailedException`/`ReleaseStorageException` stay on 502. The `problem(...)` helper now takes `HttpStatusCode` so an arbitrary cluster 4xx maps cleanly.

## Secondary — message quality (jhelm-kube, list catches only)
The four release-list catch blocks now append the cluster reason (`ex.getMessage()` + the API response body for client-java) so the message isn't just "Failed to list releases". Query bodies untouched (disjoint from #798).

## Tests
`JhelmRestExceptionHandlerTest` (401/403/404/409/429 passthrough; -1/500/503 → 502); `HelmKubeServiceTest` + new `Fabric8KubeServiceTest` (list failure keeps statusCode + reason). `verify` green: jhelm-kube 292+19, jhelm-rest 94.

Closes #797.

🤖 Generated with [Claude Code](https://claude.com/claude-code)