### PR TITLE
fix(kube): prune removed fields on upgrade via Helm-style three-way merge (#814)

### DIFF
--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -1,5 +1,19 @@
 = Changelog
 
+== 1.5.1
+
+=== Fixes
+
+* *Upgrade now prunes removed fields* -- `jhelm upgrade` deleted nothing: a field dropped from
+  a chart or values file (a removed container `env` entry, a deleted flag or label) stayed on
+  the live object forever, so an upgrade could only add or change. This was security-relevant —
+  a deliberately-removed setting (for example a TLS relaxation) silently remained live while
+  the upgrade reported success. jhelm now computes a Helm-style three-way JSON merge patch per
+  resource on upgrade — comparing the previous release's manifest, the new manifest, and the
+  live object — so fields the release no longer declares are removed regardless of which field
+  manager owns them, while controller-set fields jhelm never managed are left untouched. Applies
+  to both the `client-java` and Fabric8 backends (#814).
+
 == 1.5.0
 
 === Pluggable Kubernetes client backend

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/action/UpgradeAction.java
@@ -163,7 +163,21 @@ public class UpgradeAction {
 			}
 			kubeService.delete(newRelease.getNamespace(), regularManifest);
 		}
-		kubeService.apply(newRelease.getNamespace(), regularManifest);
+		// Apply with three-way pruning against the previous release's manifest, so fields
+		// the release no longer declares (a removed env entry, a deleted flag) are
+		// deleted
+		// on the live object rather than silently retained (#814). --force already
+		// deleted
+		// the resources above, so there is nothing to prune against — plain apply
+		// recreates.
+		String previousManifest = (currentRelease.getManifest() != null)
+				? HookParser.stripHooks(currentRelease.getManifest()) : null;
+		if (options.isForce() || previousManifest == null || previousManifest.isBlank()) {
+			kubeService.apply(newRelease.getNamespace(), regularManifest);
+		}
+		else {
+			kubeService.applyWithPrune(newRelease.getNamespace(), previousManifest, regularManifest);
+		}
 		try {
 			kubeService.storeRelease(newRelease);
 		}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/DelegatingKubeService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/DelegatingKubeService.java
@@ -77,6 +77,11 @@ public class DelegatingKubeService implements KubeService {
 	}
 
 	@Override
+	public void applyWithPrune(String namespace, String previousYaml, String yamlContent) {
+		resolver.resolve().applyWithPrune(namespace, previousYaml, yamlContent);
+	}
+
+	@Override
 	public void applyDryRun(String namespace, String yamlContent) {
 		resolver.resolve().applyDryRun(namespace, yamlContent);
 	}

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/KubeService.java
@@ -118,6 +118,33 @@ public interface KubeService {
 	void apply(String namespace, String yamlContent);
 
 	/**
+	 * Applies an upgraded manifest while pruning fields the release no longer declares.
+	 * <p>
+	 * Unlike {@link #apply(String, String)} (server-side apply, which only prunes fields
+	 * the {@code helm} field manager previously owned), this computes a Helm-style
+	 * three-way JSON merge patch per resource from three states — the resource as the
+	 * <em>previous</em> release rendered it ({@code previousYaml}), as the new release
+	 * renders it ({@code yamlContent}), and as it currently lives on the cluster — so a
+	 * field the release dropped since the last apply (a removed {@code env} entry, a
+	 * deleted label) is deleted regardless of prior field ownership. Resources absent
+	 * from the cluster are created; controller-set fields the release never managed are
+	 * left untouched. See {@code ThreeWayJsonMerge}.
+	 * <p>
+	 * The default forwards to {@link #apply(String, String)} (no field-level pruning) so
+	 * implementations without three-way support degrade to plain apply; the real backends
+	 * override it, and <strong>decorators must forward this call to their
+	 * delegate</strong> or pruning is silently bypassed.
+	 * @param namespace the target namespace
+	 * @param previousYaml the manifest the previous release applied (may be {@code null}
+	 * or blank when unavailable — then nothing is pruned)
+	 * @param yamlContent the new rendered YAML manifest (may contain multiple documents)
+	 * @throws KubernetesOperationException if a resource cannot be applied
+	 */
+	default void applyWithPrune(String namespace, String previousYaml, String yamlContent) {
+		apply(namespace, yamlContent);
+	}
+
+	/**
 	 * Validates a rendered manifest against the cluster via a server-side dry-run apply
 	 * (Helm {@code --dry-run=server}). The API server admits and validates the resources
 	 * (defaulting, admission webhooks, quota) but persists nothing.

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ThreeWayJsonMerge.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/util/ThreeWayJsonMerge.java
@@ -1,0 +1,164 @@
+package org.alexmond.jhelm.core.util;
+
+import java.util.Map;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * Computes an <a href="https://www.rfc-editor.org/rfc/rfc7386">RFC 7386 JSON merge
+ * patch</a> that upgrades a live Kubernetes object toward a newly rendered manifest
+ * <em>while pruning fields the release no longer declares</em>.
+ * <p>
+ * This mirrors Helm's three-way merge for unstructured resources
+ * ({@code jsonmergepatch.CreateThreeWayJSONMergePatch}). Given three states of a single
+ * resource:
+ * <ul>
+ * <li><b>original</b> — the resource as the <em>previous</em> release rendered it (from
+ * the stored manifest),</li>
+ * <li><b>modified</b> — the resource as the <em>new</em> release renders it,</li>
+ * <li><b>current</b> — the resource as it currently lives on the cluster.</li>
+ * </ul>
+ * the returned patch:
+ * <ul>
+ * <li>adds/changes every field where {@code current} differs from {@code modified}
+ * (computed against the live object so already-correct fields are not re-sent), and</li>
+ * <li>deletes only fields present in {@code original} but absent from {@code modified} —
+ * i.e. fields the release itself dropped since the last apply — expressed as explicit
+ * {@code null}s. Fields that live only on the cluster (controller-set defaults jhelm
+ * never managed) are left untouched.</li>
+ * </ul>
+ * Because JSON merge patch treats arrays atomically, a list whose contents changed (for
+ * example a container {@code env} array with an entry removed) is replaced wholesale, so
+ * removed entries are pruned — which server-side apply, keyed on prior field ownership,
+ * does not guarantee.
+ */
+public final class ThreeWayJsonMerge {
+
+	private static final JsonNodeFactory NODES = JsonNodeFactory.instance;
+
+	private ThreeWayJsonMerge() {
+	}
+
+	/**
+	 * Builds the three-way JSON merge patch for a single resource. A {@code null}
+	 * argument is treated as an empty object.
+	 * @param original the resource as the previous release rendered it (may be
+	 * {@code null} when no prior manifest is available — then nothing is pruned)
+	 * @param modified the resource as the new release renders it
+	 * @param current the resource as it currently lives on the cluster
+	 * @return an RFC 7386 merge patch; an empty object when the live resource already
+	 * matches and nothing is pruned
+	 */
+	public static ObjectNode threeWayMergePatch(JsonNode original, JsonNode modified, JsonNode current) {
+		JsonNode orig = objectOrEmpty(original);
+		JsonNode mod = objectOrEmpty(modified);
+		JsonNode cur = objectOrEmpty(current);
+		// Additions/changes are measured against the LIVE object, so fields already at
+		// the
+		// desired value are not re-sent; nulls (fields on the cluster but not in
+		// modified)
+		// are dropped here — they are handled by the deletion pass, and only when the
+		// release itself owned them.
+		JsonNode addAndChange = filterNulls(createMergePatch(cur, mod), false);
+		// Deletions are measured against what the PREVIOUS release rendered, so only
+		// fields
+		// the release dropped are removed — never controller-set fields jhelm never
+		// managed.
+		JsonNode deletions = filterNulls(createMergePatch(orig, mod), true);
+		return union(deletions, addAndChange);
+	}
+
+	/**
+	 * Computes the RFC 7386 merge patch that turns {@code source} into {@code target}.
+	 * Objects are diffed recursively; arrays and scalars are atomic (a change emits the
+	 * whole target value); a key present in {@code source} but not {@code target} emits
+	 * an explicit {@code null}.
+	 */
+	static ObjectNode createMergePatch(JsonNode source, JsonNode target) {
+		ObjectNode patch = NODES.objectNode();
+		for (Map.Entry<String, JsonNode> entry : target.properties()) {
+			String key = entry.getKey();
+			JsonNode targetValue = entry.getValue();
+			JsonNode sourceValue = source.get(key);
+			if (sourceValue == null) {
+				patch.set(key, targetValue);
+			}
+			else if (!sourceValue.equals(targetValue)) {
+				if (sourceValue.isObject() && targetValue.isObject()) {
+					ObjectNode sub = createMergePatch(sourceValue, targetValue);
+					if (!sub.isEmpty()) {
+						patch.set(key, sub);
+					}
+				}
+				else {
+					patch.set(key, targetValue);
+				}
+			}
+		}
+		for (String key : source.propertyNames()) {
+			if (!target.has(key)) {
+				patch.set(key, NullNode.getInstance());
+			}
+		}
+		return patch;
+	}
+
+	/**
+	 * Recursively keeps or drops {@code null}-valued leaves of a merge patch. With
+	 * {@code keepNull} {@code true} only the {@code null} deletions survive; with
+	 * {@code false} only the additions/changes survive. Objects that become empty after
+	 * filtering are dropped.
+	 */
+	static ObjectNode filterNulls(JsonNode patch, boolean keepNull) {
+		ObjectNode result = NODES.objectNode();
+		for (Map.Entry<String, JsonNode> entry : patch.properties()) {
+			String key = entry.getKey();
+			JsonNode value = entry.getValue();
+			if (value.isNull()) {
+				if (keepNull) {
+					result.set(key, NullNode.getInstance());
+				}
+			}
+			else if (value.isObject()) {
+				ObjectNode sub = filterNulls(value, keepNull);
+				if (!sub.isEmpty()) {
+					result.set(key, sub);
+				}
+			}
+			else if (!keepNull) {
+				result.set(key, value);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Deep-unions two disjoint merge-patch documents, preserving {@code null} deletions
+	 * from {@code deletions}. The two inputs never touch the same leaf (a field cannot be
+	 * both dropped by the release and required by it), so a straight recursive union is
+	 * sufficient.
+	 */
+	static ObjectNode union(JsonNode deletions, JsonNode addAndChange) {
+		ObjectNode result = (ObjectNode) deletions.deepCopy();
+		for (Map.Entry<String, JsonNode> entry : addAndChange.properties()) {
+			String key = entry.getKey();
+			JsonNode value = entry.getValue();
+			JsonNode existing = result.get(key);
+			if (existing != null && existing.isObject() && value.isObject()) {
+				result.set(key, union(existing, value));
+			}
+			else {
+				result.set(key, value);
+			}
+		}
+		return result;
+	}
+
+	private static JsonNode objectOrEmpty(JsonNode node) {
+		return (node != null && node.isObject()) ? node : NODES.objectNode();
+	}
+
+}

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/action/UpgradeActionTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.inOrder;
 import org.alexmond.jhelm.core.exception.DeploymentFailedException;
 import org.alexmond.jhelm.core.model.Capabilities;
@@ -644,6 +643,44 @@ class UpgradeActionTest {
 	}
 
 	@Test
+	void testUpgradeWithPreviousManifestAppliesWithPrune() throws Exception {
+		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("2.0.0").build();
+		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
+
+		String previousManifest = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: myapp-svc\n";
+		Release.ReleaseInfo info = Release.ReleaseInfo.builder()
+			.firstDeployed(OffsetDateTime.now().minusDays(1))
+			.lastDeployed(OffsetDateTime.now().minusDays(1))
+			.status(ReleaseStatus.DEPLOYED)
+			.build();
+		Release currentRelease = Release.builder()
+			.name("myapp")
+			.namespace("default")
+			.version(1)
+			.chart(chart)
+			.manifest(previousManifest)
+			.info(info)
+			.build();
+
+		String newManifest = "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: myapp-svc\n";
+		when(engine.render(any(Chart.class), anyMap(), any(ReleaseContext.class), any(Capabilities.class)))
+			.thenReturn(newManifest);
+		doNothing().when(kubeService).storeRelease(any(Release.class));
+
+		upgradeAction.upgrade(UpgradeOptions.builder()
+			.currentRelease(currentRelease)
+			.newChart(chart)
+			.valueStrategy(UpgradeValueStrategy.DEFAULT)
+			.build());
+
+		// A previous manifest exists -> prune via three-way merge, not a plain apply
+		// (#814).
+		verify(kubeService).applyWithPrune("default", HookParser.stripHooks(previousManifest),
+				HookParser.stripHooks(newManifest));
+		verify(kubeService, never()).apply(anyString(), anyString());
+	}
+
+	@Test
 	void testUpgradeIncrementsVersion() throws Exception {
 		ChartMetadata metadata = ChartMetadata.builder().name("mychart").version("1.0.0").build();
 		Chart chart = Chart.builder().metadata(metadata).values(new HashMap<>()).build();
@@ -709,8 +746,10 @@ class UpgradeActionTest {
 					.valueStrategy(UpgradeValueStrategy.DEFAULT)
 					.build()));
 
-		// Verify: new manifest applied, then previous manifest re-applied on rollback
-		verify(kubeService, times(2)).apply(eq("default"), anyString());
+		// Verify: new manifest applied (with pruning, since a previous manifest exists),
+		// then the previous manifest re-applied on rollback via a plain apply.
+		verify(kubeService).applyWithPrune(eq("default"), eq(HookParser.stripHooks(previousManifest)), anyString());
+		verify(kubeService).apply(eq("default"), eq(HookParser.stripHooks(previousManifest)));
 	}
 
 	@Test

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ThreeWayJsonMergeTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/util/ThreeWayJsonMergeTest.java
@@ -1,0 +1,184 @@
+package org.alexmond.jhelm.core.util;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ThreeWayJsonMerge} — the cluster-free heart of the upgrade
+ * field-pruning fix (#814). Each case builds original/modified/current as JSON and
+ * asserts the produced RFC 7386 merge patch, and (where it matters) the result of
+ * applying that patch to the live object.
+ */
+class ThreeWayJsonMergeTest {
+
+	private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+	private static JsonNode json(String text) {
+		return MAPPER.readTree(text);
+	}
+
+	private static ObjectNode patch(String original, String modified, String current) {
+		return ThreeWayJsonMerge.threeWayMergePatch(json(original), json(modified), json(current));
+	}
+
+	/**
+	 * Applies an RFC 7386 merge patch to a document, so tests can assert the end state.
+	 */
+	private static JsonNode apply(String doc, JsonNode mergePatch) {
+		return applyNode(json(doc), mergePatch);
+	}
+
+	private static JsonNode applyNode(JsonNode target, JsonNode patch) {
+		if (!patch.isObject()) {
+			return patch;
+		}
+		ObjectNode base = target.isObject() ? (ObjectNode) target.deepCopy() : MAPPER.createObjectNode();
+		for (var entry : patch.properties()) {
+			JsonNode value = entry.getValue();
+			if (value.isNull()) {
+				base.remove(entry.getKey());
+			}
+			else if (value.isObject()) {
+				base.set(entry.getKey(), applyNode(base.get(entry.getKey()), value));
+			}
+			else {
+				base.set(entry.getKey(), value);
+			}
+		}
+		return base;
+	}
+
+	@Test
+	void removedEnvEntryIsPrunedByReplacingTheWholeArray() {
+		// The #814 reproduction: env [A,B] -> [A]; B must be gone from the live object.
+		String original = """
+				{"spec":{"env":[{"name":"A","value":"1"},{"name":"B","value":"2"}]}}""";
+		String modified = """
+				{"spec":{"env":[{"name":"A","value":"1"}]}}""";
+		String current = original;
+		ObjectNode p = patch(original, modified, current);
+		JsonNode result = apply(current, p);
+		assertEquals(json(modified), result, "removed env entry B must not survive the upgrade");
+		assertEquals(1, result.get("spec").get("env").size());
+	}
+
+	@Test
+	void wholeEnvRemovalEmitsExplicitNullDeletion() {
+		String original = """
+				{"spec":{"env":[{"name":"A","value":"1"}]}}""";
+		String modified = """
+				{"spec":{}}""";
+		ObjectNode p = patch(original, modified, original);
+		assertTrue(p.path("spec").path("env").isNull(), "dropped env key must become an explicit null: " + p);
+		JsonNode result = apply(original, p);
+		assertFalse(result.get("spec").has("env"), "env must be deleted");
+	}
+
+	@Test
+	void topLevelKeyDroppedByReleaseIsDeleted() {
+		String original = """
+				{"metadata":{"labels":{"keep":"yes","drop":"old"}}}""";
+		String modified = """
+				{"metadata":{"labels":{"keep":"yes"}}}""";
+		ObjectNode p = patch(original, modified, original);
+		assertTrue(p.path("metadata").path("labels").path("drop").isNull(), "dropped label must be null: " + p);
+		JsonNode result = apply(original, p);
+		assertFalse(result.get("metadata").get("labels").has("drop"));
+		assertEquals("yes", result.get("metadata").get("labels").get("keep").asString());
+	}
+
+	@Test
+	void controllerSetFieldNotManagedByReleaseIsPreserved() {
+		// clusterIP is set by the API server; it is in neither original nor modified.
+		String original = """
+				{"spec":{"ports":[{"port":80}]}}""";
+		String modified = """
+				{"spec":{"ports":[{"port":80}]}}""";
+		String current = """
+				{"spec":{"ports":[{"port":80}],"clusterIP":"192.0.2.5"}}""";
+		ObjectNode p = patch(original, modified, current);
+		assertFalse(p.path("spec").has("clusterIP"), "must not touch a field the release never managed: " + p);
+		JsonNode result = apply(current, p);
+		assertEquals("192.0.2.5", result.get("spec").get("clusterIP").asString());
+	}
+
+	@Test
+	void identicalStatesProduceEmptyPatch() {
+		String doc = """
+				{"spec":{"replicas":3,"env":[{"name":"A","value":"1"}]}}""";
+		ObjectNode p = patch(doc, doc, doc);
+		assertTrue(p.isEmpty(), "no-op upgrade must produce an empty patch: " + p);
+	}
+
+	@Test
+	void changedScalarIsMeasuredAgainstLiveObject() {
+		String original = """
+				{"spec":{"replicas":2}}""";
+		String modified = """
+				{"spec":{"replicas":3}}""";
+		String current = """
+				{"spec":{"replicas":2}}""";
+		ObjectNode p = patch(original, modified, current);
+		assertEquals(3, p.get("spec").get("replicas").asInt());
+	}
+
+	@Test
+	void fieldAlreadyAtDesiredValueOnClusterIsNotResent() {
+		// modified == current for replicas; only original differs -> nothing to
+		// add/change.
+		String original = """
+				{"spec":{"replicas":2}}""";
+		String modified = """
+				{"spec":{"replicas":3}}""";
+		String current = """
+				{"spec":{"replicas":3}}""";
+		ObjectNode p = patch(original, modified, current);
+		assertTrue(p.isEmpty(), "already-correct field must not be re-sent: " + p);
+	}
+
+	@Test
+	void releaseReassertsItsValueWhenDriftedOnCluster() {
+		// The release owns replicas (unchanged original==modified) but the cluster
+		// drifted.
+		String original = """
+				{"spec":{"replicas":3}}""";
+		String modified = """
+				{"spec":{"replicas":3}}""";
+		String current = """
+				{"spec":{"replicas":5}}""";
+		ObjectNode p = patch(original, modified, current);
+		assertEquals(3, p.get("spec").get("replicas").asInt(), "release value must win over drift");
+	}
+
+	@Test
+	void nullOriginalPrunesNothing() {
+		// No previous manifest: we cannot know what the release dropped, so no deletions.
+		String modified = """
+				{"spec":{"replicas":3}}""";
+		String current = """
+				{"spec":{"replicas":2,"env":[{"name":"A","value":"1"}]}}""";
+		ObjectNode p = ThreeWayJsonMerge.threeWayMergePatch(null, json(modified), json(current));
+		assertEquals(3, p.get("spec").get("replicas").asInt());
+		assertFalse(p.path("spec").path("env").isNull(), "must not delete env when original is unknown: " + p);
+	}
+
+	@Test
+	void newFieldAddedByReleaseIsIncluded() {
+		String original = """
+				{"spec":{}}""";
+		String modified = """
+				{"spec":{"paused":true}}""";
+		String current = """
+				{"spec":{}}""";
+		ObjectNode p = patch(original, modified, current);
+		assertTrue(p.get("spec").get("paused").asBoolean());
+	}
+
+}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/Fabric8KubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/Fabric8KubeService.java
@@ -7,6 +7,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,11 @@ import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
 import org.alexmond.jhelm.core.service.CascadePolicy;
 import org.alexmond.jhelm.core.service.KubeService;
+import org.alexmond.jhelm.core.util.ThreeWayJsonMerge;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 import org.yaml.snakeyaml.LoaderOptions;
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import org.yaml.snakeyaml.DumperOptions;
@@ -86,6 +92,9 @@ public class Fabric8KubeService implements KubeService {
 	private static final String FIELD_MANAGER = "helm";
 
 	private static final String RESTART_ANNOTATION = "kubectl.kubernetes.io/restartedAt";
+
+	// Maps unstructured resource maps to JSON for the three-way upgrade merge patch.
+	private static final JsonMapper JSON = JsonMapper.builder().build();
 
 	private static final Set<String> RESTARTABLE_KINDS = Set.of("Deployment", "StatefulSet", "DaemonSet");
 
@@ -406,6 +415,103 @@ public class Fabric8KubeService implements KubeService {
 		else {
 			op.patch(ctx.build());
 		}
+	}
+
+	@Override
+	public void applyWithPrune(String namespace, String previousYaml, String yamlContent) {
+		if (previousYaml == null || previousYaml.isBlank()) {
+			// No prior state to diff against — fall back to plain server-side apply.
+			apply(namespace, yamlContent);
+			return;
+		}
+		try {
+			Map<String, Map<String, Object>> previous = indexById(previousYaml);
+			for (Object doc : loadUnstructured(yamlContent)) {
+				if (doc instanceof Map<?, ?> map) {
+					@SuppressWarnings("unchecked")
+					Map<String, Object> resource = (Map<String, Object>) map;
+					applyResourceWithPrune(namespace, resource, previous.get(String.join("|", identify(resource))));
+				}
+			}
+		}
+		catch (KubernetesClientException ex) {
+			throw new KubernetesOperationException("Failed to apply manifest", ex, ex.getCode());
+		}
+		catch (KubernetesOperationException ex) {
+			throw ex;
+		}
+		catch (RuntimeException ex) {
+			throw new KubernetesOperationException("Failed to apply manifest", ex);
+		}
+	}
+
+	// Indexes a manifest's documents by "apiVersion|kind|name" so an upgrade can pair
+	// each
+	// new resource with how the previous release rendered it.
+	private static Map<String, Map<String, Object>> indexById(String yamlContent) {
+		Map<String, Map<String, Object>> byId = new HashMap<>();
+		for (Object doc : loadUnstructured(yamlContent)) {
+			if (doc instanceof Map<?, ?> map) {
+				@SuppressWarnings("unchecked")
+				Map<String, Object> resource = (Map<String, Object>) map;
+				byId.put(String.join("|", identify(resource)), resource);
+			}
+		}
+		return byId;
+	}
+
+	// Applies one resource with Helm-style pruning: create it if absent, otherwise send a
+	// three-way JSON merge patch (original=previous render, modified=new render,
+	// current=live) so fields the release dropped are deleted regardless of who owns
+	// them.
+	private void applyResourceWithPrune(String namespace, Map<String, Object> resource, Map<String, Object> original) {
+		String[] id = identify(resource);
+		String kind = id[1];
+		String name = id[2];
+		boolean namespaced = isNamespaced(kind);
+		GenericKubernetesResource identity = identityResource(id, namespaced ? namespace : null);
+		GenericKubernetesResource live = this.client.resource(identity).get();
+		if (live == null) {
+			// Absent on the cluster — create it via server-side apply (establishes helm
+			// ownership); nothing to prune for a brand-new resource.
+			applyResource(namespace, resource, false);
+			return;
+		}
+		JsonNode current = JSON.valueToTree(toMap(live));
+		JsonNode modified = JSON.valueToTree(resource);
+		JsonNode originalNode = (original != null) ? JSON.valueToTree(original) : null;
+		ObjectNode patch = ThreeWayJsonMerge.threeWayMergePatch(originalNode, modified, current);
+		if (patch.isEmpty()) {
+			return;
+		}
+		log.info("Applying (prune) {} {}{}", kind, name,
+				namespaced ? " in namespace " + namespace : " (cluster-scoped)");
+		PatchContext ctx = new PatchContext.Builder().withPatchType(PatchType.JSON_MERGE)
+			.withFieldManager(FIELD_MANAGER)
+			.build();
+		this.client.resource(identity).patch(ctx, JSON.writeValueAsString(patch));
+	}
+
+	// Reconstructs the live resource as a plain map for the three-way diff. Fabric8's own
+	// serializer NPEs on a GenericKubernetesResource whose content lives in
+	// additionalProperties (keySerializer null — the same defect worked around in #779),
+	// so
+	// we assemble the map from its typed fields + additionalProperties and let jhelm's
+	// own
+	// Jackson mapper serialize it. managedFields is dropped: its fieldsV1 "f:*"-keyed
+	// maps
+	// trip the same serializer and the diff never references them.
+	private static Map<String, Object> toMap(GenericKubernetesResource live) {
+		Map<String, Object> map = new LinkedHashMap<>(live.getAdditionalProperties());
+		map.put("apiVersion", live.getApiVersion());
+		map.put("kind", live.getKind());
+		ObjectMeta meta = live.getMetadata();
+		if (meta != null) {
+			meta.setManagedFields(null);
+			map.put("metadata", JSON.convertValue(meta, new TypeReference<Map<String, Object>>() {
+			}));
+		}
+		return map;
 	}
 
 	// ---------------------------------------------------------------- delete

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/HelmKubeService.java
@@ -40,10 +40,15 @@ import org.alexmond.jhelm.core.model.Capabilities;
 import org.alexmond.jhelm.core.model.HelmReleaseCodec;
 import org.alexmond.jhelm.core.model.Release;
 import org.alexmond.jhelm.core.model.ResourceStatus;
+import org.alexmond.jhelm.core.util.ThreeWayJsonMerge;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.List;
@@ -77,6 +82,10 @@ public class HelmKubeService implements KubeService {
 
 	// Workload kinds whose pods a rolling restart (--recreate-pods) can trigger.
 	private static final Set<String> RESTARTABLE_KINDS = Set.of("Deployment", "StatefulSet", "DaemonSet");
+
+	// Maps unstructured resource maps and live objects to/from JSON for the three-way
+	// upgrade merge patch; unstructured only, so no custom modules are needed.
+	private static final JsonMapper JSON = JsonMapper.builder().build();
 
 	/** Configured Kubernetes API client used for all cluster operations. */
 	private final ApiClient apiClient;
@@ -462,6 +471,91 @@ public class HelmKubeService implements KubeService {
 		KubernetesApiResponse<DynamicKubernetesObject> response = namespaced
 				? api.patch(namespace, name, V1Patch.PATCH_FORMAT_APPLY_YAML, patch, options)
 				: api.patch(name, V1Patch.PATCH_FORMAT_APPLY_YAML, patch, options);
+		response.throwsApiException();
+	}
+
+	@Override
+	public void applyWithPrune(String namespace, String previousYaml, String yamlContent) {
+		if (previousYaml == null || previousYaml.isBlank()) {
+			// No prior state to diff against — fall back to plain server-side apply.
+			apply(namespace, yamlContent);
+			return;
+		}
+		try {
+			Map<String, Map<String, Object>> previous = indexById(previousYaml);
+			for (Object doc : loadUnstructured(yamlContent)) {
+				if (doc instanceof Map<?, ?> map) {
+					@SuppressWarnings("unchecked")
+					Map<String, Object> resource = (Map<String, Object>) map;
+					applyResourceWithPrune(namespace, resource, previous.get(String.join("|", identify(resource))));
+				}
+			}
+		}
+		catch (ApiException ex) {
+			throw new KubernetesOperationException("Failed to apply manifest", ex, ex.getCode());
+		}
+		catch (KubernetesOperationException ex) {
+			throw ex;
+		}
+		catch (Exception ex) {
+			throw new KubernetesOperationException("Failed to apply manifest", ex);
+		}
+	}
+
+	// Indexes a manifest's documents by "apiVersion|kind|name" so an upgrade can pair
+	// each
+	// new resource with how the previous release rendered it.
+	private static Map<String, Map<String, Object>> indexById(String yamlContent) {
+		Map<String, Map<String, Object>> byId = new HashMap<>();
+		for (Object doc : loadUnstructured(yamlContent)) {
+			if (doc instanceof Map<?, ?> map) {
+				@SuppressWarnings("unchecked")
+				Map<String, Object> resource = (Map<String, Object>) map;
+				byId.put(String.join("|", identify(resource)), resource);
+			}
+		}
+		return byId;
+	}
+
+	// Applies one resource with Helm-style pruning: create it if absent, otherwise send a
+	// three-way JSON merge patch (original=previous render, modified=new render,
+	// current=live) so fields the release dropped are deleted regardless of who owns
+	// them.
+	private void applyResourceWithPrune(String namespace, Map<String, Object> resource, Map<String, Object> original)
+			throws ApiException {
+		String[] id = identify(resource);
+		String apiVersion = id[0];
+		String kind = id[1];
+		String name = id[2];
+		String group = apiVersion.contains("/") ? apiVersion.split("/")[0] : "";
+		String version = apiVersion.contains("/") ? apiVersion.split("/")[1] : apiVersion;
+		String plural = inferPlural(kind);
+		boolean namespaced = inferNamespaced(kind);
+		DynamicKubernetesApi api = new DynamicKubernetesApi(group, version, plural, apiClient);
+		KubernetesApiResponse<DynamicKubernetesObject> live = namespaced ? api.get(namespace, name) : api.get(name);
+		if (!live.isSuccess()) {
+			// Absent on the cluster — create it via server-side apply (establishes helm
+			// ownership); nothing to prune for a brand-new resource.
+			applyResource(namespace, resource, false);
+			return;
+		}
+		JsonNode current = JSON.readTree(live.getObject().getRaw().toString());
+		JsonNode modified = JSON.valueToTree(resource);
+		JsonNode originalNode = (original != null) ? JSON.valueToTree(original) : null;
+		ObjectNode patch = ThreeWayJsonMerge.threeWayMergePatch(originalNode, modified, current);
+		if (patch.isEmpty()) {
+			return;
+		}
+		if (log.isInfoEnabled()) {
+			log.info("Applying (prune) {} ({}/{}) {}{}", kind, group, version, name,
+					namespaced ? " in namespace " + namespace : " (cluster-scoped)");
+		}
+		V1Patch mergePatch = new V1Patch(JSON.writeValueAsString(patch));
+		PatchOptions options = new PatchOptions();
+		options.setFieldManager("helm");
+		KubernetesApiResponse<DynamicKubernetesObject> response = namespaced
+				? api.patch(namespace, name, V1Patch.PATCH_FORMAT_JSON_MERGE_PATCH, mergePatch, options)
+				: api.patch(name, V1Patch.PATCH_FORMAT_JSON_MERGE_PATCH, mergePatch, options);
 		response.throwsApiException();
 	}
 

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/NamespaceScopedReleasesKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/NamespaceScopedReleasesKubeService.java
@@ -91,6 +91,11 @@ public class NamespaceScopedReleasesKubeService implements KubeService {
 	}
 
 	@Override
+	public void applyWithPrune(String namespace, String previousYaml, String yamlContent) {
+		delegate.applyWithPrune(namespace, previousYaml, yamlContent);
+	}
+
+	@Override
 	public void applyDryRun(String namespace, String yamlContent) {
 		delegate.applyDryRun(namespace, yamlContent);
 	}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/ObservableKubeService.java
@@ -104,6 +104,11 @@ public class ObservableKubeService implements KubeService {
 	}
 
 	@Override
+	public void applyWithPrune(String namespace, String previousYaml, String yamlContent) {
+		timeVoid(applyTimer, () -> delegate.applyWithPrune(namespace, previousYaml, yamlContent));
+	}
+
+	@Override
 	public void applyDryRun(String namespace, String yamlContent) {
 		timeVoid(applyTimer, () -> delegate.applyDryRun(namespace, yamlContent));
 	}

--- a/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeService.java
+++ b/jhelm-kube/src/main/java/org/alexmond/jhelm/kube/service/internal/RetryableKubeService.java
@@ -113,6 +113,14 @@ public class RetryableKubeService implements KubeService {
 	}
 
 	@Override
+	public void applyWithPrune(String namespace, String previousYaml, String yamlContent) {
+		executeWithRetry("applyWithPrune", () -> {
+			delegate.applyWithPrune(namespace, previousYaml, yamlContent);
+			return null;
+		});
+	}
+
+	@Override
 	public void applyDryRun(String namespace, String yamlContent) {
 		executeWithRetry("applyDryRun", () -> {
 			delegate.applyDryRun(namespace, yamlContent);

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/Fabric8KubeServiceIntegrationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/Fabric8KubeServiceIntegrationTest.java
@@ -146,6 +146,39 @@ class Fabric8KubeServiceIntegrationTest {
 	}
 
 	@Test
+	void applyWithPrune_removesDroppedField() {
+		String previous = """
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: jhelm-fabric8-prune-cm
+				data:
+				  keep: "1"
+				  drop: "2"
+				""";
+		String upgraded = """
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: jhelm-fabric8-prune-cm
+				data:
+				  keep: "1"
+				""";
+
+		this.fabric8.apply(NAMESPACE, previous);
+		// Upgrade drops the "drop" key; three-way prune must delete it from the live
+		// object.
+		this.fabric8.applyWithPrune(NAMESPACE, previous, upgraded);
+
+		var cm = this.fabric8Client.configMaps().inNamespace(NAMESPACE).withName("jhelm-fabric8-prune-cm").get();
+		assertNotNull(cm);
+		assertEquals("1", cm.getData().get("keep"));
+		assertFalse(cm.getData().containsKey("drop"), "dropped data key must be pruned on upgrade (#814)");
+
+		this.fabric8.delete(NAMESPACE, upgraded);
+	}
+
+	@Test
 	void getResourceStatuses_coversAllWorkloadKinds() {
 		String yaml = allWorkloadsManifest();
 		try {

--- a/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceIntegrationTest.java
+++ b/jhelm-kube/src/test/java/org/alexmond/jhelm/kube/service/internal/HelmKubeServiceIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest(classes = { KubernetesConfig.class, HelmKubeService.class })
@@ -54,6 +55,41 @@ class HelmKubeServiceIntegrationTest {
 
 		// Cleanup
 		api.deleteNamespacedConfigMap("jhelm-test-cm", "default");
+	}
+
+	@Test
+	void testUpgradeWithPruneRemovesDroppedField() throws ApiException {
+		String previous = """
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: jhelm-prune-cm
+				data:
+				  keep: "1"
+				  drop: "2"
+				""";
+		String upgraded = """
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: jhelm-prune-cm
+				data:
+				  keep: "1"
+				""";
+
+		helmKubeService.apply("default", previous);
+		// Upgrade drops the "drop" key; three-way prune must delete it from the live
+		// object.
+		helmKubeService.applyWithPrune("default", previous, upgraded);
+
+		CoreV1Api api = new CoreV1Api(kubeClient.apiClient());
+		V1ConfigMap cm = api.readNamespacedConfigMap("jhelm-prune-cm", "default").execute();
+		assertNotNull(cm);
+		assertEquals("1", cm.getData().get("keep"));
+		assertFalse(cm.getData().containsKey("drop"), "dropped data key must be pruned on upgrade (#814)");
+
+		// Cleanup
+		api.deleteNamespacedConfigMap("jhelm-prune-cm", "default");
 	}
 
 }


### PR DESCRIPTION
Closes #814.

## Problem

`jhelm upgrade` never **removed** fields that disappeared from the rendered manifest — a dropped container `env` entry, a deleted flag or label stayed live forever. This is worse than cosmetic: a deliberately-removed setting (in the reporter's case, TLS relaxations) silently remained active while the upgrade reported success.

## Root cause

jhelm applies manifests via **server-side apply** (`fieldManager=helm`, `force=true`). SSA only prunes fields the `helm` **Apply** fieldset previously owned. When a field was first set by a *different* manager — real Helm's client-side apply, `kubectl`, or an older jhelm — `force` resolves *conflicts* but never *deletes* a field `helm` doesn't own. Result: adds/changes work, deletions never happen.

## Fix — Helm-3 three-way merge

Helm 3 (`pkg/kube/client.go`) prunes deterministically by computing a three-way merge patch from the **stored previous manifest** (original), the new manifest (modified), and the live object (current). jhelm already keeps the previous manifest but only used it for whole-resource orphan deletion.

New `ThreeWayJsonMerge` (jhelm-core, pure Jackson, mirrors `jsonmergepatch.CreateThreeWayJSONMergePatch`):
- **additions/changes** measured against the live object (already-correct fields aren't re-sent),
- **deletions** measured against the previous release's manifest (only fields *the release* dropped are removed — never controller-set fields jhelm never managed),
- JSON merge patch is atomic on arrays, so a changed `env` list is replaced wholesale → removed entries pruned.

`UpgradeAction` calls `applyWithPrune(previous, new)` when a previous manifest exists (plain apply otherwise, and under `--force`). Both backends implement it — client-java sends a `JSON_MERGE_PATCH`; Fabric8 reconstructs the live object as a plain map to sidestep its serializer's `additionalProperties` keySerializer NPE. Ownership-agnostic, so it fixes the mixed-manager case the SSA path could not.

## Tests

- **Unit** — `ThreeWayJsonMergeTest` (10): env-removal repro, whole-key deletion, controller-field preservation, no-op → empty patch, drift re-assertion, null-original.
- **Integration** (both backends, live cluster) — create a ConfigMap with two data keys, `applyWithPrune` dropping one, assert it is pruned.

Validated locally against an ephemeral kind cluster: full `jhelm-kube` suite green (21 integration + 310 unit), all coverage checks met; `jhelm-core` 911 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)