### PR TITLE
docs: prep 1.5.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 = jhelm
-:jhelm-version: 1.3.0
+:jhelm-version: 1.5.0
 :url-docs: https://www.alexmond.org/jhelm/current/
 :url-docs-mcp: https://www.alexmond.org/jhelm/current/mcp/
 :url-docs-rest: https://www.alexmond.org/jhelm/current/rest-api/

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -17,12 +17,34 @@ xref:configuration.adoc#choosing-a-kubernetes-client-backend[Choosing a Kubernet
   storage, server-side apply, delete/cascade, wait/status, and the `lookup`/`kubeVersion`
   template data — at parity with the official-client backend (#776, #777, #778, #779).
 * *`jhelm.kubernetes.backend`* -- `auto` (default; prefers `client-java` when both are
-  present), `client-java`, or `fabric8`. Selection is deterministic — exactly one backend
-  activates even with both libraries on the classpath (#778).
+  present), `client-java`, `fabric8`, or `none` (build no ambient client — the host supplies
+  its own). Selection is deterministic — exactly one backend activates even with both
+  libraries on the classpath (#778, #796).
 * *Library-agnostic retry* -- transient-failure classification reads the HTTP status from
   either client's exception, so retry works on whichever backend is active (#780).
 
-== 1.4.0
+=== Embedding jhelm in a multi-cluster host
+
+New building blocks let a Spring Boot host embed jhelm-core/jhelm-rest as a library and
+serve many clusters. See xref:embedding-multicluster.adoc[Embedding jhelm in a multi-cluster host].
+
+* *Public per-cluster factory* -- `KubeServices.fabric8(client)` / `KubeServices.clientJava(apiClient)`
+  (and `KubernetesProviders.*`) build a fully-decorated `KubeService`/provider from a
+  host-supplied client, with no internal-package coupling (#795).
+* *Per-request cluster routing* -- a `KubeServiceResolver` bean lets the release API resolve a
+  per-cluster `KubeService` per request (e.g. from a header) instead of one ambient client (#773).
+* *Namespace-scoped release listing* -- `jhelm.kubernetes.release-namespaces` lists releases
+  across a namespace set instead of cluster-wide, so jhelm works on namespace-scoped RBAC
+  without cluster-wide `secrets:list` (#798).
+* *Accurate error status* -- Kubernetes failures now surface the real HTTP status (401/403/404
+  pass through instead of collapsing to 500/502), with the cluster reason in the message (#797).
+* *Host-security passthrough* -- `jhelm.rest.access-interceptor.enabled=false` opts out of
+  jhelm's access interceptor when the host secures the endpoints itself (#774).
+* *Health opt-out* -- `jhelm.kubernetes.health.enabled=false` suppresses the ambient Kubernetes
+  health indicator (#800).
+* *Embedded-safe repo config* -- `jhelm.config-path` is accepted under a `jhelm.core.*` alias,
+  the resolved config/cache paths are logged at startup, and jhelm warns before implicitly
+  reading/writing the operator's `~/.config/helm` (#769).
 
 === External Java plugin JARs
 
@@ -36,6 +58,17 @@ without being on the build classpath. See xref:java-plugin-api.adoc#_loading_ext
   independent of how the application is launched (#765).
 * *CLI `--plugin-dir`* -- a global flag (also `JHELM_PLUGINS_PATH`) to set the plugin
   directory for a run (#766).
+
+=== Other improvements
+
+* *Public chart-version comparator + cross-repo lookup* -- `ChartVersions.compare`, a
+  `Comparable` `ChartVersion`, and `RepoManager.findChartVersions`/`latestOf`, plus a
+  `jhelm outdated <chart>` command reporting the latest available version and whether an
+  upgrade is available (#771).
+* *`charts/show/*` resolves the latest version* -- `show` for a `repo/chart` reference with no
+  version now resolves the newest from the repo index instead of returning HTTP 500 (#772).
+* *snakeyaml-engine floor pinned* -- jhelm requires snakeyaml-engine 3.x; the version is now
+  pinned so a transitive 2.x can't cause a runtime `NoSuchMethodError` on the first chart load (#770).
 
 == 1.3.0
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -73,7 +73,7 @@ no shelling out, no glue code. See xref:mcp.adoc[MCP Server].
 
 * Java 21
 * Spring Boot 4.0.7
-* Kubernetes Client 26.0.0
+* Kubernetes client: official `client-java` 26.0.0 or Fabric8 `kubernetes-client` 6.13.5 (selectable by classpath)
 * gotmpl4j 1.3.0 (Go template + Sprig engine)
 * Picocli 4.7.7 (CLI framework)
 


### PR DESCRIPTION
Release-prep for **1.5.0** (prep-only — the release trigger is held until kweblens dogfoods the `-SNAPSHOT`, per standing instruction).

Last release was **1.3.0**; the `1.4.0` changelog section was never tagged, so per decision it's consolidated into `1.5.0`.

- **changelog**: single `== 1.5.0` section covering everything since 1.3.0 — pluggable Kubernetes backend (#776–#780, #796), multi-cluster embedding (#795 factory, #773 resolver, #798 release-namespaces, #797 HTTP status, #774/#800 opt-outs, #769 config path, #799 recipe), external Java plugin JARs folded from 1.4.0 (#765/#766), and other improvements (#771 comparator + `jhelm outdated`, #772 show latest, #770 snakeyaml pin). Removed the never-released `1.4.0` heading.
- **README**: `:jhelm-version:` 1.3.0 → 1.5.0.
- **index tech-stack**: Kubernetes client line now reflects the dual backend.

Docs-only. `docs/antora.yml` uses `version: true` (no per-version attr). No new published module since 1.3.0 → api-* links unchanged. `main` build is green on CI (run 30334142322 @ HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)