### PR TITLE
feat(core): full JSON Schema validation for values.schema.json via NetworkNT (#816)

### DIFF
--- a/jhelm-core/pom.xml
+++ b/jhelm-core/pom.xml
@@ -77,6 +77,11 @@
             <groupId>org.semver4j</groupId>
             <artifactId>semver4j</artifactId>
         </dependency>
+        <!-- Full-spec JSON Schema validation of values.schema.json (#816). -->
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpg-jdk18on</artifactId>

--- a/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SchemaValidator.java
+++ b/jhelm-core/src/main/java/org/alexmond/jhelm/core/service/SchemaValidator.java
@@ -3,29 +3,61 @@ package org.alexmond.jhelm.core.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
+import java.util.concurrent.ConcurrentHashMap;
 
+import com.networknt.schema.InputFormat;
+import com.networknt.schema.OutputFormat;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SchemaRegistryConfig;
+import com.networknt.schema.SpecificationVersion;
+import com.networknt.schema.output.OutputUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.alexmond.jhelm.core.exception.SchemaValidationException;
-import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 
 /**
- * Validates Helm chart values against a JSON Schema declared in
- * {@code values.schema.json}. Supports the most common JSON Schema Draft-07 constraints:
- * {@code type}, {@code required}, {@code properties}, {@code enum}, {@code minimum},
- * {@code maximum}, {@code minLength}, {@code maxLength}, and {@code pattern}.
+ * Validates Helm chart values against the JSON Schema declared in a chart's
+ * {@code values.schema.json}, using the full-spec
+ * <a href="https://github.com/networknt/json-schema-validator">NetworkNT</a> validator.
  * <p>
- * A malformed schema is logged as a warning and treated as absent — consistent with real
- * Helm behaviour.
+ * The entire JSON Schema vocabulary is supported — {@code $ref}/{@code $defs},
+ * {@code additionalProperties}, {@code items}, {@code oneOf}/{@code anyOf}/{@code allOf},
+ * {@code if}/{@code then}/{@code else}, {@code const}, {@code patternProperties}, and the
+ * rest — matching real Helm (Helm&nbsp;4 validates with santhosh-tekuri/jsonschema at
+ * draft 2020-12; Helm&nbsp;3 with gojsonschema at Draft-07).
+ * </p>
+ * <p>
+ * A schema with no {@code $schema} keyword is interpreted as draft 2020-12 (Helm&nbsp;4's
+ * default); a schema that declares its own {@code $schema} (for example the Draft-07 URI
+ * shipped by most existing charts) is validated against that draft. A malformed schema is
+ * logged as a warning and treated as absent — consistent with real Helm behaviour.
+ * </p>
+ * <p>
+ * Compiled schemas are cached by their raw content, so a chart rendered repeatedly parses
+ * its schema once. The class is thread-safe.
  * </p>
  */
 @Slf4j
 public class SchemaValidator {
 
 	private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
+
+	/**
+	 * Compiles schemas with draft 2020-12 as the default dialect (Helm 4's default) while
+	 * still honouring a schema's own {@code $schema} when present.
+	 */
+	private final SchemaRegistry schemaRegistry;
+
+	private final Map<String, Schema> schemaCache = new ConcurrentHashMap<>();
+
+	public SchemaValidator() {
+		SchemaRegistryConfig config = SchemaRegistryConfig.builder().build();
+		this.schemaRegistry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12,
+				(builder) -> builder.schemaRegistryConfig(config));
+	}
 
 	/**
 	 * Validates the given values map against the JSON Schema.
@@ -39,167 +71,81 @@ public class SchemaValidator {
 		if (schemaJson == null || schemaJson.isBlank()) {
 			return;
 		}
-		List<String> errors = new ArrayList<>();
-		try {
-			JsonNode schema = JSON_MAPPER.readTree(schemaJson);
-			JsonNode valuesNode = JSON_MAPPER.valueToTree(values);
-			validateNode(schema, valuesNode, "$", errors);
+		Schema schema = compile(chartName, schemaJson);
+		if (schema == null) {
+			// Malformed schema — already logged; treat as absent, like Helm.
+			return;
 		}
-		catch (Exception ex) {
+		String valuesJson;
+		try {
+			valuesJson = JSON_MAPPER.writeValueAsString((values != null) ? values : Map.of());
+		}
+		catch (RuntimeException ex) {
 			if (log.isWarnEnabled()) {
-				log.warn("Could not parse values.schema.json for chart {}: {}", chartName, ex.getMessage());
+				log.warn("Could not serialize values for schema validation of chart {}: {}", chartName,
+						ex.getMessage());
 			}
 			return;
 		}
+		OutputUnit result = schema.validate(valuesJson, InputFormat.JSON, OutputFormat.LIST);
+		if (result.isValid()) {
+			return;
+		}
+		List<String> errors = collectErrors(result);
 		if (!errors.isEmpty()) {
 			throw new SchemaValidationException(chartName, errors);
 		}
 	}
 
-	private void validateNode(JsonNode schema, JsonNode value, String path, List<String> errors) {
-		if (schema == null || schema.isMissingNode()) {
-			return;
+	private Schema compile(String chartName, String schemaJson) {
+		Schema cached = this.schemaCache.get(schemaJson);
+		if (cached != null) {
+			return cached;
 		}
-		if (schema.has("type") && schema.get("type").isString()) {
-			validateType(schema.get("type").asString(), value, path, errors);
+		try {
+			JsonNode schemaNode = JSON_MAPPER.readTree(schemaJson);
+			Schema schema = this.schemaRegistry.getSchema(SchemaLocation.of("values.schema.json"), schemaNode);
+			schema.initializeValidators();
+			this.schemaCache.put(schemaJson, schema);
+			return schema;
 		}
-		if (schema.has("required") && value.isObject()) {
-			for (JsonNode req : schema.get("required")) {
-				if (!value.has(req.asString())) {
-					errors.add(path + "." + req.asString() + " is required");
-				}
+		catch (RuntimeException ex) {
+			if (log.isWarnEnabled()) {
+				log.warn("Could not parse values.schema.json for chart {}: {}", chartName, ex.getMessage());
 			}
-		}
-		if (schema.has("properties") && value.isObject()) {
-			JsonNode props = schema.get("properties");
-			Map<String, JsonNode> propsMap = JSON_MAPPER.convertValue(props, new TypeReference<>() {
-			});
-			for (Map.Entry<String, JsonNode> entry : propsMap.entrySet()) {
-				if (value.has(entry.getKey())) {
-					validateNode(entry.getValue(), value.get(entry.getKey()), path + "." + entry.getKey(), errors);
-				}
-			}
-		}
-		if (schema.has("enum")) {
-			boolean valid = false;
-			for (JsonNode enumVal : schema.get("enum")) {
-				if (jsonValueEquals(enumVal, value)) {
-					valid = true;
-					break;
-				}
-			}
-			if (!valid) {
-				errors.add(path + ": value " + value + " is not one of the allowed values " + schema.get("enum"));
-			}
-		}
-		if (value.isNumber()) {
-			double num = value.doubleValue();
-			if (schema.has("minimum") && num < schema.get("minimum").doubleValue()) {
-				errors.add(path + ": " + num + " must be >= " + schema.get("minimum").doubleValue());
-			}
-			if (schema.has("maximum") && num > schema.get("maximum").doubleValue()) {
-				errors.add(path + ": " + num + " must be <= " + schema.get("maximum").doubleValue());
-			}
-		}
-		if (value.isString()) {
-			String text = value.asString();
-			if (schema.has("minLength") && text.length() < schema.get("minLength").asInt()) {
-				errors
-					.add(path + ": string length " + text.length() + " must be >= " + schema.get("minLength").asInt());
-			}
-			if (schema.has("maxLength") && text.length() > schema.get("maxLength").asInt()) {
-				errors
-					.add(path + ": string length " + text.length() + " must be <= " + schema.get("maxLength").asInt());
-			}
-			if (schema.has("pattern")) {
-				String patternStr = schema.get("pattern").asString();
-				try {
-					if (!Pattern.compile(patternStr).matcher(text).find()) {
-						errors.add(path + ": string does not match pattern " + patternStr);
-					}
-				}
-				catch (PatternSyntaxException ex) {
-					if (log.isWarnEnabled()) {
-						log.warn("Invalid pattern '{}' in schema at {}: {}", patternStr, path, ex.getMessage());
-					}
-				}
-			}
-		}
-	}
-
-	private void validateType(String type, JsonNode value, String path, List<String> errors) {
-		boolean valid = switch (type) {
-			case "string" -> value.isString();
-			case "integer" -> isIntegerValue(value);
-			case "number" -> value.isNumber();
-			case "boolean" -> value.isBoolean();
-			case "array" -> value.isArray();
-			case "object" -> value.isObject();
-			case "null" -> value.isNull();
-			default -> true;
-		};
-		if (!valid) {
-			errors.add(path + ": expected type " + type + " but was " + nodeTypeName(value));
+			return null;
 		}
 	}
 
 	/**
-	 * Equality for {@code enum}/{@code const} that compares numbers by value, so a schema
-	 * integer like {@code 443} matches a values float64 {@code 443.0} (Helm loads values
-	 * as float64; JSON-Schema enum equality is numeric, not type-strict).
-	 * @param a one node
-	 * @param b the other node
-	 * @return whether they are equal for schema purposes
+	 * Flattens a NetworkNT {@link OutputUnit} into human-readable error strings, one per
+	 * failing keyword, each prefixed with the JSON-pointer location of the offending
+	 * value.
+	 * @param result the validation output
+	 * @return the collected error messages
 	 */
-	private static boolean jsonValueEquals(JsonNode a, JsonNode b) {
-		if (a.isNumber() && b.isNumber()) {
-			return a.doubleValue() == b.doubleValue();
+	private List<String> collectErrors(OutputUnit result) {
+		List<String> errors = new ArrayList<>();
+		// Root-level errors (keyword -> message), e.g. a top-level required/type failure.
+		if (result.getErrors() != null) {
+			result.getErrors().forEach((keyword, message) -> errors.add(format("", keyword, message)));
 		}
-		return a.equals(b);
+		// Per-instance violations discovered deeper in the document.
+		if (result.getDetails() != null) {
+			for (OutputUnit detail : result.getDetails()) {
+				if (detail.getErrors() == null) {
+					continue;
+				}
+				String location = detail.getInstanceLocation();
+				detail.getErrors().forEach((keyword, message) -> errors.add(format(location, keyword, message)));
+			}
+		}
+		return errors;
 	}
 
-	/**
-	 * JSON Schema's {@code integer} matches any number with zero fractional part,
-	 * including a float like {@code 8080.0}. Helm loads values as float64, so chart
-	 * ports/replicas arrive as whole doubles; accept them as integers (the validator must
-	 * not be stricter than Helm's).
-	 * @param value the value node
-	 * @return whether {@code value} is an integer for schema purposes
-	 */
-	private static boolean isIntegerValue(JsonNode value) {
-		if (value.isIntegralNumber()) {
-			return true;
-		}
-		if (value.isFloatingPointNumber()) {
-			double d = value.doubleValue();
-			return !Double.isInfinite(d) && !Double.isNaN(d) && d == Math.floor(d);
-		}
-		return false;
-	}
-
-	private String nodeTypeName(JsonNode node) {
-		if (node.isString()) {
-			return "string";
-		}
-		if (node.isIntegralNumber()) {
-			return "integer";
-		}
-		if (node.isFloatingPointNumber()) {
-			return "number";
-		}
-		if (node.isBoolean()) {
-			return "boolean";
-		}
-		if (node.isArray()) {
-			return "array";
-		}
-		if (node.isObject()) {
-			return "object";
-		}
-		if (node.isNull()) {
-			return "null";
-		}
-		return "unknown";
+	private String format(String location, Object keyword, Object message) {
+		String pointer = (location == null || location.isEmpty()) ? "" : location + ": ";
+		return pointer + message + " [" + keyword + "]";
 	}
 
 }

--- a/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/SchemaValidatorTest.java
+++ b/jhelm-core/src/test/java/org/alexmond/jhelm/core/service/SchemaValidatorTest.java
@@ -1,5 +1,6 @@
 package org.alexmond.jhelm.core.service;
 
+import java.util.List;
 import java.util.Map;
 
 import org.alexmond.jhelm.core.exception.SchemaValidationException;
@@ -167,6 +168,218 @@ class SchemaValidatorTest {
 		assertTrue(ex.getMessage().contains("my-chart"));
 		assertNotNull(ex.getValidationErrors());
 		assertFalse(ex.getValidationErrors().isEmpty());
+	}
+
+	// --- Full-spec keywords the hand-rolled validator used to ignore (#816) ---
+
+	@Test
+	void validate_additionalPropertiesFalse_rejectsUnknownKey() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": { "name": { "type": "string" } },
+				  "additionalProperties": false
+				}
+				""";
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("name", "ok", "surprise", "x")));
+	}
+
+	@Test
+	void validate_unknownKeysAllowedByDefault_doesNotThrow() {
+		// Helm parity: unknown keys are permitted unless additionalProperties is false.
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": { "name": { "type": "string" } }
+				}
+				""";
+		assertDoesNotThrow(() -> validator.validate("test-chart", schema, Map.of("name", "ok", "extra", "fine")));
+	}
+
+	@Test
+	void validate_refToDefs_isResolved() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": { "port": { "$ref": "#/$defs/portNumber" } },
+				  "$defs": {
+				    "portNumber": { "type": "integer", "minimum": 1, "maximum": 65535 }
+				  }
+				}
+				""";
+		assertDoesNotThrow(() -> validator.validate("test-chart", schema, Map.of("port", 8080)));
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("port", 70000)));
+	}
+
+	@Test
+	void validate_oneOf_enforced() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": {
+				    "value": { "oneOf": [ { "type": "string" }, { "type": "integer" } ] }
+				  }
+				}
+				""";
+		assertDoesNotThrow(() -> validator.validate("test-chart", schema, Map.of("value", "a-string")));
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("value", true)));
+	}
+
+	@Test
+	void validate_anyOf_enforced() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": {
+				    "size": { "anyOf": [ { "type": "string", "enum": ["small", "large"] }, { "type": "integer" } ] }
+				  }
+				}
+				""";
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("size", "medium")));
+	}
+
+	@Test
+	void validate_allOf_enforced() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": {
+				    "name": {
+				      "allOf": [ { "type": "string", "minLength": 3 }, { "pattern": "^[a-z]" } ]
+				    }
+				  }
+				}
+				""";
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("name", "Ab")));
+	}
+
+	@Test
+	void validate_ifThenElse_conditionalRequired() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": { "env": { "type": "string" } },
+				  "if":   { "properties": { "env": { "const": "prod" } } },
+				  "then": { "required": ["replicas"] }
+				}
+				""";
+		assertDoesNotThrow(() -> validator.validate("test-chart", schema, Map.of("env", "dev")));
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("env", "prod")));
+	}
+
+	@Test
+	void validate_arrayItems_enforced() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": {
+				    "ports": { "type": "array", "items": { "type": "integer" } }
+				  }
+				}
+				""";
+		assertDoesNotThrow(() -> validator.validate("test-chart", schema, Map.of("ports", List.of(80, 443))));
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("ports", List.of(80, "https"))));
+	}
+
+	@Test
+	void validate_const_enforced() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": { "apiVersion": { "const": "v1" } }
+				}
+				""";
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("apiVersion", "v2")));
+	}
+
+	@Test
+	void validate_exclusiveMinimum_enforced() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": { "replicas": { "type": "integer", "exclusiveMinimum": 0 } }
+				}
+				""";
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("replicas", 0)));
+	}
+
+	@Test
+	void validate_multipleOf_enforced() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": { "port": { "type": "integer", "multipleOf": 5 } }
+				}
+				""";
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("port", 7)));
+	}
+
+	// --- Helm float64 semantics: values arrive as boxed doubles ---
+
+	@Test
+	void validate_wholeDoubleSatisfiesIntegerType() {
+		// Helm loads values as float64, so a port/replica count arrives as a whole double
+		// (8080.0). JSON Schema says integer matches a number with zero fractional part.
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": { "port": { "type": "integer" } }
+				}
+				""";
+		assertDoesNotThrow(() -> validator.validate("test-chart", schema, Map.of("port", 8080.0d)));
+	}
+
+	@Test
+	void validate_fractionalDoubleFailsIntegerType() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": { "port": { "type": "integer" } }
+				}
+				""";
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("port", 80.5d)));
+	}
+
+	// --- $schema-driven draft selection (Helm 3 Draft-07 charts) ---
+
+	@Test
+	void validate_draft07Schema_selectedByDollarSchema() {
+		String schema = """
+				{
+				  "$schema": "http://json-schema.org/draft-07/schema#",
+				  "type": "object",
+				  "properties": { "replicas": { "type": "integer", "minimum": 1 } },
+				  "required": ["replicas"]
+				}
+				""";
+		assertDoesNotThrow(() -> validator.validate("test-chart", schema, Map.of("replicas", 2)));
+		assertThrows(SchemaValidationException.class,
+				() -> validator.validate("test-chart", schema, Map.of("replicas", 0)));
+	}
+
+	@Test
+	void validate_sameSchemaTwice_usesCacheAndStaysConsistent() {
+		String schema = """
+				{
+				  "type": "object",
+				  "properties": { "name": { "type": "string" } },
+				  "required": ["name"]
+				}
+				""";
+		assertDoesNotThrow(() -> validator.validate("test-chart", schema, Map.of("name", "ok")));
+		// Second call hits the compiled-schema cache and must behave identically.
+		assertThrows(SchemaValidationException.class, () -> validator.validate("test-chart", schema, Map.of()));
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <fabric8-client.version>6.13.5</fabric8-client.version>
         <picocli.version>4.7.7</picocli.version>
         <semver4j.version>6.0.0</semver4j.version>
+        <json-schema-validator.version>3.0.5</json-schema-validator.version>
         <!--
             jhelm-core and jhelm-gotemplate-helm call CoreScalarResolver(boolean), added in
             snakeyaml-engine 3.x. Spring Boot's BOM does not manage snakeyaml-engine (only
@@ -196,6 +197,13 @@
                 <groupId>org.semver4j</groupId>
                 <artifactId>semver4j</artifactId>
                 <version>${semver4j.version}</version>
+            </dependency>
+            <!-- Full-spec JSON Schema validation for values.schema.json (2019-09/2020-12,
+                 Draft-07 via a schema's own $schema); replaces the hand-rolled subset (#816). -->
+            <dependency>
+                <groupId>com.networknt</groupId>
+                <artifactId>json-schema-validator</artifactId>
+                <version>${json-schema-validator.version}</version>
             </dependency>
             <!-- Explicit floor; see the snakeyaml-engine.version note above (#770). -->
             <dependency>


### PR DESCRIPTION
Closes #816.

## What

Replaces the hand-rolled `SchemaValidator` (a ~10-keyword partial Draft-07 subset) with the full-spec **`com.networknt:json-schema-validator`** (v3 API) — the same library, at the same version, that the sister **yj-schema-validator** already uses on Jackson 3.

### Why

The old validator silently ignored most of the JSON Schema vocabulary — `$ref`/`$defs`, `additionalProperties`, `items`, `oneOf`/`anyOf`/`allOf`, `if`/`then`/`else`, `const`, `patternProperties`, `exclusiveMinimum`/`exclusiveMaximum`, `multipleOf`, `format`. Charts whose `values.schema.json` used any of these **passed jhelm but behaved differently under real Helm**:

| | Library | Draft |
|---|---|---|
| Helm 3 | `xeipuuv/gojsonschema` | Draft-07 (full spec) |
| Helm 4 (`main`) | `santhosh-tekuri/jsonschema` v6 | draft 2020-12 (full spec) |
| jhelm (before) | hand-rolled | ~10 keywords |

### How

- Default dialect **draft 2020-12** (Helm 4's default); a schema declaring its own `$schema` (e.g. the Draft-07 URI most existing charts ship) validates against **that** draft — so both Helm 3 and Helm 4 charts are matched.
- **Public contract unchanged** — `validate(chartName, schemaJson, values)` still throws `SchemaValidationException`; `Engine`, `LintAction`, and the autoconfig bean are untouched.
- Compiled schemas cached by content (the old code re-parsed on every call); malformed-schema-treated-as-absent preserved; NetworkNT `OutputUnit` mapped to the existing `List<String>` error shape.
- **Helm float64 semantics** locked by test — a whole-valued double (`8080.0`) satisfies `type: integer`, a fractional one (`80.5`) fails.

## Tests

`SchemaValidatorTest` expanded **12 → 27**: the original cases plus `additionalProperties:false`, `$ref`/`$defs`, `oneOf`/`anyOf`/`allOf`, `if`/`then`/`else`, `items`, `const`, `exclusiveMinimum`, `multipleOf`, the float64-integer parity pair, `$schema`-driven Draft-07 selection, and compiled-schema cache consistency.

## Verification

- `mvn verify -pl jhelm-core -am` — **BUILD SUCCESS**: 27/27 schema tests, all coverage gates met, 0 checkstyle, PMD clean.
- `mvn -DskipTests install` (full reactor) — all 17 modules compile and package with the new transitive dependency.

## Follow-up

#817 (depends on this) tracks your ask to expose schema validation via the **REST API** and build a **schema-driven values UI editor** on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
