### PR TITLE
test(parity): mark openfunction as a known parity-harness failure

### DIFF
--- a/jhelm-core/src/test/resources/charts.csv
+++ b/jhelm-core/src/test/resources/charts.csv
@@ -333,7 +333,6 @@ couchbase/couchbase-operator,couchbase,https://couchbase-partners.github.io/helm
 netdata/netdata,netdata,https://netdata.github.io/helmchart/,3.7.169
 timescale/timescaledb-single,timescale,https://charts.timescale.com,0.33.1
 cnpg/cloudnative-pg,cnpg,https://cloudnative-pg.github.io/charts,0.29.0
-openfunction/openfunction,openfunction,https://openfunction.github.io/charts/,0.7.0
 weaviate/weaviate,weaviate,https://weaviate.github.io/weaviate-helm,17.8.3
 qdrant/qdrant,qdrant,https://qdrant.github.io/qdrant-helm,1.18.2
 milvus/milvus,milvus,https://zilliztech.github.io/milvus-helm/,5.0.24

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -53,5 +53,6 @@ redpanda/redpanda,redpanda,https://charts.redpanda.com
 # cross-namespace same-name collision, not a render diff. Both renderers emit 211 documents
 # and each config renders in the CORRECT namespace; the 5 "failures" are the 4 colliding
 # ConfigMaps + the webhook-certs Secret. Real fix: key the comparator by namespace+kind+name
-# (tracked separately); until then this is a known, expected failure.
+# (tracked separately); until then this is a known, expected failure. Removed from charts.csv
+# (so compareAllTopCharts skips it), same as gitlab/redpanda; its subcharts stay in charts.csv.
 openfunction/openfunction,openfunction,https://openfunction.github.io/charts/

--- a/jhelm-core/src/test/resources/failed.csv
+++ b/jhelm-core/src/test/resources/failed.csv
@@ -42,3 +42,16 @@ gitlab/gitlab,gitlab,https://charts.gitlab.io
 # and the chart raises. Root cause is engine-level number typing (how numeric values read
 # from .Values are typed), i.e. a gotmpl4j concern — not fixed here. Deferred low priority.
 redpanda/redpanda,redpanda,https://charts.redpanda.com
+#
+# --- Parity-harness limitation (NOT a jhelm rendering bug) ---
+# openfunction is an umbrella that bundles BOTH tekton-pipelines and knative-serving, each
+# of which ships Knative's standard config maps (config-observability, config-defaults,
+# config-logging, config-leader-election) and a webhook-certs Secret under DIFFERENT
+# namespaces. The comparator keys resources by kind+name only, so Helm's tekton
+# `ConfigMap/config-observability` (ns tekton-pipelines, chart tekton-pipelines-0.37.2) is
+# paired against jhelm's knative one (ns knative-serving, chart knative-serving-1.3.2) — a
+# cross-namespace same-name collision, not a render diff. Both renderers emit 211 documents
+# and each config renders in the CORRECT namespace; the 5 "failures" are the 4 colliding
+# ConfigMaps + the webhook-certs Secret. Real fix: key the comparator by namespace+kind+name
+# (tracked separately); until then this is a known, expected failure.
+openfunction/openfunction,openfunction,https://openfunction.github.io/charts/


### PR DESCRIPTION
The Chart Parity Suite has been red on every PR this session from a single failure — `openfunction/openfunction` (1/547). **Investigation: it's a comparator matching limitation, not a jhelm rendering bug.**

`openfunction` is an umbrella that bundles **both** `tekton-pipelines` and `knative-serving`, each shipping Knative's standard config maps (`config-observability`, `config-defaults`, `config-logging`, `config-leader-election`) + a `webhook-certs` Secret under **different namespaces**. The comparator keys resources by `kind+name` only, so:

```
ConfigMap/config-observability:
  metadata.namespace:   expected="tekton-pipelines"       actual="knative-serving"
  labels.helm.sh/chart: expected="tekton-pipelines-0.37.2" actual="knative-serving-1.3.2"
```

— Helm's *tekton* config-observability is paired against jhelm's *knative* one. Both renderers emit **211 documents each**, and each config renders in the **correct** namespace; the "5 failures / 30 diffs" are purely this cross-namespace same-name collision.

## Change
Add `openfunction/openfunction` to `failed.csv` (the same known-failure mechanism as `gitlab`/`redpanda`) with the diagnosis. This restores the parity signal (green) instead of a persistent red that masks real regressions.

The proper fix — keying the comparator by `namespace+kind+name` — is left as a separate follow-up (I can file it).

Verified via the run log ([30332395546](https://github.com/alexmond/jhelm/actions/runs/30332395546)); the parity CI job on this PR will confirm `openfunction` is now a confirmed-expected failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)