### PR TITLE
feat(kube): scope release listing to jhelm.kubernetes.release-namespaces for namespaced RBAC (#798)

### DIFF
--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
@@ -2,6 +2,7 @@ package org.alexmond.jhelm.core.service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.alexmond.jhelm.core.exception.KubernetesOperationException;
 import org.alexmond.jhelm.core.exception.ReleaseStorageException;
 import org.alexmond.jhelm.core.exception.WaitTimeoutException;
@@ -51,6 +52,24 @@ public interface KubeService {
 	 * @throws KubernetesOperationException if the Kubernetes API cannot be reached
 	 */
 	List<Release> listAllReleases();
+
+	/**
+	 * Returns the latest revision of every release across the given set of namespaces,
+	 * using only namespace-scoped list permission. Unlike {@link #listAllReleases()},
+	 * which needs cluster-wide {@code secrets:list} RBAC, this enumerates releases by
+	 * calling the namespace-scoped {@link #listReleases(String)} once per namespace and
+	 * flattening the results, so it works on a least-privilege cluster where the caller
+	 * is granted list access only within specific namespaces. The default implementation
+	 * composes {@link #listReleases(String)}, so it flows through every decorator (retry,
+	 * metrics) and both client backends with no per-backend implementation.
+	 * @param namespaces the namespaces to list; an empty set yields an empty list
+	 * @return the releases found across the given namespaces, or an empty list if there
+	 * are none
+	 * @throws KubernetesOperationException if the Kubernetes API cannot be reached
+	 */
+	default List<Release> listReleases(Set<String> namespaces) {
+		return namespaces.stream().flatMap((ns) -> listReleases(ns).stream()).toList();
+	}
 
 	/**
 	 * Returns all stored revisions of a release, newest first.

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/KubeServiceNamespaceSetListingTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/KubeServiceNamespaceSetListingTest.java
@@ -1,0 +1,54 @@
+package org.alexmond.jhelm.core.service;
+
+import java.util.List;
+import java.util.Set;
+
+import org.alexmond.jhelm.core.model.Release;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the default {@link KubeService#listReleases(Set)} composes the
+ * namespace-scoped {@link KubeService#listReleases(String)} — flattening the
+ * per-namespace results and never touching the cluster-wide
+ * {@link KubeService#listAllReleases()} — so it works with only namespace-scoped list
+ * permission.
+ */
+class KubeServiceNamespaceSetListingTest {
+
+	private final KubeService service = mock(KubeService.class);
+
+	@Test
+	void listReleasesForNamespaceSetFlattensPerNamespaceResults() {
+		Release ra = mock(Release.class);
+		Release rb1 = mock(Release.class);
+		Release rb2 = mock(Release.class);
+		when(this.service.listReleases("a")).thenReturn(List.of(ra));
+		when(this.service.listReleases("b")).thenReturn(List.of(rb1, rb2));
+		when(this.service.listReleases(Set.of("a", "b"))).thenCallRealMethod();
+
+		List<Release> result = this.service.listReleases(Set.of("a", "b"));
+
+		assertEquals(3, result.size());
+		verify(this.service).listReleases("a");
+		verify(this.service).listReleases("b");
+		// Cluster-wide listing (needs cluster-wide RBAC) is never invoked.
+		verify(this.service, never()).listAllReleases();
+	}
+
+	@Test
+	void listReleasesForEmptyNamespaceSetReturnsEmptyList() {
+		when(this.service.listReleases(Set.<String>of())).thenCallRealMethod();
+
+		assertEquals(List.of(), this.service.listReleases(Set.<String>of()));
+
+		verify(this.service, never()).listReleases("a");
+		verify(this.service, never()).listAllReleases();
+	}
+
+}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/KubeServiceDecorators.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/KubeServiceDecorators.java
@@ -1,10 +1,12 @@
 package org.alexmond.jhelm.kube;
 
 import java.time.Duration;
+import java.util.Set;
 
 import org.alexmond.jhelm.core.metrics.JhelmMetrics;
 import org.alexmond.jhelm.core.service.KubeService;
 import org.alexmond.jhelm.kube.config.JhelmKubernetesProperties;
+import org.alexmond.jhelm.kube.service.internal.NamespaceScopedReleasesKubeService;
 import org.alexmond.jhelm.kube.service.internal.ObservableKubeService;
 import org.alexmond.jhelm.kube.service.internal.RetryableKubeService;
 import org.springframework.beans.factory.ObjectProvider;
@@ -42,6 +44,11 @@ final class KubeServiceDecorators {
 		JhelmMetrics metrics = metricsProvider.getIfAvailable();
 		if (metrics != null) {
 			service = new ObservableKubeService(service, metrics);
+		}
+		// Outermost: when release listing is namespace-scoped, route listAllReleases()
+		// through the per-namespace listReleases so it still flows through retry+metrics.
+		if (!props.getReleaseNamespaces().isEmpty()) {
+			service = new NamespaceScopedReleasesKubeService(service, Set.copyOf(props.getReleaseNamespaces()));
 		}
 		return service;
 	}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/config/JhelmKubernetesProperties.java
@@ -1,5 +1,8 @@
 package org.alexmond.jhelm.kube.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -51,6 +54,16 @@ public class JhelmKubernetesProperties {
 	 * {@code ClientJavaKubeConfiguration} / {@code Fabric8KubeConfiguration}.
 	 */
 	private String backend = "auto";
+
+	/**
+	 * Namespaces to which release enumeration is restricted. When empty (the default),
+	 * {@code listAllReleases()} lists releases cluster-wide, which needs cluster-wide
+	 * {@code secrets:list} RBAC. When set, release listing is scoped to exactly these
+	 * namespaces, enumerated one at a time with only namespace-scoped list permission —
+	 * so {@code list --all-namespaces} works on a least-privilege / namespace-scoped
+	 * cluster that would otherwise return {@code 403 Forbidden}.
+	 */
+	private List<String> releaseNamespaces = new ArrayList<>();
 
 	/**
 	 * Retry configuration for transient Kubernetes API failures.

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/NamespaceScopedReleasesKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/NamespaceScopedReleasesKubeService.java
@@ -1,0 +1,138 @@
+package org.alexmond.jhelm.kube.service.internal;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.alexmond.jhelm.core.model.Capabilities;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ResourceStatus;
+import org.alexmond.jhelm.core.service.CascadePolicy;
+import org.alexmond.jhelm.core.service.KubeService;
+
+/**
+ * A {@link KubeService} decorator that scopes release enumeration to a fixed set of
+ * namespaces. It overrides only {@link #listAllReleases()} — routing it through the
+ * delegate's namespace-scoped {@link KubeService#listReleases(Set)} instead of the
+ * cluster-wide secret list — and forwards every other operation unchanged.
+ * <p>
+ * This lets {@code list --all-namespaces} (and any caller of {@code listAllReleases()})
+ * work on a least-privilege / namespace-scoped cluster where the caller holds list
+ * permission only within specific namespaces and a cluster-wide {@code secrets:list}
+ * would return {@code 403 Forbidden}. Wired as the outermost decorator so each per-
+ * namespace {@link KubeService#listReleases(String)} still flows through the retry and
+ * metrics decorators underneath.
+ */
+public class NamespaceScopedReleasesKubeService implements KubeService {
+
+	private final KubeService delegate;
+
+	private final Set<String> namespaces;
+
+	/**
+	 * Creates a namespace-scoped release-listing decorator around the given delegate.
+	 * @param delegate the underlying {@link KubeService} to which calls are forwarded
+	 * @param namespaces the namespaces to which {@link #listAllReleases()} is restricted;
+	 * held as an immutable copy
+	 */
+	public NamespaceScopedReleasesKubeService(KubeService delegate, Set<String> namespaces) {
+		this.delegate = delegate;
+		this.namespaces = Set.copyOf(namespaces);
+	}
+
+	@Override
+	public List<Release> listAllReleases() {
+		return delegate.listReleases(namespaces);
+	}
+
+	@Override
+	public void storeRelease(Release release) {
+		delegate.storeRelease(release);
+	}
+
+	@Override
+	public Optional<Release> getRelease(String name, String namespace) {
+		return delegate.getRelease(name, namespace);
+	}
+
+	@Override
+	public List<Release> listReleases(String namespace) {
+		return delegate.listReleases(namespace);
+	}
+
+	@Override
+	public List<Release> listReleases(Set<String> namespaces) {
+		return delegate.listReleases(namespaces);
+	}
+
+	@Override
+	public List<Release> getReleaseHistory(String name, String namespace) {
+		return delegate.getReleaseHistory(name, namespace);
+	}
+
+	@Override
+	public void deleteReleaseHistory(String name, String namespace) {
+		delegate.deleteReleaseHistory(name, namespace);
+	}
+
+	@Override
+	public void pruneReleaseHistory(String name, String namespace, int maxHistory) {
+		delegate.pruneReleaseHistory(name, namespace, maxHistory);
+	}
+
+	@Override
+	public void ensureNamespace(String namespace) {
+		delegate.ensureNamespace(namespace);
+	}
+
+	@Override
+	public void apply(String namespace, String yamlContent) {
+		delegate.apply(namespace, yamlContent);
+	}
+
+	@Override
+	public void applyDryRun(String namespace, String yamlContent) {
+		delegate.applyDryRun(namespace, yamlContent);
+	}
+
+	@Override
+	public void delete(String namespace, String yamlContent) {
+		delegate.delete(namespace, yamlContent);
+	}
+
+	@Override
+	public void delete(String namespace, String yamlContent, CascadePolicy cascade) {
+		delegate.delete(namespace, yamlContent, cascade);
+	}
+
+	@Override
+	public void waitForDeleted(String namespace, String manifest, int timeoutSeconds) {
+		delegate.waitForDeleted(namespace, manifest, timeoutSeconds);
+	}
+
+	@Override
+	public void restartWorkloads(String namespace, String manifest) {
+		delegate.restartWorkloads(namespace, manifest);
+	}
+
+	@Override
+	public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) {
+		return delegate.getResourceStatuses(namespace, manifest);
+	}
+
+	@Override
+	public void waitForReady(String namespace, String manifest, int timeoutSeconds) {
+		delegate.waitForReady(namespace, manifest, timeoutSeconds);
+	}
+
+	@Override
+	public void waitForReady(String namespace, String manifest, int timeoutSeconds, boolean waitForJobs) {
+		delegate.waitForReady(namespace, manifest, timeoutSeconds, waitForJobs);
+	}
+
+	@Override
+	public Capabilities getCapabilities() {
+		return delegate.getCapabilities();
+	}
+
+}

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/KubeServicesTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/KubeServicesTest.java
@@ -11,10 +11,14 @@ import org.alexmond.jhelm.kube.service.internal.AsyncHelmKubeService;
 import org.alexmond.jhelm.kube.service.internal.Fabric8AsyncKubeService;
 import org.alexmond.jhelm.kube.service.internal.Fabric8KubernetesProvider;
 import org.alexmond.jhelm.kube.service.internal.KubernetesClientProvider;
+import org.alexmond.jhelm.kube.service.internal.NamespaceScopedReleasesKubeService;
 import org.alexmond.jhelm.kube.service.internal.ObservableKubeService;
 import org.alexmond.jhelm.kube.service.internal.RetryableKubeService;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
 
@@ -68,6 +72,22 @@ class KubeServicesTest {
 	void clientJavaIsBareBaseWhenRetryDisabled() {
 		KubeService service = KubeServices.clientJava(mock(ApiClient.class), retryDisabled(), null);
 		assertInstanceOf(AsyncHelmKubeService.class, service);
+	}
+
+	@Test
+	void fabric8NotNamespaceScopedByDefault() {
+		// Default props have empty release-namespaces, so listing stays cluster-wide.
+		JhelmKubernetesProperties props = new JhelmKubernetesProperties();
+		assertFalse(KubeServices.fabric8(mock(KubernetesClient.class), props,
+				null) instanceof NamespaceScopedReleasesKubeService);
+	}
+
+	@Test
+	void fabric8IsNamespaceScopedWhenReleaseNamespacesSet() {
+		JhelmKubernetesProperties props = new JhelmKubernetesProperties();
+		props.setReleaseNamespaces(List.of("a", "b"));
+		KubeService service = KubeServices.fabric8(mock(KubernetesClient.class), props, null);
+		assertInstanceOf(NamespaceScopedReleasesKubeService.class, service);
 	}
 
 	@Test

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/NamespaceScopedReleasesKubeServiceTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/NamespaceScopedReleasesKubeServiceTest.java
@@ -1,0 +1,173 @@
+package org.alexmond.jhelm.kube.service.internal;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.alexmond.jhelm.core.model.Capabilities;
+import org.alexmond.jhelm.core.model.Release;
+import org.alexmond.jhelm.core.model.ResourceStatus;
+import org.alexmond.jhelm.core.service.CascadePolicy;
+import org.alexmond.jhelm.core.service.KubeService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link NamespaceScopedReleasesKubeService}: {@code listAllReleases()} is
+ * scoped to the configured namespaces via the delegate's {@code listReleases(Set)} — the
+ * cluster-wide {@code listAllReleases()} is never called — and every other method
+ * forwards unchanged.
+ */
+class NamespaceScopedReleasesKubeServiceTest {
+
+	private final KubeService delegate = mock(KubeService.class);
+
+	private final NamespaceScopedReleasesKubeService service = new NamespaceScopedReleasesKubeService(this.delegate,
+			Set.of("a", "b"));
+
+	@Test
+	void listAllReleasesDelegatesToNamespaceScopedListing() {
+		Release ra = mock(Release.class);
+		Release rb = mock(Release.class);
+		// The real default listReleases(Set) composes per-namespace listReleases(String).
+		when(this.delegate.listReleases(Set.of("a", "b"))).thenReturn(List.of(ra, rb));
+
+		List<Release> result = this.service.listAllReleases();
+
+		assertEquals(List.of(ra, rb), result);
+		verify(this.delegate).listReleases(Set.of("a", "b"));
+		// Cluster-wide listing (needs cluster-wide RBAC) must never be used.
+		verify(this.delegate, never()).listAllReleases();
+	}
+
+	@Test
+	void listAllReleasesReturnsUnionAcrossNamespacesWithDefaultComposition() {
+		// Exercise the KubeService default listReleases(Set) end-to-end: no stub for the
+		// Set overload, so the real default flattens per-namespace results.
+		KubeService realDefault = new KubeService() {
+			@Override
+			public List<Release> listReleases(String namespace) {
+				Release r = mock(Release.class);
+				when(r.getName()).thenReturn("rel-" + namespace);
+				return List.of(r);
+			}
+
+			@Override
+			public void storeRelease(Release release) {
+			}
+
+			@Override
+			public Optional<Release> getRelease(String name, String namespace) {
+				return Optional.empty();
+			}
+
+			@Override
+			public List<Release> listAllReleases() {
+				throw new AssertionError("cluster-wide listAllReleases must not be called");
+			}
+
+			@Override
+			public List<Release> getReleaseHistory(String name, String namespace) {
+				return List.of();
+			}
+
+			@Override
+			public void deleteReleaseHistory(String name, String namespace) {
+			}
+
+			@Override
+			public void pruneReleaseHistory(String name, String namespace, int maxHistory) {
+			}
+
+			@Override
+			public void ensureNamespace(String namespace) {
+			}
+
+			@Override
+			public void apply(String namespace, String yamlContent) {
+			}
+
+			@Override
+			public void delete(String namespace, String yamlContent) {
+			}
+
+			@Override
+			public List<ResourceStatus> getResourceStatuses(String namespace, String manifest) {
+				return List.of();
+			}
+
+			@Override
+			public void waitForReady(String namespace, String manifest, int timeoutSeconds) {
+			}
+		};
+		NamespaceScopedReleasesKubeService scoped = new NamespaceScopedReleasesKubeService(realDefault,
+				Set.of("a", "b"));
+
+		List<String> names = scoped.listAllReleases().stream().map(Release::getName).sorted().toList();
+
+		assertEquals(List.of("rel-a", "rel-b"), names);
+	}
+
+	@Test
+	void readOperationsForwardToDelegate() {
+		Release release = mock(Release.class);
+		when(this.delegate.getRelease("r", "ns")).thenReturn(Optional.of(release));
+		when(this.delegate.listReleases("ns")).thenReturn(List.of(release));
+		when(this.delegate.listReleases(Set.of("x"))).thenReturn(List.of(release));
+		when(this.delegate.getReleaseHistory("r", "ns")).thenReturn(List.of(release));
+		when(this.delegate.getResourceStatuses("ns", "m")).thenReturn(List.of());
+		when(this.delegate.getCapabilities()).thenReturn(Capabilities.DEFAULT);
+
+		assertEquals(Optional.of(release), this.service.getRelease("r", "ns"));
+		assertEquals(List.of(release), this.service.listReleases("ns"));
+		assertEquals(List.of(release), this.service.listReleases(Set.of("x")));
+		assertEquals(List.of(release), this.service.getReleaseHistory("r", "ns"));
+		assertEquals(List.of(), this.service.getResourceStatuses("ns", "m"));
+		assertSame(Capabilities.DEFAULT, this.service.getCapabilities());
+	}
+
+	@Test
+	void mutatingOperationsForwardToDelegate() {
+		Release release = mock(Release.class);
+		this.service.storeRelease(release);
+		this.service.deleteReleaseHistory("r", "ns");
+		this.service.pruneReleaseHistory("r", "ns", 3);
+		this.service.ensureNamespace("ns");
+		this.service.apply("ns", "yaml");
+		this.service.applyDryRun("ns", "yaml");
+		this.service.delete("ns", "yaml");
+		this.service.delete("ns", "yaml", CascadePolicy.FOREGROUND);
+		this.service.restartWorkloads("ns", "m");
+
+		verify(this.delegate).storeRelease(release);
+		verify(this.delegate).deleteReleaseHistory("r", "ns");
+		verify(this.delegate).pruneReleaseHistory("r", "ns", 3);
+		verify(this.delegate).ensureNamespace("ns");
+		verify(this.delegate).apply("ns", "yaml");
+		verify(this.delegate).applyDryRun("ns", "yaml");
+		verify(this.delegate).delete("ns", "yaml");
+		verify(this.delegate).delete("ns", "yaml", CascadePolicy.FOREGROUND);
+		verify(this.delegate).restartWorkloads("ns", "m");
+	}
+
+	@Test
+	void waitOperationsForwardToDelegate() {
+		this.service.waitForDeleted("ns", "m", 30);
+		this.service.waitForReady("ns", "m", 30);
+		this.service.waitForReady("ns", "m", 30, true);
+
+		verify(this.delegate).waitForDeleted("ns", "m", 30);
+		verify(this.delegate).waitForReady("ns", "m", 30);
+		verify(this.delegate).waitForReady("ns", "m", 30, true);
+		// listAllReleases was never invoked in these forwarding paths.
+		verify(this.delegate, never()).listReleases(anyString());
+	}
+
+}


### PR DESCRIPTION
`listAllReleases()` uses a cluster-wide secret list, which needs cluster-wide `secrets:list` RBAC — a namespace-scoped/least-privilege service account gets 403 and can't enumerate releases. Let a host restrict enumeration to a namespace set.

## Change (default-preserving)
- **`KubeService.listReleases(Set<String> namespaces)`** — a default method iterating the existing per-namespace `listReleases(ns)` and flattening, so it composes through every decorator and both backends with no backend edits (uses only namespace-scoped list permission).
- **`jhelm.kubernetes.release-namespaces`** property (empty default = cluster-wide, unchanged).
- **`NamespaceScopedReleasesKubeService`** decorator: overrides only `listAllReleases()` → `delegate.listReleases(namespaces)`, forwards the rest.
- Wired as the **outermost** decorator in `KubeServiceDecorators.decorate(...)` only when the property is non-empty, so each per-namespace call still routes through retry+metrics. The #795 factory (default props) stays unscoped.

## Tests
Core: default composes per-namespace and never calls `listAllReleases`; empty set → empty. jhelm-kube: decorator routes `listAllReleases`→`listReleases(Set)`; `KubeServicesTest` proves the bean is wrapped only when the property is set.

`verify` green (jhelm-core + jhelm-kube, all 19 integration tests on kind).

Closes #798.

🤖 Generated with [Claude Code](https://claude.com/claude-code)