### PR TITLE
ci(release): run Verify Build against a kind cluster (jhelm-kube coverage gate)

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -41,6 +41,20 @@ jobs:
       - name: Set Release Version
         run: ./mvnw versions:set -DnewVersion=${{ github.event.inputs.releaseVersion }} --no-transfer-progress
 
+      # jhelm-kube's coverage gate is met only when its @KubeClusterAvailable integration
+      # tests run (the Fabric8/client-java KubeService impls are integration-covered), so
+      # Verify Build needs a cluster + Helm — same as build.yml. Without it, jacoco:check
+      # fails on jhelm-kube.
+      - name: Create Kubernetes Cluster (Kind)
+        uses: helm/kind-action@v1.12.0
+        with:
+          cluster_name: kind
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.2
+
       - name: Verify Build
         run: ./mvnw --batch-mode clean verify --no-transfer-progress
 


### PR DESCRIPTION
The 1.5.0 release run failed at **Verify Build** on jhelm-kube's jacoco coverage check ("Coverage checks have not been met"). Cause: the new Fabric8 backend (and the client-java KubeService impls) are covered by `@KubeClusterAvailable` integration tests, which skip when no cluster is present — dropping jhelm-kube below the 0.75 line floor. `build.yml` spins up kind + Helm before building; `maven_release.yml` did not.

Add the same `helm/kind-action` + `azure/setup-helm` steps before `Verify Build` so the release build matches normal CI and the coverage gate passes.

Nothing was published by the failed run (Deploy/Tag/Push all skipped — clean failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)